### PR TITLE
Ensure reverts are propagated through the call hierachy

### DIFF
--- a/crates/test-files/fixtures/stress/external_calls.fe
+++ b/crates/test-files/fixtures/stress/external_calls.fe
@@ -1,3 +1,6 @@
+struct SomeError:
+    code: u256
+
 contract Foo:
     my_tuple: (u256, address)
     my_string: String<100>
@@ -27,6 +30,19 @@ contract Foo:
     pub fn get_tuple() -> (u256, u256, bool):
         return (42, 26, false)
 
+    pub fn do_revert():
+        revert
+
+    # Having the return type exercises a different path in the compiler
+    pub fn do_revert2() -> bool:
+        revert
+
+    pub fn do_revert_with_data():
+        revert SomeError(code=4711)
+
+    # Having the return type exercises a different path in the compiler
+    pub fn do_revert_with_data2() -> bool:
+        revert SomeError(code=4711)
 
 contract FooProxy:
     foo: Foo
@@ -65,3 +81,15 @@ contract FooProxy:
         assert my_array[1] == u16(2)
         assert my_array[2] == u16(3)
         assert my_array[3] == u16(257)
+
+    pub fn call_do_revert(self):
+        self.foo.do_revert()
+
+    pub fn call_do_revert2(self):
+        self.foo.do_revert2()
+
+    pub fn call_do_revert_with_data(self):
+        self.foo.do_revert_with_data()
+
+    pub fn call_do_revert_with_data2(self):
+        self.foo.do_revert_with_data2()

--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -213,7 +213,7 @@ pub fn validate_revert(
             format!("0x{}", hex::encode(expected_data))
         );
     } else {
-        panic!("failed")
+        panic!("Method was expected to revert but didn't")
     };
 }
 

--- a/crates/tests/src/stress.rs
+++ b/crates/tests/src/stress.rs
@@ -318,5 +318,23 @@ fn external_calls_stress() {
             Some(&string_token("hi")),
         );
         proxy_harness.test_function(&mut executor, "call_get_array", &[], None);
+
+        proxy_harness.test_function_reverts(&mut executor, "call_do_revert", &[], &[]);
+
+        proxy_harness.test_function_reverts(&mut executor, "call_do_revert2", &[], &[]);
+
+        proxy_harness.test_function_reverts(
+            &mut executor,
+            "call_do_revert_with_data",
+            &[],
+            &encode_revert("SomeError(uint256)", &[uint_token(4711)]),
+        );
+
+        proxy_harness.test_function_reverts(
+            &mut executor,
+            "call_do_revert_with_data2",
+            &[],
+            &encode_revert("SomeError(uint256)", &[uint_token(4711)]),
+        );
     })
 }

--- a/crates/yulgen/src/runtime/functions/contracts.rs
+++ b/crates/yulgen/src/runtime/functions/contracts.rs
@@ -49,7 +49,13 @@ pub fn calls(db: &dyn AnalyzerDb, contract: ContractId) -> Vec<yul::Statement> {
                         (let instart := alloc_mstoren([selector], 4))
                         (let insize := add(4, [encoding_size]))
                         (pop([encoding_operation]))
-                        (pop((call((gas()), addr, 0, instart, insize, 0, 0))))
+                        (let success := call((gas()), addr, 0, instart, insize, 0, 0))
+                        (if (iszero(success)) {
+                            (let outsize := returndatasize())
+                            (let outstart := alloc(outsize))
+                            (returndatacopy(outstart, 0, outsize))
+                            (revert(outstart, outsize))
+                        })
                     }
                 }
             } else {
@@ -65,10 +71,11 @@ pub fn calls(db: &dyn AnalyzerDb, contract: ContractId) -> Vec<yul::Statement> {
                         (let instart := alloc_mstoren([selector], 4))
                         (let insize := add(4, [encoding_size]))
                         (pop([encoding_operation]))
-                        (pop((call((gas()), addr, 0, instart, insize, 0, 0))))
+                        (let success := call((gas()), addr, 0, instart, insize, 0, 0))
                         (let outsize := returndatasize())
                         (let outstart := alloc(outsize))
                         (returndatacopy(outstart, 0, outsize))
+                        (if (iszero(success)) { (revert(outstart, outsize)) })
                         (return_val := [decoding_operation])
                     }
                 }

--- a/newsfragments/574.bugfix.md
+++ b/newsfragments/574.bugfix.md
@@ -1,0 +1,30 @@
+Propagate reverts from external contract calls.
+
+Before this fix the following code to `should_revert()` or `should_revert2()`
+would succeed even though it clearly should not.
+
+```
+contract A:
+  contract_b: B
+  pub fn __init__(contract_b: address):
+    self.contract_b = B(contract_b)
+
+  pub fn should_revert():
+    self.contract_b.fail()
+
+  pub fn should_revert2():
+    self.contract_b.fail_with_custom_error()
+
+struct SomeError:
+  pass
+
+contract B:
+
+  pub fn fail():
+    revert
+
+  pub fn fail_with_custom_error():
+    revert SomeError()
+```
+
+With this fix the revert errors are properly passed upwards the call hierachy.


### PR DESCRIPTION
### What was wrong?

When contract A calls a method on contract B and that method calls `revert` then the whole call should fail. That isn't the case right now.

### How was it fixed?

- Catch the `succeed` bool of the `call(..)` and revert with the return data in case `succeed` is `false`.
- Added tests