### PR TITLE
Disallow importing private type via `use`

### DIFF
--- a/crates/analyzer/src/db/queries/module.rs
+++ b/crates/analyzer/src/db/queries/module.rs
@@ -443,6 +443,14 @@ pub fn module_used_item_map(
                 diagnostics.extend(items.diagnostics.iter().cloned());
 
                 for (name, (name_span, item)) in items.value.iter() {
+                    if !item.is_public(db) {
+                        diagnostics.push(errors::error(
+                            &format!("{} {} is private", item.item_kind_display_name(), name,),
+                            *name_span,
+                            name.as_str(),
+                        ));
+                    }
+
                     if let Some((other_name_span, other_item)) =
                         accum.insert(name.clone(), (*name_span, *item))
                     {

--- a/crates/analyzer/tests/snapshots/analysis__basic_ingot.snap
+++ b/crates/analyzer/tests/snapshots/analysis__basic_ingot.snap
@@ -313,8 +313,8 @@ note:
 note: 
   ┌─ ingots/basic_ingot/src/ding/dang.fe:1:1
   │
-1 │ type Dang = Array<u256, 42>
-  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Array<u256, 42>
+1 │ pub type Dang = Array<u256, 42>
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Array<u256, 42>
 
 
 note: 

--- a/crates/analyzer/tests/snapshots/errors__bad_visibility.snap
+++ b/crates/analyzer/tests/snapshots/errors__bad_visibility.snap
@@ -3,11 +3,47 @@ source: crates/analyzer/tests/errors.rs
 expression: error_string_ingot(&path)
 
 ---
-error: unresolved path item
+error: type MyInt is private
+  ┌─ compile_errors/bad_visibility/src/main.fe:1:11
+  │
+1 │ use foo::{MyInt, MY_CONST, MyStruct, MyTrait, my_func, MyContract, MyEnum }
+  │           ^^^^^ MyInt
+
+error: constant MY_CONST is private
+  ┌─ compile_errors/bad_visibility/src/main.fe:1:18
+  │
+1 │ use foo::{MyInt, MY_CONST, MyStruct, MyTrait, my_func, MyContract, MyEnum }
+  │                  ^^^^^^^^ MY_CONST
+
+error: struct MyStruct is private
+  ┌─ compile_errors/bad_visibility/src/main.fe:1:28
+  │
+1 │ use foo::{MyInt, MY_CONST, MyStruct, MyTrait, my_func, MyContract, MyEnum }
+  │                            ^^^^^^^^ MyStruct
+
+error: trait MyTrait is private
+  ┌─ compile_errors/bad_visibility/src/main.fe:1:38
+  │
+1 │ use foo::{MyInt, MY_CONST, MyStruct, MyTrait, my_func, MyContract, MyEnum }
+  │                                      ^^^^^^^ MyTrait
+
+error: function my_func is private
+  ┌─ compile_errors/bad_visibility/src/main.fe:1:47
+  │
+1 │ use foo::{MyInt, MY_CONST, MyStruct, MyTrait, my_func, MyContract, MyEnum }
+  │                                               ^^^^^^^ my_func
+
+error: type MyContract is private
+  ┌─ compile_errors/bad_visibility/src/main.fe:1:56
+  │
+1 │ use foo::{MyInt, MY_CONST, MyStruct, MyTrait, my_func, MyContract, MyEnum }
+  │                                                        ^^^^^^^^^^ MyContract
+
+error: type MyEnum is private
   ┌─ compile_errors/bad_visibility/src/main.fe:1:68
   │
 1 │ use foo::{MyInt, MY_CONST, MyStruct, MyTrait, my_func, MyContract, MyEnum }
-  │                                                                    ^^^^^^ not found
+  │                                                                    ^^^^^^ MyEnum
 
 error: the type `MyInt` is private
   ┌─ compile_errors/bad_visibility/src/main.fe:7:33
@@ -101,10 +137,24 @@ error: the function `my_func` is private
    = `my_func` can only be used within `foo`
    = Hint: use `pub` to make `my_func` visible from outside of `foo`
 
-error: the type `MyContract` is private
+error: the type `MyEnum` is private
    ┌─ compile_errors/bad_visibility/src/main.fe:25:16
    │
-25 │         let _: MyContract = MyContract(addr)
+25 │         let e: MyEnum = MyEnum::Some
+   │                ^^^^^^ this type is not `pub`
+   │
+   ┌─ compile_errors/bad_visibility/src/foo.fe:17:6
+   │
+17 │ enum MyEnum {
+   │      ------ `MyEnum` is defined here
+   │
+   = `MyEnum` can only be used within `foo`
+   = Hint: use `pub` to make `MyEnum` visible from outside of `foo`
+
+error: the type `MyContract` is private
+   ┌─ compile_errors/bad_visibility/src/main.fe:29:16
+   │
+29 │         let _: MyContract = MyContract(addr)
    │                ^^^^^^^^^^ this type is not `pub`
    │
    ┌─ compile_errors/bad_visibility/src/foo.fe:13:10
@@ -116,9 +166,9 @@ error: the type `MyContract` is private
    = Hint: use `pub` to make `MyContract` visible from outside of `foo`
 
 error: the type `MyContract` is private
-   ┌─ compile_errors/bad_visibility/src/main.fe:25:29
+   ┌─ compile_errors/bad_visibility/src/main.fe:29:29
    │
-25 │         let _: MyContract = MyContract(addr)
+29 │         let _: MyContract = MyContract(addr)
    │                             ^^^^^^^^^^ this type is not `pub`
    │
    ┌─ compile_errors/bad_visibility/src/foo.fe:13:10
@@ -130,9 +180,9 @@ error: the type `MyContract` is private
    = Hint: use `pub` to make `MyContract` visible from outside of `foo`
 
 error: the type `MyContract` is private
-   ┌─ compile_errors/bad_visibility/src/main.fe:26:9
+   ┌─ compile_errors/bad_visibility/src/main.fe:30:9
    │
-26 │         MyContract.create(ctx, 1)
+30 │         MyContract.create(ctx, 1)
    │         ^^^^^^^^^^ this type is not `pub`
    │
    ┌─ compile_errors/bad_visibility/src/foo.fe:13:10

--- a/crates/analyzer/tests/snapshots/errors__emittable_not_implementable.snap
+++ b/crates/analyzer/tests/snapshots/errors__emittable_not_implementable.snap
@@ -3,6 +3,12 @@ source: crates/analyzer/tests/errors.rs
 expression: "error_string(&path, test_files::fixture(path))"
 
 ---
+error: struct OutOfReachMarker is private
+  ┌─ compile_errors/emittable_not_implementable.fe:1:31
+  │
+1 │ use std::context::{Emittable, OutOfReachMarker}
+  │                               ^^^^^^^^^^^^^^^^ OutOfReachMarker
+
 error: the struct `OutOfReachMarker` is private
   ┌─ compile_errors/emittable_not_implementable.fe:6:24
   │

--- a/crates/test-files/fixtures/compile_errors/bad_ingot/src/biz/bad.fe
+++ b/crates/test-files/fixtures/compile_errors/bad_ingot/src/biz/bad.fe
@@ -1,3 +1,3 @@
-struct Bur {}
+pub struct Bur {}
 
-struct Bud {}
+pub struct Bud {}

--- a/crates/test-files/fixtures/compile_errors/bad_visibility/src/foo.fe
+++ b/crates/test-files/fixtures/compile_errors/bad_visibility/src/foo.fe
@@ -13,3 +13,8 @@ fn my_func() {}
 contract MyContract {
     x: i32
 }
+
+enum MyEnum {
+    Some
+    Thing
+}

--- a/crates/test-files/fixtures/compile_errors/bad_visibility/src/main.fe
+++ b/crates/test-files/fixtures/compile_errors/bad_visibility/src/main.fe
@@ -21,6 +21,10 @@ contract Main {
         my_func()
     }
 
+    pub fn priv_enum() {
+        let e: MyEnum = MyEnum::Some
+    }
+
     pub fn priv_contract(ctx: Context, addr: address) {
         let _: MyContract = MyContract(addr)
         MyContract.create(ctx, 1)

--- a/crates/test-files/fixtures/ingots/basic_ingot/src/ding/dang.fe
+++ b/crates/test-files/fixtures/ingots/basic_ingot/src/ding/dang.fe
@@ -1,1 +1,1 @@
-type Dang = Array<u256, 42>
+pub type Dang = Array<u256, 42>

--- a/crates/test-files/fixtures/ingots/visibility_ingot/src/foo.fe
+++ b/crates/test-files/fixtures/ingots/visibility_ingot/src/foo.fe
@@ -2,7 +2,7 @@ pub struct Bing {
     pub my_address: address
 }
 
-fn get_42_backend() -> u256 {
+pub fn get_42_backend() -> u256 {
     return 42
 }
 

--- a/newsfragments/815.bugfix.md
+++ b/newsfragments/815.bugfix.md
@@ -1,0 +1,5 @@
+Disallow importing private type via `use`
+
+The following was previously allowed but will now error:
+
+`use foo::PrivateStruct`


### PR DESCRIPTION
### What was wrong?

We currently do not error when trying to import types via `use` whith are not `pub`. E.g. `use foo::PrivateStruct` does not error.

### How was it fixed?

Trivial

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/docs/src/spec/index.md) if applicable
- [ ] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [ ] Clean up commit history
