### PR TITLE
Typo: Fix cast command arguments in quickstart docs

### DIFF
--- a/docs/src/quickstart/deploy_contract.md
+++ b/docs/src/quickstart/deploy_contract.md
@@ -131,10 +131,10 @@ The response arrives in the form of hex-encoded bytes padded with zeroes:
 Foundry provides a built-in method to convert this hex string into human-readable ASCII. You can do this as follows:
 
 ```sh
-cast to_ascii "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000087765203c33204665000000000000000000000000000000000000000000000000"
+cast --to-ascii "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000087765203c33204665000000000000000000000000000000000000000000000000"
 ```
 
-or simply pipe the output of the `cast call` to `to_ascii` to do the query and conversion in a single command:
+or simply pipe the output of the `cast call` to `cast --to-ascii` to do the query and conversion in a single command:
 
 ```sh
 cast call --rpc-url https://rpc.sepolia.org <contract-address> "get_msg(address)" <your-account-address-that-signed-the-guestbook> | cast --to-ascii


### PR DESCRIPTION
### What was wrong?
Unrecognized subcommand `cast 'to_ascii'` in the deploy contract quickstart docs
Local cast version: cast 0.2.0 

### How was it fixed?

Fix wrong invocation flags from `cast to_ascii` to `cast --to-ascii`


### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/docs/src/spec/index.md) if applicable
- [x] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [x] Clean up commit history
