### PR TITLE
Fix associate type candidate collection

### DIFF
--- a/crates/hir-analysis/test_files/ty_check/default_generic_trait.fe
+++ b/crates/hir-analysis/test_files/ty_check/default_generic_trait.fe
@@ -3,12 +3,27 @@ trait Add<T = Self> {
 
     fn add(self: Self, _ rhs: T) -> Self::Output
 }
+trait Sub<T = Self> {
+    type Output = Self
 
-impl Add for i32 {
+    fn sub(self: Self, _ rhs: T) -> Self::Output
+}
+
+struct Foo {}
+struct Bar {}
+
+impl Add for Foo {
+    fn add(self: Self, _ rhs: Self) -> Self { self }
+}
+impl Sub for Foo {
+    fn sub(self: Self, _ rhs: Self) -> Self { self }
+}
+impl Add for Bar {
     fn add(self: Self, _ rhs: Self) -> Self { self }
 }
 
-fn f(x: i32) -> i32 {
+fn f(x: Foo, y: Bar) -> Foo {
+    y.add(y)
+    x.sub(x)
     x.add(x)
 }
-

--- a/crates/hir-analysis/test_files/ty_check/default_generic_trait.snap
+++ b/crates/hir-analysis/test_files/ty_check/default_generic_trait.snap
@@ -4,41 +4,102 @@ expression: res
 input_file: test_files/ty_check/default_generic_trait.fe
 ---
 note: 
-  ┌─ default_generic_trait.fe:8:45
-  │
-8 │     fn add(self: Self, _ rhs: Self) -> Self { self }
-  │                                             ^^^^^^^^ i32
+   ┌─ default_generic_trait.fe:16:45
+   │
+16 │     fn add(self: Self, _ rhs: Self) -> Self { self }
+   │                                             ^^^^^^^^ Foo
 
 note: 
-  ┌─ default_generic_trait.fe:8:47
-  │
-8 │     fn add(self: Self, _ rhs: Self) -> Self { self }
-  │                                               ^^^^ i32
+   ┌─ default_generic_trait.fe:16:47
+   │
+16 │     fn add(self: Self, _ rhs: Self) -> Self { self }
+   │                                               ^^^^ Foo
 
 note: 
-   ┌─ default_generic_trait.fe:11:21
+   ┌─ default_generic_trait.fe:19:45
+   │
+19 │     fn sub(self: Self, _ rhs: Self) -> Self { self }
+   │                                             ^^^^^^^^ Foo
+
+note: 
+   ┌─ default_generic_trait.fe:19:47
+   │
+19 │     fn sub(self: Self, _ rhs: Self) -> Self { self }
+   │                                               ^^^^ Foo
+
+note: 
+   ┌─ default_generic_trait.fe:22:45
+   │
+22 │     fn add(self: Self, _ rhs: Self) -> Self { self }
+   │                                             ^^^^^^^^ Bar
+
+note: 
+   ┌─ default_generic_trait.fe:22:47
+   │
+22 │     fn add(self: Self, _ rhs: Self) -> Self { self }
+   │                                               ^^^^ Bar
+
+note: 
+   ┌─ default_generic_trait.fe:25:29
    │  
-11 │   fn f(x: i32) -> i32 {
-   │ ╭─────────────────────^
-12 │ │     x.add(x)
-13 │ │ }
-   │ ╰─^ i32
+25 │   fn f(x: Foo, y: Bar) -> Foo {
+   │ ╭─────────────────────────────^
+26 │ │     y.add(y)
+27 │ │     x.sub(x)
+28 │ │     x.add(x)
+29 │ │ }
+   │ ╰─^ Foo
 
 note: 
-   ┌─ default_generic_trait.fe:12:5
+   ┌─ default_generic_trait.fe:26:5
    │
-12 │     x.add(x)
-   │     ^ i32
+26 │     y.add(y)
+   │     ^ Bar
 
 note: 
-   ┌─ default_generic_trait.fe:12:5
+   ┌─ default_generic_trait.fe:26:5
    │
-12 │     x.add(x)
-   │     ^^^^^^^^ i32
+26 │     y.add(y)
+   │     ^^^^^^^^ Bar
 
 note: 
-   ┌─ default_generic_trait.fe:12:11
+   ┌─ default_generic_trait.fe:26:11
    │
-12 │     x.add(x)
-   │           ^ i32
+26 │     y.add(y)
+   │           ^ Bar
 
+note: 
+   ┌─ default_generic_trait.fe:27:5
+   │
+27 │     x.sub(x)
+   │     ^ Foo
+
+note: 
+   ┌─ default_generic_trait.fe:27:5
+   │
+27 │     x.sub(x)
+   │     ^^^^^^^^ Foo
+
+note: 
+   ┌─ default_generic_trait.fe:27:11
+   │
+27 │     x.sub(x)
+   │           ^ Foo
+
+note: 
+   ┌─ default_generic_trait.fe:28:5
+   │
+28 │     x.add(x)
+   │     ^ Foo
+
+note: 
+   ┌─ default_generic_trait.fe:28:5
+   │
+28 │     x.add(x)
+   │     ^^^^^^^^ Foo
+
+note: 
+   ┌─ default_generic_trait.fe:28:11
+   │
+28 │     x.add(x)
+   │           ^ Foo


### PR DESCRIPTION
Deduping by TyId would result in erroneous diagnostics when there are two trait impls for a given type, where the impls have associated types with the same name and type. For example, in this test case, there would be an error on the return type of Foo's implementation of `fn sub`.

```rust
trait Add<T = Self> {
    type Output = Self
    fn add(self: Self, _ rhs: T) -> Self::Output
}
trait Sub<T = Self> {
    type Output = Self
    fn sub(self: Self, _ rhs: T) -> Self::Output
}

struct Foo {}

impl Add for Foo {
    fn add(self: Self, _ rhs: Self) -> Self { self }
}
impl Sub for Foo {
    fn sub(self: Self, _ rhs: Self) -> Self { self }
}
```