### PR TITLE
fix: typo in language server log message

### DIFF
--- a/crates/language-server/src/functionality/handlers.rs
+++ b/crates/language-server/src/functionality/handlers.rs
@@ -182,7 +182,7 @@ pub async fn initialized(
     backend: &Backend,
     _message: InitializedParams,
 ) -> Result<(), ResponseError> {
-    info!("language server initialized! recieved notification!");
+    info!("language server initialized! received notification!");
 
     // Get all files from the workspace
     let all_files: Vec<_> = backend


### PR DESCRIPTION
Corrected recieved → received in handlers.rs initialization log message.