### PR TITLE
fix: treat {self} in braced use as parent path

### DIFF
--- a/crates/hir/src/lower/use_tree.rs
+++ b/crates/hir/src/lower/use_tree.rs
@@ -148,9 +148,17 @@ fn decompose_subtree<'db>(
 )> {
     let (mut succ_path, mut succ_desugared) = succ;
     if let Some(path) = subtree.path() {
-        for seg in path {
+        let segs: Vec<ast::UsePathSegment> = path.into_iter().collect();
+
+        let is_self_only = segs.len() == 1 && segs[0]
+            .kind()
+            .is_some_and(|k| matches!(k, ast::UsePathSegmentKind::Self_(_)));
+
+        for seg in segs {
             succ_desugared.push_seg(&seg);
-            succ_path.push(seg.clone());
+            if !is_self_only {
+                succ_path.push(seg.clone());
+            }
         }
     }
 


### PR DESCRIPTION
issure number #1113 
please check my codes.
It should be working without any particular problems.

```bash
shiro@Shiro:~/workspace/fe$ cargo run -q -p fe -- check test_self_import.fe
shiro@Shiro:~/workspace/fe$ cat test_self_import.fe
use core::option::Option::{self, Some, None}

fn test() -> Option<u32> {
    Some(42)
}
```