### PR TITLE
`const` fixes

### DIFF
--- a/crates/hir-analysis/src/name_resolution/visibility_checker.rs
+++ b/crates/hir-analysis/src/name_resolution/visibility_checker.rs
@@ -64,7 +64,9 @@ pub(crate) fn is_ty_visible_from(db: &dyn HirAnalysisDb, ty: TyId, from_scope: S
                 is_scope_visible_from(db, param.scope(db), from_scope)
             }
             ConstTyData::Evaluated(_, _) => true,
-            ConstTyData::UnEvaluated(body) => is_scope_visible_from(db, body.scope(), from_scope),
+            ConstTyData::UnEvaluated { body, .. } => {
+                is_scope_visible_from(db, body.scope(), from_scope)
+            }
         },
         TyData::TyVar(_) | TyData::Never | TyData::Invalid(_) => true,
         TyData::QualifiedTy(trait_inst) => {

--- a/crates/hir-analysis/src/ty/fold.rs
+++ b/crates/hir-analysis/src/ty/fold.rs
@@ -65,7 +65,18 @@ impl<'db> TyFoldable<'db> for TyId<'db> {
                         let ty = folder.fold_ty(db, *ty);
                         Evaluated(val.clone(), ty)
                     }
-                    UnEvaluated(body) => UnEvaluated(*body),
+                    UnEvaluated {
+                        body,
+                        ty,
+                        const_def,
+                    } => {
+                        let ty = ty.map(|t| folder.fold_ty(db, t));
+                        UnEvaluated {
+                            body: *body,
+                            ty,
+                            const_def: *const_def,
+                        }
+                    }
                 };
 
                 let const_ty = ConstTyId::new(db, cty_data);

--- a/crates/hir-analysis/src/ty/ty_check/pat.rs
+++ b/crates/hir-analysis/src/ty/ty_check/pat.rs
@@ -169,7 +169,7 @@ impl<'db> TyChecker<'db> {
                     PathRes::Ty(ty)
                     | PathRes::TyAlias(_, ty)
                     | PathRes::Func(ty)
-                    | PathRes::Const(ty),
+                    | PathRes::Const(_, ty),
                 ) => {
                     let record_like = RecordLike::from_ty(ty);
                     if record_like.is_record(self.db) {
@@ -237,7 +237,7 @@ impl<'db> TyChecker<'db> {
                 PathRes::Ty(ty)
                 | PathRes::TyAlias(_, ty)
                 | PathRes::Func(ty)
-                | PathRes::Const(ty) => {
+                | PathRes::Const(_, ty) => {
                     let diag = BodyDiag::tuple_variant_expected(
                         self.db,
                         pat.span(self.body()).into(),
@@ -368,7 +368,7 @@ impl<'db> TyChecker<'db> {
                 PathRes::Ty(ty)
                 | PathRes::TyAlias(_, ty)
                 | PathRes::Func(ty)
-                | PathRes::Const(ty) => {
+                | PathRes::Const(_, ty) => {
                     let diag = BodyDiag::record_expected(
                         self.db,
                         pat.span(self.body()).into(),

--- a/crates/hir-analysis/src/ty/ty_def.rs
+++ b/crates/hir-analysis/src/ty/ty_def.rs
@@ -631,7 +631,7 @@ impl<'db> TyId<'db> {
 
             TyBase::Prim(PrimTy::Array) => {
                 if args.len() == 1 {
-                    Some(TyId::new(db, TyData::TyBase(TyBase::Prim(PrimTy::U256))))
+                    Some(TyId::new(db, TyData::TyBase(TyBase::Prim(PrimTy::Usize))))
                 } else {
                     None
                 }
@@ -639,7 +639,7 @@ impl<'db> TyId<'db> {
 
             TyBase::Prim(PrimTy::String) => {
                 if args.is_empty() {
-                    Some(TyId::new(db, TyData::TyBase(TyBase::Prim(PrimTy::U256))))
+                    Some(TyId::new(db, TyData::TyBase(TyBase::Prim(PrimTy::Usize))))
                 } else {
                     None
                 }

--- a/crates/hir-analysis/src/ty/ty_def.rs
+++ b/crates/hir-analysis/src/ty/ty_def.rs
@@ -352,7 +352,7 @@ impl<'db> TyId<'db> {
                 ConstTyData::TyVar(..) => None,
                 ConstTyData::TyParam(ty_param, _) => Some(ty_param.scope(db)),
                 ConstTyData::Evaluated(..) => None,
-                ConstTyData::UnEvaluated(body) => Some(body.scope()),
+                ConstTyData::UnEvaluated { body, .. } => Some(body.scope()),
             },
 
             TyData::Never | TyData::Invalid(_) | TyData::TyVar(_) => None,

--- a/crates/hir-analysis/src/ty/visitor.rs
+++ b/crates/hir-analysis/src/ty/visitor.rs
@@ -106,7 +106,7 @@ where
     match &const_ty.data(db) {
         ConstTyData::TyVar(var, _) => visitor.visit_var(var),
         ConstTyData::TyParam(param, ty) => visitor.visit_const_param(param, *ty),
-        ConstTyData::Evaluated(..) | ConstTyData::UnEvaluated(..) => {}
+        ConstTyData::Evaluated(..) | ConstTyData::UnEvaluated { .. } => {}
     }
 }
 

--- a/crates/hir-analysis/test_files/ty_check/assign.snap
+++ b/crates/hir-analysis/test_files/ty_check/assign.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/hir-analysis/tests/ty_check.rs
 expression: res
-input_file: crates/hir-analysis/test_files/ty_check/assign.fe
+input_file: test_files/ty_check/assign.fe
 ---
 note: 
    ┌─ assign.fe:20:44
@@ -149,7 +149,7 @@ note:
    ┌─ assign.fe:32:9
    │
 32 │     arr[1] = true
-   │         ^ u256
+   │         ^ usize
 
 note: 
    ┌─ assign.fe:32:14

--- a/crates/hir-analysis/test_files/ty_check/associated_types_cycle.snap
+++ b/crates/hir-analysis/test_files/ty_check/associated_types_cycle.snap
@@ -74,7 +74,7 @@ note:
    ┌─ associated_types_cycle.fe:35:27
    │
 35 │         e.write_byte(self[0])
-   │                           ^ u256
+   │                           ^ usize
 
 note: 
    ┌─ associated_types_cycle.fe:36:9
@@ -104,7 +104,7 @@ note:
    ┌─ associated_types_cycle.fe:36:27
    │
 36 │         e.write_byte(self[1])
-   │                           ^ u256
+   │                           ^ usize
 
 note: 
    ┌─ associated_types_cycle.fe:37:9
@@ -134,7 +134,7 @@ note:
    ┌─ associated_types_cycle.fe:37:27
    │
 37 │         e.write_byte(self[2])
-   │                           ^ u256
+   │                           ^ usize
 
 note: 
    ┌─ associated_types_cycle.fe:38:9
@@ -164,7 +164,7 @@ note:
    ┌─ associated_types_cycle.fe:38:27
    │
 38 │         e.write_byte(self[3])
-   │                           ^ u256
+   │                           ^ usize
 
 note: 
    ┌─ associated_types_cycle.fe:42:8

--- a/crates/hir-analysis/test_files/ty_check/aug_assign.snap
+++ b/crates/hir-analysis/test_files/ty_check/aug_assign.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/hir-analysis/tests/ty_check.rs
 expression: res
-input_file: crates/hir-analysis/test_files/ty_check/aug_assign.fe
+input_file: test_files/ty_check/aug_assign.fe
 ---
 note: 
    ┌─ aug_assign.fe:5:46
@@ -200,7 +200,7 @@ note:
    ┌─ aug_assign.fe:17:9
    │
 17 │     arr[0] -= arr[1] + 1
-   │         ^ u256
+   │         ^ usize
 
 note: 
    ┌─ aug_assign.fe:17:15
@@ -224,7 +224,7 @@ note:
    ┌─ aug_assign.fe:17:19
    │
 17 │     arr[0] -= arr[1] + 1
-   │                   ^ u256
+   │                   ^ usize
 
 note: 
    ┌─ aug_assign.fe:17:24
@@ -248,4 +248,4 @@ note:
    ┌─ aug_assign.fe:18:9
    │
 18 │     arr[0]
-   │         ^ u256
+   │         ^ usize

--- a/crates/hir-analysis/test_files/ty_check/const_path.fe
+++ b/crates/hir-analysis/test_files/ty_check/const_path.fe
@@ -1,0 +1,25 @@
+struct A<const N: usize> {
+  inner: [u8; N],
+  s: String<N>,
+}
+impl<const N: usize> A<N> {
+    fn len(self) -> usize {
+        N
+    }
+}
+
+struct B<const N: usize> {
+  inner: A<N>
+}
+
+type B5 = B<5>
+
+fn f<const N: usize>(b5: B5, arr: [u8; N], a: A<N>, s: String<N>) -> usize {
+    a.len()
+}
+
+const SIZE: usize = 10
+fn g(arr: [u8; SIZE]) -> u8 {
+    let s: String<SIZE> = "0123456789"
+    arr[SIZE-1]
+}

--- a/crates/hir-analysis/test_files/ty_check/const_path.snap
+++ b/crates/hir-analysis/test_files/ty_check/const_path.snap
@@ -1,0 +1,92 @@
+---
+source: crates/hir-analysis/tests/ty_check.rs
+expression: res
+input_file: test_files/ty_check/const_path.fe
+---
+note: 
+  ┌─ const_path.fe:6:27
+  │  
+6 │       fn len(self) -> usize {
+  │ ╭───────────────────────────^
+7 │ │         N
+8 │ │     }
+  │ ╰─────^ usize
+
+note: 
+  ┌─ const_path.fe:7:9
+  │
+7 │         N
+  │         ^ usize
+
+note: 
+   ┌─ const_path.fe:17:76
+   │  
+17 │   fn f<const N: usize>(b5: B5, arr: [u8; N], a: A<N>, s: String<N>) -> usize {
+   │ ╭────────────────────────────────────────────────────────────────────────────^
+18 │ │     a.len()
+19 │ │ }
+   │ ╰─^ usize
+
+note: 
+   ┌─ const_path.fe:18:5
+   │
+18 │     a.len()
+   │     ^ A<const N: usize>
+
+note: 
+   ┌─ const_path.fe:18:5
+   │
+18 │     a.len()
+   │     ^^^^^^^ usize
+
+note: 
+   ┌─ const_path.fe:22:29
+   │  
+22 │   fn g(arr: [u8; SIZE]) -> u8 {
+   │ ╭─────────────────────────────^
+23 │ │     let s: String<SIZE> = "0123456789"
+24 │ │     arr[SIZE-1]
+25 │ │ }
+   │ ╰─^ u8
+
+note: 
+   ┌─ const_path.fe:23:9
+   │
+23 │     let s: String<SIZE> = "0123456789"
+   │         ^ String<10>
+
+note: 
+   ┌─ const_path.fe:23:27
+   │
+23 │     let s: String<SIZE> = "0123456789"
+   │                           ^^^^^^^^^^^^ String<10>
+
+note: 
+   ┌─ const_path.fe:24:5
+   │
+24 │     arr[SIZE-1]
+   │     ^^^ [u8; 10]
+
+note: 
+   ┌─ const_path.fe:24:5
+   │
+24 │     arr[SIZE-1]
+   │     ^^^^^^^^^^^ u8
+
+note: 
+   ┌─ const_path.fe:24:9
+   │
+24 │     arr[SIZE-1]
+   │         ^^^^ usize
+
+note: 
+   ┌─ const_path.fe:24:9
+   │
+24 │     arr[SIZE-1]
+   │         ^^^^^^ usize
+
+note: 
+   ┌─ const_path.fe:24:14
+   │
+24 │     arr[SIZE-1]
+   │              ^ usize

--- a/crates/hir-analysis/test_files/ty_check/index.snap
+++ b/crates/hir-analysis/test_files/ty_check/index.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/hir-analysis/tests/ty_check.rs
 expression: res
-input_file: crates/hir-analysis/test_files/ty_check/index.fe
+input_file: test_files/ty_check/index.fe
 ---
 note: 
   ┌─ index.fe:1:21
@@ -47,4 +47,4 @@ note:
   ┌─ index.fe:3:7
   │
 3 │     x[1]
-  │       ^ u256
+  │       ^ usize

--- a/crates/hir-analysis/test_files/ty_check/string_const.fe
+++ b/crates/hir-analysis/test_files/ty_check/string_const.fe
@@ -1,0 +1,5 @@
+const SIZE: usize = 4
+
+fn f() {
+    let s: String<SIZE>
+}

--- a/crates/hir-analysis/test_files/ty_check/string_const.snap
+++ b/crates/hir-analysis/test_files/ty_check/string_const.snap
@@ -1,0 +1,20 @@
+---
+source: crates/hir-analysis/tests/ty_check.rs
+assertion_line: 48
+expression: res
+input_file: test_files/ty_check/string_const.fe
+---
+note: 
+  ┌─ string_const.fe:3:8
+  │  
+3 │   fn f() {
+  │ ╭────────^
+4 │ │     let s: String<SIZE>
+5 │ │ }
+  │ ╰─^ ()
+
+note: 
+  ┌─ string_const.fe:4:9
+  │
+4 │     let s: String<SIZE>
+  │         ^ String<4>

--- a/crates/hir/src/hir_def/mod.rs
+++ b/crates/hir/src/hir_def/mod.rs
@@ -1,5 +1,3 @@
-// TODO: Remove this when https://github.com/salsa-rs/salsa/pull/513 is fixed.
-#![allow(clippy::unused_unit)]
 pub mod attr;
 pub mod body;
 pub mod expr;

--- a/crates/uitest/fixtures/name_resolution/path_invalid_domain.snap
+++ b/crates/uitest/fixtures/name_resolution/path_invalid_domain.snap
@@ -1,7 +1,8 @@
 ---
 source: crates/uitest/tests/name_resolution.rs
+assertion_line: 26
 expression: diags
-input_file: crates/uitest/fixtures/name_resolution/path_invalid_domain.fe
+input_file: fixtures/name_resolution/path_invalid_domain.fe
 ---
 error[2-0005]: `foo` can't be used as a middle segment of a path
    ┌─ path_invalid_domain.fe:23:8
@@ -19,12 +20,6 @@ error[2-0006]: expected type item here
    │                          ^^^ expected type here, but found trait `MyT`
 
 error[2-0006]: expected type item here
-   ┌─ path_invalid_domain.fe:16:13
-   │
-16 │     Variant(MyC),
-   │             ^^^ expected type here, but found const `MyC`
-
-error[2-0006]: expected type item here
    ┌─ path_invalid_domain.fe:17:14
    │
 17 │     Variant2(Var)
@@ -35,3 +30,9 @@ error[2-0007]: expected trait item here
    │
 13 │ where T: MyE,
    │          ^^^ expected trait here, but found type `MyE`
+
+error[3-0013]: expected a normal type
+   ┌─ path_invalid_domain.fe:16:13
+   │
+16 │     Variant(MyC),
+   │             ^^^ expected a normal type here, but `const MyC` is given

--- a/crates/uitest/fixtures/ty_check/array.snap
+++ b/crates/uitest/fixtures/ty_check/array.snap
@@ -1,13 +1,13 @@
 ---
 source: crates/uitest/tests/ty_check.rs
 expression: diags
-input_file: crates/uitest/fixtures/ty_check/array.fe
+input_file: fixtures/ty_check/array.fe
 ---
 error[3-0011]: given type doesn't match the expected const type
   ┌─ array.fe:6:17
   │
 6 │     let x = [1; false]
-  │                 ^^^^^ expected `u256` type here, but `bool` is given
+  │                 ^^^^^ expected `usize` type here, but `bool` is given
 
 error[8-0000]: type mismatch
   ┌─ array.fe:2:23
@@ -44,5 +44,3 @@ error[8-0031]: type annotation is needed
   │              │
   │              type annotation is needed
   │              no default type is provided for an integer type. consider giving integer type
-
-

--- a/crates/uitest/fixtures/ty_check/index.snap
+++ b/crates/uitest/fixtures/ty_check/index.snap
@@ -7,7 +7,7 @@ error[8-0000]: type mismatch
    ┌─ index.fe:17:7
    │
 17 │     x[false]
-   │       ^^^^^ expected `u256`, but `bool` is given
+   │       ^^^^^ expected `usize`, but `bool` is given
 
 error[8-0016]: `core::ops::Index` trait is not implemented
    ┌─ index.fe:19:5


### PR DESCRIPTION
Two things:
- fixes #1120 
- fixes use of const defs in const arg position
eg
```rust
const SIZE: usize = 10
type MyString = String<SIZE> // 
```

Shoulda been separate commits, but oh well.