### PR TITLE
change attribute syntax to match rust

### DIFF
--- a/crates/hir/src/hir_def/attr.rs
+++ b/crates/hir/src/hir_def/attr.rs
@@ -1,4 +1,4 @@
-use super::{IdentId, Partial, StringId};
+use super::{IdentId, Partial, PathId, StringId};
 
 #[salsa::interned]
 #[derive(Debug)]
@@ -15,7 +15,7 @@ pub enum Attr<'db> {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct NormalAttr<'db> {
-    pub name: Partial<IdentId<'db>>,
+    pub path: Partial<PathId<'db>>,
     pub args: Vec<AttrArg<'db>>,
 }
 
@@ -27,6 +27,12 @@ pub struct DocCommentAttr<'db> {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct AttrArg<'db> {
-    pub key: Partial<IdentId<'db>>,
-    pub value: Partial<IdentId<'db>>,
+    pub key: Partial<PathId<'db>>,
+    pub value: Partial<AttrArgValue<'db>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum AttrArgValue<'db> {
+    Ident(IdentId<'db>),
+    Lit(super::LitKind<'db>),
 }

--- a/crates/hir/src/lower/attr.rs
+++ b/crates/hir/src/lower/attr.rs
@@ -1,7 +1,7 @@
 use parser::ast;
 
 use super::FileLowerCtxt;
-use crate::hir_def::{IdentId, StringId, attr::*};
+use crate::hir_def::{IdentId, LitKind, Partial, PathId, StringId, attr::*};
 
 impl<'db> AttrListId<'db> {
     pub(super) fn lower_ast(ctxt: &mut FileLowerCtxt<'db>, ast: ast::AttrList) -> Self {
@@ -29,7 +29,7 @@ impl<'db> Attr<'db> {
 
 impl<'db> NormalAttr<'db> {
     pub(super) fn lower_ast(ctxt: &mut FileLowerCtxt<'db>, ast: ast::NormalAttr) -> Self {
-        let name = IdentId::lower_token_partial(ctxt, ast.name());
+        let path = PathId::lower_ast_partial(ctxt, ast.path());
         let args = ast
             .args()
             .map(|args| {
@@ -39,7 +39,7 @@ impl<'db> NormalAttr<'db> {
             })
             .unwrap_or_default();
 
-        Self { name, args }
+        Self { path, args }
     }
 }
 
@@ -57,8 +57,25 @@ impl<'db> DocCommentAttr<'db> {
 
 impl<'db> AttrArg<'db> {
     pub(super) fn lower_ast(ctxt: &mut FileLowerCtxt<'db>, ast: ast::AttrArg) -> Self {
-        let key = IdentId::lower_token_partial(ctxt, ast.key());
-        let value = IdentId::lower_token_partial(ctxt, ast.value());
+        let key = PathId::lower_ast_partial(ctxt, ast.key());
+        let value = AttrArgValue::lower_ast_partial(ctxt, ast.value());
         Self { key, value }
+    }
+}
+
+impl<'db> AttrArgValue<'db> {
+    pub(super) fn lower_ast_partial(
+        ctxt: &mut FileLowerCtxt<'db>,
+        ast: Option<ast::AttrArgValueKind>,
+    ) -> Partial<Self> {
+        match ast {
+            Some(ast::AttrArgValueKind::Ident(token)) => {
+                Partial::Present(Self::Ident(IdentId::lower_token(ctxt, token)))
+            }
+            Some(ast::AttrArgValueKind::Lit(lit)) => {
+                Partial::Present(Self::Lit(LitKind::lower_ast(ctxt, lit)))
+            }
+            None => Partial::Absent,
+        }
     }
 }

--- a/crates/hir/src/span/attr.rs
+++ b/crates/hir/src/span/attr.rs
@@ -1,6 +1,7 @@
 use parser::ast;
 
-use super::define_lazy_span_node;
+use super::{define_lazy_span_node, path::LazyPathSpan};
+use crate::span::{LazyLitSpan, LazySpanAtom};
 
 define_lazy_span_node!(
     LazyAttrListSpan,
@@ -24,10 +25,8 @@ impl<'db> LazyAttrSpan<'db> {
 define_lazy_span_node!(
     LazyNormalAttrSpan,
     ast::NormalAttr,
-    @token {
-        (name, name),
-    }
     @node {
+        (path, path, LazyPathSpan),
         (args, args, LazyAttrArgListSpan),
     }
 );
@@ -51,8 +50,18 @@ define_lazy_span_node!(
 define_lazy_span_node!(
     LazyAttrArgSpan,
     ast::AttrArg,
-    @token {
-        (key, key),
-        (value, value),
+    @node {
+        (key, key, LazyPathSpan),
+        (value, value_node, LazyAttrArgValueSpan),
     }
 );
+
+define_lazy_span_node!(LazyAttrArgValueSpan, ast::AttrArgValue);
+impl<'db> LazyAttrArgValueSpan<'db> {
+    pub fn lit(self) -> LazyLitSpan<'db> {
+        LazyLitSpan(self.0)
+    }
+    pub fn ident(self) -> LazySpanAtom<'db> {
+        LazySpanAtom(self.0)
+    }
+}

--- a/crates/hir/src/visitor.rs
+++ b/crates/hir/src/visitor.rs
@@ -9,7 +9,9 @@ use crate::{
         ItemKind, KindBound, LitKind, MatchArm, Mod, Partial, Pat, PatId, PathId, PathKind, Stmt,
         StmtId, Struct, TopLevelMod, Trait, TraitRefId, TupleTypeId, TypeAlias, TypeBound, TypeId,
         TypeKind, Use, UseAlias, UsePathId, UsePathSegment, VariantDef, VariantDefListId,
-        VariantKind, WhereClauseId, WherePredicate, attr, scope_graph::ScopeId,
+        VariantKind, WhereClauseId, WherePredicate,
+        attr::{self, AttrArgValue},
+        scope_graph::ScopeId,
     },
     span::{
         SpanDowncast, item::LazySuperTraitListSpan, lazy_spans::*, params::LazyTraitRefSpan,
@@ -1301,15 +1303,15 @@ pub fn walk_attribute<'db, V>(
     V: Visitor<'db> + ?Sized,
 {
     match attr {
-        Attr::Normal(normal_attr) => {
+        Attr::Normal(attr) => {
             ctxt.with_new_ctxt(
                 |span| span.into_normal_attr(),
                 |ctxt| {
-                    if let Some(ident) = normal_attr.name.to_opt() {
+                    if let Some(path) = attr.path.to_opt() {
                         ctxt.with_new_ctxt(
-                            |span| span.name(),
+                            |span| span.path(),
                             |ctxt| {
-                                visitor.visit_ident(ctxt, ident);
+                                visitor.visit_path(ctxt, path);
                             },
                         )
                     }
@@ -1317,25 +1319,38 @@ pub fn walk_attribute<'db, V>(
                     ctxt.with_new_ctxt(
                         |span| span.args(),
                         |ctxt| {
-                            for (i, arg) in normal_attr.args.iter().enumerate() {
+                            for (i, arg) in attr.args.iter().enumerate() {
                                 ctxt.with_new_ctxt(
                                     |span| span.arg(i),
                                     |ctxt| {
-                                        if let Some(key) = arg.key.to_opt() {
-                                            ctxt.with_new_ctxt(
-                                                |span| span.key(),
-                                                |ctxt| {
-                                                    visitor.visit_ident(ctxt, key);
-                                                },
-                                            );
-                                        }
-                                        if let Some(value) = arg.value.to_opt() {
-                                            ctxt.with_new_ctxt(
-                                                |span| span.value(),
-                                                |ctxt| {
-                                                    visitor.visit_ident(ctxt, value);
-                                                },
-                                            );
+                                        let Some(key_path) = arg.key.to_opt() else {
+                                            return;
+                                        };
+                                        ctxt.with_new_ctxt(
+                                            |span| span.key(),
+                                            |ctxt| {
+                                                visitor.visit_path(ctxt, key_path);
+                                            },
+                                        );
+
+                                        match arg.value.clone().to_opt() {
+                                            Some(AttrArgValue::Ident(id)) => {
+                                                ctxt.with_new_ctxt(
+                                                    |span| span.value().ident(),
+                                                    |ctxt| {
+                                                        visitor.visit_ident(ctxt, id);
+                                                    },
+                                                );
+                                            }
+                                            Some(AttrArgValue::Lit(l)) => {
+                                                ctxt.with_new_ctxt(
+                                                    |span| span.value().lit(),
+                                                    |ctxt| {
+                                                        visitor.visit_lit(ctxt, l);
+                                                    },
+                                                );
+                                            }
+                                            None => {}
                                         }
                                     },
                                 );
@@ -2289,8 +2304,8 @@ mod tests {
     fn visitor() {
         let mut db = TestDb::default();
         let text = r#"
-            #attr1
-            #attr2
+            #[attr1]
+            #[attr2]
             fn foo<T: 'static, V: Add>() {
                 1
                 "foo"
@@ -2317,8 +2332,8 @@ mod tests {
         );
 
         assert_eq!(visitor.attributes.len(), 2);
-        assert_eq!("#attr1", db.text_at(top_mod, &visitor.attributes[0]));
-        assert_eq!("#attr2", db.text_at(top_mod, &visitor.attributes[1]));
+        assert_eq!("#[attr1]", db.text_at(top_mod, &visitor.attributes[0]));
+        assert_eq!("#[attr2]", db.text_at(top_mod, &visitor.attributes[1]));
 
         assert_eq!(visitor.lit_ints.len(), 2);
         assert_eq!("1", db.text_at(top_mod, &visitor.lit_ints[0]));

--- a/crates/parser/src/ast/item.rs
+++ b/crates/parser/src/ast/item.rs
@@ -595,7 +595,7 @@ mod tests {
     fn func() {
         let source = r#"
                 /// This is doc comment
-                #evm
+                #[evm]
                 pub unsafe fn foo<T, U: Trait>(_ x: T, from u: U) -> (T, U) where T: Trait2 { return }
             "#;
         let func: Func = parse_item(source);

--- a/crates/parser/src/ast/path.rs
+++ b/crates/parser/src/ast/path.rs
@@ -11,6 +11,10 @@ ast_node! {
     IntoIterator<Item=PathSegment>,
 }
 impl Path {
+    pub fn text(&self) -> rowan::SyntaxText {
+        self.syntax().text()
+    }
+
     /// Returns the segments of the path.
     pub fn segments(&self) -> AstChildren<PathSegment> {
         support::children(self.syntax())

--- a/crates/parser/src/parser/mod.rs
+++ b/crates/parser/src/parser/mod.rs
@@ -618,17 +618,18 @@ impl<S: TokenStream> Parser<S> {
 
     /// Wrap the current token in a `SyntaxKind::Error`, and add a
     /// `ParseError::Unexpected`.
-    fn unexpected_token_error(&mut self, msg: String) {
+    fn unexpected_token_error(&mut self, msg: String) -> ErrProof {
         let checkpoint = self.enter(ErrorScope::default(), None);
 
         let start_pos = self.current_pos;
         self.bump();
 
-        self.add_error(ParseError::Unexpected(
+        let proof = self.add_error(ParseError::Unexpected(
             msg,
             TextRange::new(start_pos, self.current_pos),
         ));
         self.leave(checkpoint);
+        proof
     }
 
     /// Returns `true` if the parser is in the dry run mode.

--- a/crates/parser/src/syntax_kind.rs
+++ b/crates/parser/src/syntax_kind.rs
@@ -424,12 +424,14 @@ pub enum SyntaxKind {
     /// `<Foo as SomeTrait>`
     QualifiedType,
 
-    /// `#attr`
+    /// `#[attr]`
     Attr,
     /// `(key1: value1, key2: value2)`
     AttrArgList,
     /// `key: value`
     AttrArg,
+    /// `value` in an attribute argument
+    AttrArgValue,
     /// `/// Comment`
     DocCommentAttr,
     AttrList,
@@ -721,6 +723,7 @@ impl SyntaxKind {
             SyntaxKind::Attr => "attribute",
             SyntaxKind::AttrArgList => "attribute argument list",
             SyntaxKind::AttrArg => "attribute argument",
+            SyntaxKind::AttrArgValue => "attribute argument value",
             SyntaxKind::DocCommentAttr => "doc comment",
             SyntaxKind::AttrList => "attribute list",
             SyntaxKind::Visibility => "visibility modifier",

--- a/crates/parser/test_files/syntax_node/structs/attr.fe
+++ b/crates/parser/test_files/syntax_node/structs/attr.fe
@@ -1,11 +1,11 @@
 /// DocComment1
-#attr
+#[attr]
 // normal comment
 /// DocComment2
 pub struct StructAttr {
     /// This is `x`
     x: foo::Bar,
     /// This is `y`
-    #cfg(target: evm)
+    #[cfg(target = "evm")]
     y: i32
 }

--- a/crates/parser/test_files/syntax_node/structs/attr.snap
+++ b/crates/parser/test_files/syntax_node/structs/attr.snap
@@ -1,80 +1,95 @@
 ---
 source: crates/parser/tests/syntax_node.rs
+assertion_line: 25
 expression: node
-input_file: crates/parser/test_files/syntax_node/structs/attr.fe
+input_file: test_files/syntax_node/structs/attr.fe
 ---
-Root@0..171
-  ItemList@0..171
-    Item@0..171
-      Struct@0..171
-        AttrList@0..56
+Root@0..179
+  ItemList@0..178
+    Item@0..178
+      Struct@0..178
+        AttrList@0..58
           DocCommentAttr@0..15
             DocComment@0..15 "/// DocComment1"
           Newline@15..16 "\n"
-          Attr@16..21
+          Attr@16..23
             Pound@16..17 "#"
-            Ident@17..21 "attr"
-          Newline@21..22 "\n"
-          Comment@22..39 "// normal comment"
-          Newline@39..40 "\n"
-          DocCommentAttr@40..55
-            DocComment@40..55 "/// DocComment2"
-          Newline@55..56 "\n"
-        ItemModifier@56..59
-          PubKw@56..59 "pub"
-        WhiteSpace@59..60 " "
-        StructKw@60..66 "struct"
-        WhiteSpace@66..67 " "
-        Ident@67..77 "StructAttr"
-        WhiteSpace@77..78 " "
-        RecordFieldDefList@78..171
-          LBrace@78..79 "{"
-          Newline@79..80 "\n"
-          WhiteSpace@80..84 "    "
-          RecordFieldDef@84..115
-            AttrList@84..100
-              DocCommentAttr@84..99
-                DocComment@84..99 "/// This is `x`"
-              Newline@99..100 "\n"
-            WhiteSpace@100..104 "    "
-            Ident@104..105 "x"
-            Colon@105..106 ":"
-            WhiteSpace@106..107 " "
-            PathType@107..115
-              Path@107..115
-                PathSegment@107..110
-                  Ident@107..110 "foo"
-                Colon2@110..112 "::"
-                PathSegment@112..115
-                  Ident@112..115 "Bar"
-          Comma@115..116 ","
-          Newline@116..117 "\n"
-          WhiteSpace@117..121 "    "
-          RecordFieldDef@121..169
-            AttrList@121..159
-              DocCommentAttr@121..136
-                DocComment@121..136 "/// This is `y`"
-              Newline@136..137 "\n"
-              WhiteSpace@137..141 "    "
-              Attr@141..158
-                Pound@141..142 "#"
-                Ident@142..145 "cfg"
-                AttrArgList@145..158
-                  LParen@145..146 "("
-                  AttrArg@146..157
-                    Ident@146..152 "target"
-                    Colon@152..153 ":"
-                    WhiteSpace@153..154 " "
-                    Ident@154..157 "evm"
-                  RParen@157..158 ")"
-              Newline@158..159 "\n"
-            WhiteSpace@159..163 "    "
-            Ident@163..164 "y"
-            Colon@164..165 ":"
-            WhiteSpace@165..166 " "
-            PathType@166..169
-              Path@166..169
-                PathSegment@166..169
-                  Ident@166..169 "i32"
-          Newline@169..170 "\n"
-          RBrace@170..171 "}"
+            LBracket@17..18 "["
+            Path@18..22
+              PathSegment@18..22
+                Ident@18..22 "attr"
+            RBracket@22..23 "]"
+          Newline@23..24 "\n"
+          Comment@24..41 "// normal comment"
+          Newline@41..42 "\n"
+          DocCommentAttr@42..57
+            DocComment@42..57 "/// DocComment2"
+          Newline@57..58 "\n"
+        ItemModifier@58..61
+          PubKw@58..61 "pub"
+        WhiteSpace@61..62 " "
+        StructKw@62..68 "struct"
+        WhiteSpace@68..69 " "
+        Ident@69..79 "StructAttr"
+        WhiteSpace@79..80 " "
+        RecordFieldDefList@80..178
+          LBrace@80..81 "{"
+          Newline@81..82 "\n"
+          WhiteSpace@82..86 "    "
+          RecordFieldDef@86..117
+            AttrList@86..102
+              DocCommentAttr@86..101
+                DocComment@86..101 "/// This is `x`"
+              Newline@101..102 "\n"
+            WhiteSpace@102..106 "    "
+            Ident@106..107 "x"
+            Colon@107..108 ":"
+            WhiteSpace@108..109 " "
+            PathType@109..117
+              Path@109..117
+                PathSegment@109..112
+                  Ident@109..112 "foo"
+                Colon2@112..114 "::"
+                PathSegment@114..117
+                  Ident@114..117 "Bar"
+          Comma@117..118 ","
+          Newline@118..119 "\n"
+          WhiteSpace@119..123 "    "
+          RecordFieldDef@123..176
+            AttrList@123..166
+              DocCommentAttr@123..138
+                DocComment@123..138 "/// This is `y`"
+              Newline@138..139 "\n"
+              WhiteSpace@139..143 "    "
+              Attr@143..165
+                Pound@143..144 "#"
+                LBracket@144..145 "["
+                Path@145..148
+                  PathSegment@145..148
+                    Ident@145..148 "cfg"
+                AttrArgList@148..164
+                  LParen@148..149 "("
+                  AttrArg@149..163
+                    Path@149..155
+                      PathSegment@149..155
+                        Ident@149..155 "target"
+                    WhiteSpace@155..156 " "
+                    Eq@156..157 "="
+                    WhiteSpace@157..158 " "
+                    AttrArgValue@158..163
+                      Lit@158..163
+                        String@158..163 "\"evm\""
+                  RParen@163..164 ")"
+                RBracket@164..165 "]"
+              Newline@165..166 "\n"
+            WhiteSpace@166..170 "    "
+            Ident@170..171 "y"
+            Colon@171..172 ":"
+            WhiteSpace@172..173 " "
+            PathType@173..176
+              Path@173..176
+                PathSegment@173..176
+                  Ident@173..176 "i32"
+          Newline@176..177 "\n"
+          RBrace@177..178 "}"
+  Newline@178..179 "\n"

--- a/crates/uitest/fixtures/parser/attr_errors.fe
+++ b/crates/uitest/fixtures/parser/attr_errors.fe
@@ -1,0 +1,8 @@
+#[123]
+fn attr_path_must_be_ident() {}
+
+#[foo(=42)]
+fn attr_arg_missing_key() {}
+
+#[bar(option = @)]
+fn attr_value_invalid() {}

--- a/crates/uitest/fixtures/parser/attr_errors.snap
+++ b/crates/uitest/fixtures/parser/attr_errors.snap
@@ -1,0 +1,34 @@
+---
+source: crates/uitest/tests/parser.rs
+expression: diags
+input_file: fixtures/parser/attr_errors.fe
+---
+error[1-0001]: expected path segment
+  ┌─ attr_errors.fe:1:3
+  │
+1 │ #[123]
+  │   ^ expected path segment
+
+error[1-0001]: unexpected syntax while parsing attribute
+  ┌─ attr_errors.fe:1:3
+  │
+1 │ #[123]
+  │   ^^^ unexpected
+
+error[1-0001]: expected path segment
+  ┌─ attr_errors.fe:4:7
+  │
+4 │ #[foo(=42)]
+  │       ^ expected path segment
+
+error[1-0001]: attribute value must be an ident or literal value
+  ┌─ attr_errors.fe:7:15
+  │
+7 │ #[bar(option = @)]
+  │               ^ attribute value must be an ident or literal value
+
+error[1-0001]: unexpected syntax while parsing attribute argument value
+  ┌─ attr_errors.fe:7:16
+  │
+7 │ #[bar(option = @)]
+  │                ^ unexpected


### PR DESCRIPTION
I previously advocated for a different attribute syntax, but now I think we should just copy rust here, for the sake of familiarity.