### PR TITLE
SmallVec fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ num-bigint = "0.4"
 num-traits = "0.2"
 paste = "1.0.15"
 salsa = "0.20"
-smallvec = { version = "2.0.0-alpha.10" }
+smallvec = { version = "2.0.0-alpha.11" }
 smallvec1 = { version = "1", package = "smallvec" }
 thin-vec = "0.2.14"
 smol_str = { version = "0.1", features = ["serde"] }

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -34,7 +34,7 @@ pub enum ParseError {
 impl ParseError {
     pub fn expected(tokens: &[SyntaxKind], kind: Option<ExpectedKind>, pos: TextSize) -> Self {
         ParseError::Expected(
-            SmallVec::from_slice(tokens),
+            SmallVec::from_iter(tokens.iter().copied()),
             kind.unwrap_or(ExpectedKind::Unspecified),
             pos,
         )

--- a/crates/parser/src/parser/mod.rs
+++ b/crates/parser/src/parser/mod.rs
@@ -790,7 +790,7 @@ macro_rules! define_scope {
                     pub(super) static ref RECOVERY_TOKENS: smallvec::SmallVec<SyntaxKind, 4> = {
                         #[allow(unused)]
                         use crate::SyntaxKind::*;
-                        smallvec::SmallVec::from_slice(&[$($recoveries), *])
+                        smallvec::smallvec![$($recoveries), *]
                     };
                 }
 


### PR DESCRIPTION
I was having issues installing the language server. There was a version discrepancy with smallvec 2 in the workspace config and lockfile. 

- Align workspace to `smallvec = "2.0.0-alpha.11"` to match the lockfile.
- Replace  `SmallVec::from_slice`/`from_slice_copy` usages with `smallvec!` and `SmallVec::from_iter`, keeping parser buildable on smallvec alpha.11.