### PR TITLE
Support handling of complex enums

### DIFF
--- a/crates/codegen/src/yul/emitter/expr.rs
+++ b/crates/codegen/src/yul/emitter/expr.rs
@@ -26,6 +26,10 @@ impl<'db> FunctionEmitter<'db> {
         value_id: ValueId,
         state: &BlockState,
     ) -> Result<String, YulError> {
+        // Check if this value was already bound to a temp in the current scope
+        if let Some(temp) = state.value_temp(value_id.index()) {
+            return Ok(temp.clone());
+        }
         let value = self.mir_func.body.value(value_id);
         match &value.origin {
             ValueOrigin::Expr(expr_id) => {

--- a/crates/codegen/src/yul/emitter/statements.rs
+++ b/crates/codegen/src/yul/emitter/statements.rs
@@ -203,6 +203,9 @@ impl<'db> FunctionEmitter<'db> {
         if bind_value {
             let temp = state.alloc_local();
             self.expr_temps.insert(expr, temp.clone());
+            // Also cache by ValueId in the BlockState so that arguments referencing
+            // this value can reuse it (properly scoped to the current branch).
+            state.insert_value_temp(value.index(), temp.clone());
             docs.push(YulDoc::line(format!("let {temp} := {lowered}")));
         } else {
             let value_data = self.mir_func.body.value(value);

--- a/crates/codegen/src/yul/state.rs
+++ b/crates/codegen/src/yul/state.rs
@@ -8,6 +8,8 @@ use std::cell::Cell;
 pub(super) struct BlockState {
     locals: FxHashMap<String, String>,
     next_local: Rc<Cell<usize>>,
+    /// Mapping from MIR ValueId index to Yul temp name for values bound in this scope.
+    value_temps: FxHashMap<usize, String>,
 }
 
 impl BlockState {
@@ -16,7 +18,18 @@ impl BlockState {
         Self {
             locals: FxHashMap::default(),
             next_local: Rc::new(Cell::new(0)),
+            value_temps: FxHashMap::default(),
         }
+    }
+
+    /// Caches the Yul temp name for a MIR value.
+    pub(super) fn insert_value_temp(&mut self, value_idx: usize, temp: String) {
+        self.value_temps.insert(value_idx, temp);
+    }
+
+    /// Returns the cached Yul temp name for a MIR value, if it exists.
+    pub(super) fn value_temp(&self, value_idx: usize) -> Option<&String> {
+        self.value_temps.get(&value_idx)
     }
 
     /// Allocates a new temporary Yul variable name.

--- a/crates/codegen/tests/fixtures/code_region.snap
+++ b/crates/codegen/tests/fixtures/code_region.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/codegen/tests/yul.rs
-assertion_line: 31
 expression: output
 input_file: tests/fixtures/code_region.fe
 ---
@@ -23,6 +22,7 @@ object "Foo" {
       let v1 := dataoffset("Child")
       let v2 := allocate(v0)
       codecopy(v2, v1, v0)
+      create2(0, v1, v0, 4660)
       v0 := datasize("Foo_deployed")
       v1 := dataoffset("Foo_deployed")
       v2 := allocate(v0)

--- a/crates/codegen/tests/fixtures/enum_variant_contract.fe
+++ b/crates/codegen/tests/fixtures/enum_variant_contract.fe
@@ -1,0 +1,72 @@
+use core::{
+    calldataload,
+    code_region_len,
+    code_region_offset,
+    codecopy,
+    mstore,
+    return_data,
+}
+
+enum MyOption {
+    None,
+    Some(u256),
+}
+
+fn abi_encode_u256(value: u256) {
+    let ptr: u256 = 0
+    mstore(ptr, value)
+    return_data(ptr, 32)
+}
+
+#[contract_init(EnumContract)]
+fn init() {
+    let len = code_region_len(runtime)
+    let offset = code_region_offset(runtime)
+    codecopy(dest: 0, offset, len)
+    return_data(0, len)
+}
+
+#[contract_runtime(EnumContract)]
+fn runtime() {
+    let selector = calldataload(0) >> 224
+
+    // make_some(uint256) -> returns the value back
+    // Selector: keccak256("make_some(uint256)")[:4] = 0x6c56cb0c
+    if selector == 0x6c56cb0c {
+        let value = calldataload(4)
+        let opt = MyOption::Some(value)
+        let result = match opt {
+            MyOption::Some(val) => val
+            MyOption::None => 0
+        }
+        abi_encode_u256(value: result)
+        return_data(0, 0)
+    }
+
+    // make_none() -> returns 0
+    // Selector: keccak256("make_none()")[:4] = 0x455dd373
+    if selector == 0x455dd373 {
+        let opt = MyOption::None
+        let result = match opt {
+            MyOption::Some(val) => val
+            MyOption::None => 0
+        }
+        abi_encode_u256(value: result)
+        return_data(0, 0)
+    }
+
+    // is_some_check(uint256) -> returns 1 if constructed as Some
+    // Selector: keccak256("is_some_check(uint256)")[:4] = 0xd4eee422
+    if selector == 0xd4eee422 {
+        let value = calldataload(4)
+        let opt = MyOption::Some(value)
+        let result = match opt {
+            MyOption::Some(_) => 1
+            MyOption::None => 0
+        }
+        abi_encode_u256(value: result)
+        return_data(0, 0)
+    }
+
+    return_data(0, 0)
+}

--- a/crates/codegen/tests/fixtures/enum_variant_contract.snap
+++ b/crates/codegen/tests/fixtures/enum_variant_contract.snap
@@ -1,0 +1,154 @@
+---
+source: crates/codegen/tests/yul.rs
+expression: output
+input_file: tests/fixtures/enum_variant_contract.fe
+---
+object "EnumContract" {
+  code {
+    init()
+    function init() {
+      let v0 := datasize("EnumContract_deployed")
+      let v1 := dataoffset("EnumContract_deployed")
+      codecopy(0, v1, v0)
+      return(0, v0)
+    }
+  }
+
+  object "EnumContract_deployed" {
+    code {
+      runtime()
+      function abi_encode_u256(value) {
+        let v0 := 0
+        mstore(v0, value)
+        return(v0, 32)
+      }
+      function alloc(size) -> ret {
+        let v0 := mload(64)
+        let v1 := eq(v0, 0)
+        if v1 {
+          v0 := 128
+          mstore(64, add(v0, size))
+          ret := v0
+        }
+        if iszero(v1) {
+          mstore(64, add(v0, size))
+          ret := v0
+        }
+      }
+      function from_word__u256__3271ca15373d4483(word) -> ret {
+        ret := word
+      }
+      function get_variant_field__u256__3271ca15373d4483(addr, space, field_offset) -> ret {
+        let v1 := add(add(addr, 32), field_offset)
+        let v0 := 0
+        switch space
+          case 0 {
+            v0 := mload(v1)
+          }
+          case 1 {
+            v0 := sload(v1)
+          }
+          default {
+          }
+        let v2 := v0
+        ret := from_word__u256__3271ca15373d4483(v2)
+      }
+      function runtime() {
+        let v0 := shr(224, calldataload(0))
+        let v1 := eq(v0, 1817627404)
+        if v1 {
+          let v3 := calldataload(4)
+          let v4 := alloc(64)
+          store_discriminant(v4, 0, 1)
+          store_variant_field__u256__3271ca15373d4483(v4, 0, 0, v3)
+          let v5 := v4
+          let v2 := 0
+          switch mload(v5)
+            case 1 {
+              let v6 := get_variant_field__u256__3271ca15373d4483(v5, 0, 0)
+              v2 := v6
+            }
+            case 0 {
+              v2 := 0
+            }
+            default {
+            }
+          let v7 := v2
+          abi_encode_u256(v7)
+          return(0, 0)
+        }
+        if iszero(v1) {
+          let v8 := eq(v0, 1163776883)
+          if v8 {
+            let v10 := alloc(64)
+            store_discriminant(v10, 0, 0)
+            let v11 := v10
+            let v9 := 0
+            switch mload(v11)
+              case 1 {
+                let v12 := get_variant_field__u256__3271ca15373d4483(v11, 0, 0)
+                v9 := v12
+              }
+              case 0 {
+                v9 := 0
+              }
+              default {
+              }
+            let v13 := v9
+            abi_encode_u256(v13)
+            return(0, 0)
+          }
+          if iszero(v8) {
+            let v14 := eq(v0, 3572425762)
+            if v14 {
+              let v16 := calldataload(4)
+              let v17 := alloc(64)
+              store_discriminant(v17, 0, 1)
+              store_variant_field__u256__3271ca15373d4483(v17, 0, 0, v16)
+              let v18 := v17
+              let v15 := 0
+              switch mload(v18)
+                case 1 {
+                  v15 := 1
+                }
+                case 0 {
+                  v15 := 0
+                }
+                default {
+                }
+              let v19 := v15
+              abi_encode_u256(v19)
+              return(0, 0)
+            }
+            if iszero(v14) {
+              return(0, 0)
+            }
+          }
+        }
+      }
+      function store_discriminant(addr, space, discriminant) {
+        switch space
+          case 0 {
+            mstore(addr, discriminant)
+          }
+          case 1 {
+            sstore(addr, discriminant)
+          }
+          default {
+          }
+      }
+      function store_variant_field__u256__3271ca15373d4483(addr, space, field_offset, value) {
+        let v0 := add(add(addr, 32), field_offset)
+        switch space
+          case 0 {
+            mstore(v0, from_word__u256__3271ca15373d4483(value))
+          }
+          case 1 {
+            sstore(v0, from_word__u256__3271ca15373d4483(value))
+          }
+          default {
+          }
+      }
+    }
+  }
+}

--- a/crates/codegen/tests/fixtures/match_enum_with_data.fe
+++ b/crates/codegen/tests/fixtures/match_enum_with_data.fe
@@ -1,0 +1,16 @@
+
+enum MyOption {
+    None,
+    Some(u64),
+}
+
+pub fn make_some(value: u64) -> MyOption {
+    MyOption::Some(value)
+}
+
+pub fn match_option(opt: MyOption) -> u64 {
+    match opt {
+        MyOption::Some(value) => value,
+        MyOption::None => 0,
+    }
+}

--- a/crates/codegen/tests/fixtures/match_enum_with_data.snap
+++ b/crates/codegen/tests/fixtures/match_enum_with_data.snap
@@ -1,0 +1,82 @@
+---
+source: crates/codegen/tests/yul.rs
+expression: output
+input_file: tests/fixtures/match_enum_with_data.fe
+---
+function make_some(value) -> ret {
+  let v0 := alloc(40)
+  store_discriminant(v0, 0, 1)
+  store_variant_field__u64__aee7f05a097ffa16(v0, 0, 0, value)
+  ret := v0
+}
+function match_option(opt) -> ret {
+  let v0 := 0
+  switch mload(opt)
+    case 1 {
+      let v1 := get_variant_field__u64__aee7f05a097ffa16(opt, 0, 0)
+      v0 := v1
+    }
+    case 0 {
+      v0 := 0
+    }
+    default {
+    }
+  ret := v0
+}
+function alloc(size) -> ret {
+  let v0 := mload(64)
+  let v1 := eq(v0, 0)
+  if v1 {
+    v0 := 128
+    mstore(64, add(v0, size))
+    ret := v0
+  }
+  if iszero(v1) {
+    mstore(64, add(v0, size))
+    ret := v0
+  }
+}
+function store_discriminant(addr, space, discriminant) {
+  switch space
+    case 0 {
+      mstore(addr, discriminant)
+    }
+    case 1 {
+      sstore(addr, discriminant)
+    }
+    default {
+    }
+}
+function store_variant_field__u64__aee7f05a097ffa16(addr, space, field_offset, value) {
+  let v0 := add(add(addr, 32), field_offset)
+  switch space
+    case 0 {
+      mstore(v0, to_word__deduped(value))
+    }
+    case 1 {
+      sstore(v0, to_word__deduped(value))
+    }
+    default {
+    }
+}
+function get_variant_field__u64__aee7f05a097ffa16(addr, space, field_offset) -> ret {
+  let v1 := add(add(addr, 32), field_offset)
+  let v0 := 0
+  switch space
+    case 0 {
+      v0 := mload(v1)
+    }
+    case 1 {
+      v0 := sload(v1)
+    }
+    default {
+    }
+  let v2 := v0
+  ret := from_word__u64__aee7f05a097ffa16(v2)
+}
+function to_word__deduped(self) -> ret {
+  ret := self
+}
+function from_word__u64__aee7f05a097ffa16(word) -> ret {
+  ret := and(word, 18446744073709551615)
+}

--- a/crates/mir/src/ir.rs
+++ b/crates/mir/src/ir.rs
@@ -311,6 +311,8 @@ pub enum SyntheticValue {
 
 #[derive(Debug, Clone)]
 pub struct MatchLoweringInfo {
+    /// The scrutinee value (e.g. enum pointer) for this match expression.
+    pub scrutinee: ValueId,
     pub arms: Vec<MatchArmLowering>,
 }
 
@@ -320,6 +322,17 @@ pub struct MatchArmLowering {
     pub body: ExprId,
 }
 
+/// Information about a variable binding extracted from a pattern.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PatternBinding {
+    /// The pattern ID representing the binding (e.g., `x` in `Some(x)`).
+    pub pat_id: PatId,
+    /// Byte offset of this field within the variant's data region (after discriminant).
+    pub field_offset: u64,
+    /// MIR value representing the lowered load for this binding (if synthesized).
+    pub value: Option<ValueId>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MatchArmPattern {
     Literal(SwitchValue),
@@ -327,6 +340,8 @@ pub enum MatchArmPattern {
     Enum {
         variant_index: u64,
         enum_name: String,
+        /// Bindings extracted from the variant's data (empty for unit variants).
+        bindings: Vec<PatternBinding>,
     },
 }
 

--- a/crates/mir/src/lib.rs
+++ b/crates/mir/src/lib.rs
@@ -6,7 +6,7 @@ mod monomorphize;
 
 pub use ir::{
     BasicBlockId, CallOrigin, LoopInfo, MatchArmLowering, MatchArmPattern, MatchLoweringInfo,
-    MirBody, MirFunction, MirInst, MirModule, SwitchOrigin, SwitchTarget, SwitchValue, Terminator,
-    ValueData, ValueId, ValueOrigin,
+    MirBody, MirFunction, MirInst, MirModule, PatternBinding, SwitchOrigin, SwitchTarget,
+    SwitchValue, Terminator, ValueData, ValueId, ValueOrigin,
 };
 pub use lower::{MirLowerError, MirLowerResult, lower_module};

--- a/library/core/src/enum_repr.fe
+++ b/library/core/src/enum_repr.fe
@@ -1,0 +1,53 @@
+use ingot::intrinsic::{mload, mstore, sload, sstore}
+use ingot::ptr::{AddressSpace, LoadableScalar, StorableScalar}
+
+// ============================================================================
+// Enum helpers for tagged union representation
+// ============================================================================
+//
+// Enum memory layout (tagged union):
+// ┌─────────────────┬──────────────────────────────────────┐
+// │  Discriminant   │            Variant Data              │
+// │   (32 bytes)    │   (size of largest variant payload)  │
+// └─────────────────┴──────────────────────────────────────┘
+//      offset 0                   offset 32
+
+/// The byte offset where variant data begins (after the 32-byte discriminant).
+const ENUM_DATA_OFFSET: u256 = 32
+
+/// Reads the discriminant (variant tag) from an enum's base address.
+pub fn get_discriminant(addr: u256, space: AddressSpace) -> u256 {
+    match space {
+        AddressSpace::Memory => mload(addr)
+        AddressSpace::Storage => sload(slot: addr)
+    }
+}
+
+/// Stores the discriminant (variant tag) at an enum's base address.
+pub fn store_discriminant(addr: u256, space: AddressSpace, discriminant: u256) {
+    match space {
+        AddressSpace::Memory => mstore(addr, discriminant)
+        AddressSpace::Storage => sstore(slot: addr, discriminant)
+    }
+}
+
+/// Reads a scalar field from an enum's variant data region.
+/// The field_offset is relative to the start of the variant data (after discriminant).
+pub fn get_variant_field<F: LoadableScalar>(addr: u256, space: AddressSpace, field_offset: u256) -> F {
+    let target = addr + ENUM_DATA_OFFSET + field_offset
+    let word = match space {
+        AddressSpace::Memory => mload(target)
+        AddressSpace::Storage => sload(slot: target)
+    }
+    F::from_word(word)
+}
+
+/// Writes a scalar field into an enum's variant data region.
+/// The field_offset is relative to the start of the variant data (after discriminant).
+pub fn store_variant_field<T: StorableScalar>(addr: u256, space: AddressSpace, field_offset: u256, value: T) {
+    let target = addr + ENUM_DATA_OFFSET + field_offset
+    match space {
+        AddressSpace::Memory => mstore(target, value.to_word())
+        AddressSpace::Storage => sstore(slot: target, value.to_word())
+    }
+}

--- a/library/core/src/lib.fe
+++ b/library/core/src/lib.fe
@@ -4,11 +4,14 @@ pub use default::Default
 pub use dispatcher::Dispatcher
 pub use ops::*
 pub use ptr::*
+pub use enum_repr::*
 pub use intrinsic::{
+    calldatacopy,
     calldataload,
     code_region_len,
     code_region_offset,
     codecopy,
+    create2,
     mload,
     mstore,
     mstore8,


### PR DESCRIPTION
- Lowering and codegen now support enums with payloads: variant constructors allocate space, write discriminants plus fields, and match arms can bind and read variant data when switching
    on enums.
  - Block/state caches reuse Yul temps so bound variant fields stay in scope per match arm.
  - Core library gained `enum_repr.fe` helpers (store_discriminant, store_variant_field, get_variant_field) and re-exported them for contracts.
  - New fixtures and harness tests cover constructing and matching enums with data on EVM to prove end-to-end behavior.

  Example Fe code now handled:

```
  enum MyOption {
      None,
      Some(u64),
  }

  pub fn match_option(opt: MyOption) -> u64 {
      match opt {
          MyOption::Some(value) => value,
          MyOption::None => 0,
      }
  }
```