### PR TITLE
Second attempt to cleanup core lib usage in MIR

### DIFF
--- a/crates/codegen/tests/fixtures/enum_variant_contract.snap
+++ b/crates/codegen/tests/fixtures/enum_variant_contract.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/codegen/tests/yul.rs
+assertion_line: 31
 expression: output
 input_file: tests/fixtures/enum_variant_contract.fe
 ---
@@ -37,6 +38,19 @@ object "EnumContract" {
       }
       function from_word__u256__3271ca15373d4483(word) -> ret {
         ret := word
+      }
+      function get_discriminant(addr, space) -> ret {
+        let v0 := 0
+        switch space
+          case 0 {
+            v0 := mload(addr)
+          }
+          case 1 {
+            v0 := sload(addr)
+          }
+          default {
+          }
+        ret := v0
       }
       function get_variant_field__u256__3271ca15373d4483(addr, space, field_offset) -> ret {
         let v1 := add(add(addr, 32), field_offset)
@@ -136,19 +150,6 @@ object "EnumContract" {
           }
           default {
           }
-      }
-      function get_discriminant(addr, space) -> ret {
-        let v0 := 0
-        switch space
-          case 0 {
-            v0 := mload(addr)
-          }
-          case 1 {
-            v0 := sload(addr)
-          }
-          default {
-          }
-        ret := v0
       }
       function store_variant_field__u256__3271ca15373d4483(addr, space, field_offset, value) {
         let v0 := add(add(addr, 32), field_offset)

--- a/crates/codegen/tests/fixtures/match_enum_with_data.snap
+++ b/crates/codegen/tests/fixtures/match_enum_with_data.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/codegen/tests/yul.rs
+assertion_line: 31
 expression: output
 input_file: tests/fixtures/match_enum_with_data.fe
 ---
@@ -47,19 +48,6 @@ function store_discriminant(addr, space, discriminant) {
     default {
     }
 }
-function get_discriminant(addr, space) -> ret {
-  let v0 := 0
-  switch space
-    case 0 {
-      v0 := mload(addr)
-    }
-    case 1 {
-      v0 := sload(addr)
-    }
-    default {
-    }
-  ret := v0
-}
 function store_variant_field__u64__aee7f05a097ffa16(addr, space, field_offset, value) {
   let v0 := add(add(addr, 32), field_offset)
   switch space
@@ -86,6 +74,19 @@ function get_variant_field__u64__aee7f05a097ffa16(addr, space, field_offset) -> 
     }
   let v2 := v0
   ret := from_word__u64__aee7f05a097ffa16(v2)
+}
+function get_discriminant(addr, space) -> ret {
+  let v0 := 0
+  switch space
+    case 0 {
+      v0 := mload(addr)
+    }
+    case 1 {
+      v0 := sload(addr)
+    }
+    default {
+    }
+  ret := v0
 }
 function to_word__deduped(self) -> ret {
   ret := self

--- a/crates/mir/src/core_lib.rs
+++ b/crates/mir/src/core_lib.rs
@@ -1,0 +1,273 @@
+use common::ingot::IngotKind;
+use hir::analysis::{
+    HirAnalysisDb,
+    name_resolution::{PathRes, path_resolver::resolve_path},
+    ty::{
+        trait_resolution::PredicateListId,
+        ty_check::Callable,
+        ty_def::{TyBase, TyData, TyId},
+    },
+};
+use hir::hir_def::{Body, CallableDef, ExprId, IdentId, PathId};
+use rustc_hash::FxHashMap;
+
+/// Core helper resolution and callable construction for MIR lowering.
+///
+/// `CoreLib` eagerly resolves the handful of core functions/types MIR lowering depends on,
+/// then builds `Callable`s for those helpers on demand. The enums below are the single
+/// source of truth for what constitutes a “core helper”.
+/// Errors surfaced when the core library cannot be resolved.
+#[derive(Debug)]
+pub enum CoreLibError {
+    MissingFunc(String),
+    MissingType(String),
+}
+
+/// Core helper enum/path definitions. Add new helpers or types here; everything else
+/// (resolution, call construction) stays in sync automatically.
+macro_rules! define_core_helpers {
+    (
+        helpers { $($h_variant:ident => $h_path:literal,)+ }
+        types { $($t_variant:ident => $t_path:literal,)+ }
+    ) => {
+        /// Core helper functions used during MIR lowering.
+        #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+        pub enum CoreHelper { $($h_variant,)+ }
+
+        impl CoreHelper {
+            /// Returns all helper variants for eager resolution.
+            ///
+            /// Takes no parameters and returns a slice containing every [`CoreHelper`] variant.
+            pub const fn all() -> &'static [CoreHelper] {
+                &[$(CoreHelper::$h_variant,)+]
+            }
+
+            /// Fully qualified path string for this helper (e.g. `"core::ptr::get_field"`).
+            ///
+            /// * `self` - Helper variant whose path should be returned.
+            ///
+            /// Returns the path string used when resolving the helper function.
+            pub const fn path_str(self) -> &'static str {
+                match self {
+                    $(CoreHelper::$h_variant => $h_path,)+
+                }
+            }
+        }
+
+        /// Core helper types used during MIR lowering.
+        #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+        pub enum CoreHelperTy { $($t_variant,)+ }
+
+        impl CoreHelperTy {
+            /// Returns all helper types for eager resolution.
+            ///
+            /// Takes no parameters and returns a slice containing every [`CoreHelperTy`] variant.
+            pub const fn all() -> &'static [CoreHelperTy] {
+                &[$(CoreHelperTy::$t_variant,)+]
+            }
+
+            /// Fully qualified path string for this helper type.
+            ///
+            /// * `self` - Helper type whose path should be returned.
+            ///
+            /// Returns the path string used when resolving the helper type.
+            pub const fn path_str(self) -> &'static str {
+                match self {
+                    $(CoreHelperTy::$t_variant => $t_path,)+
+                }
+            }
+        }
+    };
+}
+
+define_core_helpers! {
+    helpers {
+        GetField => "core::ptr::get_field",
+        StoreField => "core::ptr::store_field",
+        Alloc => "core::mem::alloc",
+        StoreDiscriminant => "core::enum_repr::store_discriminant",
+        GetDiscriminant => "core::enum_repr::get_discriminant",
+        StoreVariantField => "core::enum_repr::store_variant_field",
+        GetVariantField => "core::enum_repr::get_variant_field",
+    }
+    types {
+        AddressSpace => "core::ptr::AddressSpace",
+    }
+}
+
+/// Resolves and caches core helper functions and types used by MIR lowering.
+pub struct CoreLib<'db> {
+    /// Database used for all HIR/ty queries during resolution and callable construction.
+    db: &'db dyn HirAnalysisDb,
+    /// Body whose scope anchors path resolution.
+    body: Body<'db>,
+    /// Resolved helper functions keyed by their enum variant.
+    funcs: FxHashMap<CoreHelper, CallableDef<'db>>,
+    /// Resolved helper types keyed by their enum variant.
+    tys: FxHashMap<CoreHelperTy, TyId<'db>>,
+}
+
+impl<'db> CoreLib<'db> {
+    /// Create a new resolver scoped to a HIR body (used for path resolution).
+    ///
+    /// * `db` - Analysis database used for name/type queries.
+    /// * `body` - The body whose scope anchors path resolution.
+    ///
+    /// Returns a fully-populated [`CoreLib`] when all helpers resolve, or a
+    /// [`CoreLibError`] indicating which helper is missing.
+    pub fn new(db: &'db dyn HirAnalysisDb, body: Body<'db>) -> Result<Self, CoreLibError> {
+        let resolve_func = |segments| Self::resolve_core_func(db, body, segments);
+        let resolve_ty = |segments| Self::resolve_core_type(db, body, segments);
+
+        let mut funcs = FxHashMap::default();
+        for helper in CoreHelper::all() {
+            funcs.insert(*helper, resolve_func(helper.path_str())?);
+        }
+
+        let mut tys = FxHashMap::default();
+        for helper_ty in CoreHelperTy::all() {
+            tys.insert(*helper_ty, resolve_ty(helper_ty.path_str())?);
+        }
+
+        Ok(Self {
+            db,
+            body,
+            funcs,
+            tys,
+        })
+    }
+
+    /// Build a callable for a core helper with optional generic instantiation.
+    ///
+    /// * `self` - Library containing resolved core helper definitions.
+    /// * `expr` - Expression whose span should be attached to diagnostics.
+    /// * `helper` - Which core helper function to target.
+    /// * `generics` - Concrete type arguments for generic helpers (can be empty).
+    ///
+    /// Returns a fully constructed [`Callable`] for use in MIR lowering.
+    pub fn make_callable(
+        &self,
+        expr: ExprId,
+        helper: CoreHelper,
+        generics: &[TyId<'db>],
+    ) -> Callable<'db> {
+        let func_def = *self
+            .funcs
+            .get(&helper)
+            .expect("core helper should be resolved at construction");
+        let base = TyId::func(self.db, func_def);
+        let ty = if generics.is_empty() {
+            base
+        } else {
+            TyId::foldl(self.db, base, generics)
+        };
+        Callable::new(self.db, ty, expr.span(self.body).into(), None)
+            .expect("core helper callable should be valid")
+    }
+
+    /// Look up a previously resolved core helper type.
+    ///
+    /// * `self` - Library containing resolved core helper types.
+    /// * `key` - Which helper type to retrieve (e.g. `AddressSpace`).
+    ///
+    /// Returns the resolved [`TyId`] for the requested helper type.
+    pub fn helper_ty(&self, key: CoreHelperTy) -> TyId<'db> {
+        *self
+            .tys
+            .get(&key)
+            .expect("core helper type should be resolved at construction")
+    }
+
+    /// Resolve a core function given a fully-qualified path string.
+    ///
+    /// * `db` - Analysis database used for name/type queries.
+    /// * `body` - The body whose scope anchors path resolution.
+    /// * `path` - Fully-qualified path string (e.g. `"core::ptr::get_field"`).
+    ///
+    /// Returns the `CallableDef` on success or a [`CoreLibError::MissingFunc`]
+    /// when the path cannot be resolved to a function.
+    fn resolve_core_func(
+        db: &'db dyn HirAnalysisDb,
+        body: Body<'db>,
+        path: &str,
+    ) -> Result<CallableDef<'db>, CoreLibError> {
+        let segments: Vec<&str> = path.split("::").collect();
+        let PathRes::Func(func_ty) = Self::resolve_core_path(db, body, &segments)
+            .ok_or_else(|| CoreLibError::MissingFunc(path.to_string()))?
+        else {
+            return Err(CoreLibError::MissingFunc(path.to_string()));
+        };
+        let base = func_ty.base_ty(db);
+        if let TyData::TyBase(TyBase::Func(func_def)) = base.data(db) {
+            Ok(*func_def)
+        } else {
+            Err(CoreLibError::MissingFunc(path.to_string()))
+        }
+    }
+
+    /// Resolve a core type given a fully-qualified path string.
+    ///
+    /// * `db` - Analysis database used for name/type queries.
+    /// * `body` - The body whose scope anchors path resolution.
+    /// * `path` - Fully-qualified path string (e.g. `"core::ptr::AddressSpace"`).
+    ///
+    /// Returns the `TyId` on success or a [`CoreLibError::MissingType`] if resolution fails.
+    fn resolve_core_type(
+        db: &'db dyn HirAnalysisDb,
+        body: Body<'db>,
+        path: &str,
+    ) -> Result<TyId<'db>, CoreLibError> {
+        let segments: Vec<&str> = path.split("::").collect();
+        match Self::resolve_core_path(db, body, &segments) {
+            Some(PathRes::Ty(ty)) => Ok(ty),
+            _ => Err(CoreLibError::MissingType(path.to_string())),
+        }
+    }
+
+    /// Resolve a fully-qualified core path from the current body scope.
+    ///
+    /// * `db` - Analysis database used for name/type queries.
+    /// * `body` - The body whose scope anchors path resolution.
+    /// * `segments` - Path segments split on `"::"`.
+    ///
+    /// Returns the resolved [`PathRes`] if successful.
+    fn resolve_core_path(
+        db: &'db dyn HirAnalysisDb,
+        body: Body<'db>,
+        segments: &[&str],
+    ) -> Option<PathRes<'db>> {
+        let in_core_ingot = matches!(body.top_mod(db).ingot(db).kind(db), IngotKind::Core);
+
+        let mut iter = segments.iter();
+        let first = *iter.next()?;
+        let mut path = PathId::from_ident(db, Self::make_ident(db, first, in_core_ingot));
+        for segment in iter {
+            path = path.push_ident(db, Self::make_ident(db, segment, in_core_ingot));
+        }
+        resolve_path(
+            db,
+            path,
+            body.scope(),
+            PredicateListId::empty_list(db),
+            true,
+        )
+        .ok()
+    }
+
+    /// Intern a path segment as an identifier, using `ingot` when lowering core itself.
+    ///
+    /// * `db` - Analysis database used for identifier interning.
+    /// * `segment` - Path component text.
+    /// * `in_core_ingot` - Whether the current body belongs to the core ingot.
+    ///
+    /// Returns an interned [`IdentId`] for the segment.
+    fn make_ident(db: &'db dyn HirAnalysisDb, segment: &str, in_core_ingot: bool) -> IdentId<'db> {
+        if segment == "core" && in_core_ingot {
+            IdentId::make_ingot(db)
+        } else if segment == "core" {
+            IdentId::make_core(db)
+        } else {
+            IdentId::new(db, segment.to_string())
+        }
+    }
+}

--- a/crates/mir/src/lib.rs
+++ b/crates/mir/src/lib.rs
@@ -1,3 +1,4 @@
+mod core_lib;
 mod dedup;
 mod hash;
 pub mod ir;

--- a/crates/mir/src/lower.rs
+++ b/crates/mir/src/lower.rs
@@ -7,17 +7,18 @@ use hir::analysis::{
     ty::{
         adt_def::AdtRef,
         trait_resolution::PredicateListId,
-        ty_check::{Callable, RecordLike, TypedBody, check_func_body},
+        ty_check::{RecordLike, TypedBody, check_func_body},
         ty_def::{PrimTy, TyBase, TyData, TyId},
     },
 };
 use hir::hir_def::{
     Attr, AttrArg, AttrArgValue, Body, CallableDef, Const, Expr, ExprId, Field, FieldIndex, Func,
-    IdentId, ItemKind, LitKind, MatchArm, Partial, Pat, PatId, PathId, Stmt, StmtId, TopLevelMod,
+    ItemKind, LitKind, MatchArm, Partial, Pat, PatId, PathId, Stmt, StmtId, TopLevelMod,
     VariantKind, scope_graph::ScopeId,
 };
 
 use crate::{
+    core_lib::{CoreHelper, CoreHelperTy, CoreLib, CoreLibError},
     ir::{
         BasicBlock, BasicBlockId, CallOrigin, CodeRegionRoot, ContractFunction,
         ContractFunctionKind, IntrinsicOp, IntrinsicValue, LoopInfo, MatchArmLowering,
@@ -36,6 +37,8 @@ use rustc_hash::{FxHashMap, FxHashSet};
 pub enum MirLowerError {
     /// The function had no body in HIR even though we attempted to lower it.
     MissingBody { func_name: String },
+    /// Required core helper could not be resolved during initialization.
+    MissingCoreHelper { path: String },
 }
 
 impl fmt::Display for MirLowerError {
@@ -43,6 +46,19 @@ impl fmt::Display for MirLowerError {
         match self {
             MirLowerError::MissingBody { func_name } => {
                 write!(f, "function `{func_name}` is missing a body")
+            }
+            MirLowerError::MissingCoreHelper { path } => {
+                write!(f, "missing required core helper `{path}`")
+            }
+        }
+    }
+}
+
+impl From<CoreLibError> for MirLowerError {
+    fn from(err: CoreLibError) -> Self {
+        match err {
+            CoreLibError::MissingFunc(path) | CoreLibError::MissingType(path) => {
+                MirLowerError::MissingCoreHelper { path }
             }
         }
     }
@@ -133,7 +149,7 @@ pub(crate) fn lower_function<'db>(
         return Err(MirLowerError::MissingBody { func_name });
     };
 
-    let mut builder = MirBuilder::new(db, body, &typed_body);
+    let mut builder = MirBuilder::new(db, body, &typed_body)?;
     let entry = builder.alloc_block();
     let fallthrough = builder.lower_root(entry, body.expr(db));
     builder.ensure_const_expr_values();
@@ -165,21 +181,7 @@ struct MirBuilder<'db, 'a> {
     body: Body<'db>,
     typed_body: &'a TypedBody<'db>,
     mir_body: MirBody<'db>,
-    /// Cached `core::ptr::get_field` definition used for field reads.
-    get_field_func: Option<CallableDef<'db>>,
-    /// Cached `core::ptr::store_field` definition used for record writes.
-    store_field_func: Option<CallableDef<'db>>,
-    /// Cached `core::mem::alloc` definition used for record allocation.
-    alloc_func: Option<CallableDef<'db>>,
-    /// Cached `core::enum::store_discriminant` definition used for enum construction.
-    store_discriminant_func: Option<CallableDef<'db>>,
-    /// Cached `core::enum::get_discriminant` definition used for enum destructuring.
-    get_discriminant_func: Option<CallableDef<'db>>,
-    /// Cached `core::enum::store_variant_field` definition used for enum construction.
-    store_variant_field_func: Option<CallableDef<'db>>,
-    /// Cached `core::enum::get_variant_field` definition used for enum destructuring.
-    get_variant_field_func: Option<CallableDef<'db>>,
-    address_space_ty: Option<TyId<'db>>,
+    core: CoreLib<'db>,
     loop_stack: Vec<LoopScope>,
     /// Memoized literal values for resolved `const` items.
     const_cache: FxHashMap<Const<'db>, ValueId>,
@@ -195,23 +197,22 @@ struct LoopScope {
 
 impl<'db, 'a> MirBuilder<'db, 'a> {
     /// Create a new MIR builder for the given HIR body and its typed info.
-    fn new(db: &'db dyn HirAnalysisDb, body: Body<'db>, typed_body: &'a TypedBody<'db>) -> Self {
-        Self {
+    fn new(
+        db: &'db dyn HirAnalysisDb,
+        body: Body<'db>,
+        typed_body: &'a TypedBody<'db>,
+    ) -> Result<Self, MirLowerError> {
+        let core = CoreLib::new(db, body)?;
+
+        Ok(Self {
             db,
             body,
             typed_body,
             mir_body: MirBody::new(),
-            get_field_func: None,
-            store_field_func: None,
-            alloc_func: None,
-            store_discriminant_func: None,
-            get_discriminant_func: None,
-            store_variant_field_func: None,
-            get_variant_field_func: None,
-            address_space_ty: None,
+            core,
             loop_stack: Vec::new(),
             const_cache: FxHashMap::default(),
-        }
+        })
     }
 
     /// Consume the builder and return the constructed MIR body.
@@ -328,32 +329,20 @@ impl<'db, 'a> MirBuilder<'db, 'a> {
                     .iter()
                     .any(|variant| variant.num_types() > 0);
                 if has_payload {
-                    if let Some(callable) = self.get_discriminant_callable(match_expr) {
-                        let space_value = self
-                            .synthetic_address_space_memory()
-                            .unwrap_or_else(|| self.synthetic_u256(BigUint::from(0u8)));
-                        let ty = callable.ret_ty(self.db);
-                        self.mir_body.alloc_value(ValueData {
-                            ty,
-                            origin: ValueOrigin::Call(CallOrigin {
-                                expr: match_expr,
-                                callable,
-                                args: vec![scrutinee_value, space_value],
-                                resolved_name: None,
-                            }),
-                        })
-                    } else {
-                        let ty = TyId::new(self.db, TyData::TyBase(TyBase::Prim(PrimTy::U256)));
-
-                        self.mir_body.alloc_value(ValueData {
-                            ty,
-                            origin: ValueOrigin::Intrinsic(IntrinsicValue {
-                                op: IntrinsicOp::Mload,
-                                args: vec![scrutinee_value],
-                                code_region: None,
-                            }),
-                        })
-                    }
+                    let callable =
+                        self.core
+                            .make_callable(match_expr, CoreHelper::GetDiscriminant, &[]);
+                    let space_value = self.synthetic_address_space_memory();
+                    let ty = callable.ret_ty(self.db);
+                    self.mir_body.alloc_value(ValueData {
+                        ty,
+                        origin: ValueOrigin::Call(CallOrigin {
+                            expr: match_expr,
+                            callable,
+                            args: vec![scrutinee_value, space_value],
+                            resolved_name: None,
+                        }),
+                    })
                 } else {
                     discr_value
                 }
@@ -586,12 +575,10 @@ impl<'db, 'a> MirBuilder<'db, 'a> {
                     continue;
                 }
                 let binding_ty = self.typed_body.pat_ty(self.db, binding.pat_id);
-                let Some(callable) = self.get_variant_field_callable(match_expr, binding_ty) else {
-                    continue;
-                };
-                let space_value = self
-                    .synthetic_address_space_memory()
-                    .unwrap_or_else(|| self.synthetic_u256(BigUint::from(0u8)));
+                let callable =
+                    self.core
+                        .make_callable(match_expr, CoreHelper::GetVariantField, &[binding_ty]);
+                let space_value = self.synthetic_address_space_memory();
                 let offset_value = self.synthetic_u256(BigUint::from(binding.field_offset));
                 let load_value = self.mir_body.alloc_value(ValueData {
                     ty: binding_ty,
@@ -838,9 +825,11 @@ impl<'db, 'a> MirBuilder<'db, 'a> {
         let info = self.field_access_info(lhs_ty, field_index)?;
 
         let addr_value = self.ensure_value(*lhs);
-        let space_value = self.synthetic_address_space_memory()?;
+        let space_value = self.synthetic_address_space_memory();
         let offset_value = self.synthetic_u256(BigUint::from(info.offset_bytes));
-        let callable = self.get_field_callable(expr, lhs_ty, info.field_ty)?;
+        let callable =
+            self.core
+                .make_callable(expr, CoreHelper::GetField, &[lhs_ty, info.field_ty]);
 
         Some(self.mir_body.alloc_value(ValueData {
             ty: info.field_ty,
@@ -986,10 +975,7 @@ impl<'db, 'a> MirBuilder<'db, 'a> {
         };
 
         // Emit the call to `alloc(size)` and bind its result so subsequent stores can re-use it.
-        let Some(alloc_callable) = self.get_alloc_callable(expr) else {
-            let value_id = self.ensure_value(expr);
-            return (Some(curr_block), value_id);
-        };
+        let alloc_callable = self.core.make_callable(expr, CoreHelper::Alloc, &[]);
         let alloc_ret_ty = alloc_callable.ret_ty(self.db);
         let size_value = self.synthetic_u256(BigUint::from(size_bytes));
         let alloc_value = self.mir_body.alloc_value(ValueData {
@@ -1014,9 +1000,7 @@ impl<'db, 'a> MirBuilder<'db, 'a> {
                 bind_value: true,
             },
         );
-        let Some(space_value) = self.synthetic_address_space_memory() else {
-            return (Some(curr_block), value_id);
-        };
+        let space_value = self.synthetic_address_space_memory();
 
         // Call `store_field` for every initialized member, re-using the allocated pointer.
         for (label, field_value) in lowered_fields {
@@ -1024,9 +1008,9 @@ impl<'db, 'a> MirBuilder<'db, 'a> {
             let Some(info) = self.field_access_info(record_ty, field_index) else {
                 continue;
             };
-            let Some(store_callable) = self.get_store_field_callable(expr, info.field_ty) else {
-                continue;
-            };
+            let store_callable =
+                self.core
+                    .make_callable(expr, CoreHelper::StoreField, &[info.field_ty]);
             let offset_value = self.synthetic_u256(BigUint::from(info.offset_bytes));
             let store_ret_ty = store_callable.ret_ty(self.db);
             let store_call = self.mir_body.alloc_value(ValueData {
@@ -1091,7 +1075,7 @@ impl<'db, 'a> MirBuilder<'db, 'a> {
         };
 
         // Emit alloc(total_size)
-        let alloc_callable = self.get_alloc_callable(expr)?;
+        let alloc_callable = self.core.make_callable(expr, CoreHelper::Alloc, &[]);
         let alloc_ret_ty = alloc_callable.ret_ty(self.db);
         let size_value = self.synthetic_u256(BigUint::from(total_size));
         let alloc_value = self.mir_body.alloc_value(ValueData {
@@ -1117,14 +1101,13 @@ impl<'db, 'a> MirBuilder<'db, 'a> {
                 bind_value: true,
             },
         );
-        // Try AddressSpace::Memory first, fall back to u256(0) for local test helpers
-        let space_value = self
-            .synthetic_address_space_memory()
-            .unwrap_or_else(|| self.synthetic_u256(BigUint::from(0u8)));
+        let space_value = self.synthetic_address_space_memory();
 
         // Emit store_discriminant(addr, space, discriminant)
         let discriminant_value = self.synthetic_u256(BigUint::from(variant_index));
-        let store_discr_callable = self.get_store_discriminant_callable(expr)?;
+        let store_discr_callable =
+            self.core
+                .make_callable(expr, CoreHelper::StoreDiscriminant, &[]);
         let store_discr_ret_ty = store_discr_callable.ret_ty(self.db);
         let store_discr_call = self.mir_body.alloc_value(ValueData {
             ty: store_discr_ret_ty,
@@ -1148,7 +1131,9 @@ impl<'db, 'a> MirBuilder<'db, 'a> {
         let mut offset: u64 = 0;
         for (i, arg_value) in lowered_args.iter().enumerate() {
             let arg_ty = self.typed_body.expr_ty(self.db, call_args[i].expr);
-            let store_callable = self.get_store_variant_field_callable(expr, arg_ty)?;
+            let store_callable =
+                self.core
+                    .make_callable(expr, CoreHelper::StoreVariantField, &[arg_ty]);
             let offset_value = self.synthetic_u256(BigUint::from(offset));
             let store_ret_ty = store_callable.ret_ty(self.db);
             let store_call = self.mir_body.alloc_value(ValueData {
@@ -1211,7 +1196,7 @@ impl<'db, 'a> MirBuilder<'db, 'a> {
         let curr_block = block;
 
         // Emit alloc(enum_size) and bind result
-        let alloc_callable = self.get_alloc_callable(expr)?;
+        let alloc_callable = self.core.make_callable(expr, CoreHelper::Alloc, &[]);
         let alloc_ret_ty = alloc_callable.ret_ty(self.db);
         let size_value = self.synthetic_u256(BigUint::from(enum_size));
         let alloc_value = self.mir_body.alloc_value(ValueData {
@@ -1236,8 +1221,10 @@ impl<'db, 'a> MirBuilder<'db, 'a> {
         );
 
         // Emit store_discriminant(addr, space, discriminant)
-        let space_value = self.synthetic_address_space_memory()?;
-        let store_discr_callable = self.get_store_discriminant_callable(expr)?;
+        let space_value = self.synthetic_address_space_memory();
+        let store_discr_callable =
+            self.core
+                .make_callable(expr, CoreHelper::StoreDiscriminant, &[]);
         let discr_value = self.synthetic_u256(BigUint::from(variant_index));
         let store_ret_ty = store_discr_callable.ret_ty(self.db);
         let store_discr_call = self.mir_body.alloc_value(ValueData {
@@ -1259,251 +1246,6 @@ impl<'db, 'a> MirBuilder<'db, 'a> {
         );
 
         Some((Some(curr_block), value_id))
-    }
-
-    /// Builds the callable metadata for `store_discriminant`.
-    fn get_store_discriminant_callable(&mut self, expr: ExprId) -> Option<Callable<'db>> {
-        let func_def = self.resolve_store_discriminant_func()?;
-        let ty = TyId::func(self.db, func_def);
-        Callable::new(self.db, ty, expr.span(self.body).into(), None).ok()
-    }
-
-    /// Builds the callable metadata for `get_discriminant`.
-    fn get_discriminant_callable(&mut self, expr: ExprId) -> Option<Callable<'db>> {
-        let func_def = self.resolve_get_discriminant_func()?;
-        let ty = TyId::func(self.db, func_def);
-        Callable::new(self.db, ty, expr.span(self.body).into(), None).ok()
-    }
-
-    /// Builds the callable metadata for `store_variant_field`.
-    fn get_store_variant_field_callable(
-        &mut self,
-        expr: ExprId,
-        field_ty: TyId<'db>,
-    ) -> Option<Callable<'db>> {
-        let func_def = self.resolve_store_variant_field_func()?;
-        // Only apply foldl if the function is generic (from core library)
-        // Local test helpers are not generic
-        let has_generics = !func_def.params(self.db).is_empty()
-            && func_def.ingot(self.db).kind(self.db) == IngotKind::Core;
-        let ty = if has_generics {
-            TyId::foldl(self.db, TyId::func(self.db, func_def), &[field_ty])
-        } else {
-            TyId::func(self.db, func_def)
-        };
-        Callable::new(self.db, ty, expr.span(self.body).into(), None).ok()
-    }
-
-    /// Builds the callable metadata for `get_variant_field`.
-    ///
-    /// * `expr` - Expression whose span anchors diagnostics for the callable.
-    /// * `field_ty` - Concrete type of the variant field being read.
-    ///
-    /// Returns a callable pointing at the resolved helper instantiated for `field_ty`.
-    fn get_variant_field_callable(
-        &mut self,
-        expr: ExprId,
-        field_ty: TyId<'db>,
-    ) -> Option<Callable<'db>> {
-        let func_def = self.resolve_get_variant_field_func()?;
-        let has_generics = !func_def.params(self.db).is_empty()
-            && func_def.ingot(self.db).kind(self.db) == IngotKind::Core;
-        let ty = if has_generics {
-            TyId::foldl(self.db, TyId::func(self.db, func_def), &[field_ty])
-        } else {
-            TyId::func(self.db, func_def)
-        };
-        Callable::new(self.db, ty, expr.span(self.body).into(), None).ok()
-    }
-
-    fn resolve_store_discriminant_func(&mut self) -> Option<CallableDef<'db>> {
-        if let Some(func) = self.store_discriminant_func {
-            return Some(func);
-        }
-        // Try local first (for test fixtures), then fall back to core library
-        if let Some(func) = self.find_local_store_discriminant() {
-            self.store_discriminant_func = Some(func);
-            return Some(func);
-        }
-        if let Some(func) = self.resolve_store_discriminant_via_path() {
-            self.store_discriminant_func = Some(func);
-            return Some(func);
-        }
-        None
-    }
-
-    fn resolve_get_discriminant_func(&mut self) -> Option<CallableDef<'db>> {
-        if let Some(func) = self.get_discriminant_func {
-            return Some(func);
-        }
-        // Try local first (for test fixtures), then fall back to core library
-        if let Some(func) = self.find_local_get_discriminant() {
-            self.get_discriminant_func = Some(func);
-            return Some(func);
-        }
-        if let Some(func) = self.resolve_get_discriminant_via_path() {
-            self.get_discriminant_func = Some(func);
-            return Some(func);
-        }
-        None
-    }
-
-    fn resolve_store_variant_field_func(&mut self) -> Option<CallableDef<'db>> {
-        if let Some(func) = self.store_variant_field_func {
-            return Some(func);
-        }
-        // Try local first (for test fixtures), then fall back to core library
-        if let Some(func) = self.find_local_store_variant_field() {
-            self.store_variant_field_func = Some(func);
-            return Some(func);
-        }
-        if let Some(func) = self.resolve_store_variant_field_via_path() {
-            self.store_variant_field_func = Some(func);
-            return Some(func);
-        }
-        None
-    }
-
-    /// Resolves (and caches) the `get_variant_field` helper definition.
-    ///
-    /// Prefers a locally defined helper (for tests) and falls back to the core library.
-    /// Returns the callable definition when resolution succeeds.
-    fn resolve_get_variant_field_func(&mut self) -> Option<CallableDef<'db>> {
-        if let Some(func) = self.get_variant_field_func {
-            return Some(func);
-        }
-        if let Some(func) = self.find_local_get_variant_field() {
-            self.get_variant_field_func = Some(func);
-            return Some(func);
-        }
-        if let Some(func) = self.resolve_get_variant_field_via_path() {
-            self.get_variant_field_func = Some(func);
-            return Some(func);
-        }
-        None
-    }
-
-    fn resolve_store_discriminant_via_path(&self) -> Option<CallableDef<'db>> {
-        let mut path = self.resolve_core_path(&["core", "enum_repr", "store_discriminant"]);
-        if path.is_none() {
-            path = self.resolve_core_path(&["core", "store_discriminant"]);
-        }
-        let PathRes::Func(func_ty) = path? else {
-            return None;
-        };
-        let base = func_ty.base_ty(self.db);
-        if let TyData::TyBase(TyBase::Func(func_def)) = base.data(self.db) {
-            Some(*func_def)
-        } else {
-            None
-        }
-    }
-
-    fn resolve_get_discriminant_via_path(&self) -> Option<CallableDef<'db>> {
-        let mut path = self.resolve_core_path(&["core", "enum_repr", "get_discriminant"]);
-        if path.is_none() {
-            path = self.resolve_core_path(&["core", "get_discriminant"]);
-        }
-        let PathRes::Func(func_ty) = path? else {
-            return None;
-        };
-        let base = func_ty.base_ty(self.db);
-        if let TyData::TyBase(TyBase::Func(func_def)) = base.data(self.db) {
-            Some(*func_def)
-        } else {
-            None
-        }
-    }
-
-    fn resolve_store_variant_field_via_path(&self) -> Option<CallableDef<'db>> {
-        let mut path = self.resolve_core_path(&["core", "enum_repr", "store_variant_field"]);
-        if path.is_none() {
-            path = self.resolve_core_path(&["core", "store_variant_field"]);
-        }
-        let PathRes::Func(func_ty) = path? else {
-            return None;
-        };
-        let base = func_ty.base_ty(self.db);
-        if let TyData::TyBase(TyBase::Func(func_def)) = base.data(self.db) {
-            Some(*func_def)
-        } else {
-            None
-        }
-    }
-
-    /// Resolves the core `get_variant_field` helper via a well-known path.
-    ///
-    /// Returns the callable definition if the path resolves to a function.
-    fn resolve_get_variant_field_via_path(&self) -> Option<CallableDef<'db>> {
-        let mut path = self.resolve_core_path(&["core", "enum_repr", "get_variant_field"]);
-        if path.is_none() {
-            path = self.resolve_core_path(&["core", "get_variant_field"]);
-        }
-        let PathRes::Func(func_ty) = path? else {
-            return None;
-        };
-        let base = func_ty.base_ty(self.db);
-        if let TyData::TyBase(TyBase::Func(func_def)) = base.data(self.db) {
-            Some(*func_def)
-        } else {
-            None
-        }
-    }
-
-    fn find_local_store_discriminant(&self) -> Option<CallableDef<'db>> {
-        let top_mod = self.body.top_mod(self.db);
-        for &func in top_mod.all_funcs(self.db) {
-            let name = func.name(self.db).to_opt()?;
-            if name.data(self.db) == "store_discriminant"
-                && let Some(def) = func.as_callable(self.db)
-            {
-                return Some(def);
-            }
-        }
-        None
-    }
-
-    fn find_local_get_discriminant(&self) -> Option<CallableDef<'db>> {
-        let top_mod = self.body.top_mod(self.db);
-        for &func in top_mod.all_funcs(self.db) {
-            let name = func.name(self.db).to_opt()?;
-            if name.data(self.db) == "get_discriminant"
-                && let Some(def) = func.as_callable(self.db)
-            {
-                return Some(def);
-            }
-        }
-        None
-    }
-
-    fn find_local_store_variant_field(&self) -> Option<CallableDef<'db>> {
-        let top_mod = self.body.top_mod(self.db);
-        for &func in top_mod.all_funcs(self.db) {
-            let name = func.name(self.db).to_opt()?;
-            if name.data(self.db) == "store_variant_field"
-                && let Some(def) = func.as_callable(self.db)
-            {
-                return Some(def);
-            }
-        }
-        None
-    }
-
-    /// Searches the current module for a locally defined `get_variant_field`.
-    ///
-    /// Used by fixtures/tests that provide their own helpers. Returns the callable
-    /// definition when found.
-    fn find_local_get_variant_field(&self) -> Option<CallableDef<'db>> {
-        let top_mod = self.body.top_mod(self.db);
-        for &func in top_mod.all_funcs(self.db) {
-            let name = func.name(self.db).to_opt()?;
-            if name.data(self.db) == "get_variant_field"
-                && let Some(def) = func.as_callable(self.db)
-            {
-                return Some(def);
-            }
-        }
-        None
     }
 
     /// Attempts to lower a statement-only intrinsic call (`mstore`, `sstore`, …).
@@ -1654,176 +1396,6 @@ impl<'db, 'a> MirBuilder<'db, 'a> {
         }
     }
 
-    /// Builds the callable metadata for the `get_field` helper.
-    fn get_field_callable(
-        &mut self,
-        expr: ExprId,
-        owner_ty: TyId<'db>,
-        field_ty: TyId<'db>,
-    ) -> Option<Callable<'db>> {
-        let func_def = self.resolve_get_field_func()?;
-        let params = func_def.params(self.db);
-        if params.len() < 2 {
-            return None;
-        }
-        let ty = TyId::foldl(
-            self.db,
-            TyId::func(self.db, func_def),
-            &[owner_ty, field_ty],
-        );
-        Callable::new(self.db, ty, expr.span(self.body).into(), None).ok()
-    }
-
-    /// Builds the callable metadata for the `store_field` helper.
-    fn get_store_field_callable(
-        &mut self,
-        expr: ExprId,
-        field_ty: TyId<'db>,
-    ) -> Option<Callable<'db>> {
-        let func_def = self.resolve_store_field_func()?;
-        let ty = TyId::foldl(self.db, TyId::func(self.db, func_def), &[field_ty]);
-        Callable::new(self.db, ty, expr.span(self.body).into(), None).ok()
-    }
-
-    /// Builds the callable metadata for `core::mem::alloc`.
-    fn get_alloc_callable(&mut self, expr: ExprId) -> Option<Callable<'db>> {
-        let func_def = self.resolve_alloc_func()?;
-        let ty = TyId::func(self.db, func_def);
-        Callable::new(self.db, ty, expr.span(self.body).into(), None).ok()
-    }
-
-    fn resolve_get_field_func(&mut self) -> Option<CallableDef<'db>> {
-        if let Some(func) = self.get_field_func {
-            return Some(func);
-        }
-        if let Some(func) = self.resolve_get_field_via_path() {
-            self.get_field_func = Some(func);
-            return Some(func);
-        }
-        if let Some(func) = self.find_local_get_field() {
-            self.get_field_func = Some(func);
-            return Some(func);
-        }
-        None
-    }
-
-    fn resolve_store_field_func(&mut self) -> Option<CallableDef<'db>> {
-        if let Some(func) = self.store_field_func {
-            return Some(func);
-        }
-        if let Some(func) = self.resolve_store_field_via_path() {
-            self.store_field_func = Some(func);
-            return Some(func);
-        }
-        if let Some(func) = self.find_local_store_field() {
-            self.store_field_func = Some(func);
-            return Some(func);
-        }
-        None
-    }
-
-    fn resolve_alloc_func(&mut self) -> Option<CallableDef<'db>> {
-        if let Some(func) = self.alloc_func {
-            return Some(func);
-        }
-        if let Some(func) = self.resolve_alloc_via_path() {
-            self.alloc_func = Some(func);
-            return Some(func);
-        }
-        if let Some(func) = self.find_local_alloc() {
-            self.alloc_func = Some(func);
-            return Some(func);
-        }
-        None
-    }
-
-    fn resolve_get_field_via_path(&self) -> Option<CallableDef<'db>> {
-        let mut path = self.resolve_core_path(&["core", "ptr", "get_field"]);
-        if path.is_none() {
-            path = self.resolve_core_path(&["core", "get_field"]);
-        }
-        let PathRes::Func(func_ty) = path? else {
-            return None;
-        };
-        let base = func_ty.base_ty(self.db);
-        if let TyData::TyBase(TyBase::Func(func_def)) = base.data(self.db) {
-            Some(*func_def)
-        } else {
-            None
-        }
-    }
-
-    fn resolve_store_field_via_path(&self) -> Option<CallableDef<'db>> {
-        let mut path = self.resolve_core_path(&["core", "ptr", "store_field"]);
-        if path.is_none() {
-            path = self.resolve_core_path(&["core", "store_field"]);
-        }
-        let PathRes::Func(func_ty) = path? else {
-            return None;
-        };
-        let base = func_ty.base_ty(self.db);
-        if let TyData::TyBase(TyBase::Func(func_def)) = base.data(self.db) {
-            Some(*func_def)
-        } else {
-            None
-        }
-    }
-
-    fn resolve_alloc_via_path(&self) -> Option<CallableDef<'db>> {
-        let mut path = self.resolve_core_path(&["core", "mem", "alloc"]);
-        if path.is_none() {
-            path = self.resolve_core_path(&["core", "alloc"]);
-        }
-        let PathRes::Func(func_ty) = path? else {
-            return None;
-        };
-        let base = func_ty.base_ty(self.db);
-        if let TyData::TyBase(TyBase::Func(func_def)) = base.data(self.db) {
-            Some(*func_def)
-        } else {
-            None
-        }
-    }
-
-    fn find_local_get_field(&self) -> Option<CallableDef<'db>> {
-        let top_mod = self.body.top_mod(self.db);
-        for &func in top_mod.all_funcs(self.db) {
-            let name = func.name(self.db).to_opt()?;
-            if name.data(self.db) == "get_field"
-                && let Some(def) = func.as_callable(self.db)
-            {
-                return Some(def);
-            }
-        }
-        None
-    }
-
-    fn find_local_store_field(&self) -> Option<CallableDef<'db>> {
-        let top_mod = self.body.top_mod(self.db);
-        for &func in top_mod.all_funcs(self.db) {
-            let name = func.name(self.db).to_opt()?;
-            if name.data(self.db) == "store_field"
-                && let Some(def) = func.as_callable(self.db)
-            {
-                return Some(def);
-            }
-        }
-        None
-    }
-
-    fn find_local_alloc(&self) -> Option<CallableDef<'db>> {
-        let top_mod = self.body.top_mod(self.db);
-        for &func in top_mod.all_funcs(self.db) {
-            let name = func.name(self.db).to_opt()?;
-            if name.data(self.db) == "alloc"
-                && let Some(def) = func.as_callable(self.db)
-            {
-                return Some(def);
-            }
-        }
-        None
-    }
-
     /// Returns which intrinsic operation the given function represents, if any.
     fn intrinsic_kind(&self, func_def: CallableDef<'db>) -> Option<IntrinsicOp> {
         if func_def.ingot(self.db).kind(self.db) != IngotKind::Core {
@@ -1887,54 +1459,12 @@ impl<'db, 'a> MirBuilder<'db, 'a> {
     }
 
     /// Emits a synthetic `AddressSpace::Memory` literal.
-    fn synthetic_address_space_memory(&mut self) -> Option<ValueId> {
-        let ty = self.address_space_ty()?;
-        Some(self.mir_body.alloc_value(ValueData {
+    fn synthetic_address_space_memory(&mut self) -> ValueId {
+        let ty = self.core.helper_ty(CoreHelperTy::AddressSpace);
+        self.mir_body.alloc_value(ValueData {
             ty,
             origin: ValueOrigin::Synthetic(SyntheticValue::Int(BigUint::from(0u8))),
-        }))
-    }
-
-    /// Caches the `AddressSpace` type so synthetic values can reference it.
-    fn address_space_ty(&mut self) -> Option<TyId<'db>> {
-        if let Some(ty) = self.address_space_ty {
-            return Some(ty);
-        }
-        let mut path = self.resolve_core_path(&["core", "ptr", "AddressSpace"]);
-        if path.is_none() {
-            path = self.resolve_core_path(&["core", "AddressSpace"]);
-        }
-        let PathRes::Ty(ty) = path? else {
-            return None;
-        };
-        self.address_space_ty = Some(ty);
-        Some(ty)
-    }
-
-    /// Resolves a fully-qualified core path like `["core","ptr","foo"]`.
-    fn resolve_core_path(&self, segments: &[&str]) -> Option<PathRes<'db>> {
-        let mut iter = segments.iter();
-        let first = *iter.next()?;
-        let mut path = PathId::from_ident(self.db, self.make_ident(first));
-        for segment in iter {
-            path = path.push_ident(self.db, self.make_ident(segment));
-        }
-        resolve_path(
-            self.db,
-            path,
-            self.body.scope(),
-            PredicateListId::empty_list(self.db),
-            true,
-        )
-        .ok()
-    }
-
-    fn make_ident(&self, segment: &str) -> IdentId<'db> {
-        if segment == "core" {
-            IdentId::make_core(self.db)
-        } else {
-            IdentId::new(self.db, segment.to_string())
-        }
+        })
     }
 
     /// Lower a statement, returning the successor block and (optional) produced value.

--- a/crates/mir/src/monomorphize.rs
+++ b/crates/mir/src/monomorphize.rs
@@ -37,8 +37,7 @@ pub(crate) fn monomorphize_functions<'db>(
     let mut monomorphizer = Monomorphizer::new(db, templates);
     monomorphizer.seed_roots();
     monomorphizer.process_worklist();
-    let instances = monomorphizer.into_instances();
-    deduplicate_mir(db, instances)
+    deduplicate_mir(db, monomorphizer.into_instances())
 }
 
 /// Worklist-driven builder that instantiates concrete MIR bodies on demand.


### PR DESCRIPTION
 - add core_lib.rs with documented canonical paths, caches, and type/function resolvers for core helpers
 - collapse per-helper caches in MirBuilder into a single CoreLib dependency and delegate all lookups to it
 - drop duplicated resolver functions/fields and update call sites; keep address-space synthesis using the shared cache
 - refresh codegen snapshots for enum discriminant lookups
