### PR TITLE
Add all existing e2e tests as native Fe tests

### DIFF
--- a/crates/fe/tests/fixtures/fe_test/coin.fe
+++ b/crates/fe/tests/fixtures/fe_test/coin.fe
@@ -1,0 +1,192 @@
+use std::evm::{Address, Evm, Call}
+use std::evm::effects::assert
+use core::abi::{Abi, AbiEncoder, AbiSize, Encode}
+use std::abi::Sol
+
+msg CoinMsg {
+    #[selector = 0xab7ccc1c]
+    Credit { user: u256, amount: u256 } -> u256,
+
+    #[selector = 0x0cf79e0a]
+    Transfer { from: u256, amount: u256 } -> u256,
+
+    #[selector = 0x6c65aae5]
+    BalanceOf { user: u256 } -> u256,
+
+    #[selector = 0x3940e9ee]
+    TotalSupply -> u256,
+}
+
+// Boilerplate for CoinMsg variants
+
+// Credit
+impl AbiSize for CoinMsg::Credit {
+    const ENCODED_SIZE: u256 = 64
+}
+impl Encode<Sol> for CoinMsg::Credit {
+    fn encode<E: AbiEncoder<Sol>>(self, mut _ e: E) {
+        self.user.encode(e)
+        self.amount.encode(e)
+    }
+}
+
+// Transfer
+impl AbiSize for CoinMsg::Transfer {
+    const ENCODED_SIZE: u256 = 64
+}
+impl Encode<Sol> for CoinMsg::Transfer {
+    fn encode<E: AbiEncoder<Sol>>(self, mut _ e: E) {
+        self.from.encode(e)
+        self.amount.encode(e)
+    }
+}
+
+// BalanceOf
+impl AbiSize for CoinMsg::BalanceOf {
+    const ENCODED_SIZE: u256 = 32
+}
+impl Encode<Sol> for CoinMsg::BalanceOf {
+    fn encode<E: AbiEncoder<Sol>>(self, mut _ e: E) {
+        self.user.encode(e)
+    }
+}
+
+// TotalSupply
+impl AbiSize for CoinMsg::TotalSupply {
+    const ENCODED_SIZE: u256 = 0
+}
+impl Encode<Sol> for CoinMsg::TotalSupply {
+    fn encode<E: AbiEncoder<Sol>>(self, mut _ e: E) {
+    }
+}
+
+struct CoinStore {
+    alice: u256,
+    bob: u256,
+    total_supply: u256,
+}
+
+pub contract Coin {
+    mut store: CoinStore
+
+    init() uses (mut store) {
+        store.alice = 0
+        store.bob = 0
+        store.total_supply = 0
+    }
+
+    recv CoinMsg {
+        Credit { user, amount } -> u256 uses (mut store) {
+            if user == 0 {
+                store.alice += amount
+                store.total_supply += amount
+                return store.alice
+            } else {
+                store.bob += amount
+                store.total_supply += amount
+                return store.bob
+            }
+        }
+
+        Transfer { from, amount } -> u256 uses (mut store) {
+            if from == 0 {
+                if store.alice < amount {
+                    return 1
+                }
+                store.alice -= amount
+                store.bob += amount
+                return 0
+            } else {
+                if store.bob < amount {
+                    return 1
+                }
+                store.bob -= amount
+                store.alice += amount
+                return 0
+            }
+        }
+
+        BalanceOf { user } -> u256 uses (store) {
+            if user == 0 {
+                return store.alice
+            } else {
+                return store.bob
+            }
+        }
+
+        TotalSupply -> u256 uses (store) {
+            return store.total_supply
+        }
+    }
+}
+
+#[test]
+fn test_coin() uses (mut evm: Evm) {
+    let contract_addr = evm.create2<Coin>(value: 0, args: (), salt: 0)
+    assert(contract_addr.inner != 0)
+
+    let alice: u256 = 0
+    let bob: u256 = 1
+
+    // Credit Alice 10
+    let res: u256 = evm.call(
+        addr: contract_addr,
+        gas: 100000,
+        value: 0,
+        message: CoinMsg::Credit { user: alice, amount: 10 }
+    )
+    assert(res == 10)
+
+    // Credit Bob 5
+    let res: u256 = evm.call(
+        addr: contract_addr,
+        gas: 100000,
+        value: 0,
+        message: CoinMsg::Credit { user: bob, amount: 5 }
+    )
+    assert(res == 5)
+
+    // Transfer 3 from Alice to Bob
+    let res: u256 = evm.call(
+        addr: contract_addr,
+        gas: 100000,
+        value: 0,
+        message: CoinMsg::Transfer { from: alice, amount: 3 }
+    )
+    assert(res == 0)
+
+    // Check balances
+    let bal_alice: u256 = evm.call(
+        addr: contract_addr,
+        gas: 100000,
+        value: 0,
+        message: CoinMsg::BalanceOf { user: alice }
+    )
+    assert(bal_alice == 7)
+
+    let bal_bob: u256 = evm.call(
+        addr: contract_addr,
+        gas: 100000,
+        value: 0,
+        message: CoinMsg::BalanceOf { user: bob }
+    )
+    assert(bal_bob == 8)
+
+    // Transfer too much from Bob
+    let res: u256 = evm.call(
+        addr: contract_addr,
+        gas: 100000,
+        value: 0,
+        message: CoinMsg::Transfer { from: bob, amount: 20 }
+    )
+    assert(res == 1)
+
+    // Check total supply
+    let total: u256 = evm.call(
+        addr: contract_addr,
+        gas: 100000,
+        value: 0,
+        message: CoinMsg::TotalSupply {}
+    )
+    assert(total == 15)
+}

--- a/crates/fe/tests/fixtures/fe_test/enum.fe
+++ b/crates/fe/tests/fixtures/fe_test/enum.fe
@@ -1,0 +1,112 @@
+use std::evm::{Evm, Call}
+use std::evm::effects::assert
+use core::abi::{Abi, AbiEncoder, AbiSize, Encode}
+use std::abi::Sol
+
+enum MyOption {
+    None,
+    Some(u256),
+}
+
+msg EnumMsg {
+    #[selector = 0x6c56cb0c]
+    MakeSome { value: u256 } -> u256,
+
+    #[selector = 0x455dd373]
+    MakeNone -> u256,
+
+    #[selector = 0xd4eee422]
+    IsSomeCheck { value: u256 } -> u256,
+}
+
+// Boilerplate for EnumMsg variants
+
+// MakeSome
+impl AbiSize for EnumMsg::MakeSome {
+    const ENCODED_SIZE: u256 = 32
+}
+impl Encode<Sol> for EnumMsg::MakeSome {
+    fn encode<E: AbiEncoder<Sol>>(self, mut _ e: E) {
+        self.value.encode(e)
+    }
+}
+
+// MakeNone
+impl AbiSize for EnumMsg::MakeNone {
+    const ENCODED_SIZE: u256 = 0
+}
+impl Encode<Sol> for EnumMsg::MakeNone {
+    fn encode<E: AbiEncoder<Sol>>(self, mut _ e: E) {
+    }
+}
+
+// IsSomeCheck
+impl AbiSize for EnumMsg::IsSomeCheck {
+    const ENCODED_SIZE: u256 = 32
+}
+impl Encode<Sol> for EnumMsg::IsSomeCheck {
+    fn encode<E: AbiEncoder<Sol>>(self, mut _ e: E) {
+        self.value.encode(e)
+    }
+}
+
+pub contract EnumContract {
+    recv EnumMsg {
+        MakeSome { value } -> u256 {
+            let opt = MyOption::Some(value)
+            return match opt {
+                MyOption::Some(val) => val
+                MyOption::None => 0
+            }
+        }
+
+        MakeNone -> u256 {
+            let opt = MyOption::None
+            return match opt {
+                MyOption::Some(val) => val
+                MyOption::None => 0
+            }
+        }
+
+        IsSomeCheck { value } -> u256 {
+            let opt = MyOption::Some(value)
+            return match opt {
+                MyOption::Some(_) => 1
+                MyOption::None => 0
+            }
+        }
+    }
+}
+
+#[test]
+fn test_enum() uses (mut evm: Evm) {
+    let contract_addr = evm.create2<EnumContract>(value: 0, args: (), salt: 0)
+    assert(contract_addr.inner != 0)
+
+    // Test make_some(42) - should return 42
+    let res: u256 = evm.call(
+        addr: contract_addr,
+        gas: 100000,
+        value: 0,
+        message: EnumMsg::MakeSome { value: 42 }
+    )
+    assert(res == 42)
+
+    // Test is_some_check(99) - should return 1 (true)
+    let res: u256 = evm.call(
+        addr: contract_addr,
+        gas: 100000,
+        value: 0,
+        message: EnumMsg::IsSomeCheck { value: 99 }
+    )
+    assert(res == 1)
+
+    // Test make_none() - should return 0
+    let res: u256 = evm.call(
+        addr: contract_addr,
+        gas: 100000,
+        value: 0,
+        message: EnumMsg::MakeNone {}
+    )
+    assert(res == 0)
+}

--- a/crates/fe/tests/fixtures/fe_test/erc20.fe
+++ b/crates/fe/tests/fixtures/fe_test/erc20.fe
@@ -1,0 +1,210 @@
+use std::evm::{Address, Evm, Call, StorageMap, Ctx}
+use std::evm::effects::assert
+use core::abi::{Abi, AbiEncoder, AbiSize, Encode}
+use std::abi::Sol
+
+msg Erc20 {
+    #[selector = 0x06fdde03]
+    Name -> u256,
+    #[selector = 0x95d89b41]
+    Symbol -> u256,
+    #[selector = 0x313ce567]
+    Decimals -> u8,
+    #[selector = 0x18160ddd]
+    TotalSupply -> u256,
+    #[selector = 0x70a08231]
+    BalanceOf { account: Address } -> u256,
+    #[selector = 0xdd62ed3e]
+    Allowance { owner: Address, spender: Address } -> u256,
+    #[selector = 0xa9059cbb]
+    Transfer { to: Address, amount: u256 } -> bool,
+    #[selector = 0x095ea7b3]
+    Approve { spender: Address, amount: u256 } -> bool,
+    #[selector = 0x23b872dd]
+    TransferFrom { from: Address, to: Address, amount: u256 } -> bool,
+    #[selector = 0xeeeeeeee]
+    WhoAmI -> u256,
+}
+
+msg Erc20Extended {
+    #[selector = 0x40c10f19]
+    Mint { to: Address, amount: u256 } -> bool,
+}
+
+// Boilerplate for Erc20 variants
+impl AbiSize for Erc20::Name { const ENCODED_SIZE: u256 = 0 }
+impl Encode<Sol> for Erc20::Name { fn encode<E: AbiEncoder<Sol>>(self, mut _ e: E) {} }
+
+impl AbiSize for Erc20::Symbol { const ENCODED_SIZE: u256 = 0 }
+impl Encode<Sol> for Erc20::Symbol { fn encode<E: AbiEncoder<Sol>>(self, mut _ e: E) {} }
+
+impl AbiSize for Erc20::Decimals { const ENCODED_SIZE: u256 = 0 }
+impl Encode<Sol> for Erc20::Decimals { fn encode<E: AbiEncoder<Sol>>(self, mut _ e: E) {} }
+
+impl AbiSize for Erc20::TotalSupply { const ENCODED_SIZE: u256 = 0 }
+impl Encode<Sol> for Erc20::TotalSupply { fn encode<E: AbiEncoder<Sol>>(self, mut _ e: E) {} }
+
+impl AbiSize for Erc20::BalanceOf { const ENCODED_SIZE: u256 = 32 }
+impl Encode<Sol> for Erc20::BalanceOf {
+    fn encode<E: AbiEncoder<Sol>>(self, mut _ e: E) {
+        self.account.encode(e)
+    }
+}
+
+impl AbiSize for Erc20::Allowance { const ENCODED_SIZE: u256 = 64 }
+impl Encode<Sol> for Erc20::Allowance {
+    fn encode<E: AbiEncoder<Sol>>(self, mut _ e: E) {
+        self.owner.encode(e)
+        self.spender.encode(e)
+    }
+}
+
+impl AbiSize for Erc20::Transfer { const ENCODED_SIZE: u256 = 64 }
+impl Encode<Sol> for Erc20::Transfer {
+    fn encode<E: AbiEncoder<Sol>>(self, mut _ e: E) {
+        self.to.encode(e)
+        self.amount.encode(e)
+    }
+}
+
+impl AbiSize for Erc20::Approve { const ENCODED_SIZE: u256 = 64 }
+impl Encode<Sol> for Erc20::Approve {
+    fn encode<E: AbiEncoder<Sol>>(self, mut _ e: E) {
+        self.spender.encode(e)
+        self.amount.encode(e)
+    }
+}
+
+impl AbiSize for Erc20::TransferFrom { const ENCODED_SIZE: u256 = 96 }
+impl Encode<Sol> for Erc20::TransferFrom {
+    fn encode<E: AbiEncoder<Sol>>(self, mut _ e: E) {
+        self.from.encode(e)
+        self.to.encode(e)
+        self.amount.encode(e)
+    }
+}
+
+impl AbiSize for Erc20::WhoAmI { const ENCODED_SIZE: u256 = 0 }
+impl Encode<Sol> for Erc20::WhoAmI { fn encode<E: AbiEncoder<Sol>>(self, mut _ e: E) {} }
+
+impl AbiSize for Erc20Extended::Mint { const ENCODED_SIZE: u256 = 64 }
+impl Encode<Sol> for Erc20Extended::Mint {
+    fn encode<E: AbiEncoder<Sol>>(self, mut _ e: E) {
+        self.to.encode(e)
+        self.amount.encode(e)
+    }
+}
+
+struct TokenStore {
+    total_supply: u256,
+    balances: StorageMap<Address, u256>,
+    allowances: StorageMap<(Address, Address), u256>,
+}
+
+pub contract CoolCoin uses (ctx: Ctx) {
+    mut store: TokenStore
+
+    init(initial_supply: u256, owner: Address) uses (mut store) {
+        if initial_supply > 0 {
+            store.total_supply = initial_supply
+            store.balances.set(key: owner, value: initial_supply)
+        }
+    }
+
+    recv Erc20 {
+        Name -> u256 { 0x436f6f6c436f696e }
+        Symbol -> u256 { 0x434f4f4c }
+        Decimals -> u8 { 18 }
+        TotalSupply -> u256 uses store { store.total_supply }
+        BalanceOf { account } -> u256 uses store { store.balances.get(key: account) }
+        Allowance { owner, spender } -> u256 uses store { store.allowances.get(key: (owner, spender)) }
+
+        WhoAmI -> u256 uses ctx {
+            return ctx.caller().inner
+        }
+
+        Transfer { to, amount } -> bool uses (mut store, ctx) {
+            let sender = ctx.caller()
+            let sender_bal = store.balances.get(key: sender)
+            if sender_bal < amount {
+                return false
+            }
+            store.balances.set(key: sender, value: sender_bal - amount)
+            store.balances.set(key: to, value: store.balances.get(key: to) + amount)
+            return true
+        }
+
+        Approve { spender, amount } -> bool uses (mut store, ctx) {
+            let sender = ctx.caller()
+            store.allowances.set(key: (sender, spender), value: amount)
+            return true
+        }
+
+        TransferFrom { from, to, amount } -> bool uses (mut store, ctx) {
+            let spender = ctx.caller()
+            let allowed = store.allowances.get(key: (from, spender))
+            if allowed < amount {
+                return false
+            }
+            let from_bal = store.balances.get(key: from)
+            if from_bal < amount {
+                return false
+            }
+            store.allowances.set(key: (from, spender), value: allowed - amount)
+            store.balances.set(key: from, value: from_bal - amount)
+            store.balances.set(key: to, value: store.balances.get(key: to) + amount)
+            return true
+        }
+    }
+
+    recv Erc20Extended {
+        Mint { to, amount } -> bool uses (mut store) {
+            store.total_supply += amount
+            store.balances.set(key: to, value: store.balances.get(key: to) + amount)
+            return true
+        }
+    }
+}
+
+#[test]
+fn test_erc20() uses (mut evm: Evm) {
+    let owner = Address { inner: 1 }
+    let alice = Address { inner: 2 }
+    let bob = Address { inner: 3 }
+
+    let initial_supply: u256 = 1000
+    let contract_addr = evm.create2<CoolCoin>(value: 0, args: (initial_supply, owner), salt: 0)
+    assert(contract_addr.inner != 0)
+
+    // Check initial state
+    let total: u256 = evm.call(addr: contract_addr, gas: 100000, value: 0, message: Erc20::TotalSupply {})
+    assert(total == 1000)
+
+    let bal_owner: u256 = evm.call(addr: contract_addr, gas: 100000, value: 0, message: Erc20::BalanceOf { account: owner })
+    assert(bal_owner == 1000)
+
+    // Determine my address (the test runner)
+    let me_inner: u256 = evm.call(addr: contract_addr, gas: 100000, value: 0, message: Erc20::WhoAmI {})
+    let me = Address { inner: me_inner }
+
+    // Mint to me so I can transfer
+    evm.call(addr: contract_addr, gas: 100000, value: 0, message: Erc20Extended::Mint { to: me, amount: 500 })
+
+    // Transfer 50 to Alice
+    let res: bool = evm.call(addr: contract_addr, gas: 100000, value: 0, message: Erc20::Transfer { to: alice, amount: 50 })
+    assert(res == true)
+
+    // Check Alice balance
+    let bal_alice: u256 = evm.call(addr: contract_addr, gas: 100000, value: 0, message: Erc20::BalanceOf { account: alice })
+    assert(bal_alice == 50)
+
+    // Check my balance
+    let bal_me: u256 = evm.call(addr: contract_addr, gas: 100000, value: 0, message: Erc20::BalanceOf { account: me })
+    assert(bal_me == 450)
+
+    // Approve Alice to spend 100 from Me
+    evm.call(addr: contract_addr, gas: 100000, value: 0, message: Erc20::Approve { spender: alice, amount: 100 })
+
+    let allow: u256 = evm.call(addr: contract_addr, gas: 100000, value: 0, message: Erc20::Allowance { owner: me, spender: alice })
+    assert(allow == 100)
+}

--- a/crates/fe/tests/fixtures/fe_test/shape.fe
+++ b/crates/fe/tests/fixtures/fe_test/shape.fe
@@ -1,0 +1,102 @@
+use std::evm::{Evm, Call}
+use std::evm::effects::assert
+use core::abi::{Abi, AbiEncoder, AbiSize, Encode}
+use std::abi::Sol
+
+struct Point {
+    x: u256,
+    y: u256,
+}
+
+impl Point {
+    fn area(self) -> u256 {
+        return self.x * self.y
+    }
+}
+
+struct Square {
+    side: u256,
+}
+
+impl Square {
+    fn area(self) -> u256 {
+        return self.side * self.side
+    }
+}
+
+msg ShapeMsg {
+    #[selector = 0x090251bf]
+    DispatchPoint { x: u256, y: u256 } -> u256,
+
+    #[selector = 0x7b292909]
+    DispatchSquare { side: u256 } -> u256,
+}
+
+// Boilerplate for ShapeMsg variants
+
+// DispatchPoint
+impl AbiSize for ShapeMsg::DispatchPoint {
+    const ENCODED_SIZE: u256 = 64
+}
+impl Encode<Sol> for ShapeMsg::DispatchPoint {
+    fn encode<E: AbiEncoder<Sol>>(self, mut _ e: E) {
+        self.x.encode(e)
+        self.y.encode(e)
+    }
+}
+
+// DispatchSquare
+impl AbiSize for ShapeMsg::DispatchSquare {
+    const ENCODED_SIZE: u256 = 32
+}
+impl Encode<Sol> for ShapeMsg::DispatchSquare {
+    fn encode<E: AbiEncoder<Sol>>(self, mut _ e: E) {
+        self.side.encode(e)
+    }
+}
+
+pub contract ShapeDispatcher {
+    recv ShapeMsg {
+        DispatchPoint { x, y } -> u256 {
+            let mut p = Point { x: x, y: y }
+            p.x += 1
+            p.y += 2
+            return p.area()
+        }
+
+        DispatchSquare { side } -> u256 {
+            let mut s = Square { side: side }
+            s.side += 3
+            return s.area()
+        }
+    }
+}
+
+#[test]
+fn test_shape() uses (mut evm: Evm) {
+    let contract_addr = evm.create2<ShapeDispatcher>(value: 0, args: (), salt: 0)
+    assert(contract_addr.inner != 0)
+
+    // Test point(3, 4)
+    // p.x = 3 + 1 = 4
+    // p.y = 4 + 2 = 6
+    // area = 4 * 6 = 24
+    let res: u256 = evm.call(
+        addr: contract_addr,
+        gas: 100000,
+        value: 0,
+        message: ShapeMsg::DispatchPoint { x: 3, y: 4 }
+    )
+    assert(res == 24)
+
+    // Test square(5)
+    // s.side = 5 + 3 = 8
+    // area = 8 * 8 = 64
+    let res: u256 = evm.call(
+        addr: contract_addr,
+        gas: 100000,
+        value: 0,
+        message: ShapeMsg::DispatchSquare { side: 5 }
+    )
+    assert(res == 64)
+}

--- a/crates/fe/tests/fixtures/fe_test/storage_map.fe
+++ b/crates/fe/tests/fixtures/fe_test/storage_map.fe
@@ -1,0 +1,244 @@
+use std::evm::{Evm, Call, StorageMap}
+use std::evm::effects::assert
+use core::abi::{Abi, AbiEncoder, AbiSize, Encode}
+use std::abi::Sol
+
+msg MapMsg {
+    #[selector = 0x9cc7f708]
+    BalanceOf { user: u256 } -> u256,
+
+    #[selector = 0x4a4b9feb]
+    SetBalance { user: u256, value: u256 } -> u256,
+
+    #[selector = 0x90dd2627]
+    Transfer { from: u256, to: u256, amount: u256 } -> u256,
+
+    #[selector = 0xc960174e]
+    GetAllowance { user: u256 } -> u256,
+
+    #[selector = 0x0bca4841]
+    SetAllowance { user: u256, value: u256 } -> u256,
+}
+
+// Boilerplate for MapMsg variants
+
+// BalanceOf
+impl AbiSize for MapMsg::BalanceOf {
+    const ENCODED_SIZE: u256 = 32
+}
+impl Encode<Sol> for MapMsg::BalanceOf {
+    fn encode<E: AbiEncoder<Sol>>(self, mut _ e: E) {
+        self.user.encode(e)
+    }
+}
+
+// SetBalance
+impl AbiSize for MapMsg::SetBalance {
+    const ENCODED_SIZE: u256 = 64
+}
+impl Encode<Sol> for MapMsg::SetBalance {
+    fn encode<E: AbiEncoder<Sol>>(self, mut _ e: E) {
+        self.user.encode(e)
+        self.value.encode(e)
+    }
+}
+
+// Transfer
+impl AbiSize for MapMsg::Transfer {
+    const ENCODED_SIZE: u256 = 96
+}
+impl Encode<Sol> for MapMsg::Transfer {
+    fn encode<E: AbiEncoder<Sol>>(self, mut _ e: E) {
+        self.from.encode(e)
+        self.to.encode(e)
+        self.amount.encode(e)
+    }
+}
+
+// GetAllowance
+impl AbiSize for MapMsg::GetAllowance {
+    const ENCODED_SIZE: u256 = 32
+}
+impl Encode<Sol> for MapMsg::GetAllowance {
+    fn encode<E: AbiEncoder<Sol>>(self, mut _ e: E) {
+        self.user.encode(e)
+    }
+}
+
+// SetAllowance
+impl AbiSize for MapMsg::SetAllowance {
+    const ENCODED_SIZE: u256 = 64
+}
+impl Encode<Sol> for MapMsg::SetAllowance {
+    fn encode<E: AbiEncoder<Sol>>(self, mut _ e: E) {
+        self.user.encode(e)
+        self.value.encode(e)
+    }
+}
+
+struct BalanceMapStore {
+    balances: StorageMap<u256, u256>,
+    allowances: StorageMap<u256, u256>,
+}
+
+pub contract BalanceMap {
+    mut store: BalanceMapStore
+
+    init() uses (mut store) {
+        // StorageMaps are empty by default
+    }
+
+    recv MapMsg {
+        BalanceOf { user } -> u256 uses (store) {
+            return store.balances.get(key: user)
+        }
+
+        SetBalance { user, value } -> u256 uses (mut store) {
+            store.balances.set(key: user, value: value)
+            return 0
+        }
+
+        Transfer { from, to, amount } -> u256 uses (mut store) {
+            let from_bal = store.balances.get(key: from)
+            if from_bal < amount {
+                return 1
+            }
+            let to_bal = store.balances.get(key: to)
+            store.balances.set(key: from, value: from_bal - amount)
+            store.balances.set(key: to, value: to_bal + amount)
+            return 0
+        }
+
+        GetAllowance { user } -> u256 uses (store) {
+            return store.allowances.get(key: user)
+        }
+
+        SetAllowance { user, value } -> u256 uses (mut store) {
+            store.allowances.set(key: user, value: value)
+            return 0
+        }
+    }
+}
+
+#[test]
+fn test_storage_map() uses (mut evm: Evm) {
+    let contract_addr = evm.create2<BalanceMap>(value: 0, args: (), salt: 0)
+    assert(contract_addr.inner != 0)
+
+    let alice: u256 = 0x1111
+    let bob: u256 = 0x2222
+
+    // 1. balanceOf(alice) -> 0
+    let bal: u256 = evm.call(
+        addr: contract_addr,
+        gas: 100000,
+        value: 0,
+        message: MapMsg::BalanceOf { user: alice }
+    )
+    assert(bal == 0)
+
+    // 2. setBalance(alice, 100)
+    evm.call(
+        addr: contract_addr,
+        gas: 100000,
+        value: 0,
+        message: MapMsg::SetBalance { user: alice, value: 100 }
+    )
+
+    // 3. balanceOf(alice) -> 100
+    let bal: u256 = evm.call(
+        addr: contract_addr,
+        gas: 100000,
+        value: 0,
+        message: MapMsg::BalanceOf { user: alice }
+    )
+    assert(bal == 100)
+
+    // 4. setBalance(bob, 50)
+    evm.call(
+        addr: contract_addr,
+        gas: 100000,
+        value: 0,
+        message: MapMsg::SetBalance { user: bob, value: 50 }
+    )
+
+    // 5. transfer(alice, bob, 30) -> 0 (success)
+    let res: u256 = evm.call(
+        addr: contract_addr,
+        gas: 100000,
+        value: 0,
+        message: MapMsg::Transfer { from: alice, to: bob, amount: 30 }
+    )
+    assert(res == 0)
+
+    // 6. balanceOf(alice) -> 70
+    let bal: u256 = evm.call(
+        addr: contract_addr,
+        gas: 100000,
+        value: 0,
+        message: MapMsg::BalanceOf { user: alice }
+    )
+    assert(bal == 70)
+
+    // 7. balanceOf(bob) -> 80
+    let bal: u256 = evm.call(
+        addr: contract_addr,
+        gas: 100000,
+        value: 0,
+        message: MapMsg::BalanceOf { user: bob }
+    )
+    assert(bal == 80)
+
+    // 8. transfer(alice, bob, 1000) -> 1 (fail)
+    let res: u256 = evm.call(
+        addr: contract_addr,
+        gas: 100000,
+        value: 0,
+        message: MapMsg::Transfer { from: alice, to: bob, amount: 1000 }
+    )
+    assert(res == 1)
+
+    // 9. balanceOf(alice) -> 70
+    let bal: u256 = evm.call(
+        addr: contract_addr,
+        gas: 100000,
+        value: 0,
+        message: MapMsg::BalanceOf { user: alice }
+    )
+    assert(bal == 70)
+
+    // 10. setAllowance(alice, 999)
+    evm.call(
+        addr: contract_addr,
+        gas: 100000,
+        value: 0,
+        message: MapMsg::SetAllowance { user: alice, value: 999 }
+    )
+
+    // 11. getAllowance(alice) -> 999
+    let allow: u256 = evm.call(
+        addr: contract_addr,
+        gas: 100000,
+        value: 0,
+        message: MapMsg::GetAllowance { user: alice }
+    )
+    assert(allow == 999)
+
+    // 12. balanceOf(alice) -> 70 (maps independent)
+    let bal: u256 = evm.call(
+        addr: contract_addr,
+        gas: 100000,
+        value: 0,
+        message: MapMsg::BalanceOf { user: alice }
+    )
+    assert(bal == 70)
+
+    // 13. getAllowance(bob) -> 0
+    let allow: u256 = evm.call(
+        addr: contract_addr,
+        gas: 100000,
+        value: 0,
+        message: MapMsg::GetAllowance { user: bob }
+    )
+    assert(allow == 0)
+}


### PR DESCRIPTION
This adds all existing e2e tests as tests that are written in Fe and tested via "fe test". I didn't actually remove the tests from `contract-harness` because I think there might be value in keeping those as a second line of defense as long as maintaining them doesn't become too much of a burden. However, I think going forward we probably want to write all such tests as native *fe test* tests.