### PR TITLE
fe.toml no longer updated by `fe new`

### DIFF
--- a/crates/fe/src/main.rs
+++ b/crates/fe/src/main.rs
@@ -76,9 +76,6 @@ pub enum Command {
         /// Override the default version (default: 0.1.0).
         #[arg(long)]
         version: Option<String>,
-        /// Do not attempt to add this ingot to an enclosing workspace.
-        #[arg(long)]
-        no_workspace_update: bool,
     },
 }
 
@@ -122,15 +119,8 @@ pub fn run(opts: &Options) {
             workspace,
             name,
             version,
-            no_workspace_update,
         } => {
-            if let Err(err) = cli::new::run(
-                path,
-                *workspace,
-                name.as_deref(),
-                version.as_deref(),
-                *no_workspace_update,
-            ) {
+            if let Err(err) = cli::new::run(path, *workspace, name.as_deref(), version.as_deref()) {
                 eprintln!("❌ {err}");
                 std::process::exit(1);
             }

--- a/docs/src/workspaces.md
+++ b/docs/src/workspaces.md
@@ -173,11 +173,11 @@ Remote workspaces are supported: a git dependency pointing at a workspace root c
 Creating projects:
 
 - `fe new --workspace <path>` creates a workspace root with `fe.toml` (members are empty by default).
-- `fe new <path>` creates a single ingot; if run inside an existing workspace, it attempts to add the ingot’s relative path to the workspace’s members (disable with `--no-workspace-update`).
+- `fe new <path>` creates a single ingot; if run inside an existing workspace, it prints a suggestion to add the ingot’s relative path to the workspace’s members.
 
 Notes on `fe new`:
 
 - `fe new` refuses to overwrite existing `fe.toml` / `src/lib.fe` files.
-- When adding to an enclosing workspace, `fe new` updates `members` as follows:
-  - If `members` is a table, it adds the new path to `members.main`.
-  - If the new ingot is already covered by an existing `members` glob (or is already listed explicitly), it skips updating the workspace file.
+- When run inside an enclosing workspace, `fe new` prints a member suggestion as follows:
+  - If `members` is a table, it suggests adding the new path to `members.main`.
+  - If the new ingot is already covered by an existing `members` glob (or is already listed explicitly), it prints no suggestion.


### PR DESCRIPTION
Running `fe new` no longer edits the `members` table in workspace fe.toml files.