### PR TITLE
feat(fe-cli): generate shell completions 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1071,6 +1071,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.5.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "430b4dc2b5e3861848de79627b2bedc9f3342c7da5173a14eaa5d0f8dc18ae5d"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1746,6 +1755,7 @@ version = "0.26.0"
 dependencies = [
  "camino",
  "clap",
+ "clap_complete",
  "colored",
  "cranelift-entity",
  "dir-test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,10 @@ test-utils = { path = "crates/test-utils", package = "fe-test-utils" }
 resolver = { path = "crates/resolver", package = "fe-resolver" }
 mir = { path = "crates/mir", package = "fe-mir" }
 cranelift-entity = "0.115"
-
 url = "2.5.4"
 camino = "1.1.9"
 clap = { version = "4.5.26", features = ["derive"] }
+clap_complete = "4.5.65"
 codespan-reporting = "0.11"
 derive_more = { version = "1.0", default-features = false, features = [
     "from",

--- a/crates/fe/Cargo.toml
+++ b/crates/fe/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 
 [dependencies]
 clap.workspace = true
+clap_complete.workspace = true
 driver.workspace = true
 tracing.workspace = true
 common.workspace = true

--- a/crates/fe/src/main.rs
+++ b/crates/fe/src/main.rs
@@ -9,7 +9,7 @@ use std::fs;
 
 use camino::Utf8PathBuf;
 use check::check;
-use clap::{Parser, Subcommand};
+use clap::{CommandFactory, Parser, Subcommand};
 use colored::Colorize;
 use fmt as fe_fmt;
 use similar::{ChangeTag, TextDiff};
@@ -77,6 +77,12 @@ pub enum Command {
         #[arg(long)]
         version: Option<String>,
     },
+    /// Generate shell completion scripts.
+    Completion {
+        /// Shell to generate completions for
+        #[arg(value_name = "shell")]
+        shell: clap_complete::Shell,
+    },
 }
 
 fn default_project_path() -> Utf8PathBuf {
@@ -124,6 +130,14 @@ pub fn run(opts: &Options) {
                 eprintln!("❌ {err}");
                 std::process::exit(1);
             }
+        }
+        Command::Completion { shell } => {
+            clap_complete::generate(
+                *shell,
+                &mut Options::command(),
+                "fe",
+                &mut std::io::stdout(),
+            );
         }
     }
 }


### PR DESCRIPTION
# Description 
-   Generate shell completions for the `fe` cli in.
```bash
./target/debug/fe completion <shell>` # bash, elvish, fish, powershell, zsh
```

You should add the generated script above to the shell completion folders to make it work perfectly. 
Example in oh my zsh: 
```
./target/debug/fe completion zsh > ~/.oh-my-zsh/completions/_fe
```
Then you can use \<Tab\> to complete the commands. 

For other shells, please check the instructions on the internet :D.