### PR TITLE
Add support for enums as const generics

### DIFF
--- a/crates/hir/src/analysis/diagnostics.rs
+++ b/crates/hir/src/analysis/diagnostics.rs
@@ -1393,7 +1393,7 @@ impl DiagnosticVoucher for TyLowerDiag<'_> {
                 message: "invalid const parameter type".to_string(),
                 sub_diagnostics: vec![SubDiagnostic {
                     style: LabelStyle::Primary,
-                    message: "only integer or bool types are allowed as a const parameter type"
+                    message: "only integer, bool, or unit-variant enum types are allowed as a const parameter type"
                         .to_string(),
                     span: span.resolve(db),
                 }],

--- a/crates/hir/src/analysis/ty/const_eval.rs
+++ b/crates/hir/src/analysis/ty/const_eval.rs
@@ -19,6 +19,7 @@ pub enum ConstValue {
     Int(BigUint),
     Bool(bool),
     Bytes(Vec<u8>),
+    EnumVariant(u16),
 }
 
 pub fn try_eval_const_body<'db>(
@@ -80,6 +81,9 @@ pub fn eval_const_expr<'db>(
         ConstTyData::Evaluated(EvaluatedConstTy::Bytes(bytes), _) => {
             Some(ConstValue::Bytes(bytes.clone()))
         }
+        ConstTyData::Evaluated(EvaluatedConstTy::EnumVariant(variant), _) => {
+            Some(ConstValue::EnumVariant(variant.idx))
+        }
         _ => None,
     })
 }
@@ -101,6 +105,9 @@ fn eval_const_ty<'db>(
         ConstTyData::Evaluated(EvaluatedConstTy::LitBool(b), _) => Some(ConstValue::Bool(*b)),
         ConstTyData::Evaluated(EvaluatedConstTy::Bytes(bytes), _) => {
             Some(ConstValue::Bytes(bytes.clone()))
+        }
+        ConstTyData::Evaluated(EvaluatedConstTy::EnumVariant(variant), _) => {
+            Some(ConstValue::EnumVariant(variant.idx))
         }
         _ => None,
     })

--- a/crates/hir/src/analysis/ty/ctfe.rs
+++ b/crates/hir/src/analysis/ty/ctfe.rs
@@ -383,15 +383,30 @@ impl<'db> CtfeInterpreter<'db> {
                     _ => Err(InvalidCause::ConstEvalUnsupported { body, expr }),
                 }
             }
-            Pat::Path(_, is_mut) => {
+            Pat::Path(path_partial, is_mut) => {
                 if *is_mut {
                     return Err(InvalidCause::ConstEvalUnsupported { body, expr });
                 }
-                let Some(binding) = self.typed_body().pat_binding(pat) else {
-                    return Err(InvalidCause::ConstEvalUnsupported { body, expr });
-                };
-                bindings.insert(binding, value);
-                Ok(true)
+                // Try variable binding first
+                if let Some(binding) = self.typed_body().pat_binding(pat) {
+                    bindings.insert(binding, value);
+                    return Ok(true);
+                }
+                // Try enum variant comparison
+                if let Partial::Present(path) = path_partial {
+                    let assumptions = PredicateListId::empty_list(self.db);
+                    if let Ok(PathRes::EnumVariant(resolved)) =
+                        resolve_path(self.db, *path, body.scope(), assumptions, true)
+                        && resolved.ty.is_unit_variant_only_enum(self.db)
+                        && let ConstTyData::Evaluated(
+                            EvaluatedConstTy::EnumVariant(scrutinee_variant),
+                            _,
+                        ) = value.data(self.db)
+                    {
+                        return Ok(resolved.variant == *scrutinee_variant);
+                    }
+                }
+                Err(InvalidCause::ConstEvalUnsupported { body, expr })
             }
             Pat::Tuple(pats) => {
                 let ConstTyData::Evaluated(EvaluatedConstTy::Tuple(elems), _) = value.data(self.db)
@@ -586,22 +601,31 @@ impl<'db> CtfeInterpreter<'db> {
         }
 
         let assumptions = PredicateListId::empty_list(self.db);
-        if let Ok(PathRes::Ty(ty) | PathRes::TyAlias(_, ty)) =
-            resolve_path(self.db, path, body.scope(), assumptions, true)
-        {
-            if let TyData::ConstTy(const_ty) = ty.data(self.db)
-                && let ConstTyData::TyParam(param, _) = const_ty.data(self.db)
-                && let Some(arg) = self.generic_args().get(param.idx)
-                && let TyData::ConstTy(arg_const) = arg.data(self.db)
-            {
-                return Ok(arg_const.evaluate(self.db, Some(arg_const.ty(self.db))));
-            }
+        match resolve_path(self.db, path, body.scope(), assumptions, true) {
+            Ok(PathRes::Ty(ty) | PathRes::TyAlias(_, ty)) => {
+                if let TyData::ConstTy(const_ty) = ty.data(self.db)
+                    && let ConstTyData::TyParam(param, _) = const_ty.data(self.db)
+                    && let Some(arg) = self.generic_args().get(param.idx)
+                    && let TyData::ConstTy(arg_const) = arg.data(self.db)
+                {
+                    return Ok(arg_const.evaluate(self.db, Some(arg_const.ty(self.db))));
+                }
 
-            if let TyData::ConstTy(const_ty) = ty.data(self.db)
-                && matches!(const_ty.data(self.db), ConstTyData::TyParam(..))
-            {
-                return Ok(*const_ty);
+                if let TyData::ConstTy(const_ty) = ty.data(self.db)
+                    && matches!(const_ty.data(self.db), ConstTyData::TyParam(..))
+                {
+                    return Ok(*const_ty);
+                }
             }
+            Ok(PathRes::EnumVariant(variant)) if variant.ty.is_unit_variant_only_enum(self.db) => {
+                let ty = self.typed_body().expr_ty(self.db, expr);
+                let evaluated = EvaluatedConstTy::EnumVariant(variant.variant);
+                return Ok(ConstTyId::new(
+                    self.db,
+                    ConstTyData::Evaluated(evaluated, ty),
+                ));
+            }
+            _ => {}
         }
 
         Err(InvalidCause::ConstEvalUnsupported { body, expr }.into())
@@ -1545,6 +1569,23 @@ fn const_as_bytes<'db>(
                     expr,
                 )?);
             }
+            Ok(out)
+        }
+        ConstTyData::Evaluated(EvaluatedConstTy::EnumVariant(variant), _) => {
+            // Enums are represented by a 32-byte discriminant in Fe's EVM layout.
+            // Currently, const-evaluable enum variants are limited to unit-only enums.
+            // Encode the discriminant as a big-endian 256-bit integer.
+            if !value.ty(db).is_unit_variant_only_enum(db) {
+                return Err(InvalidCause::ConstEvalUnsupported { body, expr });
+            }
+            let width = 32;
+            let bytes = BigUint::from(variant.idx as u64).to_bytes_be();
+            if bytes.len() > width {
+                return Err(InvalidCause::ConstEvalUnsupported { body, expr });
+            }
+            let mut out = vec![0u8; width];
+            let offset = width - bytes.len();
+            out[offset..].copy_from_slice(&bytes);
             Ok(out)
         }
         _ => Err(InvalidCause::ConstEvalUnsupported { body, expr }),

--- a/crates/hir/src/analysis/ty/simplified_pattern.rs
+++ b/crates/hir/src/analysis/ty/simplified_pattern.rs
@@ -293,7 +293,7 @@ impl<'db> SimplifiedPattern<'db> {
                 match try_eval_const_ref(db, cref, expected_ty)? {
                     ConstValue::Int(int) => Some(LitKind::Int(IntegerId::new(db, int))),
                     ConstValue::Bool(flag) => Some(LitKind::Bool(flag)),
-                    ConstValue::Bytes(_) => None,
+                    ConstValue::Bytes(_) | ConstValue::EnumVariant(_) => None,
                 }
             }
             PathRes::TraitConst(_recv_ty, inst, name) => {
@@ -301,7 +301,7 @@ impl<'db> SimplifiedPattern<'db> {
                 match try_eval_const_ref(db, cref, expected_ty)? {
                     ConstValue::Int(int) => Some(LitKind::Int(IntegerId::new(db, int))),
                     ConstValue::Bool(flag) => Some(LitKind::Bool(flag)),
-                    ConstValue::Bytes(_) => None,
+                    ConstValue::Bytes(_) | ConstValue::EnumVariant(_) => None,
                 }
             }
             _ => None,

--- a/crates/hir/src/analysis/ty/ty_def.rs
+++ b/crates/hir/src/analysis/ty/ty_def.rs
@@ -5,7 +5,7 @@ use std::fmt;
 use crate::{
     hir_def::{
         Body, Enum, ExprId, GenericParamOwner, IdentId, IntegerId, ItemKind, PathId,
-        TypeAlias as HirTypeAlias,
+        TypeAlias as HirTypeAlias, VariantKind,
         prim_ty::{IntTy as HirIntTy, PrimTy as HirPrimTy, UintTy as HirUintTy},
         scope_graph::ScopeId,
     },
@@ -432,6 +432,17 @@ impl<'db> TyId<'db> {
 
     pub fn is_prim(self, db: &dyn HirAnalysisDb) -> bool {
         matches!(self.base_ty(db).data(db), TyData::TyBase(TyBase::Prim(_)))
+    }
+
+    pub fn is_unit_variant_only_enum(self, db: &'db dyn HirAnalysisDb) -> bool {
+        if let Some(enum_) = self.as_enum(db) {
+            enum_.len_variants(db) > 0
+                && enum_
+                    .variants(db)
+                    .all(|v| matches!(v.kind(db), VariantKind::Unit))
+        } else {
+            false
+        }
     }
 
     pub fn as_enum(self, db: &'db dyn HirAnalysisDb) -> Option<Enum<'db>> {

--- a/crates/hir/src/analysis/ty/ty_error.rs
+++ b/crates/hir/src/analysis/ty/ty_error.rs
@@ -1,13 +1,14 @@
 use crate::{
-    hir_def::{PathId, TypeId, scope_graph::ScopeId},
-    span::{path::LazyPathSpan, types::LazyTySpan},
-    visitor::{Visitor, VisitorCtxt, prelude::DynLazySpan, walk_path, walk_type},
+    hir_def::{GenericArg, PathId, TypeId, TypeKind, scope_graph::ScopeId},
+    span::{params::LazyGenericArgSpan, path::LazyPathSpan, types::LazyTySpan},
+    visitor::{Visitor, VisitorCtxt, prelude::DynLazySpan, walk_generic_arg, walk_path, walk_type},
 };
 
 use crate::analysis::{
     HirAnalysisDb,
     name_resolution::{
-        ExpectedPathKind, PathRes, diagnostics::PathResDiag, resolve_path_with_observer,
+        ExpectedPathKind, PathRes, diagnostics::PathResDiag, resolve_path,
+        resolve_path_with_observer,
     },
     ty::visitor::TyVisitor,
 };
@@ -77,6 +78,91 @@ impl<'db> HirTyErrVisitor<'db> {
 }
 
 impl<'db> Visitor<'db> for HirTyErrVisitor<'db> {
+    fn visit_generic_arg(
+        &mut self,
+        ctxt: &mut VisitorCtxt<'db, LazyGenericArgSpan<'db>>,
+        arg: &GenericArg<'db>,
+    ) {
+        // Generic args are syntactically ambiguous: `String<N>` may parse `N` as a type
+        // even when `String` expects a const generic arg. Avoid emitting spurious
+        // type-expected diagnostics for const-like paths in generic-arg position.
+        if let GenericArg::Type(type_arg) = arg
+            && let Some(hir_ty) = type_arg.ty.to_opt()
+            && let TypeKind::Path(path_partial) = hir_ty.data(self.db)
+            && let Some(path) = path_partial.to_opt()
+            && let Ok(resolved) = resolve_path(self.db, path, ctxt.scope(), self.assumptions, true)
+        {
+            let is_const_like = match resolved {
+                PathRes::Const(..) | PathRes::TraitConst(..) => true,
+                PathRes::Ty(ty) | PathRes::TyAlias(_, ty) => {
+                    matches!(ty.data(self.db), TyData::ConstTy(_))
+                }
+                PathRes::EnumVariant(v) => v.ty.is_unit_variant_only_enum(self.db),
+                _ => false,
+            };
+
+            if is_const_like {
+                if let Some(span) = ctxt.span() {
+                    let path_span = span.into_type_arg().ty().into_path_type().path();
+
+                    // Preserve path visibility diagnostics even though we suppress
+                    // "expected type" errors for const-like paths in generic-arg
+                    // position.
+                    let scope = ctxt.scope();
+                    let mut invisible = None;
+                    let mut check_visibility = |path: PathId<'db>, reso: &PathRes<'db>| {
+                        if invisible.is_some() {
+                            return;
+                        }
+                        if !reso.is_visible_from(self.db, scope) {
+                            invisible = Some((path, reso.name_span(self.db)));
+                        }
+                    };
+
+                    match resolve_path_with_observer(
+                        self.db,
+                        path,
+                        scope,
+                        self.assumptions,
+                        true,
+                        &mut check_visibility,
+                    ) {
+                        Ok(_) => {
+                            if let Some((path, deriv_span)) = invisible
+                                && let Some(ident) = path.ident(self.db).to_opt()
+                            {
+                                let span = path_span
+                                    .clone()
+                                    .segment(path.segment_index(self.db))
+                                    .ident();
+                                let diag = PathResDiag::Invisible(span.into(), ident, deriv_span);
+                                self.diags.push(diag.into());
+                            }
+                        }
+                        Err(err) => {
+                            if let Some(diag) = err.into_diag(
+                                self.db,
+                                path,
+                                path_span.clone(),
+                                ExpectedPathKind::Value,
+                            ) {
+                                self.diags.push(diag.into());
+                            }
+                        }
+                    }
+
+                    // Walk the underlying path to validate any nested generic arguments,
+                    // but don't validate the path itself as a type.
+                    let mut path_ctxt = VisitorCtxt::new(ctxt.db(), ctxt.scope(), path_span);
+                    walk_path(self, &mut path_ctxt, path);
+                }
+                return;
+            }
+        }
+
+        walk_generic_arg(self, ctxt, arg);
+    }
+
     fn visit_body(
         &mut self,
         _ctxt: &mut VisitorCtxt<'db, crate::core::span::item::LazyBodySpan<'db>>,

--- a/crates/hir/src/core/semantic/mod.rs
+++ b/crates/hir/src/core/semantic/mod.rs
@@ -1346,8 +1346,7 @@ fn get_variant_selector<'db>(db: &'db dyn HirAnalysisDb, struct_: Struct<'db>) -
     let expected_ty = TyId::new(db, TyData::TyBase(TyBase::Prim(PrimTy::U32)));
     match try_eval_const_body(db, body, expected_ty)? {
         ConstValue::Int(value) => value.to_u32(),
-        ConstValue::Bool(_) => None,
-        ConstValue::Bytes(_) => None,
+        ConstValue::Bool(_) | ConstValue::Bytes(_) | ConstValue::EnumVariant(_) => None,
     }
 }
 

--- a/crates/mir/src/lower/prepass.rs
+++ b/crates/mir/src/lower/prepass.rs
@@ -243,6 +243,7 @@ impl<'db, 'a> MirBuilder<'db, 'a> {
                 ConstValue::Int(int) => SyntheticValue::Int(int),
                 ConstValue::Bool(flag) => SyntheticValue::Bool(flag),
                 ConstValue::Bytes(bytes) => SyntheticValue::Bytes(bytes),
+                ConstValue::EnumVariant(idx) => SyntheticValue::Int(BigUint::from(idx as u64)),
             };
 
             let value_id = self.alloc_synthetic_value(ty, value);
@@ -286,11 +287,15 @@ impl<'db, 'a> MirBuilder<'db, 'a> {
             ConstTyData::Evaluated(EvaluatedConstTy::LitBool(flag), _) => {
                 SyntheticValue::Bool(*flag)
             }
+            ConstTyData::Evaluated(EvaluatedConstTy::EnumVariant(variant), _) => {
+                SyntheticValue::Int(BigUint::from(variant.idx as u64))
+            }
             ConstTyData::UnEvaluated { body, .. } => {
                 match try_eval_const_body(self.db, *body, expected_ty)? {
                     ConstValue::Int(value) => SyntheticValue::Int(value),
                     ConstValue::Bool(flag) => SyntheticValue::Bool(flag),
                     ConstValue::Bytes(bytes) => SyntheticValue::Bytes(bytes),
+                    ConstValue::EnumVariant(idx) => SyntheticValue::Int(BigUint::from(idx as u64)),
                 }
             }
             _ => return None,

--- a/crates/uitest/fixtures/ty/const_ty/enum_variant_const_ty_mismatch.fe
+++ b/crates/uitest/fixtures/ty/const_ty/enum_variant_const_ty_mismatch.fe
@@ -1,0 +1,9 @@
+enum E {
+    A,
+}
+
+struct Foo<const N: u32> {
+    x: u32
+}
+
+type X = Foo<{ E::A }>

--- a/crates/uitest/fixtures/ty/const_ty/enum_variant_const_ty_mismatch.snap
+++ b/crates/uitest/fixtures/ty/const_ty/enum_variant_const_ty_mismatch.snap
@@ -1,0 +1,10 @@
+---
+source: crates/uitest/tests/ty.rs
+expression: diags
+input_file: fixtures/ty/const_ty/enum_variant_const_ty_mismatch.fe
+---
+error[3-0011]: given type doesn't match the expected const type
+  ┌─ enum_variant_const_ty_mismatch.fe:9:10
+  │
+9 │ type X = Foo<{ E::A }>
+  │          ^^^^^^^^^^^^^ expected `u32` type here, but `E` is given

--- a/crates/uitest/fixtures/ty/def/const_generic_arg_invisible.fe
+++ b/crates/uitest/fixtures/ty/def/const_generic_arg_invisible.fe
@@ -1,0 +1,9 @@
+pub struct Foo<const N: u32> {}
+
+mod private_mod {
+    const CONST: u32 = 1
+}
+
+pub struct Bar {
+    foo: Foo<private_mod::CONST>,
+}

--- a/crates/uitest/fixtures/ty/def/const_generic_arg_invisible.snap
+++ b/crates/uitest/fixtures/ty/def/const_generic_arg_invisible.snap
@@ -1,0 +1,13 @@
+---
+source: crates/uitest/tests/ty.rs
+expression: diags
+input_file: fixtures/ty/def/const_generic_arg_invisible.fe
+---
+error[2-0003]: `CONST` is not visible
+  ┌─ const_generic_arg_invisible.fe:8:27
+  │
+4 │     const CONST: u32 = 1
+  │           ----- `CONST` is defined here
+  ·
+8 │     foo: Foo<private_mod::CONST>,
+  │                           ^^^^^ `CONST` is not visible

--- a/crates/uitest/fixtures/ty/def/const_generics_cycle.snap
+++ b/crates/uitest/fixtures/ty/def/const_generics_cycle.snap
@@ -1,16 +1,16 @@
 ---
 source: crates/uitest/tests/ty.rs
 expression: diags
-input_file: crates/uitest/fixtures/ty/def/const_generics_cycle.fe
+input_file: fixtures/ty/def/const_generics_cycle.fe
 ---
 error[3-0009]: invalid const parameter type
   ┌─ const_generics_cycle.fe:1:28
   │
 1 │ pub struct Foo<T, const U: T> {}
-  │                            ^ only integer or bool types are allowed as a const parameter type
+  │                            ^ only integer, bool, or unit-variant enum types are allowed as a const parameter type
 
 error[3-0009]: invalid const parameter type
   ┌─ const_generics_cycle.fe:2:28
   │
 2 │ pub struct Bar<T, const U: Bar> {}
-  │                            ^^^ only integer or bool types are allowed as a const parameter type
+  │                            ^^^ only integer, bool, or unit-variant enum types are allowed as a const parameter type

--- a/crates/uitest/fixtures/ty/def/const_generics_enum.fe
+++ b/crates/uitest/fixtures/ty/def/const_generics_enum.fe
@@ -1,0 +1,13 @@
+enum AddrSpace {
+    Mem,
+    Stor,
+    Tran,
+}
+
+struct Ptr<T, const S: AddrSpace> {
+    pub addr: u256
+}
+
+fn make_ptr() -> Ptr<u8, AddrSpace::Mem> {
+    Ptr { addr: 0 }
+}

--- a/crates/uitest/fixtures/ty/def/const_generics_enum.snap
+++ b/crates/uitest/fixtures/ty/def/const_generics_enum.snap
@@ -1,0 +1,6 @@
+---
+source: crates/uitest/tests/ty.rs
+expression: diags
+input_file: fixtures/ty/def/const_generics_enum.fe
+---
+

--- a/crates/uitest/fixtures/ty/def/const_generics_invalid_ty.snap
+++ b/crates/uitest/fixtures/ty/def/const_generics_invalid_ty.snap
@@ -1,16 +1,16 @@
 ---
 source: crates/uitest/tests/ty.rs
 expression: diags
-input_file: crates/uitest/fixtures/ty/def/const_generics_invalid_ty.fe
+input_file: fixtures/ty/def/const_generics_invalid_ty.fe
 ---
 error[3-0009]: invalid const parameter type
   ┌─ const_generics_invalid_ty.fe:2:25
   │
 2 │ pub struct Bar<const T: Foo> {}
-  │                         ^^^ only integer or bool types are allowed as a const parameter type
+  │                         ^^^ only integer, bool, or unit-variant enum types are allowed as a const parameter type
 
 error[3-0009]: invalid const parameter type
   ┌─ const_generics_invalid_ty.fe:4:21
   │
 4 │ pub fn foo<const T: Foo>() {}
-  │                     ^^^ only integer or bool types are allowed as a const parameter type
+  │                     ^^^ only integer, bool, or unit-variant enum types are allowed as a const parameter type

--- a/crates/uitest/fixtures/ty/def/const_generics_non_unit_enum.fe
+++ b/crates/uitest/fixtures/ty/def/const_generics_non_unit_enum.fe
@@ -1,0 +1,8 @@
+enum Payload {
+    A(u32),
+    B,
+}
+
+struct Foo<const P: Payload> {
+    pub val: u32
+}

--- a/crates/uitest/fixtures/ty/def/const_generics_non_unit_enum.snap
+++ b/crates/uitest/fixtures/ty/def/const_generics_non_unit_enum.snap
@@ -1,0 +1,10 @@
+---
+source: crates/uitest/tests/ty.rs
+expression: diags
+input_file: fixtures/ty/def/const_generics_non_unit_enum.fe
+---
+error[3-0009]: invalid const parameter type
+  ┌─ const_generics_non_unit_enum.fe:6:21
+  │
+6 │ struct Foo<const P: Payload> {
+  │                     ^^^^^^^ only integer, bool, or unit-variant enum types are allowed as a const parameter type

--- a/crates/uitest/fixtures/ty/def/enum_variant_as_type.fe
+++ b/crates/uitest/fixtures/ty/def/enum_variant_as_type.fe
@@ -1,0 +1,6 @@
+enum E {
+    A,
+    B,
+}
+
+type X = E::A

--- a/crates/uitest/fixtures/ty/def/enum_variant_as_type.snap
+++ b/crates/uitest/fixtures/ty/def/enum_variant_as_type.snap
@@ -1,0 +1,10 @@
+---
+source: crates/uitest/tests/ty.rs
+expression: diags
+input_file: fixtures/ty/def/enum_variant_as_type.fe
+---
+error[2-0006]: expected type item here
+  ┌─ enum_variant_as_type.fe:6:13
+  │
+6 │ type X = E::A
+  │             ^ expected type here, but found enum variant `A`

--- a/crates/uitest/fixtures/ty_check/const_eval/as_bytes_enum_discriminant_ok.fe
+++ b/crates/uitest/fixtures/ty_check/const_eval/as_bytes_enum_discriminant_ok.fe
@@ -1,0 +1,20 @@
+use core::intrinsic
+
+enum AddrSpace {
+    Mem,
+    Stor,
+    Tran,
+}
+
+const fn stor_code() -> usize {
+    let bytes: [u8; 32] = intrinsic::__as_bytes(AddrSpace::Stor)
+    (bytes[0] as usize) * 2 + (bytes[31] as usize)
+}
+
+type StorCode = [u8; stor_code()]
+
+fn takes_one(_x: [u8; 1]) {}
+
+fn ok(x: StorCode) {
+    takes_one(x)
+}

--- a/crates/uitest/fixtures/ty_check/const_eval/as_bytes_enum_discriminant_ok.snap
+++ b/crates/uitest/fixtures/ty_check/const_eval/as_bytes_enum_discriminant_ok.snap
@@ -1,0 +1,7 @@
+---
+source: crates/uitest/tests/ty_check.rs
+assertion_line: 27
+expression: diags
+input_file: fixtures/ty_check/const_eval/as_bytes_enum_discriminant_ok.fe
+---
+

--- a/crates/uitest/fixtures/ty_check/const_eval/as_bytes_mixed_enum_unsupported.fe
+++ b/crates/uitest/fixtures/ty_check/const_eval/as_bytes_mixed_enum_unsupported.fe
@@ -1,0 +1,15 @@
+use core::intrinsic
+
+enum Mixed {
+    A(u256),
+    B,
+}
+
+const fn len() -> usize {
+    let bytes: [u8; 32] = intrinsic::__as_bytes(Mixed::B)
+    bytes[31] as usize
+}
+
+type Arr = [u8; len()]
+
+fn takes(_x: Arr) {}

--- a/crates/uitest/fixtures/ty_check/const_eval/as_bytes_mixed_enum_unsupported.snap
+++ b/crates/uitest/fixtures/ty_check/const_eval/as_bytes_mixed_enum_unsupported.snap
@@ -1,0 +1,10 @@
+---
+source: crates/uitest/tests/ty_check.rs
+expression: diags
+input_file: fixtures/ty_check/const_eval/as_bytes_mixed_enum_unsupported.fe
+---
+error[3-0023]: the expression cannot be evaluated at compile time
+  ┌─ as_bytes_mixed_enum_unsupported.fe:9:49
+  │
+9 │     let bytes: [u8; 32] = intrinsic::__as_bytes(Mixed::B)
+  │                                                 ^^^^^^^^ unsupported in const evaluation


### PR DESCRIPTION
Allow unit-only enums to be used as const generic parameter types,                                                                                                                                                
  enabling patterns like:
      
      ```                                                                                                                                                                                                              
      enum AddrSpace { Mem, Stor, Tran }                    
      struct Ptr<T, const S: AddrSpace> { addr: usize }
      fn make_ptr() -> Ptr<u8, AddrSpace::Mem> { ... }
      ```

  Enums with tuple or record variants are rejected.

  Changes:
  - Add TyId::is_unit_variant_only_enum() helper
  - Accept unit-only enums in const parameter type validation
  - Add EnumVariant to EvaluatedConstTy and ConstValue
  - Handle enum variant paths in generic arg lowering, CTFE
    evaluation, pattern matching, and as_bytes serialization
  - Encode enum discriminants as 32-byte big-endian values matching
    Fe's EVM layout
  - Override visit_generic_arg in the diagnostic visitor to suppress
    spurious "expected type" errors for const-like paths in generic
    arg position while still rejecting enum variants in type position
    (e.g. type X = E::A)
  - Handle EnumVariant in MIR lowering prepass
  
  This addresses #1251 
