### PR TITLE
Upgrade radix_immutable to 0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3414,8 +3414,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "radix_immutable"
-version = "0.0.1"
-source = "git+https://github.com/micahscopes/radix_immutable.git#514098f05404713bd3bf8ed0dbbca12ec8a8590b"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dafbb83194e5cbdc904a1cb110deb10368327536b8129ca0f361f21dbd7a5703"
 dependencies = [
  "once_cell",
 ]

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -24,4 +24,4 @@ parser.workspace = true
 url.workspace = true
 ordermap = "0.5.5"
 rustc-hash.workspace = true
-radix_immutable = { version = "0.0.1", git = "https://github.com/micahscopes/radix_immutable.git" }
+radix_immutable = "0.1"

--- a/crates/common/src/file/workspace.rs
+++ b/crates/common/src/file/workspace.rs
@@ -65,7 +65,7 @@ impl Workspace {
     }
 
     #[salsa::tracked]
-    pub fn items_at_base(self, db: &dyn InputDb, base: Url) -> StringPrefixView<'_, Url, File> {
+    pub fn items_at_base(self, db: &dyn InputDb, base: Url) -> StringPrefixView<Url, File> {
         self.files(db).view_subtrie(base)
     }
 

--- a/crates/common/src/ingot.rs
+++ b/crates/common/src/ingot.rs
@@ -95,7 +95,7 @@ impl<'db> Ingot<'db> {
     }
 
     #[salsa::tracked]
-    pub fn files(self, db: &'db dyn InputDb) -> StringPrefixView<'db, Url, File> {
+    pub fn files(self, db: &'db dyn InputDb) -> StringPrefixView<Url, File> {
         if let Some(standalone_file) = self.standalone_file(db) {
             // For standalone ingots, use the standalone file URL as the base
             db.workspace().items_at_base(


### PR DESCRIPTION
## Summary

- Upgrade `radix_immutable` from 0.0.1 (git) to 0.1.0 (crates.io)
- Drop phantom lifetime from `StringPrefixView` type alias (breaking change in upstream)

Picks up bug fixes (PartialEq deep comparison, insert prefix overwrite, path compression after remove), BTreeMap children for deterministic ordering and ~30-60% perf improvement, and new features (longest_prefix_match, iter_prefix, FromIterator, serde support).

## Test plan

- [x] `cargo test --workspace` passes (all crates)