### PR TITLE
allow non-unit-typed expr at end of unit-typed block

### DIFF
--- a/crates/codegen/tests/fixtures/erc20_low_level.snap
+++ b/crates/codegen/tests/fixtures/erc20_low_level.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/codegen/tests/yul.rs
-assertion_line: 33
 expression: output
 input_file: tests/fixtures/erc20_low_level.fe
 ---
@@ -275,7 +274,6 @@ object "Erc20Contract" {
           default {
             revert(0, 0)
           }
-        leave
       }
       function $stor_ptr__Evm_hef0af3106e109414_Erc20_h7a8a7a2800ba6809__828ea75549970aee($self, $slot) -> ret {
         let v0 := $storptr_t__hc45dea9607fd5340_effecthandle_hfc52f915596f993a_from_raw__Erc20_h7a8a7a2800ba6809__f6f4aaca4c5af1b3($slot)

--- a/crates/codegen/tests/fixtures/nested_struct.snap
+++ b/crates/codegen/tests/fixtures/nested_struct.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/codegen/tests/yul.rs
-assertion_line: 33
 expression: output
 input_file: tests/fixtures/nested_struct.fe
 ---
@@ -55,7 +54,6 @@ object "NestedStruct" {
           default {
             return(0, 0)
           }
-        leave
       }
       function $stor_ptr__Evm_hef0af3106e109414_Outer_hccd04e332bd35653__177c3c9a6f7ae368($self, $slot) -> ret {
         let v0 := $storptr_t__hc45dea9607fd5340_effecthandle_hfc52f915596f993a_from_raw__Outer_hccd04e332bd35653__f44d0100de7cf929($slot)

--- a/crates/codegen/tests/fixtures/sonatina_ir/erc20_low_level.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/erc20_low_level.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/codegen/tests/sonatina_ir.rs
-assertion_line: 64
 expression: output
 input_file: crates/codegen/tests/fixtures/erc20_low_level.fe
 ---
@@ -94,103 +93,100 @@ func private %runtime__StorPtr_Evm___207f35a85ac4062e() {
         v1.i256 = call %stor_ptr__Evm_hef0af3106e109414_Erc20_h7a8a7a2800ba6809__828ea75549970aee 0.i256 0.i256;
         v2.i256 = evm_calldata_load 0.i256;
         v4.i256 = shr 224.i256 v2;
-        jump block12;
+        jump block11;
 
     block1:
         v6.i256 = evm_calldata_load 4.i256;
         v8.i256 = call %balance_of__StorPtr_Erc20___2745299687a147d4 v6 v1;
         call %abi_encode_u256__Evm_hef0af3106e109414__3af54274b2985741 v8 0.i256;
-        jump block2;
+        evm_invalid;
 
     block2:
-        evm_stop;
-
-    block3:
         v9.i256 = evm_calldata_load 4.i256;
         v11.i256 = evm_calldata_load 36.i256;
         v13.i256 = call %allowance__StorPtr_Erc20___2745299687a147d4 v9 v11 v1;
         call %abi_encode_u256__Evm_hef0af3106e109414__3af54274b2985741 v13 0.i256;
-        jump block2;
+        evm_invalid;
+
+    block3:
+        call %abi_encode_string__Evm_hef0af3106e109414__3af54274b2985741 31840933704928615426292613906591192052886564858731089189578963311002547912704.i256 7.i256 0.i256;
+        evm_invalid;
 
     block4:
-        call %abi_encode_string__Evm_hef0af3106e109414__3af54274b2985741 31840933704928615426292613906591192052886564858731089189578963311002547912704.i256 7.i256 0.i256;
-        jump block2;
+        call %abi_encode_string__Evm_hef0af3106e109414__3af54274b2985741 31784391594991486112232083260356792451358613714049171750120207607087736291328.i256 3.i256 0.i256;
+        evm_invalid;
 
     block5:
-        call %abi_encode_string__Evm_hef0af3106e109414__3af54274b2985741 31784391594991486112232083260356792451358613714049171750120207607087736291328.i256 3.i256 0.i256;
-        jump block2;
+        call %abi_encode_u256__Evm_hef0af3106e109414__3af54274b2985741 18.i256 0.i256;
+        evm_invalid;
 
     block6:
-        call %abi_encode_u256__Evm_hef0af3106e109414__3af54274b2985741 18.i256 0.i256;
-        jump block2;
-
-    block7:
         v19.i256 = evm_calldata_load 4.i256;
         v20.i256 = evm_calldata_load 36.i256;
         v22.i256 = call %transfer__StorPtr_Erc20__Evm_hef0af3106e109414_Evm_hef0af3106e109414__a43599a61c4c3ec5 v19 v20 v1 0.i256 0.i256;
         call %abi_encode_u256__Evm_hef0af3106e109414__3af54274b2985741 v22 0.i256;
-        jump block2;
+        evm_invalid;
 
-    block8:
+    block7:
         v23.i256 = evm_calldata_load 4.i256;
         v24.i256 = evm_calldata_load 36.i256;
         v26.i256 = call %approve__StorPtr_Erc20__Evm_hef0af3106e109414__cb64805ecdbd6d6e v23 v24 v1 0.i256;
         call %abi_encode_u256__Evm_hef0af3106e109414__3af54274b2985741 v26 0.i256;
-        jump block2;
+        evm_invalid;
 
-    block9:
+    block8:
         v27.i256 = evm_calldata_load 4.i256;
         v28.i256 = evm_calldata_load 36.i256;
         v30.i256 = evm_calldata_load 68.i256;
         v32.i256 = call %transfer_from__StorPtr_Erc20__Evm_hef0af3106e109414_Evm_hef0af3106e109414__a43599a61c4c3ec5 v27 v28 v30 v1 0.i256 0.i256;
         call %abi_encode_u256__Evm_hef0af3106e109414__3af54274b2985741 v32 0.i256;
-        jump block2;
+        evm_invalid;
 
-    block10:
+    block9:
         v33.i256 = evm_calldata_load 4.i256;
         v34.i256 = evm_calldata_load 36.i256;
         v36.i256 = call %mint__StorPtr_Erc20__Evm_hef0af3106e109414_Evm_hef0af3106e109414__a43599a61c4c3ec5 v33 v34 v1 0.i256 0.i256;
         call %abi_encode_u256__Evm_hef0af3106e109414__3af54274b2985741 v36 0.i256;
-        jump block2;
+        evm_invalid;
 
-    block11:
+    block10:
         evm_revert 0.i256 0.i256;
 
-    block12:
+    block11:
         v47.i1 = eq v4 1889567281.i256;
-        br v47 block1 block13;
+        br v47 block1 block12;
+
+    block12:
+        v48.i1 = eq v4 3714247998.i256;
+        br v48 block2 block13;
 
     block13:
-        v48.i1 = eq v4 3714247998.i256;
-        br v48 block3 block14;
+        v49.i1 = eq v4 117300739.i256;
+        br v49 block3 block14;
 
     block14:
-        v49.i1 = eq v4 117300739.i256;
-        br v49 block4 block15;
+        v50.i1 = eq v4 2514000705.i256;
+        br v50 block4 block15;
 
     block15:
-        v50.i1 = eq v4 2514000705.i256;
-        br v50 block5 block16;
+        v51.i1 = eq v4 826074471.i256;
+        br v51 block5 block16;
 
     block16:
-        v51.i1 = eq v4 826074471.i256;
-        br v51 block6 block17;
+        v52.i1 = eq v4 2835717307.i256;
+        br v52 block6 block17;
 
     block17:
-        v52.i1 = eq v4 2835717307.i256;
-        br v52 block7 block18;
+        v53.i1 = eq v4 157198259.i256;
+        br v53 block7 block18;
 
     block18:
-        v53.i1 = eq v4 157198259.i256;
-        br v53 block8 block19;
+        v54.i1 = eq v4 599290589.i256;
+        br v54 block8 block19;
 
     block19:
-        v54.i1 = eq v4 599290589.i256;
-        br v54 block9 block20;
-
-    block20:
         v55.i1 = eq v4 1086394137.i256;
-        br v55 block10 block11;
+        br v55 block9 block10;
 }
 
 func private %erc20_h7a8a7a2800ba6809_balance_of(v0.i256, v1.i256) -> i256 {

--- a/crates/codegen/tests/fixtures/sonatina_ir/nested_struct.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/nested_struct.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/codegen/tests/sonatina_ir.rs
-assertion_line: 64
 expression: output
 input_file: crates/codegen/tests/fixtures/nested_struct.fe
 ---
@@ -42,42 +41,39 @@ func private %runtime__StorPtr_Evm___207f35a85ac4062e() {
         v1.i256 = call %stor_ptr__Evm_hef0af3106e109414_Outer_hccd04e332bd35653__177c3c9a6f7ae368 0.i256 0.i256;
         v2.i256 = evm_calldata_load 0.i256;
         v4.i256 = shr 224.i256 v2;
-        jump block6;
+        jump block5;
 
     block1:
         v6.i256 = evm_calldata_load 4.i256;
         call %write_inner__StorPtr_Outer___dab28b9da6c3e28 v6 v1;
         call %abi_encode__Evm_hef0af3106e109414__3af54274b2985741 v6 0.i256;
-        jump block2;
+        evm_invalid;
 
     block2:
-        evm_stop;
-
-    block3:
         v9.i256 = call %read_inner__StorPtr_Outer___dab28b9da6c3e28 v1;
         call %abi_encode__Evm_hef0af3106e109414__3af54274b2985741 v9 0.i256;
-        jump block2;
+        evm_invalid;
 
-    block4:
+    block3:
         v10.i256 = evm_calldata_load 4.i256;
         v11.i256 = call %mem_read v10;
         call %abi_encode__Evm_hef0af3106e109414__3af54274b2985741 v11 0.i256;
-        jump block2;
+        evm_invalid;
 
-    block5:
+    block4:
         evm_return 0.i256 0.i256;
 
-    block6:
+    block5:
         v16.i1 = eq v4 3091856072.i256;
-        br v16 block1 block7;
+        br v16 block1 block6;
+
+    block6:
+        v17.i1 = eq v4 3513050253.i256;
+        br v17 block2 block7;
 
     block7:
-        v17.i1 = eq v4 3513050253.i256;
-        br v17 block3 block8;
-
-    block8:
         v18.i1 = eq v4 2154770637.i256;
-        br v18 block4 block5;
+        br v18 block3 block4;
 }
 
 func private %stor_ptr__Evm_hef0af3106e109414_Outer_hccd04e332bd35653__177c3c9a6f7ae368(v0.i256, v1.i256) -> i256 {

--- a/crates/codegen/tests/fixtures/sonatina_ir/storage.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/storage.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/codegen/tests/sonatina_ir.rs
-assertion_line: 64
 expression: output
 input_file: crates/codegen/tests/fixtures/storage.fe
 ---
@@ -255,7 +254,7 @@ func private %runtime__StorPtr_Evm___207f35a85ac4062e() {
         v3.i256 = call %stor_ptr__Evm_hef0af3106e109414_TotalSupply_hddb16bb19b5b088e__f5679b0709de743a 0.i256 2.i256;
         v4.i256 = evm_calldata_load 0.i256;
         v6.i256 = shr 224.i256 v4;
-        jump block15;
+        jump block14;
 
     block1:
         v8.i256 = evm_calldata_load 4.i256;
@@ -269,7 +268,7 @@ func private %runtime__StorPtr_Evm___207f35a85ac4062e() {
     block3:
         v15.i256 = phi (v14 block2) (v19 block4);
         call %abi_encode__Evm_hef0af3106e109414__3af54274b2985741 v15 0.i256;
-        jump block6;
+        evm_invalid;
 
     block4:
         v19.i256 = call %credit_bob__StorPtr_CoinStore__StorPtr_TotalSupply___c407f5b00af9ba78 v10 v1 v3;
@@ -280,60 +279,57 @@ func private %runtime__StorPtr_Evm___207f35a85ac4062e() {
         br v21 block2 block4;
 
     block6:
-        evm_stop;
-
-    block7:
         v22.i256 = evm_calldata_load 4.i256;
         v24.i256 = call %balance_of_raw__StorPtr_CoinStore___ba1c0d0726e89ba2 v22 v1;
         call %abi_encode__Evm_hef0af3106e109414__3af54274b2985741 v24 0.i256;
-        jump block6;
+        evm_invalid;
 
-    block8:
+    block7:
         v25.i256 = evm_calldata_load 4.i256;
         v26.i256 = evm_calldata_load 36.i256;
-        jump block12;
+        jump block11;
+
+    block8:
+        v29.i256 = call %transfer_from_alice__StorPtr_CoinStore___ba1c0d0726e89ba2 v26 v1;
+        jump block9;
 
     block9:
-        v29.i256 = call %transfer_from_alice__StorPtr_CoinStore___ba1c0d0726e89ba2 v26 v1;
-        jump block10;
-
-    block10:
-        v30.i256 = phi (v29 block9) (v34 block11);
+        v30.i256 = phi (v29 block8) (v34 block10);
         v31.i256 = call %transfer_result_code v30;
         call %abi_encode__Evm_hef0af3106e109414__3af54274b2985741 v31 0.i256;
-        jump block6;
+        evm_invalid;
+
+    block10:
+        v34.i256 = call %transfer_from_bob__StorPtr_CoinStore___ba1c0d0726e89ba2 v26 v1;
+        jump block9;
 
     block11:
-        v34.i256 = call %transfer_from_bob__StorPtr_CoinStore___ba1c0d0726e89ba2 v26 v1;
-        jump block10;
+        v36.i1 = eq v25 0.i256;
+        br v36 block8 block10;
 
     block12:
-        v36.i1 = eq v25 0.i256;
-        br v36 block9 block11;
-
-    block13:
         v38.i256 = call %total_supply__StorPtr_TotalSupply___2e654c25952f42f9 v3;
         call %abi_encode__Evm_hef0af3106e109414__3af54274b2985741 v38 0.i256;
-        jump block6;
+        evm_invalid;
 
-    block14:
+    block13:
         evm_return 0.i256 0.i256;
 
-    block15:
+    block14:
         v44.i1 = eq v6 2877082652.i256;
-        br v44 block1 block16;
+        br v44 block1 block15;
+
+    block15:
+        v45.i1 = eq v6 1818602213.i256;
+        br v45 block6 block16;
 
     block16:
-        v45.i1 = eq v6 1818602213.i256;
-        br v45 block7 block17;
+        v46.i1 = eq v6 217554442.i256;
+        br v46 block7 block17;
 
     block17:
-        v46.i1 = eq v6 217554442.i256;
-        br v46 block8 block18;
-
-    block18:
         v47.i1 = eq v6 960555502.i256;
-        br v47 block13 block14;
+        br v47 block12 block13;
 }
 
 func private %stor_ptr__Evm_hef0af3106e109414_CoinStore_hd26a92ca525e0e79__b6feb5585dda62f1(v0.i256, v1.i256) -> i256 {

--- a/crates/codegen/tests/fixtures/sonatina_ir/storage_map_contract.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/storage_map_contract.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/codegen/tests/sonatina_ir.rs
-assertion_line: 64
 expression: output
 input_file: crates/codegen/tests/fixtures/storage_map_contract.fe
 ---
@@ -70,67 +69,64 @@ func private %runtime__StorPtr_Evm___207f35a85ac4062e() {
         call %storagemap_k__v__const_salt__u256__h5955888dd44c2a19_new__u256_u256_1__3c02c0f2b86be0bb;
         v1.i256 = evm_calldata_load 0.i256;
         v3.i256 = shr 224.i256 v1;
-        jump block8;
+        jump block7;
 
     block1:
         v5.i256 = evm_calldata_load 4.i256;
         v6.i256 = call %get_balance__MemPtr_StorageMap_u256__u256__0____3cd7ace0c4584833 v5 0.i256;
         call %abi_encode__Evm_hef0af3106e109414__3af54274b2985741 v6 0.i256;
-        jump block2;
+        evm_invalid;
 
     block2:
-        evm_stop;
-
-    block3:
         v7.i256 = evm_calldata_load 4.i256;
         v9.i256 = evm_calldata_load 36.i256;
         call %set_balance__MemPtr_StorageMap_u256__u256__0____3cd7ace0c4584833 v7 v9 0.i256;
         call %abi_encode__Evm_hef0af3106e109414__3af54274b2985741 0.i256 0.i256;
-        jump block2;
+        evm_invalid;
 
-    block4:
+    block3:
         v10.i256 = evm_calldata_load 4.i256;
         v11.i256 = evm_calldata_load 36.i256;
         v13.i256 = evm_calldata_load 68.i256;
         v14.i256 = call %transfer__MemPtr_StorageMap_u256__u256__0____3cd7ace0c4584833 v10 v11 v13 0.i256;
         call %abi_encode__Evm_hef0af3106e109414__3af54274b2985741 v14 0.i256;
-        jump block2;
+        evm_invalid;
 
-    block5:
+    block4:
         v15.i256 = evm_calldata_load 4.i256;
         v16.i256 = call %get_allowance__MemPtr_StorageMap_u256__u256__1____e8f0bd5888eece94 v15 0.i256;
         call %abi_encode__Evm_hef0af3106e109414__3af54274b2985741 v16 0.i256;
-        jump block2;
+        evm_invalid;
 
-    block6:
+    block5:
         v17.i256 = evm_calldata_load 4.i256;
         v18.i256 = evm_calldata_load 36.i256;
         call %set_allowance__MemPtr_StorageMap_u256__u256__1____e8f0bd5888eece94 v17 v18 0.i256;
         call %abi_encode__Evm_hef0af3106e109414__3af54274b2985741 0.i256 0.i256;
-        jump block2;
+        evm_invalid;
 
-    block7:
+    block6:
         evm_return 0.i256 0.i256;
 
-    block8:
+    block7:
         v25.i1 = eq v3 2630350600.i256;
-        br v25 block1 block9;
+        br v25 block1 block8;
+
+    block8:
+        v26.i1 = eq v3 1246470123.i256;
+        br v26 block2 block9;
 
     block9:
-        v26.i1 = eq v3 1246470123.i256;
-        br v26 block3 block10;
+        v27.i1 = eq v3 2430412327.i256;
+        br v27 block3 block10;
 
     block10:
-        v27.i1 = eq v3 2430412327.i256;
-        br v27 block4 block11;
+        v28.i1 = eq v3 3378517838.i256;
+        br v28 block4 block11;
 
     block11:
-        v28.i1 = eq v3 3378517838.i256;
-        br v28 block5 block12;
-
-    block12:
         v29.i1 = eq v3 197806145.i256;
-        br v29 block6 block7;
+        br v29 block5 block6;
 }
 
 func public %storagemap_k__v__const_salt__u256__h5955888dd44c2a19_get_stor__u256_u256_0__6a346ad3c930d971(v0.i256, v1.i256) -> i256 {

--- a/crates/codegen/tests/fixtures/storage.snap
+++ b/crates/codegen/tests/fixtures/storage.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/codegen/tests/yul.rs
-assertion_line: 33
 expression: output
 input_file: tests/fixtures/storage.fe
 ---
@@ -107,7 +106,6 @@ object "Coin" {
           default {
             return(0, 0)
           }
-        leave
       }
       function $stor_ptr__Evm_hef0af3106e109414_CoinStore_hd26a92ca525e0e79__b6feb5585dda62f1($self, $slot) -> ret {
         let v0 := $storptr_t__hc45dea9607fd5340_effecthandle_hfc52f915596f993a_from_raw__CoinStore_hd26a92ca525e0e79__a9c0a742c4f0cede($slot)

--- a/crates/codegen/tests/fixtures/storage_map_contract.snap
+++ b/crates/codegen/tests/fixtures/storage_map_contract.snap
@@ -87,7 +87,6 @@ object "BalanceMap" {
           default {
             return(0, 0)
           }
-        leave
       }
       function $set_allowance__MemPtr_StorageMap_u256__u256__1____e8f0bd5888eece94($addr, $value, $allowances) {
         $storagemap_k__v__const_salt__u256__h5955888dd44c2a19_set__u256_u256_1__3c02c0f2b86be0bb($allowances, $addr, $value)

--- a/crates/fe/tests/fixtures/fe_test/reentrancy_tstor_ptr.fe
+++ b/crates/fe/tests/fixtures/fe_test/reentrancy_tstor_ptr.fe
@@ -39,7 +39,6 @@ pub contract A uses (ctx: Ctx, call: mut Call) {
                 value: 0,
                 message: BMsg::Protected {},
             )
-            ()
         }
     }
 }

--- a/crates/hir/src/analysis/ty/ty_check/expr.rs
+++ b/crates/hir/src/analysis/ty/ty_check/expr.rs
@@ -228,7 +228,13 @@ impl<'db> TyChecker<'db> {
             }
 
             let last_stmt = stmts[stmts.len() - 1];
-            let res = self.check_stmt(last_stmt, expected);
+            let res = if expected == TyId::unit(self.db) {
+                let ty = self.fresh_ty();
+                self.check_stmt(last_stmt, ty);
+                TyId::unit(self.db)
+            } else {
+                self.check_stmt(last_stmt, expected)
+            };
             self.env.leave_scope();
             ExprProp::new(res, true)
         }

--- a/crates/hir/test_files/ty_check/effect_ambiguous_generic.fe
+++ b/crates/hir/test_files/ty_check/effect_ambiguous_generic.fe
@@ -6,7 +6,6 @@ pub struct Storage<T> {
 pub fn process()
   uses (st: Storage<u8>)
 {
-    ()
 }
 
 pub fn ambiguous_effects() {

--- a/crates/hir/test_files/ty_check/effect_ambiguous_generic.snap
+++ b/crates/hir/test_files/ty_check/effect_ambiguous_generic.snap
@@ -1,129 +1,123 @@
 ---
-source: crates/hir-analysis/tests/ty_check.rs
+source: crates/hir/tests/ty_check.rs
+assertion_line: 40
 expression: res
 input_file: test_files/ty_check/effect_ambiguous_generic.fe
 ---
 note: 
-   ┌─ effect_ambiguous_generic.fe:8:1
-   │  
- 8 │ ╭ {
- 9 │ │     ()
-10 │ │ }
-   │ ╰─^ ()
+  ┌─ effect_ambiguous_generic.fe:8:1
+  │  
+8 │ ╭ {
+9 │ │ }
+  │ ╰─^ ()
 
 note: 
-  ┌─ effect_ambiguous_generic.fe:9:5
-  │
-9 │     ()
-  │     ^^ ()
-
-note: 
-   ┌─ effect_ambiguous_generic.fe:12:28
+   ┌─ effect_ambiguous_generic.fe:11:28
    │  
-12 │   pub fn ambiguous_effects() {
+11 │   pub fn ambiguous_effects() {
    │ ╭────────────────────────────^
-13 │ │     let st1 = Storage<u8> { value: 1 }
-14 │ │     let st2 = Storage<u8> { value: 2 }
-15 │ │ 
+12 │ │     let st1 = Storage<u8> { value: 1 }
+13 │ │     let st2 = Storage<u8> { value: 2 }
+14 │ │ 
    · │
-22 │ │     }
-23 │ │ }
+21 │ │     }
+22 │ │ }
    │ ╰─^ ()
+
+note: 
+   ┌─ effect_ambiguous_generic.fe:12:9
+   │
+12 │     let st1 = Storage<u8> { value: 1 }
+   │         ^^^ Storage<u8>
+
+note: 
+   ┌─ effect_ambiguous_generic.fe:12:15
+   │
+12 │     let st1 = Storage<u8> { value: 1 }
+   │               ^^^^^^^^^^^^^^^^^^^^^^^^ Storage<u8>
+
+note: 
+   ┌─ effect_ambiguous_generic.fe:12:36
+   │
+12 │     let st1 = Storage<u8> { value: 1 }
+   │                                    ^ u8
 
 note: 
    ┌─ effect_ambiguous_generic.fe:13:9
    │
-13 │     let st1 = Storage<u8> { value: 1 }
+13 │     let st2 = Storage<u8> { value: 2 }
    │         ^^^ Storage<u8>
 
 note: 
    ┌─ effect_ambiguous_generic.fe:13:15
    │
-13 │     let st1 = Storage<u8> { value: 1 }
+13 │     let st2 = Storage<u8> { value: 2 }
    │               ^^^^^^^^^^^^^^^^^^^^^^^^ Storage<u8>
 
 note: 
    ┌─ effect_ambiguous_generic.fe:13:36
    │
-13 │     let st1 = Storage<u8> { value: 1 }
+13 │     let st2 = Storage<u8> { value: 2 }
    │                                    ^ u8
 
 note: 
-   ┌─ effect_ambiguous_generic.fe:14:9
-   │
-14 │     let st2 = Storage<u8> { value: 2 }
-   │         ^^^ Storage<u8>
-
-note: 
-   ┌─ effect_ambiguous_generic.fe:14:15
-   │
-14 │     let st2 = Storage<u8> { value: 2 }
-   │               ^^^^^^^^^^^^^^^^^^^^^^^^ Storage<u8>
-
-note: 
-   ┌─ effect_ambiguous_generic.fe:14:36
-   │
-14 │     let st2 = Storage<u8> { value: 2 }
-   │                                    ^ u8
-
-note: 
-   ┌─ effect_ambiguous_generic.fe:18:5
+   ┌─ effect_ambiguous_generic.fe:17:5
    │  
-18 │ ╭     with (Storage = st1) {
-19 │ │         with (Storage = st2) {
-20 │ │             process()  // should use st2
-21 │ │         }
-22 │ │     }
+17 │ ╭     with (Storage = st1) {
+18 │ │         with (Storage = st2) {
+19 │ │             process()  // should use st2
+20 │ │         }
+21 │ │     }
    │ ╰─────^ ()
 
 note: 
-   ┌─ effect_ambiguous_generic.fe:18:21
+   ┌─ effect_ambiguous_generic.fe:17:21
    │
-18 │     with (Storage = st1) {
+17 │     with (Storage = st1) {
    │                     ^^^ Storage<u8>
 
 note: 
-   ┌─ effect_ambiguous_generic.fe:18:26
+   ┌─ effect_ambiguous_generic.fe:17:26
    │  
-18 │       with (Storage = st1) {
+17 │       with (Storage = st1) {
    │ ╭──────────────────────────^
-19 │ │         with (Storage = st2) {
-20 │ │             process()  // should use st2
-21 │ │         }
-22 │ │     }
+18 │ │         with (Storage = st2) {
+19 │ │             process()  // should use st2
+20 │ │         }
+21 │ │     }
    │ ╰─────^ ()
 
 note: 
-   ┌─ effect_ambiguous_generic.fe:19:9
+   ┌─ effect_ambiguous_generic.fe:18:9
    │  
-19 │ ╭         with (Storage = st2) {
-20 │ │             process()  // should use st2
-21 │ │         }
+18 │ ╭         with (Storage = st2) {
+19 │ │             process()  // should use st2
+20 │ │         }
    │ ╰─────────^ ()
 
 note: 
-   ┌─ effect_ambiguous_generic.fe:19:25
+   ┌─ effect_ambiguous_generic.fe:18:25
    │
-19 │         with (Storage = st2) {
+18 │         with (Storage = st2) {
    │                         ^^^ Storage<u8>
 
 note: 
-   ┌─ effect_ambiguous_generic.fe:19:30
+   ┌─ effect_ambiguous_generic.fe:18:30
    │  
-19 │           with (Storage = st2) {
+18 │           with (Storage = st2) {
    │ ╭──────────────────────────────^
-20 │ │             process()  // should use st2
-21 │ │         }
+19 │ │             process()  // should use st2
+20 │ │         }
    │ ╰─────────^ ()
 
 note: 
-   ┌─ effect_ambiguous_generic.fe:20:13
+   ┌─ effect_ambiguous_generic.fe:19:13
    │
-20 │             process()  // should use st2
+19 │             process()  // should use st2
    │             ^^^^^^^ fn process
 
 note: 
-   ┌─ effect_ambiguous_generic.fe:20:13
+   ┌─ effect_ambiguous_generic.fe:19:13
    │
-20 │             process()  // should use st2
+19 │             process()  // should use st2
    │             ^^^^^^^^^ ()

--- a/crates/hir/test_files/ty_check/effect_trait_generic_instantiation.fe
+++ b/crates/hir/test_files/ty_check/effect_trait_generic_instantiation.fe
@@ -9,7 +9,6 @@ impl Ctx<u16> for CtxU16 {}
 pub fn needs_ctx<T>()
   uses Ctx<T>
 {
-    ()
 }
 
 pub fn ok() {

--- a/crates/hir/test_files/ty_check/effect_trait_generic_instantiation.snap
+++ b/crates/hir/test_files/ty_check/effect_trait_generic_instantiation.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/hir/tests/ty_check.rs
+assertion_line: 40
 expression: res
 input_file: test_files/ty_check/effect_trait_generic_instantiation.fe
 ---
@@ -7,64 +8,57 @@ note:
    ┌─ effect_trait_generic_instantiation.fe:11:1
    │  
 11 │ ╭ {
-12 │ │     ()
-13 │ │ }
+12 │ │ }
    │ ╰─^ ()
 
 note: 
-   ┌─ effect_trait_generic_instantiation.fe:12:5
-   │
-12 │     ()
-   │     ^^ ()
-
-note: 
-   ┌─ effect_trait_generic_instantiation.fe:15:13
+   ┌─ effect_trait_generic_instantiation.fe:14:13
    │  
-15 │   pub fn ok() {
+14 │   pub fn ok() {
    │ ╭─────────────^
-16 │ │     with (Ctx<u8> = CtxU8 {}, Ctx<u16> = CtxU16 {}) {
-17 │ │         needs_ctx<u16>()
-18 │ │     }
-19 │ │ }
+15 │ │     with (Ctx<u8> = CtxU8 {}, Ctx<u16> = CtxU16 {}) {
+16 │ │         needs_ctx<u16>()
+17 │ │     }
+18 │ │ }
    │ ╰─^ ()
 
 note: 
-   ┌─ effect_trait_generic_instantiation.fe:16:5
+   ┌─ effect_trait_generic_instantiation.fe:15:5
    │  
-16 │ ╭     with (Ctx<u8> = CtxU8 {}, Ctx<u16> = CtxU16 {}) {
-17 │ │         needs_ctx<u16>()
-18 │ │     }
+15 │ ╭     with (Ctx<u8> = CtxU8 {}, Ctx<u16> = CtxU16 {}) {
+16 │ │         needs_ctx<u16>()
+17 │ │     }
    │ ╰─────^ ()
 
 note: 
-   ┌─ effect_trait_generic_instantiation.fe:16:21
+   ┌─ effect_trait_generic_instantiation.fe:15:21
    │
-16 │     with (Ctx<u8> = CtxU8 {}, Ctx<u16> = CtxU16 {}) {
+15 │     with (Ctx<u8> = CtxU8 {}, Ctx<u16> = CtxU16 {}) {
    │                     ^^^^^^^^ CtxU8
 
 note: 
-   ┌─ effect_trait_generic_instantiation.fe:16:42
+   ┌─ effect_trait_generic_instantiation.fe:15:42
    │
-16 │     with (Ctx<u8> = CtxU8 {}, Ctx<u16> = CtxU16 {}) {
+15 │     with (Ctx<u8> = CtxU8 {}, Ctx<u16> = CtxU16 {}) {
    │                                          ^^^^^^^^^ CtxU16
 
 note: 
-   ┌─ effect_trait_generic_instantiation.fe:16:53
+   ┌─ effect_trait_generic_instantiation.fe:15:53
    │  
-16 │       with (Ctx<u8> = CtxU8 {}, Ctx<u16> = CtxU16 {}) {
+15 │       with (Ctx<u8> = CtxU8 {}, Ctx<u16> = CtxU16 {}) {
    │ ╭─────────────────────────────────────────────────────^
-17 │ │         needs_ctx<u16>()
-18 │ │     }
+16 │ │         needs_ctx<u16>()
+17 │ │     }
    │ ╰─────^ ()
 
 note: 
-   ┌─ effect_trait_generic_instantiation.fe:17:9
+   ┌─ effect_trait_generic_instantiation.fe:16:9
    │
-17 │         needs_ctx<u16>()
+16 │         needs_ctx<u16>()
    │         ^^^^^^^^^^^^^^ fn needs_ctx<u16>
 
 note: 
-   ┌─ effect_trait_generic_instantiation.fe:17:9
+   ┌─ effect_trait_generic_instantiation.fe:16:9
    │
-17 │         needs_ctx<u16>()
+16 │         needs_ctx<u16>()
    │         ^^^^^^^^^^^^^^^^ ()

--- a/crates/hir/test_files/ty_check/effects_generic_type_nested.fe
+++ b/crates/hir/test_files/ty_check/effects_generic_type_nested.fe
@@ -40,6 +40,5 @@ pub fn mutable_storage() {
     with (Storage<u8> = storage) {
         write_u8(val: 20)
         let _ = read_u8()
-        ()
     }
 }

--- a/crates/hir/test_files/ty_check/effects_generic_type_nested.snap
+++ b/crates/hir/test_files/ty_check/effects_generic_type_nested.snap
@@ -1,5 +1,6 @@
 ---
-source: crates/hir-analysis/tests/ty_check.rs
+source: crates/hir/tests/ty_check.rs
+assertion_line: 40
 expression: res
 input_file: test_files/ty_check/effects_generic_type_nested.fe
 ---
@@ -268,9 +269,9 @@ note:
 39 │ │     let mut storage = Storage<u8> { value: 10 }
 40 │ │     with (Storage<u8> = storage) {
 41 │ │         write_u8(val: 20)
-   · │
-44 │ │     }
-45 │ │ }
+42 │ │         let _ = read_u8()
+43 │ │     }
+44 │ │ }
    │ ╰─^ ()
 
 note: 
@@ -297,8 +298,7 @@ note:
 40 │ ╭     with (Storage<u8> = storage) {
 41 │ │         write_u8(val: 20)
 42 │ │         let _ = read_u8()
-43 │ │         ()
-44 │ │     }
+43 │ │     }
    │ ╰─────^ ()
 
 note: 
@@ -314,8 +314,7 @@ note:
    │ ╭──────────────────────────────────^
 41 │ │         write_u8(val: 20)
 42 │ │         let _ = read_u8()
-43 │ │         ()
-44 │ │     }
+43 │ │     }
    │ ╰─────^ ()
 
 note: 
@@ -353,9 +352,3 @@ note:
    │
 42 │         let _ = read_u8()
    │                 ^^^^^^^^^ u8
-
-note: 
-   ┌─ effects_generic_type_nested.fe:43:9
-   │
-43 │         ()
-   │         ^^ ()

--- a/crates/hir/test_files/ty_check/effects_super.fe
+++ b/crates/hir/test_files/ty_check/effects_super.fe
@@ -38,7 +38,6 @@ fn example() {
     with (r) {
         do_stuff(10)
     }
-    ()
 }
 
 fn do_stuff(x: u256) -> u256

--- a/crates/hir/test_files/ty_check/effects_super.snap
+++ b/crates/hir/test_files/ty_check/effects_super.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/hir/tests/ty_check.rs
+assertion_line: 40
 expression: res
 input_file: test_files/ty_check/effects_super.fe
 ---
@@ -73,8 +74,7 @@ note:
 38 │ │     with (r) {
 39 │ │         do_stuff(10)
 40 │ │     }
-41 │ │     ()
-42 │ │ }
+41 │ │ }
    │ ╰─^ ()
 
 note: 
@@ -131,89 +131,83 @@ note:
    │                  ^^ u256
 
 note: 
-   ┌─ effects_super.fe:41:5
-   │
-41 │     ()
-   │     ^^ ()
-
-note: 
-   ┌─ effects_super.fe:46:1
+   ┌─ effects_super.fe:45:1
    │  
-46 │ ╭ {
-47 │ │     mem.store(offset: x, value: ctx.caller())
-48 │ │     sto.store(slot: x, value: 100)
-49 │ │     sto.load(slot: x)
-50 │ │ }
+45 │ ╭ {
+46 │ │     mem.store(offset: x, value: ctx.caller())
+47 │ │     sto.store(slot: x, value: 100)
+48 │ │     sto.load(slot: x)
+49 │ │ }
    │ ╰─^ u256
 
 note: 
-   ┌─ effects_super.fe:47:5
+   ┌─ effects_super.fe:46:5
    │
-47 │     mem.store(offset: x, value: ctx.caller())
+46 │     mem.store(offset: x, value: ctx.caller())
    │     ^^^ __effprov1
 
 note: 
-   ┌─ effects_super.fe:47:5
+   ┌─ effects_super.fe:46:5
    │
-47 │     mem.store(offset: x, value: ctx.caller())
+46 │     mem.store(offset: x, value: ctx.caller())
    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ()
 
 note: 
-   ┌─ effects_super.fe:47:23
+   ┌─ effects_super.fe:46:23
    │
-47 │     mem.store(offset: x, value: ctx.caller())
+46 │     mem.store(offset: x, value: ctx.caller())
    │                       ^ u256
 
 note: 
-   ┌─ effects_super.fe:47:33
+   ┌─ effects_super.fe:46:33
    │
-47 │     mem.store(offset: x, value: ctx.caller())
+46 │     mem.store(offset: x, value: ctx.caller())
    │                                 ^^^ __effprov0
 
 note: 
-   ┌─ effects_super.fe:47:33
+   ┌─ effects_super.fe:46:33
    │
-47 │     mem.store(offset: x, value: ctx.caller())
+46 │     mem.store(offset: x, value: ctx.caller())
    │                                 ^^^^^^^^^^^^ u256
 
 note: 
-   ┌─ effects_super.fe:48:5
+   ┌─ effects_super.fe:47:5
    │
-48 │     sto.store(slot: x, value: 100)
+47 │     sto.store(slot: x, value: 100)
    │     ^^^ __effprov2
 
 note: 
-   ┌─ effects_super.fe:48:5
+   ┌─ effects_super.fe:47:5
    │
-48 │     sto.store(slot: x, value: 100)
+47 │     sto.store(slot: x, value: 100)
    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ()
 
 note: 
-   ┌─ effects_super.fe:48:21
+   ┌─ effects_super.fe:47:21
    │
-48 │     sto.store(slot: x, value: 100)
+47 │     sto.store(slot: x, value: 100)
    │                     ^ u256
 
 note: 
-   ┌─ effects_super.fe:48:31
+   ┌─ effects_super.fe:47:31
    │
-48 │     sto.store(slot: x, value: 100)
+47 │     sto.store(slot: x, value: 100)
    │                               ^^^ u256
 
 note: 
-   ┌─ effects_super.fe:49:5
+   ┌─ effects_super.fe:48:5
    │
-49 │     sto.load(slot: x)
+48 │     sto.load(slot: x)
    │     ^^^ __effprov2
 
 note: 
-   ┌─ effects_super.fe:49:5
+   ┌─ effects_super.fe:48:5
    │
-49 │     sto.load(slot: x)
+48 │     sto.load(slot: x)
    │     ^^^^^^^^^^^^^^^^^ u256
 
 note: 
-   ┌─ effects_super.fe:49:20
+   ┌─ effects_super.fe:48:20
    │
-49 │     sto.load(slot: x)
+48 │     sto.load(slot: x)
    │                    ^ u256

--- a/crates/uitest/fixtures/mir_check/borrowck_terminating_call_read_under_mut.snap
+++ b/crates/uitest/fixtures/mir_check/borrowck_terminating_call_read_under_mut.snap
@@ -4,9 +4,9 @@ expression: res
 input_file: fixtures/mir_check/borrowck_terminating_call_read_under_mut.fe
 ---
 error[11-0002]: borrow conflict in `fn borrowck_terminating_call_read_under_mut`
-  ┌─ borrowck_terminating_call_read_under_mut.fe:8:9
-  │
-8 │     let mut x: u256 = 0
-  │         ^^^^^ access overlaps an active `mut` borrow
-9 │     let p: mut u256 = mut x
-  │                           - `x` is borrowed here
+   ┌─ borrowck_terminating_call_read_under_mut.fe:10:5
+   │
+ 9 │     let p: mut u256 = mut x
+   │                           - `x` is borrowed here
+10 │     trap(p, x)
+   │     ^^^^^^^^^^ access overlaps an active `mut` borrow

--- a/crates/uitest/fixtures/ty/const_ty/const_generic_impl_target_array.fe
+++ b/crates/uitest/fixtures/ty/const_ty/const_generic_impl_target_array.fe
@@ -24,5 +24,4 @@ fn use_seq() {
     let second: ref u256 = borrowed.get(1)
     first
     second
-    ()
 }

--- a/crates/uitest/fixtures/ty_check/arg_count_mismatch.fe
+++ b/crates/uitest/fixtures/ty_check/arg_count_mismatch.fe
@@ -7,7 +7,6 @@ fn f() {
     add(1)
     add(1, 2)
     add(1, 2, 3)
-    ()
 }
 
 struct Adder {
@@ -23,5 +22,4 @@ fn g() {
     let a = Adder{ x: 10 }
     a.add(1)
     a.add(1, 2)
-    ()
 }

--- a/crates/uitest/fixtures/ty_check/arg_count_mismatch.snap
+++ b/crates/uitest/fixtures/ty_check/arg_count_mismatch.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/uitest/tests/ty_check.rs
+assertion_line: 27
 expression: diags
 input_file: fixtures/ty_check/arg_count_mismatch.fe
 ---
@@ -22,12 +23,12 @@ error[8-0023]: argument number mismatch
   │        ^^^^^^^^^ expected 2 arguments, but 3 given
 
 error[8-0033]: `add` is not a method
-   ┌─ arg_count_mismatch.fe:24:5
+   ┌─ arg_count_mismatch.fe:23:5
    │
-17 │     fn add(_ a: usize, _ b: usize) -> usize {
+16 │     fn add(_ a: usize, _ b: usize) -> usize {
    │        --- function defined here
    ·
-24 │     a.add(1)
+23 │     a.add(1)
    │     ^^^^^^^^
    │     │ │
    │     │ `add` is an associated function, not a method
@@ -36,12 +37,12 @@ error[8-0033]: `add` is not a method
    = note: to be used as a method, a function must have a `self` parameter
 
 error[8-0033]: `add` is not a method
-   ┌─ arg_count_mismatch.fe:25:5
+   ┌─ arg_count_mismatch.fe:24:5
    │
-17 │     fn add(_ a: usize, _ b: usize) -> usize {
+16 │     fn add(_ a: usize, _ b: usize) -> usize {
    │        --- function defined here
    ·
-25 │     a.add(1, 2)
+24 │     a.add(1, 2)
    │     ^^^^^^^^^^^
    │     │ │
    │     │ `add` is an associated function, not a method

--- a/crates/uitest/fixtures/ty_check/borrow_from_non_place.fe
+++ b/crates/uitest/fixtures/ty_check/borrow_from_non_place.fe
@@ -1,5 +1,4 @@
 fn borrow_from_non_place() {
     let x: u256 = 1
     let r: ref u256 = ref (x + 1)
-    ()
 }

--- a/crates/uitest/fixtures/ty_check/cannot_borrow_mut.fe
+++ b/crates/uitest/fixtures/ty_check/cannot_borrow_mut.fe
@@ -1,5 +1,4 @@
 fn cannot_borrow_mut() {
     let x: u256 = 0
     let p: mut u256 = mut x
-    ()
 }

--- a/crates/uitest/fixtures/ty_check/const_eval/array_rep_requires_literal.fe
+++ b/crates/uitest/fixtures/ty_check/const_eval/array_rep_requires_literal.fe
@@ -4,5 +4,4 @@ extern {
 
 fn foo() {
     let x: [u8; n()] = [0; n()]
-    ()
 }

--- a/crates/uitest/fixtures/ty_check/contract_effect_opt_in.fe
+++ b/crates/uitest/fixtures/ty_check/contract_effect_opt_in.fe
@@ -7,6 +7,5 @@ fn who_called() -> Address uses (ctx: Ctx) {
 contract C uses (ctx: Ctx) {
     init() {
         who_called()
-        ()
     }
 }

--- a/crates/uitest/fixtures/ty_check/effect_ambiguous_generic.fe
+++ b/crates/uitest/fixtures/ty_check/effect_ambiguous_generic.fe
@@ -5,7 +5,6 @@ pub struct Storage<T> {
 pub fn needs_storage<T>()
   uses Storage<T>
 {
-    ()
 }
 
 pub fn ambig() {
@@ -15,4 +14,3 @@ pub fn ambig() {
         needs_storage()
     }
 }
-

--- a/crates/uitest/fixtures/ty_check/effect_ambiguous_generic.snap
+++ b/crates/uitest/fixtures/ty_check/effect_ambiguous_generic.snap
@@ -5,16 +5,16 @@ expression: diags
 input_file: fixtures/ty_check/effect_ambiguous_generic.fe
 ---
 error[8-0031]: type annotation is needed
-   ┌─ effect_ambiguous_generic.fe:15:9
+   ┌─ effect_ambiguous_generic.fe:14:9
    │
-15 │         needs_storage()
+14 │         needs_storage()
    │         ^^^^^^^^^^^^^
    │         │
    │         type annotation is needed
    │         consider giving `: fn needs_storage<_>` here
 
 error[8-0040]: multiple effect candidates found
-   ┌─ effect_ambiguous_generic.fe:15:9
+   ┌─ effect_ambiguous_generic.fe:14:9
    │
-15 │         needs_storage()
+14 │         needs_storage()
    │         ^^^^^^^^^^^^^^^ effect `Storage<T>` is ambiguous when calling `needs_storage`

--- a/crates/uitest/fixtures/ty_check/effect_missing.fe
+++ b/crates/uitest/fixtures/ty_check/effect_missing.fe
@@ -5,7 +5,6 @@ pub struct Storage {
 pub fn needs_storage()
   uses Storage
 {
-    ()
 }
 
 pub fn missing_effect() {

--- a/crates/uitest/fixtures/ty_check/effect_missing.snap
+++ b/crates/uitest/fixtures/ty_check/effect_missing.snap
@@ -1,12 +1,13 @@
 ---
 source: crates/uitest/tests/ty_check.rs
+assertion_line: 27
 expression: diags
 input_file: fixtures/ty_check/effect_missing.fe
 ---
 error[8-0036]: missing effect `Storage` required by `needs_storage`
-   ┌─ effect_missing.fe:12:5
+   ┌─ effect_missing.fe:11:5
    │
-12 │     needs_storage()
+11 │     needs_storage()
    │     ^^^^^^^^^^^^^^^ `needs_storage` requires effect `Storage` to be in scope
    │
    = provide it with `with (Storage = value)` or require it via `uses Storage`

--- a/crates/uitest/fixtures/ty_check/effect_mut_mismatch.fe
+++ b/crates/uitest/fixtures/ty_check/effect_mut_mismatch.fe
@@ -5,7 +5,6 @@ pub struct Storage {
 pub fn needs_mut_storage()
   uses mut Storage
 {
-    ()
 }
 
 pub fn mut_mismatch() {

--- a/crates/uitest/fixtures/ty_check/effect_mut_mismatch.snap
+++ b/crates/uitest/fixtures/ty_check/effect_mut_mismatch.snap
@@ -1,14 +1,15 @@
 ---
 source: crates/uitest/tests/ty_check.rs
+assertion_line: 27
 expression: diags
 input_file: fixtures/ty_check/effect_mut_mismatch.fe
 ---
 error[8-0037]: effect `Storage` must be mutable when calling `needs_mut_storage`
-   ┌─ effect_mut_mismatch.fe:14:9
+   ┌─ effect_mut_mismatch.fe:13:9
    │
-13 │     with (Storage = st) {
+12 │     with (Storage = st) {
    │                     -- effect `Storage` is provided here
-14 │         needs_mut_storage()
+13 │         needs_mut_storage()
    │         ^^^^^^^^^^^^^^^^^^^ `needs_mut_storage` requires `mut Storage`
    │
    = use a mutable binding or pass a mutable reference in the `with` block

--- a/crates/uitest/fixtures/ty_check/effect_type_mismatch.fe
+++ b/crates/uitest/fixtures/ty_check/effect_type_mismatch.fe
@@ -9,7 +9,6 @@ pub struct Other {
 pub fn needs_storage()
   uses Storage
 {
-    ()
 }
 
 pub fn wrong_capability() {

--- a/crates/uitest/fixtures/ty_check/effect_type_mismatch.snap
+++ b/crates/uitest/fixtures/ty_check/effect_type_mismatch.snap
@@ -1,12 +1,13 @@
 ---
 source: crates/uitest/tests/ty_check.rs
+assertion_line: 27
 expression: diags
 input_file: fixtures/ty_check/effect_type_mismatch.fe
 ---
 error[8-0038]: effect `Storage` provided to `needs_storage` has type `Other`, but `Storage` is required
-   ┌─ effect_type_mismatch.fe:18:9
+   ┌─ effect_type_mismatch.fe:17:9
    │
-17 │     with (Storage = other) {
+16 │     with (Storage = other) {
    │                     ----- effect `Storage` is provided here
-18 │         needs_storage()
+17 │         needs_storage()
    │         ^^^^^^^^^^^^^^^ expected `Storage` for effect `Storage`, found `Other`

--- a/crates/uitest/fixtures/ty_check/unit_block_tail.fe
+++ b/crates/uitest/fixtures/ty_check/unit_block_tail.fe
@@ -1,0 +1,29 @@
+use std::evm::{Address, Ctx}
+
+fn address() -> Address uses (ctx: Ctx) {
+    ctx.caller()
+}
+
+fn unit_tail_relaxed() {
+    true
+}
+
+fn nested_unit_tail_relaxed() {
+    {
+        true
+    }
+}
+
+fn unit_tail_preserves_effect_error() {
+    address()
+}
+
+fn non_unit_tail_stays_strict() -> bool {
+    {
+        1
+    }
+}
+
+fn explicit_return_stays_strict() {
+    return true
+}

--- a/crates/uitest/fixtures/ty_check/unit_block_tail.snap
+++ b/crates/uitest/fixtures/ty_check/unit_block_tail.snap
@@ -1,0 +1,27 @@
+---
+source: crates/uitest/tests/ty_check.rs
+assertion_line: 27
+expression: diags
+input_file: fixtures/ty_check/unit_block_tail.fe
+---
+error[8-0000]: type mismatch
+   ┌─ unit_block_tail.fe:23:9
+   │
+23 │         1
+   │         ^ expected `bool`, but `{integer}` is given
+
+error[8-0013]: returned type mismatch
+   ┌─ unit_block_tail.fe:28:5
+   │
+27 │ fn explicit_return_stays_strict() {
+   │    ---------------------------- try adding `-> bool`
+28 │     return true
+   │     ^^^^^^^^^^^ expected `()`, but `bool` is returned
+
+error[8-0036]: missing effect `Ctx` required by `address`
+   ┌─ unit_block_tail.fe:18:5
+   │
+18 │     address()
+   │     ^^^^^^^^^ `address` requires effect `Ctx` to be in scope
+   │
+   = provide it with `with (Ctx = value)` or require it via `uses Ctx`


### PR DESCRIPTION
```rust
fn bar() -> bool {}
fn foo() {
  bar()
  () // <- don't have to write this anymore
}
```

This change had the unexpected side-effect of correcting our codegen output to correctly handle terminating functions. Previously the `!` ("never") return type would be coerced to unit. We now correctly recognize eg `fn call_revert() -> ! { revert(0, 0) }` as a terminating function, and thus calls to it are recognized as terminating.