### PR TITLE
fmt: fix `uses mut` formatting and add round-trip fmt test

### DIFF
--- a/crates/fe/tests/fmt_semantic_roundtrip.rs
+++ b/crates/fe/tests/fmt_semantic_roundtrip.rs
@@ -1,0 +1,37 @@
+use common::InputDb;
+use dir_test::{Fixture, dir_test};
+use driver::DriverDataBase;
+use fmt::{Config, format_str};
+use mir::lower_module;
+use url::Url;
+
+#[dir_test(
+    dir: "$CARGO_MANIFEST_DIR/tests/fixtures/fe_test",
+    glob: "*.fe",
+)]
+fn test_fmt_fe_test_fixtures_semantic_roundtrip(fixture: Fixture<&str>) {
+    let formatted = format_str(fixture.content(), &Config::default())
+        .unwrap_or_else(|err| panic!("format failed for {}: {err:?}", fixture.path()));
+
+    let mut db = DriverDataBase::default();
+    let file_url = Url::from_file_path(fixture.path())
+        .unwrap_or_else(|_| panic!("fixture path should be absolute: {}", fixture.path()));
+    let file = db.workspace().touch(&mut db, file_url, Some(formatted));
+    let top_mod = db.top_mod(file);
+
+    let diagnostics = db.run_on_top_mod(top_mod);
+    assert!(
+        diagnostics.is_empty(),
+        "formatted output failed parse/HIR analysis for {}:\n{}",
+        fixture.path(),
+        diagnostics.format_diags(&db),
+    );
+
+    if let Err(err) = lower_module(&db, top_mod) {
+        panic!(
+            "formatted output failed MIR lowering/analysis for {}:\n{}",
+            fixture.path(),
+            err,
+        );
+    }
+}

--- a/crates/fmt/tests/fixtures/advanced_expressions.snap
+++ b/crates/fmt/tests/fixtures/advanced_expressions.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/fmt/tests/format_snapshots.rs
+assertion_line: 16
 expression: output
 input_file: tests/fixtures/advanced_expressions.fe
 ---
 pub unsafe fn advanced_expressions<T, U: Trait>(arr: Array<i32, 10>, ctx: Ctx, storage: Storage<T>)
-uses (ctx: Ctx, mut st: Storage<T>)
+uses (ctx: Ctx, st: mut Storage<T>)
 where T: Trait2, U: Trait3
 {
     let first = arr[0]

--- a/crates/fmt/tests/fixtures/erc20.snap
+++ b/crates/fmt/tests/fixtures/erc20.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/fmt/tests/format_snapshots.rs
+assertion_line: 16
 expression: output
 input_file: tests/fixtures/erc20.fe
 ---
@@ -9,7 +10,7 @@ use std::evm::effects::Address
 const MINTER: u256 = 1
 const BURNER: u256 = 2
 
-pub contract CoolCoin uses (mut ctx: Ctx, mut log: Log) {
+pub contract CoolCoin uses (ctx: mut Ctx, log: mut Log) {
     // Storage fields. These act as effects within the contract.
     mut store: TokenStore,
     mut auth: AccessControl,
@@ -114,7 +115,7 @@ pub contract CoolCoin uses (mut ctx: Ctx, mut log: Log) {
 }
 
 fn transfer(from: Address, to: Address, amount: u256)
-uses (mut store: TokenStore, mut log: Log)
+uses (store: mut TokenStore, log: mut Log)
 {
     assert(from != Address::zero(), "transfer from zero address")
     assert(to != Address::zero(), "transfer to zero address")
@@ -128,7 +129,7 @@ uses (mut store: TokenStore, mut log: Log)
     log.emit(TransferEvent { from, to, value: amount })
 }
 
-fn mint(to: Address, amount: u256) uses (mut store: TokenStore, mut log: Log) {
+fn mint(to: Address, amount: u256) uses (store: mut TokenStore, log: mut Log) {
     assert(to != Address::zero(), "mint to zero address")
 
     store.total_supply += amount
@@ -138,7 +139,7 @@ fn mint(to: Address, amount: u256) uses (mut store: TokenStore, mut log: Log) {
 }
 
 fn burn(from: Address, amount: u256)
-uses (mut store: TokenStore, mut log: Log)
+uses (store: mut TokenStore, log: mut Log)
 {
     assert(from != Address::zero(), "burn from zero address")
 
@@ -152,7 +153,7 @@ uses (mut store: TokenStore, mut log: Log)
 }
 
 fn approve(owner: Address, spender: Address, amount: u256)
-uses (mut store: TokenStore, mut log: Log)
+uses (store: mut TokenStore, log: mut Log)
 {
     assert(owner != Address::zero(), "approve from zero address")
     assert(spender != Address::zero(), "approve to zero address")
@@ -164,7 +165,7 @@ uses (mut store: TokenStore, mut log: Log)
 
 // Internal function to spend allowance
 fn spend_allowance(owner: Address, spender: Address, amount: u256)
-uses (mut store: TokenStore)
+uses (store: mut TokenStore)
 {
     let current = store.allowances[(owner, spender)]
     // if current != u256::MAX { // TODO: define ::MAX constants


### PR DESCRIPTION
The mut effect syntax changed recently to match the new mut borrow param syntax, but fmt was writing the old syntax. `uses (mut evm: Evm)` is now `uses (evm: mut Evm)`