### PR TITLE
Don't push to master in make push-tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,4 +70,4 @@ push-tag:
 	./newsfragments/validate_files.py is-empty
 	# Tag the release with the current version number
 	git tag "v$$(cargo pkgid fe | cut -d# -f2 | cut -d: -f2)"
-	git push --tags upstream master
+	git push --tags upstream


### PR DESCRIPTION
It's unnecessary that `make push-tag` pushes straight to master. It should only push the tags which is enough to kick off the Github Action for the release.