### PR TITLE
Fix macOS Abort trap: 6 in feup install script

### DIFF
--- a/feup/feup.sh
+++ b/feup/feup.sh
@@ -187,6 +187,13 @@ download_fe() {
     }
 
     chmod +x "$tmp_file"
+
+    # macOS quarantines binaries downloaded via curl; remove the flag so the
+    # binary can execute without Gatekeeper killing it (Abort trap: 6).
+    if [ "$OS" = "mac" ]; then
+        xattr -d com.apple.quarantine "$tmp_file" 2>/dev/null || true
+    fi
+
     mv "$tmp_file" "$FE_BIN_DIR/fe"
     trap - EXIT
 


### PR DESCRIPTION
## Summary

- Strip `com.apple.quarantine` xattr after downloading the `fe` binary in `feup.sh`
- macOS Gatekeeper quarantines binaries downloaded via `curl`, causing `SIGABRT` (Abort trap: 6) when the script tries to verify the install with `fe --version`
- Only runs on macOS, silently no-ops if the attribute isn't present

## Test plan

- [ ] Run `curl ... | bash` on macOS (both Intel and Apple Silicon)
- [ ] Verify `fe --version` succeeds without Abort trap: 6
- [ ] Verify the script still works on Linux (xattr line is skipped)