### PR TITLE
Add missing ContractAnalysisPass to LSP diagnostics

### DIFF
--- a/crates/language-server/src/lsp_diagnostics.rs
+++ b/crates/language-server/src/lsp_diagnostics.rs
@@ -13,9 +13,9 @@ use hir::analysis::analysis_pass::{
 };
 use hir::analysis::name_resolution::ImportAnalysisPass;
 use hir::analysis::ty::{
-    AdtDefAnalysisPass, BodyAnalysisPass, DefConflictAnalysisPass, FuncAnalysisPass,
-    ImplAnalysisPass, ImplTraitAnalysisPass, MsgSelectorAnalysisPass, TraitAnalysisPass,
-    TypeAliasAnalysisPass,
+    AdtDefAnalysisPass, BodyAnalysisPass, ContractAnalysisPass, DefConflictAnalysisPass,
+    FuncAnalysisPass, ImplAnalysisPass, ImplTraitAnalysisPass, MsgSelectorAnalysisPass,
+    TraitAnalysisPass, TypeAliasAnalysisPass,
 };
 use hir::hir_def::HirIngot;
 use hir::lower::map_file_to_mod;
@@ -185,6 +185,7 @@ fn initialize_analysis_pass() -> AnalysisPassManager {
     pass_manager.add_module_pass("ImplTrait", Box::new(ImplTraitAnalysisPass {}));
     pass_manager.add_module_pass("Func", Box::new(FuncAnalysisPass {}));
     pass_manager.add_module_pass("Body", Box::new(BodyAnalysisPass {}));
+    pass_manager.add_module_pass("Contract", Box::new(ContractAnalysisPass {}));
     pass_manager
 }
 


### PR DESCRIPTION
## Summary

- The LSP's analysis pass manager was missing `ContractAnalysisPass`, so contract-level diagnostics (e.g. duplicate selector across recv blocks, error `8-0047`) were never surfaced in the editor
- `fe check` already included this pass via the driver; the LSP just needed the same registration

## Test plan

- [x] Verified `fe check` on a file with duplicate selectors across recv blocks shows both diagnostics
- [x] Verified the LSP now surfaces the duplicate selector diagnostic in the editor after this change
