### PR TITLE
fix slow parsing issue on some code

### DIFF
--- a/crates/parser/src/parser/expr.rs
+++ b/crates/parser/src/parser/expr.rs
@@ -505,14 +505,17 @@ fn bump_aug_assign_op<S: TokenStream>(parser: &mut Parser<S>) -> bool {
 
 fn is_method_call<S: TokenStream>(parser: &mut Parser<S>) -> bool {
     let is_trivia = parser.set_newline_as_trivia(true);
-    let res = parser.dry_run(|parser| {
-        if !parser.bump_if(SyntaxKind::Dot) {
-            return false;
-        }
+    if !matches!(
+        parser.peek_n_non_trivia(2).as_slice(),
+        [SyntaxKind::Dot, SyntaxKind::Ident]
+    ) {
+        parser.set_newline_as_trivia(is_trivia);
+        return false;
+    }
 
-        if !parser.bump_if(SyntaxKind::Ident) {
-            return false;
-        }
+    let res = parser.dry_run(|parser| {
+        parser.bump_expected(SyntaxKind::Dot);
+        parser.bump_expected(SyntaxKind::Ident);
 
         // After the identifier, require `<` or `(` to be on the same line
         parser.set_newline_as_trivia(false);

--- a/crates/parser/src/parser/expr_atom.rs
+++ b/crates/parser/src/parser/expr_atom.rs
@@ -40,29 +40,25 @@ pub(super) fn parse_expr_atom<S: TokenStream>(
         Some(SyntaxKind::Ident) => {
             // Contextual 'with': only treat as with-block when:
             // ident text is "with" AND we can parse a WithParamList AND next is '{'
-            let is_with = parser.dry_run(|p| {
-                let is_with_ident = p
-                    .current_token()
-                    .map(|t| t.text() == "with")
-                    .unwrap_or(false);
-                if !is_with_ident {
-                    return false;
-                }
-                p.bump();
-                // Must start with '(' for with param list
-                if p.current_kind() != Some(SyntaxKind::LParen) {
-                    return false;
-                }
-                // Try parse the with param list
-                if !p
-                    .parse_ok(WithParamListScope::default())
-                    .is_ok_and(identity)
-                {
-                    return false;
-                }
-                // Require a block immediately after
-                p.current_kind() == Some(SyntaxKind::LBrace)
-            });
+            let is_with = parser
+                .current_token()
+                .map(|t| t.text() == "with")
+                .unwrap_or(false)
+                && matches!(
+                    parser.peek_n_non_trivia(2).as_slice(),
+                    [SyntaxKind::Ident, SyntaxKind::LParen]
+                )
+                && parser.dry_run(|p| {
+                    p.bump_expected(SyntaxKind::Ident);
+                    // Try parse the with param list body and require a block right after.
+                    if !p
+                        .parse_ok(WithParamListScope::default())
+                        .is_ok_and(identity)
+                    {
+                        return false;
+                    }
+                    p.current_kind() == Some(SyntaxKind::LBrace)
+                });
             if is_with {
                 parser.parse_cp(WithExprScope::default(), None)
             } else {
@@ -217,7 +213,10 @@ impl super::Parse for WithParamScope {
         // `with` parameter supports either:
         // - `Key = value` (legacy)
         // - `value` (shorthand; key inferred from value type / usage)
-        let is_keyed = parser.dry_run(|p| {
+        let is_keyed = matches!(
+            parser.peek_n_non_trivia(1).as_slice(),
+            [kind] if path::is_path_segment(*kind)
+        ) && parser.dry_run(|p| {
             if !p.parse_ok(path::PathScope::default()).is_ok_and(identity) {
                 return false;
             }

--- a/crates/parser/src/parser/func.rs
+++ b/crates/parser/src/parser/func.rs
@@ -200,25 +200,25 @@ impl super::Parse for UsesParamScope {
         // - `f: mut Foo`
         //
         // Legacy typed form `mut f: Foo` is rejected with a targeted parse error.
-        let is_legacy_labeled = parser.dry_run(|p| {
-            p.bump_if(SyntaxKind::MutKw)
-                && (p.current_kind() == Some(SyntaxKind::Ident)
-                    || p.current_kind() == Some(SyntaxKind::Underscore))
-                && {
-                    p.bump();
-                    p.current_kind() == Some(SyntaxKind::Colon)
-                }
-        });
+        let lookahead = parser.peek_n_non_trivia(3);
+        let is_legacy_labeled = matches!(
+            lookahead.as_slice(),
+            [
+                SyntaxKind::MutKw,
+                SyntaxKind::Ident | SyntaxKind::Underscore,
+                SyntaxKind::Colon
+            ]
+        );
 
         // Detect labeled form (ident/underscore, then `:`)
-        let is_labeled = parser.dry_run(|p| {
-            (p.current_kind() == Some(SyntaxKind::Ident)
-                || p.current_kind() == Some(SyntaxKind::Underscore))
-                && {
-                    p.bump();
-                    p.current_kind() == Some(SyntaxKind::Colon)
-                }
-        });
+        let is_labeled = matches!(
+            lookahead.as_slice(),
+            [
+                SyntaxKind::Ident | SyntaxKind::Underscore,
+                SyntaxKind::Colon,
+                ..
+            ]
+        );
 
         if is_legacy_labeled {
             let pos = parser.current_pos;

--- a/crates/parser/src/parser/item.rs
+++ b/crates/parser/src/parser/item.rs
@@ -158,10 +158,10 @@ impl super::Parse for ItemScope {
 fn is_fn_item_head<S: TokenStream>(parser: &mut Parser<S>) -> bool {
     match parser.current_kind() {
         Some(SyntaxKind::FnKw) => true,
-        Some(SyntaxKind::ConstKw) => parser.dry_run(|p| {
-            p.bump_expected(SyntaxKind::ConstKw);
-            p.current_kind() == Some(SyntaxKind::FnKw)
-        }),
+        Some(SyntaxKind::ConstKw) => matches!(
+            parser.peek_n_non_trivia(2).as_slice(),
+            [SyntaxKind::ConstKw, SyntaxKind::FnKw]
+        ),
         _ => false,
     }
 }
@@ -876,7 +876,9 @@ fn parse_fn_item_block<S: TokenStream>(
             )?;
         } else {
             let proof = parser.error("only `fn` is allowed in this block");
-            parser.bump();
+            if parser.current_kind() == Some(SyntaxKind::ConstKw) {
+                parser.bump();
+            }
             parser.try_recover().map_err(|r| r.add_err_proof(proof))?;
         }
     }

--- a/crates/parser/src/parser/pat.rs
+++ b/crates/parser/src/parser/pat.rs
@@ -157,10 +157,10 @@ impl super::Parse for RecordPatFieldScope {
     type Error = Recovery<ErrProof>;
 
     fn parse<S: TokenStream>(&mut self, parser: &mut Parser<S>) -> Result<(), Self::Error> {
-        let has_label = parser.dry_run(|parser| {
-            //
-            parser.bump_if(SyntaxKind::Ident) && parser.bump_if(SyntaxKind::Colon)
-        });
+        let has_label = matches!(
+            parser.peek_n_non_trivia(2).as_slice(),
+            [SyntaxKind::Ident, SyntaxKind::Colon]
+        );
         if has_label {
             parser.bump_expected(SyntaxKind::Ident);
             parser.bump_expected(SyntaxKind::Colon);
@@ -255,9 +255,10 @@ impl super::Parse for RecvArmRecordPatFieldScope {
     type Error = Recovery<ErrProof>;
 
     fn parse<S: TokenStream>(&mut self, parser: &mut Parser<S>) -> Result<(), Self::Error> {
-        let has_label = parser.dry_run(|parser| {
-            parser.bump_if(SyntaxKind::Ident) && parser.bump_if(SyntaxKind::Colon)
-        });
+        let has_label = matches!(
+            parser.peek_n_non_trivia(2).as_slice(),
+            [SyntaxKind::Ident, SyntaxKind::Colon]
+        );
         if has_label {
             parser.bump_expected(SyntaxKind::Ident);
             parser.bump_expected(SyntaxKind::Colon);

--- a/crates/parser/src/parser/use_tree.rs
+++ b/crates/parser/src/parser/use_tree.rs
@@ -1,4 +1,4 @@
-use std::{cell::Cell, convert::identity, rc::Rc};
+use std::{cell::Cell, rc::Rc};
 
 use crate::{ParseError, SyntaxKind, TextRange, parser::path::is_path_segment};
 
@@ -69,12 +69,10 @@ impl super::Parse for UsePathScope {
         parser.parse(UsePathSegmentScope::default())?;
 
         loop {
-            let is_path_segment = parser.dry_run(|parser| {
-                parser.bump_if(SyntaxKind::Colon2)
-                    && parser
-                        .parse_ok(UsePathSegmentScope::default())
-                        .is_ok_and(identity)
-            });
+            let is_path_segment = matches!(
+                parser.peek_n_non_trivia(2).as_slice(),
+                [SyntaxKind::Colon2, kind] if is_use_path_segment(*kind)
+            );
             if is_path_segment {
                 if self.is_glob.get() {
                     parser.error_msg_on_current_token("can't specify path after `*`");


### PR DESCRIPTION
- reduce parser `dry_run` calls via 2-3 token lookahead
- reduce memory use of `dry_run` by reusing allocations
- fix recovery behavior on `ConstKw` in `parse_fn_item_block`

This fixes pathological parser slowness in a particularly large file I'm using to ferret out compiler bugs (an ai port of some math code).