### PR TITLE
Fix scalar cast address-backing in MIR lowering

### DIFF
--- a/crates/codegen/tests/fixtures/cast_u8_usize_cmp.fe
+++ b/crates/codegen/tests/fixtures/cast_u8_usize_cmp.fe
@@ -1,0 +1,13 @@
+pub fn cast_u8_usize_cmp(indices: [u8; 8], i: usize, j: usize) -> u8 {
+    let path = indices[i]
+    if j < path as usize {
+        return 1
+    }
+    if j == path as usize {
+        return 2
+    }
+    if j > path as usize {
+        return 3
+    }
+    0
+}

--- a/crates/codegen/tests/fixtures/cast_u8_usize_cmp.snap
+++ b/crates/codegen/tests/fixtures/cast_u8_usize_cmp.snap
@@ -1,0 +1,31 @@
+---
+source: crates/codegen/tests/yul.rs
+expression: output
+input_file: tests/fixtures/cast_u8_usize_cmp.fe
+---
+function $cast_u8_usize_cmp($indices, $i, $j) -> ret {
+  let v0 := and(mload(add($indices, mul($i, 32))), 0xff)
+  let v1 := lt($j, v0)
+  if v1 {
+    ret := 1
+    leave
+  }
+  if iszero(v1) {
+    let v2 := eq($j, v0)
+    if v2 {
+      ret := 2
+      leave
+    }
+    if iszero(v2) {
+      let v3 := gt($j, v0)
+      if v3 {
+        ret := 3
+        leave
+      }
+      if iszero(v3) {
+        ret := 0
+        leave
+      }
+    }
+  }
+}

--- a/crates/codegen/tests/fixtures/sonatina_ir/cast_u8_usize_cmp.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/cast_u8_usize_cmp.snap
@@ -1,0 +1,57 @@
+---
+source: crates/codegen/tests/sonatina_ir.rs
+expression: output
+input_file: crates/codegen/tests/fixtures/cast_u8_usize_cmp.fe
+---
+target = "evm-ethereum-osaka"
+
+func public %cast_u8_usize_cmp(v0.i256, v1.i256, v2.i256) -> i256 {
+    block0:
+        v4.*[i256; 8] = int_to_ptr v0 *[i256; 8];
+        v5.*i256 = gep v4 0.i256 v1;
+        v6.i256 = ptr_to_int v5 i256;
+        v7.i256 = mload v6 i256;
+        v8.i8 = trunc v7 i8;
+        v9.i256 = zext v8 i256;
+        v10.i1 = lt v2 v9;
+        v11.i256 = zext v10 i256;
+        v12.i1 = ne v11 0.i256;
+        br v12 block1 block2;
+
+    block1:
+        return 1.i256;
+
+    block2:
+        v16.i1 = eq v2 v9;
+        v17.i256 = zext v16 i256;
+        v18.i1 = ne v17 0.i256;
+        br v18 block3 block4;
+
+    block3:
+        return 2.i256;
+
+    block4:
+        v22.i1 = gt v2 v9;
+        v23.i256 = zext v22 i256;
+        v24.i1 = ne v23 0.i256;
+        br v24 block5 block6;
+
+    block5:
+        return 3.i256;
+
+    block6:
+        return 0.i256;
+}
+
+func public %__fe_sonatina_entry() {
+    block0:
+        v1.i256 = call %cast_u8_usize_cmp 0.i256 0.i256 0.i256;
+        evm_stop;
+}
+
+
+object @Contract {
+    section runtime {
+        entry %__fe_sonatina_entry;
+    }
+}

--- a/crates/mir/src/lower/expr.rs
+++ b/crates/mir/src/lower/expr.rs
@@ -379,11 +379,9 @@ impl<'db, 'a> MirBuilder<'db, 'a> {
         }
 
         let root_value = self.builder.body.value(root);
-        if root_value.ty.as_capability(self.db).is_some() {
-            match crate::repr::repr_kind_for_ty(self.db, &self.core, root_value.ty) {
-                crate::repr::ReprKind::Zst | crate::repr::ReprKind::Word => return false,
-                crate::repr::ReprKind::Ptr(_) | crate::repr::ReprKind::Ref => {}
-            }
+        match crate::repr::repr_kind_for_ty(self.db, &self.core, root_value.ty) {
+            crate::repr::ReprKind::Zst | crate::repr::ReprKind::Word => return false,
+            crate::repr::ReprKind::Ptr(_) | crate::repr::ReprKind::Ref => {}
         }
         matches!(
             root_value.origin,

--- a/crates/mir/tests/fixtures/cast_u8_usize_cmp.fe
+++ b/crates/mir/tests/fixtures/cast_u8_usize_cmp.fe
@@ -1,0 +1,13 @@
+pub fn cast_u8_usize_cmp(indices: [u8; 8], i: usize, j: usize) -> u8 {
+    let path = indices[i]
+    if j < path as usize {
+        return 1
+    }
+    if j == path as usize {
+        return 2
+    }
+    if j > path as usize {
+        return 3
+    }
+    0
+}

--- a/crates/mir/tests/fixtures/cast_u8_usize_cmp.mir.snap
+++ b/crates/mir/tests/fixtures/cast_u8_usize_cmp.mir.snap
@@ -1,0 +1,20 @@
+---
+source: crates/mir/tests/lowering_snapshots.rs
+expression: mir_output
+---
+fn cast_u8_usize_cmp(v0: [u8; 8], v1: usize, v2: usize) -> u8:
+  bb0:
+    v3: u8 = load mem[v0][v1]
+    br (v2 < v3) bb1 bb2
+  bb1:
+    ret 1
+  bb2:
+    br (v2 == v3) bb3 bb4
+  bb3:
+    ret 2
+  bb4:
+    br (v2 > v3) bb5 bb6
+  bb5:
+    ret 3
+  bb6:
+    ret 0


### PR DESCRIPTION
Fixes a MIR lowering bug where casts of scalars derived from a memory location could be treated as being memory-backed. For example:
```
  let path = indices[i] // u8
  if j < path as usize { ... } // erroneous mload here
```

`capability_value_is_address_backed` now always checks the root value’s runtime representation first:

  - Word / Zst => not address-backed
  - Ptr / Ref => may be address-backed (origin check still applies)

This preserves legitimate capability/address-backed handling while preventing scalar cast values from being lowered as memory addresses.