### PR TITLE
Fix tab parsing and with-shorthand formatter deletion

### DIFF
--- a/crates/fmt/src/ast/expr.rs
+++ b/crates/fmt/src/ast/expr.rs
@@ -1145,7 +1145,13 @@ impl ToDoc for ast::WithParam {
 
         let path = match self.path() {
             Some(p) => p.to_doc(ctx),
-            None => return alloc.nil(),
+            None => {
+                // Shorthand form: `with (expr)` — no key path, just a value.
+                return match self.value_expr() {
+                    Some(v) => v.to_doc(ctx),
+                    None => alloc.nil(),
+                };
+            }
         };
         let value = match self.value_expr() {
             Some(v) => v.to_doc(ctx),

--- a/crates/fmt/src/tests.rs
+++ b/crates/fmt/src/tests.rs
@@ -56,3 +56,16 @@ fn test_takes_array_single_param() {
     let result = crate::format_str(source, &config).unwrap();
     assert_eq!(result, "fn takes_array(arr: Array<i32, 10>) {}");
 }
+
+#[test]
+fn test_with_shorthand_preserves_content() {
+    // Regression: `with (expr)` shorthand (no `Key = value`) was silently
+    // deleted because WithParam::to_doc only looked for a Path child.
+    let source = "fn test() {\n    with (counter) {\n        bump_twice()\n    }\n}\n";
+    let config = crate::Config::default();
+    let result = crate::format_str(source, &config).unwrap();
+    assert!(
+        result.contains("counter"),
+        "formatter deleted with-param content! got:\n{result}"
+    );
+}

--- a/crates/fmt/tests/fixtures/with_expr.fe
+++ b/crates/fmt/tests/fixtures/with_expr.fe
@@ -1,0 +1,17 @@
+fn keyed() {
+    with (Counter = counter) {
+        bump()
+    }
+}
+
+fn shorthand() {
+    with (counter) {
+        bump()
+    }
+}
+
+fn multi() {
+    with (Counter = counter, Logger = logger) {
+        bump()
+    }
+}

--- a/crates/fmt/tests/fixtures/with_expr.snap
+++ b/crates/fmt/tests/fixtures/with_expr.snap
@@ -1,0 +1,22 @@
+---
+source: crates/fmt/tests/format_snapshots.rs
+expression: output
+input_file: tests/fixtures/with_expr.fe
+---
+fn keyed() {
+    with (Counter = counter) {
+        bump()
+    }
+}
+
+fn shorthand() {
+    with (counter) {
+        bump()
+    }
+}
+
+fn multi() {
+    with (Counter = counter, Logger = logger) {
+        bump()
+    }
+}

--- a/crates/parser/src/syntax_kind.rs
+++ b/crates/parser/src/syntax_kind.rs
@@ -12,7 +12,7 @@ pub enum SyntaxKind {
 
     #[regex(r"(\n|\r\n|\r)+")]
     Newline,
-    #[regex(r"[ ]+")]
+    #[regex(r"[ \t]+")]
     WhiteSpace,
     /// `foo`
     #[regex("[a-zA-Z_][a-zA-Z0-9_]*")]

--- a/crates/parser/test_files/syntax_node/items/uses_with_tabs.fe
+++ b/crates/parser/test_files/syntax_node/items/uses_with_tabs.fe
@@ -1,0 +1,3 @@
+fn f()	uses	Ctx {}
+
+fn g()	uses	(Foo, Bar) {}

--- a/crates/parser/test_files/syntax_node/items/uses_with_tabs.snap
+++ b/crates/parser/test_files/syntax_node/items/uses_with_tabs.snap
@@ -1,0 +1,60 @@
+---
+source: crates/parser/tests/syntax_node.rs
+expression: node
+input_file: test_files/syntax_node/items/uses_with_tabs.fe
+---
+Root@0..46
+  ItemList@0..45
+    Item@0..18
+      Func@0..18
+        FnKw@0..2 "fn"
+        WhiteSpace@2..3 " "
+        FuncSignature@3..15
+          Ident@3..4 "f"
+          FuncParamList@4..6
+            LParen@4..5 "("
+            RParen@5..6 ")"
+          WhiteSpace@6..7 "\t"
+          UsesClause@7..15
+            UsesKw@7..11 "uses"
+            WhiteSpace@11..12 "\t"
+            UsesParam@12..15
+              Path@12..15
+                PathSegment@12..15
+                  Ident@12..15 "Ctx"
+        WhiteSpace@15..16 " "
+        BlockExpr@16..18
+          LBrace@16..17 "{"
+          RBrace@17..18 "}"
+    Newline@18..20 "\n\n"
+    Item@20..45
+      Func@20..45
+        FnKw@20..22 "fn"
+        WhiteSpace@22..23 " "
+        FuncSignature@23..42
+          Ident@23..24 "g"
+          FuncParamList@24..26
+            LParen@24..25 "("
+            RParen@25..26 ")"
+          WhiteSpace@26..27 "\t"
+          UsesClause@27..42
+            UsesKw@27..31 "uses"
+            WhiteSpace@31..32 "\t"
+            UsesParamList@32..42
+              LParen@32..33 "("
+              UsesParam@33..36
+                Path@33..36
+                  PathSegment@33..36
+                    Ident@33..36 "Foo"
+              Comma@36..37 ","
+              WhiteSpace@37..38 " "
+              UsesParam@38..41
+                Path@38..41
+                  PathSegment@38..41
+                    Ident@38..41 "Bar"
+              RParen@41..42 ")"
+        WhiteSpace@42..43 " "
+        BlockExpr@43..45
+          LBrace@43..44 "{"
+          RBrace@44..45 "}"
+  Newline@45..46 "\n"


### PR DESCRIPTION
## Summary

Two independent bugs from #1292:

- **Tabs rejected as whitespace**: The lexer's `WhiteSpace` regex was `[ ]+` (spaces only). Tabs produced `InvalidToken`, breaking any code indented with tabs. Fix: `[ \t]+`.

- **Formatter deletes `with (expr)` content**: `with (counter) { ... }` was formatted as `with () { ... }`. `WithParam::to_doc` only handled the keyed form (`Key = value`, which stores a `Path` child), returning `nil()` for the shorthand form where the param is an expression. Fix: fall back to `value_expr()` when no path is found.

  Before: `with (counter) { bump() }` → `with () { bump() }`
  After: `with (counter) { bump() }` → `with (counter) { bump() }`

## Test plan

- [x] Parser snapshot test with tab-indented `uses` clauses
- [x] Formatter unit test: `with (counter)` preserves content (fails without fix)
- [x] Formatter snapshot fixture with keyed and shorthand `with` expressions
- [x] All existing parser, formatter, and semantic roundtrip tests pass