### PR TITLE
Fix ICE in test runner

### DIFF
--- a/crates/codegen/src/sonatina/tests.rs
+++ b/crates/codegen/src/sonatina/tests.rs
@@ -4,7 +4,7 @@ use mir::analysis::{CallGraph, build_call_graph, reachable_functions};
 use mir::{
     MirFunction, MirInst, Rvalue,
     ir::{IntrinsicOp, MirFunctionOrigin},
-    layout, lower_module,
+    layout, lower_ingot,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use sonatina_codegen::{
@@ -75,7 +75,8 @@ pub fn emit_test_module_sonatina(
     opt_level: OptLevel,
     debug: &SonatinaTestDebugConfig,
 ) -> Result<TestModuleOutput, LowerError> {
-    let mir_module = lower_module(db, top_mod)?;
+    let ingot = top_mod.ingot(db);
+    let mir_module = lower_ingot(db, ingot)?;
     let tests = collect_tests(db, &mir_module.functions);
 
     if tests.is_empty() {

--- a/crates/codegen/src/yul/emitter/module.rs
+++ b/crates/codegen/src/yul/emitter/module.rs
@@ -301,7 +301,8 @@ pub fn emit_test_module_yul_with_layout(
     top_mod: TopLevelMod<'_>,
     layout: TargetDataLayout,
 ) -> Result<TestModuleOutput, EmitModuleError> {
-    let module = lower_module(db, top_mod).map_err(EmitModuleError::MirLower)?;
+    let ingot = top_mod.ingot(db);
+    let module = lower_ingot(db, ingot).map_err(EmitModuleError::MirLower)?;
 
     let contract_graph = build_contract_graph(&module.functions);
 


### PR DESCRIPTION
  ## Summary

  - Fix internal compiler error (panic) when `fe test` uses `evm.create2<Contract>()` on a contract imported from a child module (`use ingot::counter::Counter`)
  - Replace `lower_module()` with `lower_ingot()` in both test codegen paths (Yul and Sonatina)

  ## Repro

  ```toml
  # fe.toml
  [ingot]
  name = "fe_bug1"
  version = "0.1.0"
  ```

  ```fe
  // src/counter.fe
  pub msg CounterMsg {
      #[selector = 0x01]
      Increment,
      #[selector = 0x02]
      Get -> u256,
  }

  struct CounterStore {
      value: u256,
  }

  pub contract Counter {
      mut store: CounterStore

      init() uses (mut store) {
          store.value = 0
      }

      recv CounterMsg {
          Increment uses (mut store) {
              store.value = store.value + 1
          }

          Get -> u256 uses (store) {
              store.value
          }
      }
  }
  ```

  ```fe
  // src/lib.fe
  use std::evm::{Evm}
  use std::evm::effects::assert
  use ingot::counter::{Counter, CounterMsg}

  #[test]
  fn test_deploy_child_module_contract() uses (evm: mut Evm) {
      let addr = evm.create2<Counter>(value: 0, args: (), salt: 0)
      assert(addr.inner != 0)
  }
  ```

  Running `fe test .` panics:

  ```
  panicked at crates/mir/src/monomorphize.rs:526:
  failed to instantiate synthetic MIR for `Synthetic(ContractInitCodeLen(...))`
  ```

  ## Problem

  `lower_module()` only lowers contracts from the single `TopLevelMod` passed to it. Child module contracts are missing from the MIR, so the monomorphizer can't find their synthetic templates (init entrypoints,
  code region offsets/lengths).

  ## Fix

  Call `lower_ingot()` instead of `lower_module()` in `emit_test_module_yul_with_layout()` and `emit_test_module_sonatina()`. This is the same function `fe build` already uses — it iterates all modules in the
  ingot and includes all contracts.

  For single-file tests, the synthetic ingot has exactly one module, so behavior is unchanged.
