### PR TITLE
Fix test discovery for ingots where lib.fe has no tests

### DIFF
--- a/crates/fe/src/test/mod.rs
+++ b/crates/fe/src/test/mod.rs
@@ -21,6 +21,7 @@ use colored::Colorize;
 use common::{
     InputDb,
     config::{Config, WorkspaceMemberSelection},
+    ingot::Ingot,
 };
 use contract_harness::{CallGasProfile, EvmTraceOptions, ExecutionOptions, RuntimeInstance};
 use driver::DriverDataBase;
@@ -1266,7 +1267,7 @@ fn run_tests_ingot(
     }
 
     let root_mod = ingot.root_mod(db);
-    if !has_test_functions(db, root_mod) {
+    if !ingot_has_test_functions(db, ingot) {
         return Vec::new();
     }
 
@@ -1742,6 +1743,15 @@ fn expand_workspace_test_paths(
 
 fn has_test_functions(db: &DriverDataBase, top_mod: TopLevelMod<'_>) -> bool {
     top_mod.all_funcs(db).iter().any(|func| {
+        ItemKind::from(*func)
+            .attrs(db)
+            .is_some_and(|attrs| attrs.has_attr(db, "test"))
+    })
+}
+
+/// Like [`has_test_functions`] but checks all modules in the ingot, not just one.
+fn ingot_has_test_functions(db: &DriverDataBase, ingot: Ingot<'_>) -> bool {
+    ingot.all_funcs(db).iter().any(|func| {
         ItemKind::from(*func)
             .attrs(db)
             .is_some_and(|attrs| attrs.has_attr(db, "test"))

--- a/crates/fe/tests/cli_output.rs
+++ b/crates/fe/tests/cli_output.rs
@@ -918,6 +918,26 @@ fn test_cli_test_workspace_ingot_missing_member_is_error() {
     );
 }
 
+/// Regression test: `fe test` must discover tests in non-root modules of an
+/// ingot even when `lib.fe` itself contains no `#[test]` functions.
+#[test]
+fn test_cli_test_ingot_discovers_tests_in_non_root_modules() {
+    let fixture_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/fe_test_runner/ingot_tests_in_non_root_module");
+    let fixture_dir_str = fixture_dir.to_str().expect("fixture dir utf8");
+
+    let (output, exit_code) = run_fe_main(&["test", fixture_dir_str]);
+    assert_eq!(exit_code, 0, "fe test failed:\n{output}");
+    assert!(
+        output.contains("test test_add"),
+        "expected test_add to be discovered, got:\n{output}"
+    );
+    assert!(
+        output.contains("1 passed"),
+        "expected 1 passed test, got:\n{output}"
+    );
+}
+
 #[test]
 fn test_cli_test_repo_core_ingot_without_tests_is_ok() {
     let project_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/crates/fe/tests/fixtures/fe_test_runner/ingot_tests_in_non_root_module/fe.toml
+++ b/crates/fe/tests/fixtures/fe_test_runner/ingot_tests_in_non_root_module/fe.toml
@@ -1,0 +1,3 @@
+[ingot]
+name = "ingot_tests_in_non_root_module"
+version = "0.1.0"

--- a/crates/fe/tests/fixtures/fe_test_runner/ingot_tests_in_non_root_module/src/helper.fe
+++ b/crates/fe/tests/fixtures/fe_test_runner/ingot_tests_in_non_root_module/src/helper.fe
@@ -1,0 +1,7 @@
+use std::evm::{Evm, assert}
+use ingot::add
+
+#[test]
+fn test_add() uses (evm: mut Evm) {
+    assert(add(2, 3) == 5)
+}

--- a/crates/fe/tests/fixtures/fe_test_runner/ingot_tests_in_non_root_module/src/lib.fe
+++ b/crates/fe/tests/fixtures/fe_test_runner/ingot_tests_in_non_root_module/src/lib.fe
@@ -1,0 +1,6 @@
+// Root module with no #[test] functions.
+// Tests live only in the sibling module (helper.fe).
+
+pub fn add(a: u256, b: u256) -> u256 {
+    a + b
+}


### PR DESCRIPTION
## Summary                                                                                                                                                                                                        
                                               
  - `run_tests_ingot` only checked the root module (`lib.fe`) for `#[test]` functions via `has_test_functions(db, root_mod)`. If `lib.fe` contained no tests, the entire ingot was silently skipped with "No tests  
  found" — even when other modules had tests.                                                                                                                                                                       
  - Add `ingot_has_test_functions` that checks all modules in the ingot via `Ingot::all_funcs`, and use it in place of the root-module-only check.                                                                  
  - Add a regression test with an ingot fixture whose `lib.fe` has no tests while a sibling module (`helper.fe`) does.

  ## Reproduction

  Create an ingot where `lib.fe` only exports helpers and all `#[test]` functions live in other modules:

  src/lib.fe      ← pub fn add(a: u256, b: u256) -> u256 { ... }  (no tests)
  src/helper.fe   ← #[test] fn test_add() { ... }

  $ fe test .
  Warning: No tests found in .

  After this fix, `fe test` correctly discovers and runs `test_add`.

  ## Test plan

  - [x] New test `test_cli_test_ingot_discovers_tests_in_non_root_modules` passes with fix, fails without
  - [x] All existing `fe_test` / `fe_test_runner` tests pass (49/49)
