### PR TITLE
Fix cross-ingot create2 by generating dependency contract templates

### DIFF
--- a/crates/codegen/tests/fixtures/sonatina_ir/by_ref_trait_provider_storage_bug.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/by_ref_trait_provider_storage_bug.snap
@@ -120,18 +120,6 @@ func private %__ByRefTraitProviderStorageBug_runtime() {
         evm_invalid;
 }
 
-func private %__ByRefTraitProviderStorageBug_init_code_offset() -> i256 {
-    block0:
-        v1.i256 = sym_addr &__ByRefTraitProviderStorageBug_init;
-        return v1;
-}
-
-func private %__ByRefTraitProviderStorageBug_init_code_len() -> i256 {
-    block0:
-        v1.i256 = sym_size &__ByRefTraitProviderStorageBug_init;
-        return v1;
-}
-
 func private %use_ctx_eff0_stor__Pair_h956dff41e88ee341__acec41afdc898140(v0.i256) -> i256 {
     block0:
         v2.i256 = call %pair_h956dff41e88ee341_ctx_h4952b3c1f066f039_sum_stor_arg0_root_stor v0;

--- a/crates/codegen/tests/fixtures/sonatina_ir/create_contract.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/create_contract.snap
@@ -78,18 +78,6 @@ func private %__Child_runtime() {
         evm_invalid;
 }
 
-func private %__Child_init_code_offset() -> i256 {
-    block0:
-        v1.i256 = sym_addr &__Child_init;
-        return v1;
-}
-
-func private %__Child_init_code_len() -> i256 {
-    block0:
-        v1.i256 = sym_size &__Child_init;
-        return v1;
-}
-
 func private %__Factory_recv_0_0(v0.i256, v1.i256) -> i256 {
     block0:
         v3.*@__fe_Deploy_1 = int_to_ptr v0 *@__fe_Deploy_1;
@@ -176,18 +164,6 @@ func private %__Factory_runtime() {
     block4:
         v6.i1 = eq v1 2.i256;
         br v6 block3 block1;
-}
-
-func private %__Factory_init_code_offset() -> i256 {
-    block0:
-        v1.i256 = sym_addr &__Factory_init;
-        return v1;
-}
-
-func private %__Factory_init_code_len() -> i256 {
-    block0:
-        v1.i256 = sym_size &__Factory_init;
-        return v1;
 }
 
 func private %init_field__Evm_hef0af3106e109414_Pair_h956dff41e88ee341__18f2eb617f185785(v0.i256, v1.i256) -> i256 {
@@ -519,6 +495,18 @@ func private %sol_hfd482bb803ad8c5f_abi_h2da9a2d0b1ddaeb7_decoder_with_base__Cal
     block0:
         v3.i256 = call %soldecoder_i__ha12a03fcb5ba844b_with_base__CallData_hf71d505b6ff5dc81__e6d5f05c3478f563 v0 v1;
         return v3;
+}
+
+func private %__Child_init_code_len() -> i256 {
+    block0:
+        v1.i256 = sym_size &__Child_init;
+        return v1;
+}
+
+func private %__Child_init_code_offset() -> i256 {
+    block0:
+        v1.i256 = sym_addr &__Child_init;
+        return v1;
 }
 
 func private %_t0__t1__h61373471174c18a_encode_hab7243eccf2714fb_encode__Sol_hfd482bb803ad8c5f_u256_u256_SolEncoder_h1b9228b90dad6928__9e0831f7c11d9f64(v0.i256, v1.i256) {

--- a/crates/codegen/tests/fixtures/sonatina_ir/erc20.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/erc20.snap
@@ -434,18 +434,6 @@ func private %__CoolCoin_runtime() {
         br v33 block15 block1;
 }
 
-func private %__CoolCoin_init_code_offset() -> i256 {
-    block0:
-        v1.i256 = sym_addr &__CoolCoin_init;
-        return v1;
-}
-
-func private %__CoolCoin_init_code_len() -> i256 {
-    block0:
-        v1.i256 = sym_size &__CoolCoin_init;
-        return v1;
-}
-
 func public %accesscontrol____h4c85da5bbb505ade_grant_stor_arg0_root_stor__3__577ab43c73dd3cef(v0.i256, v1.i256, v2.i256) {
     block0:
         v5.*i8 = evm_malloc 64.i256;

--- a/crates/codegen/tests/fixtures/sonatina_ir/high_level_contract.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/high_level_contract.snap
@@ -119,18 +119,6 @@ func private %__EchoContract_runtime() {
         br v9 block4 block1;
 }
 
-func private %__EchoContract_init_code_offset() -> i256 {
-    block0:
-        v1.i256 = sym_addr &__EchoContract_init;
-        return v1;
-}
-
-func private %__EchoContract_init_code_len() -> i256 {
-    block0:
-        v1.i256 = sym_size &__EchoContract_init;
-        return v1;
-}
-
 func private %init_field__Evm_hef0af3106e109414_Foo_h6dbce71a6ea992b8__c09e6c6fc5a7b23d(v0.i256, v1.i256) -> i256 {
     block0:
         v3.i256 = call %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_field__Foo_h6dbce71a6ea992b8__21493237fe9c2c26 v0 v1;

--- a/crates/codegen/tests/fixtures/sonatina_ir/init_args_with_child_dep.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/init_args_with_child_dep.snap
@@ -71,18 +71,6 @@ func private %__Child_runtime() {
         evm_invalid;
 }
 
-func private %__Child_init_code_offset() -> i256 {
-    block0:
-        v1.i256 = sym_addr &__Child_init;
-        return v1;
-}
-
-func private %__Child_init_code_len() -> i256 {
-    block0:
-        v1.i256 = sym_size &__Child_init;
-        return v1;
-}
-
 func private %__Parent_init_contract(v0.i256, v1.i256) {
     block0:
         v4.*i8 = evm_malloc 64.i256;
@@ -148,18 +136,6 @@ func private %__Parent_runtime() {
     block1:
         call %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort 0.i256;
         evm_invalid;
-}
-
-func private %__Parent_init_code_offset() -> i256 {
-    block0:
-        v1.i256 = sym_addr &__Parent_init;
-        return v1;
-}
-
-func private %__Parent_init_code_len() -> i256 {
-    block0:
-        v1.i256 = sym_size &__Parent_init;
-        return v1;
 }
 
 func private %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort(v0.i256) {
@@ -374,6 +350,18 @@ func private %sol_hfd482bb803ad8c5f_abi_h2da9a2d0b1ddaeb7_decoder_with_base__Cal
     block0:
         v3.i256 = call %soldecoder_i__ha12a03fcb5ba844b_with_base__CallData_hf71d505b6ff5dc81__e6d5f05c3478f563 v0 v1;
         return v3;
+}
+
+func private %__Child_init_code_len() -> i256 {
+    block0:
+        v1.i256 = sym_size &__Child_init;
+        return v1;
+}
+
+func private %__Child_init_code_offset() -> i256 {
+    block0:
+        v1.i256 = sym_addr &__Child_init;
+        return v1;
 }
 
 func private %_t0__t1__h61373471174c18a_encode_hab7243eccf2714fb_encode__Sol_hfd482bb803ad8c5f_u256_u256_SolEncoder_h1b9228b90dad6928__9e0831f7c11d9f64(v0.i256, v1.i256) {

--- a/crates/codegen/tests/fixtures/sonatina_ir/newtype_storage_byplace_effect_arg.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/newtype_storage_byplace_effect_arg.snap
@@ -98,18 +98,6 @@ func private %__NewtypeByPlaceEffectArg_runtime() {
         evm_invalid;
 }
 
-func private %__NewtypeByPlaceEffectArg_init_code_offset() -> i256 {
-    block0:
-        v1.i256 = sym_addr &__NewtypeByPlaceEffectArg_init;
-        return v1;
-}
-
-func private %__NewtypeByPlaceEffectArg_init_code_len() -> i256 {
-    block0:
-        v1.i256 = sym_size &__NewtypeByPlaceEffectArg_init;
-        return v1;
-}
-
 func private %init_field__Evm_hef0af3106e109414_u256__3b1b0af5b20737f9(v0.i256, v1.i256) -> i256 {
     block0:
         v3.i256 = call %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_field__u256__3271ca15373d4483 v0 v1;

--- a/crates/codegen/tests/fixtures/sonatina_ir/newtype_storage_field_mut_method_call.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/newtype_storage_field_mut_method_call.snap
@@ -96,18 +96,6 @@ func private %__NewtypeStorageFieldMutMethodCall_runtime() {
         evm_invalid;
 }
 
-func private %__NewtypeStorageFieldMutMethodCall_init_code_offset() -> i256 {
-    block0:
-        v1.i256 = sym_addr &__NewtypeStorageFieldMutMethodCall_init;
-        return v1;
-}
-
-func private %__NewtypeStorageFieldMutMethodCall_init_code_len() -> i256 {
-    block0:
-        v1.i256 = sym_size &__NewtypeStorageFieldMutMethodCall_init;
-        return v1;
-}
-
 func private %wrap_haf9e70905fcbd513_bump_stor_arg0_root_stor(v0.i256) {
     block0:
         v2.i256 = evm_sload v0;

--- a/crates/codegen/tests/fixtures/sonatina_ir/tstor_ptr_contract.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/tstor_ptr_contract.snap
@@ -99,18 +99,6 @@ func private %__GuardContract_runtime() {
         evm_invalid;
 }
 
-func private %__GuardContract_init_code_offset() -> i256 {
-    block0:
-        v1.i256 = sym_addr &__GuardContract_init;
-        return v1;
-}
-
-func private %__GuardContract_init_code_len() -> i256 {
-    block0:
-        v1.i256 = sym_size &__GuardContract_init;
-        return v1;
-}
-
 func private %init_field__Evm_hef0af3106e109414_u256__3b1b0af5b20737f9(v0.i256, v1.i256) -> i256 {
     block0:
         v3.i256 = call %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_field__u256__3271ca15373d4483 v0 v1;

--- a/crates/fe/tests/cli_output.rs
+++ b/crates/fe/tests/cli_output.rs
@@ -918,6 +918,26 @@ fn test_cli_test_workspace_ingot_missing_member_is_error() {
     );
 }
 
+/// Regression test: `create2` of a contract defined in another ingot within
+/// the same workspace must compile and run correctly.
+#[test]
+fn test_cli_test_cross_ingot_create2() {
+    let fixture_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/fe_test_runner/cross_ingot_create2");
+    let fixture_dir_str = fixture_dir.to_str().expect("fixture dir utf8");
+
+    let (output, exit_code) = run_fe_main(&["test", fixture_dir_str]);
+    assert_eq!(exit_code, 0, "fe test failed:\n{output}");
+    assert!(
+        output.contains("test test_create2_contract_from_other_ingot"),
+        "expected cross-ingot create2 test, got:\n{output}"
+    );
+    assert!(
+        output.contains("1 passed"),
+        "expected 1 passed test, got:\n{output}"
+    );
+}
+
 /// Regression test: `fe test` must discover tests in non-root modules of an
 /// ingot even when `lib.fe` itself contains no `#[test]` functions.
 #[test]
@@ -937,7 +957,6 @@ fn test_cli_test_ingot_discovers_tests_in_non_root_modules() {
         "expected 1 passed test, got:\n{output}"
     );
 }
-
 #[test]
 fn test_cli_test_repo_core_ingot_without_tests_is_ok() {
     let project_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/crates/fe/tests/fixtures/fe_test_runner/cross_ingot_create2/fe.toml
+++ b/crates/fe/tests/fixtures/fe_test_runner/cross_ingot_create2/fe.toml
@@ -1,0 +1,4 @@
+[workspace]
+name = "cross_ingot_create2"
+version = "0.1.0"
+members = ["ingots/*"]

--- a/crates/fe/tests/fixtures/fe_test_runner/cross_ingot_create2/ingots/consumer/fe.toml
+++ b/crates/fe/tests/fixtures/fe_test_runner/cross_ingot_create2/ingots/consumer/fe.toml
@@ -1,0 +1,6 @@
+[ingot]
+name = "consumer"
+version = "0.1.0"
+
+[dependencies]
+provider = true

--- a/crates/fe/tests/fixtures/fe_test_runner/cross_ingot_create2/ingots/consumer/src/lib.fe
+++ b/crates/fe/tests/fixtures/fe_test_runner/cross_ingot_create2/ingots/consumer/src/lib.fe
@@ -1,0 +1,14 @@
+// Regression test: create2 of a contract defined in another ingot
+// within the same workspace must work correctly.
+
+use std::evm::{Evm, assert}
+use provider::{Greeter, GreetMsg}
+
+#[test]
+fn test_create2_contract_from_other_ingot() uses (evm: mut Evm) {
+    let addr = evm.create2<Greeter>(value: 0, args: (42,), salt: 1)
+    assert(addr.inner != 0)
+
+    let result: u256 = evm.call(addr: addr, gas: 100000, value: 0, message: GreetMsg::Greet {})
+    assert(result == 42)
+}

--- a/crates/fe/tests/fixtures/fe_test_runner/cross_ingot_create2/ingots/provider/fe.toml
+++ b/crates/fe/tests/fixtures/fe_test_runner/cross_ingot_create2/ingots/provider/fe.toml
@@ -1,0 +1,3 @@
+[ingot]
+name = "provider"
+version = "0.1.0"

--- a/crates/fe/tests/fixtures/fe_test_runner/cross_ingot_create2/ingots/provider/src/lib.fe
+++ b/crates/fe/tests/fixtures/fe_test_runner/cross_ingot_create2/ingots/provider/src/lib.fe
@@ -1,0 +1,20 @@
+use std::abi::sol
+
+pub msg GreetMsg {
+    #[selector = sol("greet()")]
+    Greet -> u256,
+}
+
+pub contract Greeter {
+    mut value: u256,
+
+    init(initial_value: u256) uses (mut value) {
+        value = initial_value
+    }
+
+    recv GreetMsg {
+        Greet -> u256 uses (value) {
+            value
+        }
+    }
+}

--- a/crates/mir/src/ir.rs
+++ b/crates/mir/src/ir.rs
@@ -47,6 +47,10 @@ pub struct MirFunction<'db> {
     pub symbol_name: String,
     /// For methods, the address space variant of the receiver for this instance.
     pub receiver_space: Option<AddressSpaceKind>,
+    /// When true, the monomorphizer will NOT automatically seed this template
+    /// as a root.  Used for dependency contract templates that should only be
+    /// instantiated when referenced by `create2`.
+    pub defer_root: bool,
 }
 
 /// Source identity of a MIR function.
@@ -69,6 +73,20 @@ pub enum SyntheticId<'db> {
     },
     ContractInitCodeOffset(Contract<'db>),
     ContractInitCodeLen(Contract<'db>),
+}
+
+impl<'db> SyntheticId<'db> {
+    /// Return the contract this synthetic function belongs to.
+    pub fn contract(&self) -> Contract<'db> {
+        match *self {
+            Self::ContractInitEntrypoint(c)
+            | Self::ContractRuntimeEntrypoint(c)
+            | Self::ContractInitHandler(c)
+            | Self::ContractInitCodeOffset(c)
+            | Self::ContractInitCodeLen(c) => c,
+            Self::ContractRecvArmHandler { contract, .. } => contract,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/crates/mir/src/lower/contracts.rs
+++ b/crates/mir/src/lower/contracts.rs
@@ -3,7 +3,10 @@
 //! This is the implementation of `contract_lowering_target_architecture.md`'s contract lowering
 //! pipeline: HIR remains purely syntactic, while typed contract elaboration drives MIR generation.
 
-use common::{indexmap::IndexMap, ingot::IngotKind};
+use common::{
+    indexmap::IndexMap,
+    ingot::{Ingot, IngotKind},
+};
 use hir::hir_def::params::FuncParamMode;
 use hir::{
     analysis::{
@@ -26,7 +29,7 @@ use hir::{
         },
     },
     hir_def::{
-        CallableDef, Contract, IdentId, PathId, TopLevelMod,
+        CallableDef, Contract, HirIngot, IdentId, PathId, TopLevelMod,
         expr::{ArithBinOp, BinOp, CompBinOp},
     },
 };
@@ -49,56 +52,99 @@ pub(super) fn lower_contract_templates<'db>(
     db: &'db dyn SpannedHirAnalysisDb,
     top_mod: TopLevelMod<'db>,
 ) -> MirLowerResult<Vec<MirFunction<'db>>> {
-    let mut out = Vec::new();
-
     let target = TargetContext::new(db, top_mod)?;
-
+    let mut out = Vec::new();
     for &contract in top_mod.all_contracts(db) {
-        let symbols = ContractSymbols::new(db, contract);
-
-        let core_lib = CoreLib::new(db, contract.scope());
-
-        let slot_offsets = contract
-            .field_layout(db)
-            .values()
-            .map(|field| BigUint::from(field.slot_offset))
-            .collect::<Vec<_>>();
-
-        // User-body handlers first (so entrypoints can call them by symbol).
-        if contract.init(db).is_some() {
-            out.push(lower_init_handler(db, contract, &symbols, &core_lib)?);
-        }
-        for recv in contract.recv_views(db) {
-            for arm in recv.arms(db) {
-                out.push(lower_recv_arm_handler(
-                    db,
-                    contract,
-                    arm,
-                    target.abi.abi_ty,
-                    &symbols,
-                    &core_lib,
-                )?);
-            }
-        }
-
-        // Entrypoints + metadata hooks.
-        out.push(lower_init_entrypoint(
-            db,
-            contract,
-            &target,
-            &symbols,
-            &slot_offsets,
-        )?);
-        out.push(lower_runtime_entrypoint(
-            db,
-            contract,
-            &target,
-            &symbols,
-            &slot_offsets,
-        )?);
-        out.push(lower_init_code_offset(db, contract, &symbols)?);
-        out.push(lower_init_code_len(db, contract, &symbols)?);
+        out.extend(lower_single_contract(&target, db, contract, None)?);
     }
+    Ok(out)
+}
+
+/// Lower contract templates for contracts defined in a dependency ingot.
+///
+/// `host_top_mod` is a module from the *current* ingot and is used to create
+/// the [`TargetContext`] (resolving `std::evm::EvmTarget` etc.).  The contracts
+/// come from `dep_ingot` which may be a different ingot in the same workspace.
+///
+/// This is needed so that `create2<SomeContract>` works when `SomeContract`
+/// lives in a different ingot.
+pub(super) fn lower_dependency_contract_templates<'db>(
+    db: &'db dyn SpannedHirAnalysisDb,
+    host_top_mod: TopLevelMod<'db>,
+    dep_ingot: Ingot<'db>,
+    dep_name: &str,
+) -> MirLowerResult<Vec<MirFunction<'db>>> {
+    let target = TargetContext::new(db, host_top_mod)?;
+    let mut out = Vec::new();
+    for &dep_mod in dep_ingot.all_modules(db).iter() {
+        for &contract in dep_mod.all_contracts(db) {
+            let mut templates = lower_single_contract(&target, db, contract, Some(dep_name))?;
+            // Mark dependency templates so the monomorphizer does not eagerly
+            // seed them as roots.  They will still be instantiated on demand
+            // when referenced by `create2`.
+            for t in &mut templates {
+                t.defer_root = true;
+            }
+            out.extend(templates);
+        }
+    }
+    Ok(out)
+}
+
+/// Generate all synthetic MIR templates for a single contract.
+///
+/// `ingot_prefix` is used to qualify symbol names for dependency contracts,
+/// preventing collisions when two ingots define contracts with the same name.
+fn lower_single_contract<'db>(
+    target: &TargetContext<'db>,
+    db: &'db dyn SpannedHirAnalysisDb,
+    contract: Contract<'db>,
+    ingot_prefix: Option<&str>,
+) -> MirLowerResult<Vec<MirFunction<'db>>> {
+    let mut out = Vec::new();
+    let symbols = ContractSymbols::with_prefix(db, contract, ingot_prefix);
+    let core_lib = CoreLib::new(db, contract.scope());
+
+    let slot_offsets = contract
+        .field_layout(db)
+        .values()
+        .map(|field| BigUint::from(field.slot_offset))
+        .collect::<Vec<_>>();
+
+    // User-body handlers first (so entrypoints can call them by symbol).
+    if contract.init(db).is_some() {
+        out.push(lower_init_handler(db, contract, &symbols, &core_lib)?);
+    }
+    for recv in contract.recv_views(db) {
+        for arm in recv.arms(db) {
+            out.push(lower_recv_arm_handler(
+                db,
+                contract,
+                arm,
+                target.abi.abi_ty,
+                &symbols,
+                &core_lib,
+            )?);
+        }
+    }
+
+    // Entrypoints + metadata hooks.
+    out.push(lower_init_entrypoint(
+        db,
+        contract,
+        target,
+        &symbols,
+        &slot_offsets,
+    )?);
+    out.push(lower_runtime_entrypoint(
+        db,
+        contract,
+        target,
+        &symbols,
+        &slot_offsets,
+    )?);
+    out.push(lower_init_code_offset(db, contract, &symbols)?);
+    out.push(lower_init_code_len(db, contract, &symbols)?);
 
     Ok(out)
 }
@@ -113,12 +159,22 @@ struct ContractSymbols {
 }
 
 impl ContractSymbols {
-    fn new(db: &dyn HirAnalysisDb, contract: Contract<'_>) -> Self {
-        let contract_name = contract
+    /// Build symbols with an optional ingot-name prefix to disambiguate
+    /// contracts from different ingots that share the same name.
+    fn with_prefix(
+        db: &dyn HirAnalysisDb,
+        contract: Contract<'_>,
+        ingot_prefix: Option<&str>,
+    ) -> Self {
+        let bare_name = contract
             .name(db)
             .to_opt()
             .map(|id| id.data(db).to_string())
             .unwrap_or_else(|| "<anonymous_contract>".to_string());
+        let contract_name = match ingot_prefix {
+            Some(prefix) => format!("{prefix}__{bare_name}"),
+            None => bare_name,
+        };
         let init_entrypoint = format!("__{contract_name}_init");
         let runtime_entrypoint = format!("__{contract_name}_runtime");
         let init_handler = format!("__{contract_name}_init_contract");
@@ -768,6 +824,7 @@ fn lower_init_handler<'db>(
         contract_function: None,
         symbol_name: symbols.init_handler.clone(),
         receiver_space: None,
+        defer_root: false,
     })
 }
 
@@ -895,6 +952,7 @@ fn lower_recv_arm_handler<'db>(
         contract_function: None,
         symbol_name: symbols.recv_handler(recv_idx, arm_idx),
         receiver_space: None,
+        defer_root: false,
     })
 }
 
@@ -1178,6 +1236,7 @@ fn lower_init_entrypoint<'db>(
         contract_function: Some(contract_fn),
         symbol_name: symbols.init_entrypoint.clone(),
         receiver_space: None,
+        defer_root: false,
     })
 }
 
@@ -1309,6 +1368,7 @@ fn lower_runtime_entrypoint<'db>(
         contract_function: Some(contract_fn),
         symbol_name: symbols.runtime_entrypoint.clone(),
         receiver_space: None,
+        defer_root: false,
     })
 }
 
@@ -1383,5 +1443,12 @@ fn lower_code_region_query<'db>(
         contract_function: None,
         symbol_name,
         receiver_space: None,
+        // Code-region queries (init_code_offset / init_code_len) use
+        // `sym_addr` / `sym_size` that reference the init entrypoint as an
+        // embed symbol.  They must only be instantiated when `create2`
+        // actually triggers them; otherwise the Sonatina verifier complains
+        // about undeclared embed symbols in ingots where the contract is
+        // never deployed.
+        defer_root: true,
     })
 }

--- a/crates/mir/tests/fixtures/const_hole_storage_map_contract_defaults.mir.snap
+++ b/crates/mir/tests/fixtures/const_hole_storage_map_contract_defaults.mir.snap
@@ -62,16 +62,6 @@ fn __BalanceMap_runtime() -> ():
     v5: u256 = __BalanceMap_recv_0_1(v4, v0)
     terminate return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f((), v5)
 
-fn __BalanceMap_init_code_offset() -> u256:
-  bb0:
-    v0: u256 = code_region_offset(func_item(__BalanceMap_init))
-    ret v0
-
-fn __BalanceMap_init_code_len() -> u256:
-  bb0:
-    v0: u256 = code_region_len(func_item(__BalanceMap_init))
-    ret v0
-
 fn storagemap_k__v__const_salt__u256__h5955888dd44c2a19_set_stor_arg0_root_stor__u256_u256_0__6a346ad3c930d971(v0: StorageMap<u256, u256, 0>, v1: u256, v2: u256) -> ():
   bb0:
     v3: u256 = u256_h3271ca15373d4483_wordrepr_h7483d41ac8178d88_to_word(v2)

--- a/crates/mir/tests/fixtures/contract_field_layout_slots_const_hole.mir.snap
+++ b/crates/mir/tests/fixtures/contract_field_layout_slots_const_hole.mir.snap
@@ -50,16 +50,6 @@ fn __LayoutHoles_runtime() -> ():
     v8: u256 = __LayoutHoles_recv_0_1(v7, v1, v3)
     terminate return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f((), v8)
 
-fn __LayoutHoles_init_code_offset() -> u256:
-  bb0:
-    v0: u256 = code_region_offset(func_item(__LayoutHoles_init))
-    ret v0
-
-fn __LayoutHoles_init_code_len() -> u256:
-  bb0:
-    v0: u256 = code_region_len(func_item(__LayoutHoles_init))
-    ret v0
-
 fn storagemap_k__v__const_salt__u256__h5955888dd44c2a19_set_stor_arg0_root_stor__u256_u256_2__7d7bd47f3e4876cc(v0: StorageMap<u256, u256, 2>, v1: u256, v2: u256) -> ():
   bb0:
     v3: u256 = u256_h3271ca15373d4483_wordrepr_h7483d41ac8178d88_to_word(v2)

--- a/crates/mir/tests/fixtures/echo.mir.snap
+++ b/crates/mir/tests/fixtures/echo.mir.snap
@@ -67,16 +67,6 @@ fn __EchoContract_runtime() -> ():
     v6: u256 = __EchoContract_recv_0_2((), v0)
     terminate return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f((), v6)
 
-fn __EchoContract_init_code_offset() -> u256:
-  bb0:
-    v0: u256 = code_region_offset(func_item(__EchoContract_init))
-    ret v0
-
-fn __EchoContract_init_code_len() -> u256:
-  bb0:
-    v0: u256 = code_region_len(func_item(__EchoContract_init))
-    ret v0
-
 fn init_field__Evm_hef0af3106e109414_Foo_h6dbce71a6ea992b8__c09e6c6fc5a7b23d(v0: mut Evm, v1: u256) -> StorPtr<Foo>:
   bb0:
     v2: StorPtr<Foo> = evm_hef0af3106e109414_contracthost_h57111e7eb283a125_field__Foo_h6dbce71a6ea992b8__21493237fe9c2c26(v0, v1)

--- a/crates/mir/tests/fixtures/transient_field_effects.mir.snap
+++ b/crates/mir/tests/fixtures/transient_field_effects.mir.snap
@@ -53,16 +53,6 @@ fn __Guard_runtime() -> ():
     eval __Guard_recv_0_0((), v0)
     terminate return_unit__Evm_hef0af3106e109414__3af54274b2985741(())
 
-fn __Guard_init_code_offset() -> u256:
-  bb0:
-    v0: u256 = code_region_offset(func_item(__Guard_init))
-    ret v0
-
-fn __Guard_init_code_len() -> u256:
-  bb0:
-    v0: u256 = code_region_len(func_item(__Guard_init))
-    ret v0
-
 fn bump_lock__TStorPtr_u256___e67d09080c0f1393(v0: u256) -> ():
   bb0:
     v1: u256 = load tstor[v0]


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                        
                                               
  - Fix compiler panic when using `create2<Contract>` where the contract is defined in a different ingot within the same workspace                                                                                  
  - Generate synthetic MIR templates for dependency ingot contracts so cross-ingot deployment works                                                                                                                 
  - Defer `ContractInitCodeOffset`/`ContractInitCodeLen` templates to avoid Sonatina verifier errors for contracts that are never deployed in their defining ingot                                                  
                                                                  
  ## Problem

  Using `create2<SomeContract>` in ingot B when `SomeContract` is defined in ingot A caused:

  failed to instantiate synthetic MIR for ContractInitCodeLen

  `lower_contract_templates` only generated synthetic MIR for contracts in the current ingot's modules. Dependency ingot contracts were never lowered, so the monomorphizer couldn't find their templates.

  ## Approach

  Three changes work together:

  1. **Dependency contract template generation** (`contracts.rs`, `mod.rs`): `lower_ingot` now iterates `resolved_external_ingots` and generates templates via a new `lower_dependency_contract_templates` function.
   It uses the host ingot's `TargetContext` so `std::evm::EvmTarget` resolves correctly.

  2. **Deferred seeding** (`ir.rs`, `contracts.rs`, `monomorphize.rs`): Dependency templates are marked `defer_root: true` so the monomorphizer skips them in `seed_roots`. `ContractInitCodeOffset` and
  `ContractInitCodeLen` are deferred for *all* contracts — they emit `sym_addr`/`sym_size` referencing the init entrypoint as a Sonatina embed symbol, which only exists when `create2` triggers deployment.

  3. **Sibling co-instantiation** (`monomorphize.rs`): When a deferred template is first instantiated on-demand, all other synthetic templates for the same contract are co-instantiated. This is needed because
  contract entrypoints call `init_handler` and `recv_arm_handlers` via `call_symbol` (pre-resolved names), which the monomorphizer cannot trace through `resolve_call_target`.

  ## Test plan

  - [x] New regression test `test_cli_test_cross_ingot_create2` — workspace with provider/consumer ingots exercising cross-ingot `create2`