### PR TITLE
Implement call on Address type

### DIFF
--- a/crates/fe/tests/fixtures/fe_test/address_call_method.fe
+++ b/crates/fe/tests/fixtures/fe_test/address_call_method.fe
@@ -1,0 +1,49 @@
+/// Regression test: calling a contract via `addr.call(msg)` (impl method on
+/// Address that references the Call trait) must not trigger a Salsa cycle crash
+/// in `collect_methods`.
+
+use std::abi::sol
+
+msg CounterMsg {
+    #[selector = sol("increment()")]
+    Increment,
+    #[selector = sol("get()")]
+    Get -> u256,
+}
+
+struct CounterStore {
+    value: u256,
+}
+
+pub contract Counter {
+    mut store: CounterStore
+
+    init() uses (mut store) {
+        store.value = 0
+    }
+
+    recv CounterMsg {
+        Increment uses (mut store) {
+            store.value = store.value + 1
+        }
+
+        Get -> u256 uses (store) {
+            store.value
+        }
+    }
+}
+
+#[test]
+fn test_address_call_method() uses (evm: mut Evm, call: mut Call) {
+    let addr = evm.create2<Counter>(value: 0, args: (), salt: 0)
+    assert(addr.inner != 0)
+
+    // Use the impl Address::call method (not the trait method directly)
+    let v0: u256 = addr.call(CounterMsg::Get {})
+    assert(v0 == 0)
+
+    addr.call(CounterMsg::Increment {})
+
+    let v1: u256 = addr.call(CounterMsg::Get {})
+    assert(v1 == 1)
+}

--- a/ingots/std/src/evm/effects.fe
+++ b/ingots/std/src/evm/effects.fe
@@ -288,6 +288,18 @@ pub trait Call {
               M::Return: Decode<Sol>
 }
 
+impl Address {
+    /// Call a contract at this address with a typed message.
+    ///
+    /// Forwards all available gas and sends no value. Reverts on failure.
+    pub fn call<M>(self, _ message: own M) -> M::Return uses (call: mut Call)
+        where M: MsgVariant<Sol> + Encode<Sol>,
+              M::Return: Decode<Sol>
+    {
+        call.call(addr: self, gas: ops::gas(), value: 0, message)
+    }
+}
+
 /// Combined EVM capability: provides all EVM effects.
 pub trait Super: Ctx + RawOps + Log + Create + Call {}
 


### PR DESCRIPTION
Implements `call` on `Address` and fixes an ICE that would prevent to implement this.
Currently, this only supports providing the `msg` to be most ergonomic for the default scenario. If one needs to set `gas` or `value` they can fall back to the current mechanism...for now.