### PR TITLE
Add Array out of bounds checks

### DIFF
--- a/crates/codegen/src/sonatina/lower.rs
+++ b/crates/codegen/src/sonatina/lower.rs
@@ -2418,9 +2418,32 @@ fn lower_place_address_gep<'db, C: sonatina_ir::func_cursor::FuncCursor>(
                 )?;
             }
             Projection::Index(idx_source) => {
+                // Bounds check: revert if index >= array length
+                let arr_len = layout::array_len(ctx.db, step.owner.ty);
                 let idx_val = match idx_source {
-                    IndexSource::Constant(idx) => ctx.fb.make_imm_value(I256::from(*idx as u64)),
-                    IndexSource::Dynamic(value_id) => lower_value(ctx, *value_id)?,
+                    IndexSource::Constant(idx) => {
+                        if let Some(len) = arr_len
+                            && *idx >= len
+                        {
+                            let revert_block = ensure_overflow_revert_block(ctx)?;
+                            ctx.fb
+                                .insert_inst_no_result(Jump::new(ctx.is, revert_block));
+                            let unreachable_block = ctx.fb.append_block();
+                            ctx.fb.switch_to_block(unreachable_block);
+                        }
+                        ctx.fb.make_imm_value(I256::from(*idx as u64))
+                    }
+                    IndexSource::Dynamic(value_id) => {
+                        let val = lower_value(ctx, *value_id)?;
+                        if let Some(len) = arr_len {
+                            let len_val = ctx.fb.make_imm_value(I256::from(len as u64));
+                            let in_bounds =
+                                ctx.fb.insert_inst(Lt::new(ctx.is, val, len_val), Type::I1);
+                            let oob = ctx.fb.insert_inst(IsZero::new(ctx.is, in_bounds), Type::I1);
+                            emit_overflow_revert(ctx, oob)?;
+                        }
+                        val
+                    }
                 };
                 gep_values.push(idx_val);
 
@@ -2565,8 +2588,21 @@ fn lower_place_address_arithmetic<'db, C: sonatina_ir::func_cursor::FuncCursor>(
                     ))
                 })?;
 
+                // Get the array length for bounds checking
+                let arr_len = layout::array_len(ctx.db, step.owner.ty);
+
                 match idx_source {
                     IndexSource::Constant(idx) => {
+                        // Compile-time bounds check for constant indices
+                        if let Some(len) = arr_len
+                            && *idx >= len
+                        {
+                            let revert_block = ensure_overflow_revert_block(ctx)?;
+                            ctx.fb
+                                .insert_inst_no_result(Jump::new(ctx.is, revert_block));
+                            let unreachable_block = ctx.fb.append_block();
+                            ctx.fb.switch_to_block(unreachable_block);
+                        }
                         total_offset += idx * stride;
                     }
                     IndexSource::Dynamic(value_id) => {
@@ -2578,8 +2614,21 @@ fn lower_place_address_arithmetic<'db, C: sonatina_ir::func_cursor::FuncCursor>(
                                 .insert_inst(Add::new(ctx.is, base_val, offset_val), Type::I256);
                             total_offset = 0;
                         }
-                        // Compute dynamic index offset: idx * stride
+
+                        // Bounds check: revert if index >= array length
                         let idx_val = lower_value(ctx, *value_id)?;
+                        if let Some(len) = arr_len {
+                            let len_val = ctx.fb.make_imm_value(I256::from(len as u64));
+                            // idx < len → 1 (in bounds) → IsZero → 0 (don't revert)
+                            // idx >= len → 0 (OOB) → IsZero → 1 (revert)
+                            let in_bounds = ctx
+                                .fb
+                                .insert_inst(Lt::new(ctx.is, idx_val, len_val), Type::I1);
+                            let oob = ctx.fb.insert_inst(IsZero::new(ctx.is, in_bounds), Type::I1);
+                            emit_overflow_revert(ctx, oob)?;
+                        }
+
+                        // Compute dynamic index offset: idx * stride
                         let offset_val = if stride == 1 {
                             idx_val
                         } else {

--- a/crates/codegen/tests/fixtures/sonatina_ir/cast_u8_usize_cmp.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/cast_u8_usize_cmp.snap
@@ -7,34 +7,42 @@ target = "evm-ethereum-osaka"
 
 func private %cast_u8_usize_cmp(v0.*[i8; 8], v1.i256, v2.i256) -> i8 {
     block0:
-        v4.*i8 = gep v0 0.i256 v1;
-        v5.i256 = mload v4 i256;
-        v6.i8 = trunc v5 i8;
-        v7.i256 = zext v6 i256;
-        v8.i1 = call %usize_ha12462c6d36e68b0_ord_h264f6d6d75097a_lt v2 v7;
-        br v8 block1 block2;
+        v5.i1 = lt v1 8.i256;
+        v6.i1 = is_zero v5;
+        br v6 block7 block8;
 
     block1:
         return 1.i8;
 
     block2:
-        v12.i256 = zext v6 i256;
-        v13.i1 = call %usize_ha12462c6d36e68b0_eq_he50383edd273619f_eq v2 v12;
-        br v13 block3 block4;
+        v16.i256 = zext v9 i256;
+        v17.i1 = call %usize_ha12462c6d36e68b0_eq_he50383edd273619f_eq v2 v16;
+        br v17 block3 block4;
 
     block3:
         return 2.i8;
 
     block4:
-        v17.i256 = zext v6 i256;
-        v18.i1 = call %usize_ha12462c6d36e68b0_ord_h264f6d6d75097a_gt v2 v17;
-        br v18 block5 block6;
+        v21.i256 = zext v9 i256;
+        v22.i1 = call %usize_ha12462c6d36e68b0_ord_h264f6d6d75097a_gt v2 v21;
+        br v22 block5 block6;
 
     block5:
         return 3.i8;
 
     block6:
         return 0.i8;
+
+    block7:
+        evm_revert 0.i256 0.i256;
+
+    block8:
+        v7.*i8 = gep v0 0.i256 v1;
+        v8.i256 = mload v7 i256;
+        v9.i8 = trunc v8 i8;
+        v11.i256 = zext v9 i256;
+        v12.i1 = call %usize_ha12462c6d36e68b0_ord_h264f6d6d75097a_lt v2 v11;
+        br v12 block1 block2;
 }
 
 func private %usize_ha12462c6d36e68b0_ord_h264f6d6d75097a_lt(v0.i256, v1.i256) -> i1 {

--- a/crates/codegen/tests/fixtures/sonatina_ir/const_array.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/const_array.snap
@@ -15,24 +15,34 @@ func private %sum_two(v0.i256, v1.i256) -> i256 {
         v6.i256 = ptr_to_int v3 i256;
         evm_code_copy v6 v4 v5;
         v7.*[i256; 3] = bitcast v3 *[i256; 3];
-        v9.*i256 = gep v7 0.i256 v0;
-        v10.i256 = mload v9 i256;
-        v11.*i8 = evm_malloc 96.i256;
-        v12.i256 = sym_addr $__fe_const_data_0;
-        v13.i256 = sym_size $__fe_const_data_0;
-        v14.i256 = ptr_to_int v11 i256;
-        evm_code_copy v14 v12 v13;
-        v15.*[i256; 3] = bitcast v11 *[i256; 3];
-        v16.*i256 = gep v15 0.i256 v1;
-        v17.i256 = mload v16 i256;
-        (v18.i256, v19.i1) = uaddo v10 v17;
-        br v19 block1 block2;
+        v10.i1 = lt v0 3.i256;
+        v11.i1 = is_zero v10;
+        br v11 block1 block2;
 
     block1:
         evm_revert 0.i256 0.i256;
 
     block2:
-        return v18;
+        v12.*i256 = gep v7 0.i256 v0;
+        v13.i256 = mload v12 i256;
+        v14.*i8 = evm_malloc 96.i256;
+        v15.i256 = sym_addr $__fe_const_data_0;
+        v16.i256 = sym_size $__fe_const_data_0;
+        v17.i256 = ptr_to_int v14 i256;
+        evm_code_copy v17 v15 v16;
+        v18.*[i256; 3] = bitcast v14 *[i256; 3];
+        v20.i1 = lt v1 3.i256;
+        v21.i1 = is_zero v20;
+        br v21 block1 block3;
+
+    block3:
+        v22.*i256 = gep v18 0.i256 v1;
+        v23.i256 = mload v22 i256;
+        (v25.i256, v26.i1) = uaddo v13 v23;
+        br v26 block1 block4;
+
+    block4:
+        return v25;
 }
 
 func private %__fe_sonatina_entry() {

--- a/crates/codegen/tests/fixtures/sonatina_ir/for_array.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/for_array.snap
@@ -50,10 +50,18 @@ func private %_t__const_n__usize__h8b63f3f6d3df6413_seq_ha637d2df505bccf2_len__u
 
 func private %_t__const_n__usize__h8b63f3f6d3df6413_seq_ha637d2df505bccf2_get__u64_25__540b817a073b29f5(v0.*[i64; 25], v1.i256) -> i64 {
     block0:
-        v3.*i64 = gep v0 0.i256 v1;
-        v4.i256 = mload v3 i256;
-        v5.i64 = trunc v4 i64;
-        return v5;
+        v4.i1 = lt v1 25.i256;
+        v5.i1 = is_zero v4;
+        br v5 block1 block2;
+
+    block1:
+        evm_revert 0.i256 0.i256;
+
+    block2:
+        v6.*i64 = gep v0 0.i256 v1;
+        v7.i256 = mload v6 i256;
+        v8.i64 = trunc v7 i64;
+        return v8;
 }
 
 func private %__fe_sonatina_entry() {

--- a/crates/codegen/tests/fixtures/sonatina_ir/for_array_large.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/for_array_large.snap
@@ -50,10 +50,18 @@ func private %_t__const_n__usize__h8b63f3f6d3df6413_seq_ha637d2df505bccf2_len__u
 
 func private %_t__const_n__usize__h8b63f3f6d3df6413_seq_ha637d2df505bccf2_get__u64_10__2b47acd750beacf4(v0.*[i64; 10], v1.i256) -> i64 {
     block0:
-        v3.*i64 = gep v0 0.i256 v1;
-        v4.i256 = mload v3 i256;
-        v5.i64 = trunc v4 i64;
-        return v5;
+        v4.i1 = lt v1 10.i256;
+        v5.i1 = is_zero v4;
+        br v5 block1 block2;
+
+    block1:
+        evm_revert 0.i256 0.i256;
+
+    block2:
+        v6.*i64 = gep v0 0.i256 v1;
+        v7.i256 = mload v6 i256;
+        v8.i64 = trunc v7 i64;
+        return v8;
 }
 
 func private %__fe_sonatina_entry() {

--- a/crates/fe/tests/fixtures/fe_test_runner/array_oob_reverts.fe
+++ b/crates/fe/tests/fixtures/fe_test_runner/array_oob_reverts.fe
@@ -1,0 +1,57 @@
+use std::evm::effects::assert
+
+// Verifies that out-of-bounds array access reverts at runtime.
+// The Sonatina backend emits `lt idx len` + `is_zero` + conditional branch
+// to a revert block for every dynamic array index.
+
+// --- used results (value is consumed) ---
+
+#[test(should_revert)]
+fn test_oob_read_reverts() {
+    let arr: [u256; 4] = [10, 20, 30, 40]
+    let i: u256 = 4
+    let val = arr[i as usize]
+    assert(val == 0)
+}
+
+#[test(should_revert)]
+fn test_oob_write_reverts() {
+    let mut arr: [u256; 4] = [10, 20, 30, 40]
+    let i: u256 = 4
+    arr[i as usize] = 99
+}
+
+#[test(should_revert)]
+fn test_oob_large_index_reverts() {
+    let arr: [u256; 4] = [10, 20, 30, 40]
+    let i: u256 = 100
+    let val = arr[i as usize]
+    assert(val == 0)
+}
+
+#[test(should_revert)]
+fn test_oob_into_adjacent_array_reverts() {
+    let a: [u256; 4] = [10, 20, 30, 40]
+    let b: [u256; 4] = [100, 200, 300, 400]
+
+    // i=4 is OOB for `a` — reverts instead of silently reading b[0]
+    let i: u256 = 4
+    let leaked = a[i as usize]
+    assert(leaked == 100)
+}
+
+// --- dead results (value unused — DCE must not drop the bounds check) ---
+
+#[test(should_revert)]
+fn test_oob_dead_read_reverts() {
+    let arr: [u256; 4] = [10, 20, 30, 40]
+    let i: u256 = 4
+    let _val = arr[i as usize]
+}
+
+#[test(should_revert)]
+fn test_oob_dead_write_reverts() {
+    let mut arr: [u256; 4] = [10, 20, 30, 40]
+    let i: u256 = 4
+    arr[i as usize] = 99
+}

--- a/crates/fe/tests/fixtures/fe_test_runner/array_oob_reverts.snap
+++ b/crates/fe/tests/fixtures/fe_test_runner/array_oob_reverts.snap
@@ -1,0 +1,16 @@
+---
+source: crates/fe/tests/cli_output.rs
+expression: output
+input_file: tests/fixtures/fe_test_runner/array_oob_reverts.fe
+---
+=== STDOUT ===
+PASS  [<time>] test_oob_read_reverts
+PASS  [<time>] test_oob_write_reverts
+PASS  [<time>] test_oob_large_index_reverts
+PASS  [<time>] test_oob_into_adjacent_array_reverts
+PASS  [<time>] test_oob_dead_read_reverts
+PASS  [<time>] test_oob_dead_write_reverts
+
+test result: ok. 6 passed; 0 failed
+
+=== EXIT CODE: 0 ===

--- a/crates/mir/src/transform.rs
+++ b/crates/mir/src/transform.rs
@@ -703,6 +703,46 @@ fn path_has_deref<'db>(path: &MirProjectionPath<'db>) -> bool {
     path.iter().any(|proj| matches!(proj, Projection::Deref))
 }
 
+fn path_has_index<'db>(path: &MirProjectionPath<'db>) -> bool {
+    path.iter().any(|proj| matches!(proj, Projection::Index(_)))
+}
+
+/// Returns `true` when any projection in the full resolution chain of `place`
+/// (both the base-value prefix obtained via `resolve_local_projection_root` and
+/// the explicit `place.projection`) contains an `Index` step.  Evaluating such
+/// a place has a side effect in codegen (an OOB bounds-check revert), so
+/// instructions that touch it must not be eliminated as dead code.
+fn place_has_indexed_projection<'db>(body: &MirBody<'db>, place: &Place<'db>) -> bool {
+    if path_has_index(&place.projection) {
+        return true;
+    }
+    value_has_indexed_origin(&body.values, place.base)
+}
+
+/// Walks the value origin chain and returns `true` if any `PlaceRef` or
+/// `MoveOut` along the way contains an `Index` projection.  This catches
+/// by-ref element accesses that are wrapped in `Rvalue::Value(value_id)`
+/// rather than `Rvalue::Load { place }`.
+fn value_has_indexed_origin<'db>(values: &[ValueData<'db>], value: ValueId) -> bool {
+    use crate::ir::ValueOrigin;
+    let mut current = value;
+    loop {
+        let Some(data) = values.get(current.index()) else {
+            return false;
+        };
+        match &data.origin {
+            ValueOrigin::TransparentCast { value } => current = *value,
+            ValueOrigin::PlaceRef(place) | ValueOrigin::MoveOut { place } => {
+                if path_has_index(&place.projection) {
+                    return true;
+                }
+                current = place.base;
+            }
+            _ => return false,
+        }
+    }
+}
+
 fn removable_memory_root_local_for_place<'db>(
     body: &MirBody<'db>,
     place: &Place<'db>,
@@ -711,20 +751,40 @@ fn removable_memory_root_local_for_place<'db>(
     if path_has_deref(&prefix) || path_has_deref(&place.projection) {
         return None;
     }
+    // Stores/loads through indexed projections must not be eliminated: the
+    // codegen emits a bounds check (revert on OOB) as a side effect of
+    // evaluating the index.  Removing the instruction would silently drop
+    // that check.
+    if path_has_index(&prefix) || path_has_index(&place.projection) {
+        return None;
+    }
     (crate::ir::try_place_address_space_in(&body.values, &body.locals, place)
         == Some(AddressSpaceKind::Memory))
     .then_some(local)
 }
 
-fn removable_assign_rvalue<'db>(_body: &MirBody<'db>, rvalue: &Rvalue<'db>) -> bool {
+fn removable_assign_rvalue<'db>(body: &MirBody<'db>, rvalue: &Rvalue<'db>) -> bool {
     match rvalue {
-        Rvalue::ZeroInit
-        | Rvalue::Alloc { .. }
-        | Rvalue::ConstAggregate { .. }
-        | Rvalue::Value(_) => true,
-        Rvalue::Load { .. } => true,
+        Rvalue::ZeroInit | Rvalue::Alloc { .. } | Rvalue::ConstAggregate { .. } => true,
+        // A plain value is removable unless it originates from an indexed
+        // place (PlaceRef/MoveOut with an Index projection).  By-ref element
+        // accesses lower to PlaceRef values, and evaluating the place in
+        // codegen triggers a bounds check that must not be dropped.
+        Rvalue::Value(value) => !value_has_indexed_origin(&body.values, *value),
+        // Loads through indexed projections are not removable: the codegen
+        // emits a bounds check (revert on OOB) as a side effect of evaluating
+        // the index.  Removing the load would silently drop that check.
+        // We check both `place.projection` and the base-value prefix to
+        // cover nested accesses like `arr[i].field`.
+        Rvalue::Load { place } => !place_has_indexed_projection(body, place),
         Rvalue::Call(_) | Rvalue::Intrinsic { .. } => false,
     }
+}
+
+fn removable_bind_value<'db>(body: &MirBody<'db>, value: ValueId) -> bool {
+    // Binding an indexed place is not side-effect-free: lowering the value
+    // evaluates the place and emits the OOB bounds check in codegen.
+    !value_has_indexed_origin(&body.values, value)
 }
 
 fn mark_value_runtime_live<'db>(
@@ -813,7 +873,8 @@ fn instruction_is_runtime_root<'db>(
                 .is_none_or(|local| live_locals.contains(&local))
         }
         MirInst::BindValue { value, .. } => {
-            live_values.get(value.index()).copied().unwrap_or(false)
+            !removable_bind_value(body, *value)
+                || live_values.get(value.index()).copied().unwrap_or(false)
         }
     }
 }


### PR DESCRIPTION
## Summary                                                                                                                                                                                                        
                                                                                                                                                                                                                    
  Adds runtime array bounds checks to Fe's Sonatina backend. Previously, dynamic array indexing (`array[i as usize]`) emitted no bounds validation, allowing silent out-of-bounds reads and writes. This is a       
  **critical security bug**: OOB access can corrupt adjacent memory, leak data from neighboring arrays, and — in smart contract contexts — be exploited to corrupt on-chain state.                                  
                                                                                                                                                                                                                    
  ### The bug                                                                                                                                                                                                       
   
  Fe's Sonatina codegen lowered `array[index]` to a plain GEP or offset computation without checking `index < array.length`. Unlike Rust (which panics) or Solidity (which reverts), Fe silently computed the       
  out-of-bounds address and read/wrote whatever happened to be there in EVM memory.                                                                                                                               

  ### The fix

  Bounds checks are emitted in the two code paths that compute array element addresses in crates/codegen/src/sonatina/lower.rs:

  1. GEP path (lower_place_address_gep) — memory-addressed arrays with Field/Index projections
  2. Arithmetic path (lower_place_address_arithmetic) — storage-addressed arrays and complex projections

  For constant indices known at codegen time: unconditional jump to the revert block if idx >= len.
  For dynamic indices: emit lt idx len → is_zero → conditional branch to the shared overflow revert block (revert(0, 0)).

