### PR TITLE
bump sonatina; change optimize cli flag and defaults

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5282,7 +5282,7 @@ dependencies = [
 [[package]]
 name = "sonatina-codegen"
 version = "0.0.3-alpha"
-source = "git+https://github.com/fe-lang/sonatina?rev=b5f600f#b5f600fc61fb9e67527c79356fc7de444c362979"
+source = "git+https://github.com/fe-lang/sonatina?rev=c6c0062#c6c006250f76352e83103baadc34621a59668f73"
 dependencies = [
  "bit-set",
  "cranelift-entity 0.126.2",
@@ -5302,7 +5302,7 @@ dependencies = [
 [[package]]
 name = "sonatina-ir"
 version = "0.0.3-alpha"
-source = "git+https://github.com/fe-lang/sonatina?rev=b5f600f#b5f600fc61fb9e67527c79356fc7de444c362979"
+source = "git+https://github.com/fe-lang/sonatina?rev=c6c0062#c6c006250f76352e83103baadc34621a59668f73"
 dependencies = [
  "bit-set",
  "bitflags 2.11.0",
@@ -5324,7 +5324,7 @@ dependencies = [
 [[package]]
 name = "sonatina-macros"
 version = "0.0.3-alpha"
-source = "git+https://github.com/fe-lang/sonatina?rev=b5f600f#b5f600fc61fb9e67527c79356fc7de444c362979"
+source = "git+https://github.com/fe-lang/sonatina?rev=c6c0062#c6c006250f76352e83103baadc34621a59668f73"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5334,7 +5334,7 @@ dependencies = [
 [[package]]
 name = "sonatina-parser"
 version = "0.0.3-alpha"
-source = "git+https://github.com/fe-lang/sonatina?rev=b5f600f#b5f600fc61fb9e67527c79356fc7de444c362979"
+source = "git+https://github.com/fe-lang/sonatina?rev=c6c0062#c6c006250f76352e83103baadc34621a59668f73"
 dependencies = [
  "annotate-snippets",
  "bimap",
@@ -5355,7 +5355,7 @@ dependencies = [
 [[package]]
 name = "sonatina-triple"
 version = "0.0.3-alpha"
-source = "git+https://github.com/fe-lang/sonatina?rev=b5f600f#b5f600fc61fb9e67527c79356fc7de444c362979"
+source = "git+https://github.com/fe-lang/sonatina?rev=c6c0062#c6c006250f76352e83103baadc34621a59668f73"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -5363,7 +5363,7 @@ dependencies = [
 [[package]]
 name = "sonatina-verifier"
 version = "0.0.3-alpha"
-source = "git+https://github.com/fe-lang/sonatina?rev=b5f600f#b5f600fc61fb9e67527c79356fc7de444c362979"
+source = "git+https://github.com/fe-lang/sonatina?rev=c6c0062#c6c006250f76352e83103baadc34621a59668f73"
 dependencies = [
  "cranelift-entity 0.126.2",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,10 +47,10 @@ tracing-tree = "0.4.0"
 wasm-bindgen-test = "0.3"
 semver = "1.0.26"
 petgraph = "0.8"
-sonatina-ir = { git = "https://github.com/fe-lang/sonatina", rev = "b5f600f" }
-sonatina-triple = { git = "https://github.com/fe-lang/sonatina", rev = "b5f600f" }
-sonatina-codegen = { git = "https://github.com/fe-lang/sonatina", rev = "b5f600f" }
-sonatina-verifier = { git = "https://github.com/fe-lang/sonatina", rev = "b5f600f" }
+sonatina-ir = { git = "https://github.com/fe-lang/sonatina", rev = "c6c0062" }
+sonatina-triple = { git = "https://github.com/fe-lang/sonatina", rev = "c6c0062" }
+sonatina-codegen = { git = "https://github.com/fe-lang/sonatina", rev = "c6c0062" }
+sonatina-verifier = { git = "https://github.com/fe-lang/sonatina", rev = "c6c0062" }
 
 [profile.dev]
 # Set to 0 to make the build faster and debugging more difficult.

--- a/crates/codegen/src/backend.rs
+++ b/crates/codegen/src/backend.rs
@@ -15,10 +15,10 @@ use std::fmt;
 pub enum OptLevel {
     /// No optimization — maximum debuggability.
     O0,
-    /// Balanced optimization (default).
+    /// Size-oriented optimization.
+    Os,
+    /// Speed-oriented optimization (default).
     #[default]
-    O1,
-    /// Aggressive optimization.
     O2,
 }
 
@@ -28,10 +28,11 @@ impl std::str::FromStr for OptLevel {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "0" => Ok(OptLevel::O0),
-            "1" => Ok(OptLevel::O1),
+            "s" => Ok(OptLevel::Os),
+            "1" => Ok(OptLevel::O2),
             "2" => Ok(OptLevel::O2),
             _ => Err(format!(
-                "unknown optimization level: {s} (expected '0', '1', or '2')"
+                "unknown optimization level: {s} (expected '0', '1', '2', or 's')"
             )),
         }
     }
@@ -48,7 +49,7 @@ impl fmt::Display for OptLevel {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             OptLevel::O0 => write!(f, "0"),
-            OptLevel::O1 => write!(f, "1"),
+            OptLevel::Os => write!(f, "s"),
             OptLevel::O2 => write!(f, "2"),
         }
     }
@@ -277,8 +278,8 @@ impl Backend for SonatinaBackend {
         // Run the optimization pipeline based on opt_level.
         match opt_level {
             OptLevel::O0 => { /* no optimization */ }
-            OptLevel::O1 => sonatina_codegen::optim::Pipeline::balanced().run(&mut module),
-            OptLevel::O2 => sonatina_codegen::optim::Pipeline::aggressive().run(&mut module),
+            OptLevel::Os => sonatina_codegen::optim::Pipeline::size().run(&mut module),
+            OptLevel::O2 => sonatina_codegen::optim::Pipeline::speed().run(&mut module),
         }
         if opt_level != OptLevel::O0 {
             crate::sonatina::ensure_module_sonatina_ir_valid(&module)?;
@@ -358,5 +359,31 @@ impl Backend for SonatinaBackend {
         })?;
 
         Ok(BackendOutput::Bytecode(runtime_section.bytes.clone()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::OptLevel;
+    use std::str::FromStr;
+
+    #[test]
+    fn opt_level_parses_os() {
+        assert_eq!(OptLevel::from_str("s"), Ok(OptLevel::Os));
+    }
+
+    #[test]
+    fn opt_level_parses_o1_as_o2() {
+        assert_eq!(OptLevel::from_str("1"), Ok(OptLevel::O2));
+    }
+
+    #[test]
+    fn opt_level_default_is_o2() {
+        assert_eq!(OptLevel::default(), OptLevel::O2);
+    }
+
+    #[test]
+    fn opt_level_display_uses_os() {
+        assert_eq!(OptLevel::Os.to_string(), "s");
     }
 }

--- a/crates/codegen/src/sonatina/mod.rs
+++ b/crates/codegen/src/sonatina/mod.rs
@@ -417,8 +417,8 @@ fn compile_mir_module_for_sonatina_output<'db>(
 
     match opt_level {
         OptLevel::O0 => {}
-        OptLevel::O1 => sonatina_codegen::optim::Pipeline::balanced().run(&mut module),
-        OptLevel::O2 => sonatina_codegen::optim::Pipeline::aggressive().run(&mut module),
+        OptLevel::Os => sonatina_codegen::optim::Pipeline::size().run(&mut module),
+        OptLevel::O2 => sonatina_codegen::optim::Pipeline::speed().run(&mut module),
     }
     if opt_level != OptLevel::O0 {
         ensure_module_sonatina_ir_valid(&module)?;

--- a/crates/codegen/src/sonatina/tests.rs
+++ b/crates/codegen/src/sonatina/tests.rs
@@ -164,8 +164,8 @@ pub fn emit_test_module_sonatina(
 fn run_sonatina_optimization_pipeline(module: &mut Module, opt_level: OptLevel) {
     match opt_level {
         OptLevel::O0 => { /* no optimization */ }
-        OptLevel::O1 => sonatina_codegen::optim::Pipeline::balanced().run(module),
-        OptLevel::O2 => sonatina_codegen::optim::Pipeline::aggressive().run(module),
+        OptLevel::Os => sonatina_codegen::optim::Pipeline::size().run(module),
+        OptLevel::O2 => sonatina_codegen::optim::Pipeline::speed().run(module),
     }
 }
 

--- a/crates/fe/src/main.rs
+++ b/crates/fe/src/main.rs
@@ -81,23 +81,23 @@ pub enum Command {
         /// Code generation backend to use (yul or sonatina).
         #[arg(long, default_value = "sonatina")]
         backend: String,
-        /// Optimization level (0 = none, 1 = balanced, 2 = aggressive).
+        /// Optimization level (0 = none, s = size-oriented, 1/2 = speed-oriented).
         ///
-        /// Defaults to `1`.
+        /// Defaults to `2`.
         ///
-        /// Note: with `--backend yul`, opt levels `1` and `2` are currently equivalent.
+        /// Note: with `--backend yul`, optimize levels `s`, `1`, and `2` are currently equivalent.
+        ///
+        /// `1` is currently an alias for `2`.
         ///
         /// - Sonatina backend: controls the optimization pipeline.
-        /// - Yul backend: controls whether solc optimization is enabled (0 = disabled, 1/2 = enabled).
-        #[arg(long, default_value = "1", value_name = "LEVEL")]
-        opt_level: String,
-        /// Enable optimization.
-        ///
-        /// Shorthand for `--opt-level 1`.
-        ///
-        /// It is an error to pass `--optimize` with `--opt-level 0`.
-        #[arg(long)]
-        optimize: bool,
+        /// - Yul backend: controls whether solc optimization is enabled (0 = disabled, s/1/2 = enabled).
+        #[arg(
+            long = "optimize",
+            short = 'O',
+            value_name = "LEVEL",
+            value_parser = ["0", "1", "2", "s"]
+        )]
+        optimize: Option<String>,
         /// solc binary to use (overrides FE_SOLC_PATH).
         ///
         /// Only used with `--backend yul` (ignored with a warning otherwise).
@@ -234,23 +234,23 @@ pub enum Command {
         /// Only used with `--backend yul` (ignored with a warning otherwise).
         #[arg(long)]
         solc: Option<String>,
-        /// Optimization level (0 = none, 1 = balanced, 2 = aggressive).
+        /// Optimization level (0 = none, s = size-oriented, 1/2 = speed-oriented).
         ///
-        /// Defaults to `1`.
+        /// Defaults to `2`.
         ///
-        /// Note: with `--backend yul`, opt levels `1` and `2` are currently equivalent.
+        /// Note: with `--backend yul`, optimize levels `s`, `1`, and `2` are currently equivalent.
+        ///
+        /// `1` is currently an alias for `2`.
         ///
         /// - Sonatina backend: controls the optimization pipeline.
-        /// - Yul backend: controls whether solc optimization is enabled (0 = disabled, 1/2 = enabled).
-        #[arg(long, default_value = "1", value_name = "LEVEL")]
-        opt_level: String,
-        /// Enable optimization.
-        ///
-        /// Shorthand for `--opt-level 1`.
-        ///
-        /// It is an error to pass `--optimize` with `--opt-level 0`.
-        #[arg(long)]
-        optimize: bool,
+        /// - Yul backend: controls whether solc optimization is enabled (0 = disabled, s/1/2 = enabled).
+        #[arg(
+            long = "optimize",
+            short = 'O',
+            value_name = "LEVEL",
+            value_parser = ["0", "1", "2", "s"]
+        )]
+        optimize: Option<String>,
         /// Trace executed EVM opcodes while running tests.
         #[arg(long)]
         trace_evm: bool,
@@ -423,7 +423,6 @@ pub fn run(opts: &Options) {
             standalone,
             contract,
             backend,
-            opt_level,
             optimize,
             solc,
             out_dir,
@@ -440,7 +439,7 @@ pub fn run(opts: &Options) {
                     std::process::exit(1);
                 }
             };
-            let opt_level = match effective_opt_level(backend_kind, opt_level, *optimize) {
+            let opt_level = match effective_opt_level(backend_kind, optimize.as_deref()) {
                 Ok(level) => level,
                 Err(err) => {
                     eprintln!("Error: {err}");
@@ -527,7 +526,6 @@ pub fn run(opts: &Options) {
             debug: test_debug,
             backend,
             solc,
-            opt_level,
             optimize,
             trace_evm,
             trace_evm_keep,
@@ -548,7 +546,7 @@ pub fn run(opts: &Options) {
                     std::process::exit(1);
                 }
             };
-            let opt_level = match effective_opt_level(backend_kind, opt_level, *optimize) {
+            let opt_level = match effective_opt_level(backend_kind, optimize.as_deref()) {
                 Ok(level) => level,
                 Err(err) => {
                     eprintln!("Error: {err}");
@@ -971,20 +969,16 @@ fn generate_lsp_doc_html(resolved_root: Option<&Utf8PathBuf>) -> String {
 
 fn effective_opt_level(
     backend_kind: codegen::BackendKind,
-    opt_level: &str,
-    optimize: bool,
+    optimize: Option<&str>,
 ) -> Result<codegen::OptLevel, String> {
-    let level: codegen::OptLevel = opt_level.parse()?;
+    let level: codegen::OptLevel = optimize.unwrap_or("2").parse()?;
 
-    if optimize && level == codegen::OptLevel::O0 {
-        return Err(
-            "--optimize is shorthand for `--opt-level 1` and cannot be used with `--opt-level 0`"
-                .to_string(),
+    if backend_kind == codegen::BackendKind::Yul
+        && let Some(optimize @ ("1" | "2")) = optimize
+    {
+        eprintln!(
+            "Warning: --optimize {optimize} has no additional effect for --backend yul (same as s)"
         );
-    }
-
-    if backend_kind == codegen::BackendKind::Yul && level == codegen::OptLevel::O2 {
-        eprintln!("Warning: --opt-level 2 has no additional effect for --backend yul (same as 1)");
     }
 
     Ok(level)

--- a/crates/fe/tests/cli_output.rs
+++ b/crates/fe/tests/cli_output.rs
@@ -1374,28 +1374,26 @@ fn test_cli_test_solc_flag_overrides_env() {
 }
 
 #[test]
-fn test_cli_build_optimize_and_opt_level_0_is_error() {
+fn test_cli_build_opt_level_flag_is_error() {
     let fixture_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("tests/fixtures/cli_output/build/simple_contract.fe");
     let fixture_path_str = fixture_path.to_str().expect("fixture path utf8");
 
-    let (output, exit_code) =
-        run_fe_main(&["build", "--optimize", "--opt-level", "0", fixture_path_str]);
+    let (output, exit_code) = run_fe_main(&["build", "--opt-level", "0", fixture_path_str]);
     assert_ne!(exit_code, 0, "expected non-zero exit code:\n{output}");
     assert!(
-        output.contains("Error: --optimize is shorthand for"),
-        "expected error about conflicting optimization flags, got:\n{output}"
+        output.contains("unexpected argument '--opt-level'"),
+        "expected `fe build` to reject `--opt-level`, got:\n{output}"
     );
 }
 
 #[test]
-fn test_cli_check_optimize_and_opt_level_0_is_error() {
+fn test_cli_check_optimize_flag_is_error() {
     let fixture_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("tests/fixtures/cli_output/build/simple_contract.fe");
     let fixture_path_str = fixture_path.to_str().expect("fixture path utf8");
 
-    let (output, exit_code) =
-        run_fe_main(&["check", "--optimize", "--opt-level", "0", fixture_path_str]);
+    let (output, exit_code) = run_fe_main(&["check", "--optimize", "0", fixture_path_str]);
     assert_ne!(exit_code, 0, "expected non-zero exit code:\n{output}");
     assert!(
         output.contains("unexpected argument '--optimize'"),
@@ -1404,23 +1402,22 @@ fn test_cli_check_optimize_and_opt_level_0_is_error() {
 }
 
 #[test]
-fn test_cli_test_optimize_and_opt_level_0_is_error() {
+fn test_cli_test_opt_level_flag_is_error() {
     let fixture_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("tests/fixtures/fe_test_runner/pass.fe");
     let fixture_path_str = fixture_path.to_str().expect("fixture path utf8");
 
-    let (output, exit_code) =
-        run_fe_main(&["test", "--optimize", "--opt-level", "0", fixture_path_str]);
+    let (output, exit_code) = run_fe_main(&["test", "--opt-level", "0", fixture_path_str]);
     assert_ne!(exit_code, 0, "expected non-zero exit code:\n{output}");
     assert!(
-        output.contains("Error: --optimize is shorthand for"),
-        "expected error about conflicting optimization flags, got:\n{output}"
+        output.contains("unexpected argument '--opt-level'"),
+        "expected `fe test` to reject `--opt-level`, got:\n{output}"
     );
 }
 
 #[cfg(unix)]
 #[test]
-fn test_cli_test_optimize_flag_is_forwarded_to_solc() {
+fn test_cli_test_optimize_s_enables_solc_optimizer_for_yul() {
     let fixture_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("tests/fixtures/fe_test_runner/pass.fe");
     let fixture_path_str = fixture_path.to_str().expect("fixture path utf8");
@@ -1435,6 +1432,7 @@ fn test_cli_test_optimize_flag_is_forwarded_to_solc() {
             "--backend",
             "yul",
             "--optimize",
+            "s",
             "--solc",
             fake_solc_str,
             fixture_path_str,
@@ -1450,7 +1448,7 @@ fn test_cli_test_optimize_flag_is_forwarded_to_solc() {
 
 #[cfg(unix)]
 #[test]
-fn test_cli_test_opt_level_enables_solc_optimizer_for_yul() {
+fn test_cli_test_optimize_1_enables_solc_optimizer_for_yul() {
     let fixture_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("tests/fixtures/fe_test_runner/pass.fe");
     let fixture_path_str = fixture_path.to_str().expect("fixture path utf8");
@@ -1464,7 +1462,38 @@ fn test_cli_test_opt_level_enables_solc_optimizer_for_yul() {
             "test",
             "--backend",
             "yul",
-            "--opt-level",
+            "-O",
+            "1",
+            "--solc",
+            fake_solc_str,
+            fixture_path_str,
+        ],
+        &[
+            ("FE_SOLC_PATH", "/no/such/solc"),
+            ("FAKE_SOLC_CONTRACT", "test_test_pass"),
+            ("FAKE_SOLC_EXPECT_OPTIMIZE", "true"),
+        ],
+    );
+    assert_eq!(exit_code, 0, "fe test failed:\n{output}");
+}
+
+#[cfg(unix)]
+#[test]
+fn test_cli_test_optimize_2_enables_solc_optimizer_for_yul() {
+    let fixture_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/fe_test_runner/pass.fe");
+    let fixture_path_str = fixture_path.to_str().expect("fixture path utf8");
+
+    let temp = tempdir().expect("tempdir");
+    let fake_solc = write_fake_solc(&temp);
+    let fake_solc_str = fake_solc.to_str().expect("fake solc utf8");
+
+    let (output, exit_code) = run_fe_main_with_env(
+        &[
+            "test",
+            "--backend",
+            "yul",
+            "--optimize",
             "2",
             "--solc",
             fake_solc_str,
@@ -1481,7 +1510,7 @@ fn test_cli_test_opt_level_enables_solc_optimizer_for_yul() {
 
 #[cfg(unix)]
 #[test]
-fn test_cli_test_opt_level_0_disables_solc_optimizer_for_yul() {
+fn test_cli_test_optimize_0_disables_solc_optimizer_for_yul() {
     let fixture_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("tests/fixtures/fe_test_runner/pass.fe");
     let fixture_path_str = fixture_path.to_str().expect("fixture path utf8");
@@ -1495,7 +1524,7 @@ fn test_cli_test_opt_level_0_disables_solc_optimizer_for_yul() {
             "test",
             "--backend",
             "yul",
-            "--opt-level",
+            "--optimize",
             "0",
             "--solc",
             fake_solc_str,
@@ -1512,7 +1541,7 @@ fn test_cli_test_opt_level_0_disables_solc_optimizer_for_yul() {
 
 #[cfg(unix)]
 #[test]
-fn test_cli_build_optimize_flag_is_forwarded_to_solc() {
+fn test_cli_build_optimize_s_enables_solc_optimizer_for_yul() {
     let fixture_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("tests/fixtures/cli_output/build/simple_contract.fe");
     let fixture_path_str = fixture_path.to_str().expect("fixture path utf8");
@@ -1531,6 +1560,7 @@ fn test_cli_build_optimize_flag_is_forwarded_to_solc() {
             "--contract",
             "Foo",
             "--optimize",
+            "s",
             "--out-dir",
             out_dir_str.as_str(),
             fixture_path_str,
@@ -1546,7 +1576,7 @@ fn test_cli_build_optimize_flag_is_forwarded_to_solc() {
 
 #[cfg(unix)]
 #[test]
-fn test_cli_build_opt_level_enables_solc_optimizer_for_yul() {
+fn test_cli_build_optimize_1_enables_solc_optimizer_for_yul() {
     let fixture_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("tests/fixtures/cli_output/build/simple_contract.fe");
     let fixture_path_str = fixture_path.to_str().expect("fixture path utf8");
@@ -1564,8 +1594,8 @@ fn test_cli_build_opt_level_enables_solc_optimizer_for_yul() {
             "yul",
             "--contract",
             "Foo",
-            "--opt-level",
-            "2",
+            "-O",
+            "1",
             "--out-dir",
             out_dir_str.as_str(),
             fixture_path_str,
@@ -1581,7 +1611,7 @@ fn test_cli_build_opt_level_enables_solc_optimizer_for_yul() {
 
 #[cfg(unix)]
 #[test]
-fn test_cli_build_opt_level_0_disables_solc_optimizer_for_yul() {
+fn test_cli_build_optimize_0_disables_solc_optimizer_for_yul() {
     let fixture_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("tests/fixtures/cli_output/build/simple_contract.fe");
     let fixture_path_str = fixture_path.to_str().expect("fixture path utf8");
@@ -1599,7 +1629,7 @@ fn test_cli_build_opt_level_0_disables_solc_optimizer_for_yul() {
             "yul",
             "--contract",
             "Foo",
-            "--opt-level",
+            "--optimize",
             "0",
             "--out-dir",
             out_dir_str.as_str(),


### PR DESCRIPTION
Bumped to include sonatina's multi-block inliner.

`--opt-level` is now `--optimize`/`-O`, and defaults to `2`, options are 0, 1, 2, s. For now, 1 is the same as 2. `s` is the same as 2, except that the inliner settings are tuned to avoid code growth. In practice, both `-Os` and `-O2` should be tested to see which performs best. We need to improve the inliner rules, ideally to be more evm-aware.

fe_test gas usage before and after. Note that the "call" gas often includes create2 calls and is thus dominated by deployment costs (we need better benchmarking). Sorted by master Sonatina total gas, top 20 common comparable cases. delta = inliner2 - master, so negative is better.

  | Test case | Call master | Call inliner2 | Call delta | Call delta % | Total master | Total inliner2 | Total delta | Total delta % |
  |---|---:|---:|---:|---:|---:|---:|---:|---:|
  | vault/test_vault_multiuser | 688,060 | 685,298 | -2,762 | -0.40% | 2,036,551 | 2,037,109 | +558 | +0.03% |
  | reentrancy_mutex_storage_map | 726,995 | 714,075 | -12,920 | -1.78% | 1,868,081 | 1,847,209 | -20,872 | -1.12% |
  | escrow/test_escrow_release | 659,078 | 674,988 | +15,910 | +2.41% | 1,807,577 | 1,847,701 | +40,124 | +2.22% |
  | erc20/test_erc20 | 598,481 | 578,425 | -20,056 | -3.35% | 1,774,782 | 1,736,841 | -37,941 | -2.14% |
  | mandelbrot/known_points | 793,324 | 790,543 | -2,781 | -0.35% | 1,757,358 | 1,749,175 | -8,183 | -0.47% |
  | factory/test_factory | 755,405 | 693,174 | -62,231 | -8.24% | 1,646,812 | 1,553,688 | -93,124 | -5.65% |
  | escrow/refund | 643,910 | 660,394 | +16,484 | +2.56% | 1,625,019 | 1,660,885 | +35,866 | +2.21% |
  | mandelbrot/row | 776,528 | 773,982 | -2,546 | -0.33% | 1,566,614 | 1,526,848 | -39,766 | -2.54% |
  | reentrancy_mutex | 611,782 | 622,112 | +10,330 | +1.69% | 1,492,914 | 1,516,809 | +23,895 | +1.60% |
  | voting/test_voting | 517,516 | 502,053 | -15,463 | -2.99% | 1,481,838 | 1,457,798 | -24,040 | -1.62% |
  | reentrancy_tstor_ptr | 577,888 | 570,689 | -7,199 | -1.25% | 1,423,757 | 1,411,108 | -12,649 | -0.89% |
  | ownable/test_ownable | 494,349 | 499,118 | +4,769 | +0.96% | 1,311,035 | 1,320,192 | +9,157 | +0.70% |
  | storage_map/test_storage_map | 375,607 | 365,902 | -9,705 | -2.58% | 1,210,203 | 1,195,576 | -14,627 | -1.21% |
  | contract_field_mut_borrow_matrix | 364,143 | 348,898 | -15,245 | -4.19% | 1,202,682 | 1,174,726 | -27,956 | -2.32% |
  | simple_amm/test_amm_basic | 368,896 | 359,787 | -9,109 | -2.47% | 1,164,568 | 1,148,457 | -16,111 | -1.38% |
  | simple_amm/test_amm_edge_cases | 359,680 | 350,930 | -8,750 | -2.43% | 1,059,115 | 1,036,694 | -22,421 | -2.12% |
  | coin/test_coin | 351,555 | 346,971 | -4,584 | -1.30% | 1,052,924 | 1,047,428 | -5,496 | -0.52% |
  | mode_receivers_contract | 261,247 | 256,687 | -4,560 | -1.75% | 832,221 | 819,733 | -12,488 | -1.50% |
  | effect_handle_field_deref | 259,394 | 257,075 | -2,319 | -0.89% | 816,504 | 815,895 | -609 | -0.07% |
  | non_mem_effect_provider_m.. | 306,011 | 302,911 | -3,100 | -1.01% | 756,531 | 751,451 | -5,080 | -0.67% |
