### PR TITLE
Add payable

### DIFF
--- a/crates/codegen/src/sonatina/lower.rs
+++ b/crates/codegen/src/sonatina/lower.rs
@@ -1527,6 +1527,9 @@ fn lower_intrinsic<'db, C: sonatina_ir::func_cursor::FuncCursor>(
             )))
         }
         IntrinsicOp::Caller => Ok(Some(ctx.fb.insert_inst(EvmCaller::new(ctx.is), Type::I256))),
+        IntrinsicOp::Callvalue => Ok(Some(
+            ctx.fb.insert_inst(EvmCallValue::new(ctx.is), Type::I256),
+        )),
         IntrinsicOp::ReturnData | IntrinsicOp::Revert => Err(LowerError::Internal(
             "terminating intrinsic must be lowered as Terminator::TerminatingCall".to_string(),
         )),

--- a/crates/codegen/src/sonatina/tests.rs
+++ b/crates/codegen/src/sonatina/tests.rs
@@ -1,4 +1,5 @@
 use driver::DriverDataBase;
+use hir::HirDb;
 use hir::hir_def::{ItemKind, TopLevelMod};
 use mir::analysis::{CallGraph, build_call_graph, reachable_functions};
 use mir::{
@@ -6,6 +7,7 @@ use mir::{
     ir::{IntrinsicOp, MirFunctionOrigin},
     layout, lower_ingot,
 };
+use num_bigint::BigUint;
 use rustc_hash::{FxHashMap, FxHashSet};
 use sonatina_codegen::{
     domtree::DomTree,
@@ -78,7 +80,7 @@ pub fn emit_test_module_sonatina(
     let ingot = top_mod.ingot(db);
     let mir_module = lower_ingot(db, ingot)?;
 
-    let tests = collect_tests(db, &mir_module.functions);
+    let tests = collect_tests(db, &mir_module.functions)?;
 
     if tests.is_empty() {
         return Ok(TestModuleOutput { tests: Vec::new() });
@@ -153,6 +155,7 @@ pub fn emit_test_module_sonatina(
             value_param_count: test.value_param_count,
             effect_param_count: test.effect_param_count,
             expected_revert: test.expected_revert.clone(),
+            initial_balance: test.initial_balance.map(|b| b.to_bytes_be()),
         });
     }
 
@@ -178,9 +181,13 @@ struct TestInfo {
     value_param_count: usize,
     effect_param_count: usize,
     expected_revert: Option<ExpectedRevert>,
+    initial_balance: Option<BigUint>,
 }
 
-fn collect_tests(db: &DriverDataBase, functions: &[MirFunction<'_>]) -> Vec<TestInfo> {
+fn collect_tests(
+    db: &DriverDataBase,
+    functions: &[MirFunction<'_>],
+) -> Result<Vec<TestInfo>, LowerError> {
     let mut tests: Vec<TestInfo> = functions
         .iter()
         .filter_map(|mir_func| {
@@ -201,9 +208,13 @@ fn collect_tests(db: &DriverDataBase, functions: &[MirFunction<'_>]) -> Vec<Test
                 .to_opt()
                 .map(|n| n.data(db).to_string())
                 .unwrap_or_else(|| "<anonymous>".to_string());
+            let initial_balance = match parse_test_balance_arg(db, &hir_name, test_attr) {
+                Ok(balance) => balance,
+                Err(err) => return Some(Err(err)),
+            };
             let value_param_count = mir_func.runtime_param_count();
             let effect_param_count = mir_func.runtime_effect_param_count();
-            Some(TestInfo {
+            Some(Ok(TestInfo {
                 hir_name,
                 display_name: String::new(),
                 symbol_name: mir_func.symbol_name.clone(),
@@ -211,13 +222,47 @@ fn collect_tests(db: &DriverDataBase, functions: &[MirFunction<'_>]) -> Vec<Test
                 value_param_count,
                 effect_param_count,
                 expected_revert,
-            })
+                initial_balance,
+            }))
         })
-        .collect();
+        .collect::<Result<Vec<_>, _>>()?;
 
     assign_test_display_names(&mut tests);
     assign_test_object_names(&mut tests);
-    tests
+    Ok(tests)
+}
+
+/// Extracts the `balance` argument from `#[test(balance = N)]`, if present.
+fn parse_test_balance_arg<'db>(
+    db: &'db dyn HirDb,
+    test_name: &str,
+    test_attr: &hir::hir_def::attr::NormalAttr<'db>,
+) -> Result<Option<BigUint>, LowerError> {
+    for arg in &test_attr.args {
+        if arg.key_str(db) != Some("balance") {
+            continue;
+        }
+        let Some(value) = arg.value.as_ref() else {
+            return Err(LowerError::Unsupported(format!(
+                "invalid #[test] function `{test_name}`: #[test(balance = ...)] expects an integer literal"
+            )));
+        };
+        let hir::hir_def::attr::AttrArgValue::Lit(hir::hir_def::LitKind::Int(int_id)) = value
+        else {
+            return Err(LowerError::Unsupported(format!(
+                "invalid #[test] function `{test_name}`: #[test(balance = ...)] expects an integer literal"
+            )));
+        };
+        let balance = int_id.data(db).clone();
+        if balance.to_bytes_be().len() > 32 {
+            return Err(LowerError::Unsupported(format!(
+                "invalid #[test] function `{test_name}`: #[test(balance = ...)] must fit in u256"
+            )));
+        };
+        return Ok(Some(balance));
+    }
+
+    Ok(None)
 }
 
 fn assign_test_display_names(tests: &mut [TestInfo]) {
@@ -1137,7 +1182,8 @@ fn smoke() {
         let top_mod = db.top_mod(file);
         let ingot = top_mod.ingot(&db);
         let mir_module = lower_ingot(&db, ingot).expect("module should lower to MIR");
-        let tests = collect_tests(&db, &mir_module.functions);
+        let tests = collect_tests(&db, &mir_module.functions)
+            .expect("test metadata collection should succeed");
         let call_graph = build_call_graph(&mir_module.functions);
         let funcs_by_symbol = build_funcs_by_symbol(&mir_module.functions);
         let code_region_roots = collect_code_region_roots(&mir_module.functions);

--- a/crates/codegen/src/yul/emitter/module.rs
+++ b/crates/codegen/src/yul/emitter/module.rs
@@ -19,6 +19,7 @@ use mir::{
     layout::{self, TargetDataLayout},
     lower_ingot, lower_module, prepare_module_for_evm_yul_codegen,
 };
+use num_bigint::BigUint;
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::{collections::VecDeque, sync::Arc};
 
@@ -50,6 +51,9 @@ pub struct TestMetadata {
     pub value_param_count: usize,
     pub effect_param_count: usize,
     pub expected_revert: Option<ExpectedRevert>,
+    /// Optional initial ETH balance (in wei) to seed the deployed test contract.
+    /// When `None`, the contract starts with zero balance.
+    pub initial_balance: Option<Vec<u8>>,
 }
 
 /// Describes the expected revert behavior for a test.
@@ -370,7 +374,7 @@ pub fn emit_test_module_yul_with_layout(
 
     let call_graph = build_call_graph(&module.functions);
 
-    let mut tests = collect_test_infos(db, &module.functions);
+    let mut tests = collect_test_infos(db, &module.functions)?;
     if tests.is_empty() {
         return Ok(TestModuleOutput { tests: Vec::new() });
     }
@@ -417,6 +421,7 @@ pub fn emit_test_module_yul_with_layout(
             value_param_count: test.value_param_count,
             effect_param_count: test.effect_param_count,
             expected_revert: test.expected_revert,
+            initial_balance: test.initial_balance.map(|b| b.to_bytes_be()),
         });
     }
 
@@ -677,6 +682,7 @@ struct TestInfo {
     value_param_count: usize,
     effect_param_count: usize,
     expected_revert: Option<ExpectedRevert>,
+    initial_balance: Option<BigUint>,
 }
 
 /// Dependency set required to emit a single test object.
@@ -691,7 +697,10 @@ struct TestDependencies {
 /// * `functions` - Monomorphized MIR functions to scan.
 ///
 /// Returns a list of test info entries with placeholder names filled in.
-fn collect_test_infos(db: &dyn HirDb, functions: &[MirFunction<'_>]) -> Vec<TestInfo> {
+fn collect_test_infos(
+    db: &dyn HirDb,
+    functions: &[MirFunction<'_>],
+) -> Result<Vec<TestInfo>, EmitModuleError> {
     functions
         .iter()
         .filter_map(|mir_func| {
@@ -713,9 +722,14 @@ fn collect_test_infos(db: &dyn HirDb, functions: &[MirFunction<'_>]) -> Vec<Test
                 .to_opt()
                 .map(|n| n.data(db).to_string())
                 .unwrap_or_else(|| "<anonymous>".to_string());
+            // Check for #[test(balance = N)]
+            let initial_balance = match parse_test_balance_arg(db, &hir_name, test_attr) {
+                Ok(balance) => balance,
+                Err(err) => return Some(Err(err)),
+            };
             let value_param_count = mir_func.runtime_param_count();
             let effect_param_count = mir_func.runtime_effect_param_count();
-            Some(TestInfo {
+            Some(Ok(TestInfo {
                 hir_name,
                 display_name: String::new(),
                 symbol_name: mir_func.symbol_name.clone(),
@@ -723,9 +737,43 @@ fn collect_test_infos(db: &dyn HirDb, functions: &[MirFunction<'_>]) -> Vec<Test
                 value_param_count,
                 effect_param_count,
                 expected_revert,
-            })
+                initial_balance,
+            }))
         })
         .collect()
+}
+
+/// Extracts the `balance` argument from `#[test(balance = N)]`, if present.
+fn parse_test_balance_arg<'db>(
+    db: &'db dyn HirDb,
+    test_name: &str,
+    test_attr: &hir::hir_def::attr::NormalAttr<'db>,
+) -> Result<Option<BigUint>, EmitModuleError> {
+    for arg in &test_attr.args {
+        if arg.key_str(db) != Some("balance") {
+            continue;
+        }
+        let Some(value) = arg.value.as_ref() else {
+            return Err(EmitModuleError::Yul(YulError::Unsupported(format!(
+                "invalid #[test] function `{test_name}`: #[test(balance = ...)] expects an integer literal"
+            ))));
+        };
+        let hir::hir_def::attr::AttrArgValue::Lit(hir::hir_def::LitKind::Int(int_id)) = value
+        else {
+            return Err(EmitModuleError::Yul(YulError::Unsupported(format!(
+                "invalid #[test] function `{test_name}`: #[test(balance = ...)] expects an integer literal"
+            ))));
+        };
+        let balance = int_id.data(db).clone();
+        if balance.to_bytes_be().len() > 32 {
+            return Err(EmitModuleError::Yul(YulError::Unsupported(format!(
+                "invalid #[test] function `{test_name}`: #[test(balance = ...)] must fit in u256"
+            ))));
+        };
+        return Ok(Some(balance));
+    }
+
+    Ok(None)
 }
 
 /// Validates that a `#[test]` function conforms to runner constraints.
@@ -1474,6 +1522,7 @@ mod tests {
                 value_param_count: 0,
                 effect_param_count: 0,
                 expected_revert: None,
+                initial_balance: None,
             },
             TestInfo {
                 hir_name: "foo_bar".to_string(),
@@ -1483,6 +1532,7 @@ mod tests {
                 value_param_count: 0,
                 effect_param_count: 0,
                 expected_revert: None,
+                initial_balance: None,
             },
         ];
 

--- a/crates/codegen/src/yul/emitter/statements.rs
+++ b/crates/codegen/src/yul/emitter/statements.rs
@@ -800,6 +800,7 @@ impl<'db> FunctionEmitter<'db> {
             IntrinsicOp::Addmod => "addmod",
             IntrinsicOp::Mulmod => "mulmod",
             IntrinsicOp::Caller => "caller",
+            IntrinsicOp::Callvalue => "callvalue",
         }
     }
 }

--- a/crates/codegen/tests/fixtures/by_ref_trait_provider_storage_bug.snap
+++ b/crates/codegen/tests/fixtures/by_ref_trait_provider_storage_bug.snap
@@ -6,12 +6,17 @@ input_file: tests/fixtures/by_ref_trait_provider_storage_bug.fe
 object "ByRefTraitProviderStorageBug" {
   code {
     function $__ByRefTraitProviderStorageBug_init() {
-      let v0 := dataoffset("ByRefTraitProviderStorageBug_deployed")
-      let v1 := datasize("ByRefTraitProviderStorageBug_deployed")
-      let v2 := $init_field__Evm_hef0af3106e109414_Pair_h956dff41e88ee341__18f2eb617f185785(0)
-      $__ByRefTraitProviderStorageBug_init_contract(v2)
-      codecopy(0, v0, v1)
-      return(0, v1)
+      let v0 := callvalue()
+      let v1 := iszero(eq(v0, 0))
+      if v1 {
+        $evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
+      }
+      let v2 := dataoffset("ByRefTraitProviderStorageBug_deployed")
+      let v3 := datasize("ByRefTraitProviderStorageBug_deployed")
+      let v4 := $init_field__Evm_hef0af3106e109414_Pair_h956dff41e88ee341__18f2eb617f185785(0)
+      $__ByRefTraitProviderStorageBug_init_contract(v4)
+      codecopy(0, v2, v3)
+      return(0, v3)
     }
     function $__ByRefTraitProviderStorageBug_init_contract($ctx) {
       let v0 := mload(0x40)
@@ -25,6 +30,9 @@ object "ByRefTraitProviderStorageBug" {
       sstore($ctx, mload(v1))
       sstore(add($ctx, 1), mload(add(v1, 32)))
       leave
+    }
+    function $evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort() {
+      revert(0, 0)
     }
     function $evm_hef0af3106e109414_contracthost_h57111e7eb283a125_field__Pair_h956dff41e88ee341__acec41afdc898140($slot) -> ret {
       let v0 := $stor_ptr__Evm_hef0af3106e109414_Pair_h956dff41e88ee341__18f2eb617f185785($slot)
@@ -61,8 +69,13 @@ object "ByRefTraitProviderStorageBug" {
         let v1 := $runtime_selector__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f__e4e3f8d20b3805a2()
         switch v1
           case 1 {
-            let v2 := $__ByRefTraitProviderStorageBug_recv_0_0(v0)
-            $return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f(v2)
+            let v2 := callvalue()
+            let v3 := iszero(eq(v2, 0))
+            if v3 {
+              $evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
+            }
+            let v4 := $__ByRefTraitProviderStorageBug_recv_0_0(v0)
+            $return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f(v4)
           }
           default {
             $evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()

--- a/crates/codegen/tests/fixtures/create_contract.snap
+++ b/crates/codegen/tests/fixtures/create_contract.snap
@@ -6,10 +6,18 @@ input_file: tests/fixtures/create_contract.fe
 object "Factory" {
   code {
     function $__Factory_init() {
-      let v0 := dataoffset("Factory_deployed")
-      let v1 := datasize("Factory_deployed")
-      codecopy(0, v0, v1)
-      return(0, v1)
+      let v0 := callvalue()
+      let v1 := iszero(eq(v0, 0))
+      if v1 {
+        $evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
+      }
+      let v2 := dataoffset("Factory_deployed")
+      let v3 := datasize("Factory_deployed")
+      codecopy(0, v2, v3)
+      return(0, v3)
+    }
+    function $evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort() {
+      revert(0, 0)
     }
     $__Factory_init()
   }
@@ -65,14 +73,24 @@ object "Factory" {
         let v1 := $runtime_decoder__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f__e4e3f8d20b3805a2()
         switch v0
           case 1 {
-            let v2 := $deploy_h5c6b1804553edb1_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966(v1)
-            let v3 := $__Factory_recv_0_0(v2)
-            $return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_Address_h257056268eac7027__2d9a2ca106cd007c(v3)
+            let v2 := callvalue()
+            let v3 := iszero(eq(v2, 0))
+            if v3 {
+              $evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
+            }
+            let v4 := $deploy_h5c6b1804553edb1_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966(v1)
+            let v5 := $__Factory_recv_0_0(v4)
+            $return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_Address_h257056268eac7027__2d9a2ca106cd007c(v5)
           }
           case 2 {
-            let v4 := $deploy2_ha2b981aa2f8bf9fd_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966(v1)
-            let v5 := $__Factory_recv_0_1(v4)
-            $return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_Address_h257056268eac7027__2d9a2ca106cd007c(v5)
+            let v6 := callvalue()
+            let v7 := iszero(eq(v6, 0))
+            if v7 {
+              $evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
+            }
+            let v8 := $deploy2_ha2b981aa2f8bf9fd_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966(v1)
+            let v9 := $__Factory_recv_0_1(v8)
+            $return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_Address_h257056268eac7027__2d9a2ca106cd007c(v9)
           }
           default {
             $evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
@@ -456,35 +474,40 @@ object "Factory" {
     object "Child" {
       code {
         function $__Child_init() {
-          let v0 := dataoffset("Child_deployed")
-          let v1 := datasize("Child_deployed")
-          let v2 := $init_field__Evm_hef0af3106e109414_Pair_h956dff41e88ee341__18f2eb617f185785(0)
-          let v3 := datasize("Child")
-          let v4 := codesize()
-          let v5 := lt(v4, v3)
-          if v5 {
+          let v0 := callvalue()
+          let v1 := iszero(eq(v0, 0))
+          if v1 {
             $evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
           }
-          let v6 := sub(v4, v3)
-          let v7 := mload(64)
-          if iszero(v7) {
-            v7 := 0x80
+          let v2 := dataoffset("Child_deployed")
+          let v3 := datasize("Child_deployed")
+          let v4 := $init_field__Evm_hef0af3106e109414_Pair_h956dff41e88ee341__18f2eb617f185785(0)
+          let v5 := datasize("Child")
+          let v6 := codesize()
+          let v7 := lt(v6, v5)
+          if v7 {
+            $evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
           }
-          mstore(64, add(v7, v6))
-          codecopy(v7, v3, v6)
-          let v8 := mload(0x40)
-          if iszero(v8) {
-            v8 := 0x80
+          let v8 := sub(v6, v5)
+          let v9 := mload(64)
+          if iszero(v9) {
+            v9 := 0x80
           }
-          mstore(0x40, add(v8, 64))
-          mstore(v8, v7)
-          mstore(add(v8, 32), v6)
-          let v9 := $sol_hfd482bb803ad8c5f_abi_h2da9a2d0b1ddaeb7_decoder_new__MemoryBytes_h1e381015a9b0111b__59e0d528d54cca1b(v8)
-          let v10 := $u256_h3271ca15373d4483_decode_hb2fe2bf528775e55_decode__Sol_hfd482bb803ad8c5f_SolDecoder_MemoryBytes___a53dbc6192a658d6(v9)
-          let v11 := $u256_h3271ca15373d4483_decode_hb2fe2bf528775e55_decode__Sol_hfd482bb803ad8c5f_SolDecoder_MemoryBytes___a53dbc6192a658d6(v9)
-          $__Child_init_contract(v10, v11, v2)
-          codecopy(0, v0, v1)
-          return(0, v1)
+          mstore(64, add(v9, v8))
+          codecopy(v9, v5, v8)
+          let v10 := mload(0x40)
+          if iszero(v10) {
+            v10 := 0x80
+          }
+          mstore(0x40, add(v10, 64))
+          mstore(v10, v9)
+          mstore(add(v10, 32), v8)
+          let v11 := $sol_hfd482bb803ad8c5f_abi_h2da9a2d0b1ddaeb7_decoder_new__MemoryBytes_h1e381015a9b0111b__59e0d528d54cca1b(v10)
+          let v12 := $u256_h3271ca15373d4483_decode_hb2fe2bf528775e55_decode__Sol_hfd482bb803ad8c5f_SolDecoder_MemoryBytes___a53dbc6192a658d6(v11)
+          let v13 := $u256_h3271ca15373d4483_decode_hb2fe2bf528775e55_decode__Sol_hfd482bb803ad8c5f_SolDecoder_MemoryBytes___a53dbc6192a658d6(v11)
+          $__Child_init_contract(v12, v13, v4)
+          codecopy(0, v2, v3)
+          return(0, v3)
         }
         function $__Child_init_contract($x, $y, $state) {
           sstore($state, $x)

--- a/crates/codegen/tests/fixtures/effect_handle_field_deref.snap
+++ b/crates/codegen/tests/fixtures/effect_handle_field_deref.snap
@@ -6,10 +6,18 @@ input_file: tests/fixtures/effect_handle_field_deref.fe
 object "EffectHandleFieldDeref" {
   code {
     function $__EffectHandleFieldDeref_init() {
-      let v0 := dataoffset("EffectHandleFieldDeref_deployed")
-      let v1 := datasize("EffectHandleFieldDeref_deployed")
-      codecopy(0, v0, v1)
-      return(0, v1)
+      let v0 := callvalue()
+      let v1 := iszero(eq(v0, 0))
+      if v1 {
+        $evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
+      }
+      let v2 := dataoffset("EffectHandleFieldDeref_deployed")
+      let v3 := datasize("EffectHandleFieldDeref_deployed")
+      codecopy(0, v2, v3)
+      return(0, v3)
+    }
+    function $evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort() {
+      revert(0, 0)
     }
     $__EffectHandleFieldDeref_init()
   }
@@ -58,19 +66,34 @@ object "EffectHandleFieldDeref" {
         let v2 := $runtime_decoder__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f__e4e3f8d20b3805a2()
         switch v1
           case 1 {
-            let v3 := $seedslot_h54140d6d3003b4fb_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966(v2)
-            let v4 := $__EffectHandleFieldDeref_recv_0_0(v3)
-            $return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f(v4)
-          }
-          case 2 {
-            let v5 := $readviaholder_h9a52c49def8cf7ae_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966(v2)
-            let v6 := $__EffectHandleFieldDeref_recv_0_1(v5)
+            let v3 := callvalue()
+            let v4 := iszero(eq(v3, 0))
+            if v4 {
+              $evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
+            }
+            let v5 := $seedslot_h54140d6d3003b4fb_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966(v2)
+            let v6 := $__EffectHandleFieldDeref_recv_0_0(v5)
             $return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f(v6)
           }
+          case 2 {
+            let v7 := callvalue()
+            let v8 := iszero(eq(v7, 0))
+            if v8 {
+              $evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
+            }
+            let v9 := $readviaholder_h9a52c49def8cf7ae_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966(v2)
+            let v10 := $__EffectHandleFieldDeref_recv_0_1(v9)
+            $return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f(v10)
+          }
           case 3 {
-            let v7 := $bumpmover_hdc9ecd58bf94824a_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966(v2)
-            let v8 := $__EffectHandleFieldDeref_recv_0_2(v7, v0)
-            $return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f(v8)
+            let v11 := callvalue()
+            let v12 := iszero(eq(v11, 0))
+            if v12 {
+              $evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
+            }
+            let v13 := $bumpmover_hdc9ecd58bf94824a_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966(v2)
+            let v14 := $__EffectHandleFieldDeref_recv_0_2(v13, v0)
+            $return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f(v14)
           }
           default {
             $evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()

--- a/crates/codegen/tests/fixtures/erc20.snap
+++ b/crates/codegen/tests/fixtures/erc20.snap
@@ -6,36 +6,41 @@ input_file: tests/fixtures/erc20.fe
 object "CoolCoin" {
   code {
     function $__CoolCoin_init() {
-      let v0 := dataoffset("CoolCoin_deployed")
-      let v1 := datasize("CoolCoin_deployed")
-      let v2 := $init_field__Evm_hef0af3106e109414_TokenStore_0__1___db7d7c067dc14cc5(0)
-      let v3 := $init_field__Evm_hef0af3106e109414_AccessControl_3___1911f7c438797961(3)
-      let v4 := datasize("CoolCoin")
-      let v5 := codesize()
-      let v6 := lt(v5, v4)
-      if v6 {
+      let v0 := callvalue()
+      let v1 := iszero(eq(v0, 0))
+      if v1 {
         $evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
       }
-      let v7 := sub(v5, v4)
-      let v8 := mload(64)
-      if iszero(v8) {
-        v8 := 0x80
+      let v2 := dataoffset("CoolCoin_deployed")
+      let v3 := datasize("CoolCoin_deployed")
+      let v4 := $init_field__Evm_hef0af3106e109414_TokenStore_0__1___db7d7c067dc14cc5(0)
+      let v5 := $init_field__Evm_hef0af3106e109414_AccessControl_3___1911f7c438797961(3)
+      let v6 := datasize("CoolCoin")
+      let v7 := codesize()
+      let v8 := lt(v7, v6)
+      if v8 {
+        $evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
       }
-      mstore(64, add(v8, v7))
-      codecopy(v8, v4, v7)
-      let v9 := mload(0x40)
-      if iszero(v9) {
-        v9 := 0x80
+      let v9 := sub(v7, v6)
+      let v10 := mload(64)
+      if iszero(v10) {
+        v10 := 0x80
       }
-      mstore(0x40, add(v9, 64))
-      mstore(v9, v8)
-      mstore(add(v9, 32), v7)
-      let v10 := $sol_hfd482bb803ad8c5f_abi_h2da9a2d0b1ddaeb7_decoder_new__MemoryBytes_h1e381015a9b0111b__59e0d528d54cca1b(v9)
-      let v11 := $u256_h3271ca15373d4483_decode_hb2fe2bf528775e55_decode__Sol_hfd482bb803ad8c5f_SolDecoder_MemoryBytes___a53dbc6192a658d6(v10)
-      let v12 := $address_h257056268eac7027_decode_hb2fe2bf528775e55_decode__Sol_hfd482bb803ad8c5f_SolDecoder_MemoryBytes___a53dbc6192a658d6(v10)
-      $__CoolCoin_init_contract(v11, v12, v2)
-      codecopy(0, v0, v1)
-      return(0, v1)
+      mstore(64, add(v10, v9))
+      codecopy(v10, v6, v9)
+      let v11 := mload(0x40)
+      if iszero(v11) {
+        v11 := 0x80
+      }
+      mstore(0x40, add(v11, 64))
+      mstore(v11, v10)
+      mstore(add(v11, 32), v9)
+      let v12 := $sol_hfd482bb803ad8c5f_abi_h2da9a2d0b1ddaeb7_decoder_new__MemoryBytes_h1e381015a9b0111b__59e0d528d54cca1b(v11)
+      let v13 := $u256_h3271ca15373d4483_decode_hb2fe2bf528775e55_decode__Sol_hfd482bb803ad8c5f_SolDecoder_MemoryBytes___a53dbc6192a658d6(v12)
+      let v14 := $address_h257056268eac7027_decode_hb2fe2bf528775e55_decode__Sol_hfd482bb803ad8c5f_SolDecoder_MemoryBytes___a53dbc6192a658d6(v12)
+      $__CoolCoin_init_contract(v13, v14, v4)
+      codecopy(0, v2, v3)
+      return(0, v3)
     }
     function $__CoolCoin_init_contract($initial_supply, $owner, $store) {
       $accesscontrol____h4c85da5bbb505ade_grant_stor_arg0_root_stor__3__577ab43c73dd3cef(1, $owner)
@@ -592,70 +597,140 @@ object "CoolCoin" {
         let v3 := $runtime_decoder__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f__e4e3f8d20b3805a2()
         switch v2
           case 2835717307 {
-            let v4 := $transfer_h13f5ec5985ebba60_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966(v3)
-            let v5 := $__CoolCoin_recv_0_0(v4, v0)
-            $return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_bool__397940bf296cce2a(v5)
-          }
-          case 157198259 {
-            let v6 := $approve_h90175fc19dafde67_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966(v3)
-            let v7 := $__CoolCoin_recv_0_1(v6, v0)
+            let v4 := callvalue()
+            let v5 := iszero(eq(v4, 0))
+            if v5 {
+              $evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
+            }
+            let v6 := $transfer_h13f5ec5985ebba60_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966(v3)
+            let v7 := $__CoolCoin_recv_0_0(v6, v0)
             $return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_bool__397940bf296cce2a(v7)
           }
+          case 157198259 {
+            let v8 := callvalue()
+            let v9 := iszero(eq(v8, 0))
+            if v9 {
+              $evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
+            }
+            let v10 := $approve_h90175fc19dafde67_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966(v3)
+            let v11 := $__CoolCoin_recv_0_1(v10, v0)
+            $return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_bool__397940bf296cce2a(v11)
+          }
           case 599290589 {
-            let v8 := $transferfrom_h939549e4bad999e8_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966(v3)
-            let v9 := $__CoolCoin_recv_0_2(v8, v0)
-            $return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_bool__397940bf296cce2a(v9)
+            let v12 := callvalue()
+            let v13 := iszero(eq(v12, 0))
+            if v13 {
+              $evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
+            }
+            let v14 := $transferfrom_h939549e4bad999e8_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966(v3)
+            let v15 := $__CoolCoin_recv_0_2(v14, v0)
+            $return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_bool__397940bf296cce2a(v15)
           }
           case 1889567281 {
-            let v10 := $balanceof_hf830ebedc81244a7_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966(v3)
-            let v11 := $__CoolCoin_recv_0_3(v10, v0)
-            $return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f(v11)
+            let v16 := callvalue()
+            let v17 := iszero(eq(v16, 0))
+            if v17 {
+              $evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
+            }
+            let v18 := $balanceof_hf830ebedc81244a7_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966(v3)
+            let v19 := $__CoolCoin_recv_0_3(v18, v0)
+            $return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f(v19)
           }
           case 3714247998 {
-            let v12 := $allowance_h4bb1267f662bd2a8_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966(v3)
-            let v13 := $__CoolCoin_recv_0_4(v12, v0)
-            $return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f(v13)
+            let v20 := callvalue()
+            let v21 := iszero(eq(v20, 0))
+            if v21 {
+              $evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
+            }
+            let v22 := $allowance_h4bb1267f662bd2a8_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966(v3)
+            let v23 := $__CoolCoin_recv_0_4(v22, v0)
+            $return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f(v23)
           }
           case 404098525 {
-            let v14 := $__CoolCoin_recv_0_5(v0)
-            $return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f(v14)
+            let v24 := callvalue()
+            let v25 := iszero(eq(v24, 0))
+            if v25 {
+              $evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
+            }
+            let v26 := $__CoolCoin_recv_0_5(v0)
+            $return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f(v26)
           }
           case 117300739 {
-            let v15 := $__CoolCoin_recv_0_6()
-            $return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_String_32___7798a45a8b22b7ed(v15)
+            let v27 := callvalue()
+            let v28 := iszero(eq(v27, 0))
+            if v28 {
+              $evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
+            }
+            let v29 := $__CoolCoin_recv_0_6()
+            $return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_String_32___7798a45a8b22b7ed(v29)
           }
           case 2514000705 {
-            let v16 := $__CoolCoin_recv_0_7()
-            $return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_String_8___99627a2b067a3b64(v16)
+            let v30 := callvalue()
+            let v31 := iszero(eq(v30, 0))
+            if v31 {
+              $evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
+            }
+            let v32 := $__CoolCoin_recv_0_7()
+            $return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_String_8___99627a2b067a3b64(v32)
           }
           case 826074471 {
-            let v17 := $__CoolCoin_recv_0_8()
-            $return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u8__5f40d25b4a1c5efd(v17)
+            let v33 := callvalue()
+            let v34 := iszero(eq(v33, 0))
+            if v34 {
+              $evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
+            }
+            let v35 := $__CoolCoin_recv_0_8()
+            $return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u8__5f40d25b4a1c5efd(v35)
           }
           case 1086394137 {
-            let v18 := $mint_ha2f94817be433a2e_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966(v3)
-            let v19 := $__CoolCoin_recv_1_0(v18, v0)
-            $return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_bool__397940bf296cce2a(v19)
+            let v36 := callvalue()
+            let v37 := iszero(eq(v36, 0))
+            if v37 {
+              $evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
+            }
+            let v38 := $mint_ha2f94817be433a2e_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966(v3)
+            let v39 := $__CoolCoin_recv_1_0(v38, v0)
+            $return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_bool__397940bf296cce2a(v39)
           }
           case 1117154408 {
-            let v20 := $burn_h25a61f4466d20eed_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966(v3)
-            let v21 := $__CoolCoin_recv_1_1(v20, v0)
-            $return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_bool__397940bf296cce2a(v21)
+            let v40 := callvalue()
+            let v41 := iszero(eq(v40, 0))
+            if v41 {
+              $evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
+            }
+            let v42 := $burn_h25a61f4466d20eed_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966(v3)
+            let v43 := $__CoolCoin_recv_1_1(v42, v0)
+            $return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_bool__397940bf296cce2a(v43)
           }
           case 2043438992 {
-            let v22 := $burnfrom_ha9fb0972f143e40c_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966(v3)
-            let v23 := $__CoolCoin_recv_1_2(v22, v0)
-            $return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_bool__397940bf296cce2a(v23)
+            let v44 := callvalue()
+            let v45 := iszero(eq(v44, 0))
+            if v45 {
+              $evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
+            }
+            let v46 := $burnfrom_ha9fb0972f143e40c_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966(v3)
+            let v47 := $__CoolCoin_recv_1_2(v46, v0)
+            $return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_bool__397940bf296cce2a(v47)
           }
           case 961581905 {
-            let v24 := $increaseallowance_h9840135eaea36633_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966(v3)
-            let v25 := $__CoolCoin_recv_1_3(v24, v0)
-            $return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_bool__397940bf296cce2a(v25)
+            let v48 := callvalue()
+            let v49 := iszero(eq(v48, 0))
+            if v49 {
+              $evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
+            }
+            let v50 := $increaseallowance_h9840135eaea36633_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966(v3)
+            let v51 := $__CoolCoin_recv_1_3(v50, v0)
+            $return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_bool__397940bf296cce2a(v51)
           }
           case 2757214935 {
-            let v26 := $decreaseallowance_h635474f45639c83d_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966(v3)
-            let v27 := $__CoolCoin_recv_1_4(v26, v0)
-            $return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_bool__397940bf296cce2a(v27)
+            let v52 := callvalue()
+            let v53 := iszero(eq(v52, 0))
+            if v53 {
+              $evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
+            }
+            let v54 := $decreaseallowance_h635474f45639c83d_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966(v3)
+            let v55 := $__CoolCoin_recv_1_4(v54, v0)
+            $return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_bool__397940bf296cce2a(v55)
           }
           default {
             $evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()

--- a/crates/codegen/tests/fixtures/high_level_contract.snap
+++ b/crates/codegen/tests/fixtures/high_level_contract.snap
@@ -6,35 +6,40 @@ input_file: tests/fixtures/high_level_contract.fe
 object "EchoContract" {
   code {
     function $__EchoContract_init() {
-      let v0 := dataoffset("EchoContract_deployed")
-      let v1 := datasize("EchoContract_deployed")
-      let v2 := $init_field__Evm_hef0af3106e109414_Foo_h6dbce71a6ea992b8__c09e6c6fc5a7b23d(0)
-      let v3 := datasize("EchoContract")
-      let v4 := codesize()
-      let v5 := lt(v4, v3)
-      if v5 {
+      let v0 := callvalue()
+      let v1 := iszero(eq(v0, 0))
+      if v1 {
         $evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
       }
-      let v6 := sub(v4, v3)
-      let v7 := mload(64)
-      if iszero(v7) {
-        v7 := 0x80
+      let v2 := dataoffset("EchoContract_deployed")
+      let v3 := datasize("EchoContract_deployed")
+      let v4 := $init_field__Evm_hef0af3106e109414_Foo_h6dbce71a6ea992b8__c09e6c6fc5a7b23d(0)
+      let v5 := datasize("EchoContract")
+      let v6 := codesize()
+      let v7 := lt(v6, v5)
+      if v7 {
+        $evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
       }
-      mstore(64, add(v7, v6))
-      codecopy(v7, v3, v6)
-      let v8 := mload(0x40)
-      if iszero(v8) {
-        v8 := 0x80
+      let v8 := sub(v6, v5)
+      let v9 := mload(64)
+      if iszero(v9) {
+        v9 := 0x80
       }
-      mstore(0x40, add(v8, 64))
-      mstore(v8, v7)
-      mstore(add(v8, 32), v6)
-      let v9 := $sol_hfd482bb803ad8c5f_abi_h2da9a2d0b1ddaeb7_decoder_new__MemoryBytes_h1e381015a9b0111b__59e0d528d54cca1b(v8)
-      let v10 := $u256_h3271ca15373d4483_decode_hb2fe2bf528775e55_decode__Sol_hfd482bb803ad8c5f_SolDecoder_MemoryBytes___a53dbc6192a658d6(v9)
-      let v11 := $u256_h3271ca15373d4483_decode_hb2fe2bf528775e55_decode__Sol_hfd482bb803ad8c5f_SolDecoder_MemoryBytes___a53dbc6192a658d6(v9)
-      $__EchoContract_init_contract(v10, v11, v2)
-      codecopy(0, v0, v1)
-      return(0, v1)
+      mstore(64, add(v9, v8))
+      codecopy(v9, v5, v8)
+      let v10 := mload(0x40)
+      if iszero(v10) {
+        v10 := 0x80
+      }
+      mstore(0x40, add(v10, 64))
+      mstore(v10, v9)
+      mstore(add(v10, 32), v8)
+      let v11 := $sol_hfd482bb803ad8c5f_abi_h2da9a2d0b1ddaeb7_decoder_new__MemoryBytes_h1e381015a9b0111b__59e0d528d54cca1b(v10)
+      let v12 := $u256_h3271ca15373d4483_decode_hb2fe2bf528775e55_decode__Sol_hfd482bb803ad8c5f_SolDecoder_MemoryBytes___a53dbc6192a658d6(v11)
+      let v13 := $u256_h3271ca15373d4483_decode_hb2fe2bf528775e55_decode__Sol_hfd482bb803ad8c5f_SolDecoder_MemoryBytes___a53dbc6192a658d6(v11)
+      $__EchoContract_init_contract(v12, v13, v4)
+      codecopy(0, v2, v3)
+      return(0, v3)
     }
     function $__EchoContract_init_contract($x, $y, $state) {
       sstore($state, $x)
@@ -160,17 +165,32 @@ object "EchoContract" {
         let v2 := $runtime_decoder__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f__e4e3f8d20b3805a2()
         switch v1
           case 1 {
-            let v3 := $__EchoContract_recv_0_0()
-            $return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f(v3)
-          }
-          case 2 {
-            let v4 := $echo_h9f932a87feb06bd2_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966(v2)
-            let v5 := $__EchoContract_recv_0_1(v4)
+            let v3 := callvalue()
+            let v4 := iszero(eq(v3, 0))
+            if v4 {
+              $evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
+            }
+            let v5 := $__EchoContract_recv_0_0()
             $return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f(v5)
           }
+          case 2 {
+            let v6 := callvalue()
+            let v7 := iszero(eq(v6, 0))
+            if v7 {
+              $evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
+            }
+            let v8 := $echo_h9f932a87feb06bd2_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966(v2)
+            let v9 := $__EchoContract_recv_0_1(v8)
+            $return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f(v9)
+          }
           case 3 {
-            let v6 := $__EchoContract_recv_0_2(v0)
-            $return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f(v6)
+            let v10 := callvalue()
+            let v11 := iszero(eq(v10, 0))
+            if v11 {
+              $evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
+            }
+            let v12 := $__EchoContract_recv_0_2(v0)
+            $return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f(v12)
           }
           default {
             $evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()

--- a/crates/codegen/tests/fixtures/init_args_with_child_dep.snap
+++ b/crates/codegen/tests/fixtures/init_args_with_child_dep.snap
@@ -16,33 +16,38 @@ object "Parent" {
       leave
     }
     function $__Parent_init() {
-      let v0 := dataoffset("Parent_deployed")
-      let v1 := datasize("Parent_deployed")
-      let v2 := datasize("Parent")
-      let v3 := codesize()
-      let v4 := lt(v3, v2)
-      if v4 {
+      let v0 := callvalue()
+      let v1 := iszero(eq(v0, 0))
+      if v1 {
         $evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
       }
-      let v5 := sub(v3, v2)
-      let v6 := mload(64)
-      if iszero(v6) {
-        v6 := 0x80
+      let v2 := dataoffset("Parent_deployed")
+      let v3 := datasize("Parent_deployed")
+      let v4 := datasize("Parent")
+      let v5 := codesize()
+      let v6 := lt(v5, v4)
+      if v6 {
+        $evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
       }
-      mstore(64, add(v6, v5))
-      codecopy(v6, v2, v5)
-      let v7 := mload(0x40)
-      if iszero(v7) {
-        v7 := 0x80
+      let v7 := sub(v5, v4)
+      let v8 := mload(64)
+      if iszero(v8) {
+        v8 := 0x80
       }
-      mstore(0x40, add(v7, 64))
-      mstore(v7, v6)
-      mstore(add(v7, 32), v5)
-      let v8 := $sol_hfd482bb803ad8c5f_abi_h2da9a2d0b1ddaeb7_decoder_new__MemoryBytes_h1e381015a9b0111b__59e0d528d54cca1b(v7)
-      let v9 := $u256_h3271ca15373d4483_decode_hb2fe2bf528775e55_decode__Sol_hfd482bb803ad8c5f_SolDecoder_MemoryBytes___a53dbc6192a658d6(v8)
-      $__Parent_init_contract(v9)
-      codecopy(0, v0, v1)
-      return(0, v1)
+      mstore(64, add(v8, v7))
+      codecopy(v8, v4, v7)
+      let v9 := mload(0x40)
+      if iszero(v9) {
+        v9 := 0x80
+      }
+      mstore(0x40, add(v9, 64))
+      mstore(v9, v8)
+      mstore(add(v9, 32), v7)
+      let v10 := $sol_hfd482bb803ad8c5f_abi_h2da9a2d0b1ddaeb7_decoder_new__MemoryBytes_h1e381015a9b0111b__59e0d528d54cca1b(v9)
+      let v11 := $u256_h3271ca15373d4483_decode_hb2fe2bf528775e55_decode__Sol_hfd482bb803ad8c5f_SolDecoder_MemoryBytes___a53dbc6192a658d6(v10)
+      $__Parent_init_contract(v11)
+      codecopy(0, v2, v3)
+      return(0, v3)
     }
     function $__Parent_init_contract($seed) {
       let v0 := mload(0x40)
@@ -338,10 +343,18 @@ object "Parent" {
   object "Child" {
     code {
       function $__Child_init() {
-        let v0 := dataoffset("Child_deployed")
-        let v1 := datasize("Child_deployed")
-        codecopy(0, v0, v1)
-        return(0, v1)
+        let v0 := callvalue()
+        let v1 := iszero(eq(v0, 0))
+        if v1 {
+          $evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
+        }
+        let v2 := dataoffset("Child_deployed")
+        let v3 := datasize("Child_deployed")
+        codecopy(0, v2, v3)
+        return(0, v3)
+      }
+      function $evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort() {
+        revert(0, 0)
       }
       $__Child_init()
     }

--- a/crates/codegen/tests/fixtures/newtype_storage_byplace_effect_arg.snap
+++ b/crates/codegen/tests/fixtures/newtype_storage_byplace_effect_arg.snap
@@ -6,10 +6,18 @@ input_file: tests/fixtures/newtype_storage_byplace_effect_arg.fe
 object "NewtypeByPlaceEffectArg" {
   code {
     function $__NewtypeByPlaceEffectArg_init() {
-      let v0 := dataoffset("NewtypeByPlaceEffectArg_deployed")
-      let v1 := datasize("NewtypeByPlaceEffectArg_deployed")
-      codecopy(0, v0, v1)
-      return(0, v1)
+      let v0 := callvalue()
+      let v1 := iszero(eq(v0, 0))
+      if v1 {
+        $evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
+      }
+      let v2 := dataoffset("NewtypeByPlaceEffectArg_deployed")
+      let v3 := datasize("NewtypeByPlaceEffectArg_deployed")
+      codecopy(0, v2, v3)
+      return(0, v3)
+    }
+    function $evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort() {
+      revert(0, 0)
     }
     $__NewtypeByPlaceEffectArg_init()
   }
@@ -31,8 +39,13 @@ object "NewtypeByPlaceEffectArg" {
         let v2 := $runtime_selector__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f__e4e3f8d20b3805a2()
         switch v2
           case 1 {
-            let v3 := $__NewtypeByPlaceEffectArg_recv_0_0(v1, v0)
-            $return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f(v3)
+            let v3 := callvalue()
+            let v4 := iszero(eq(v3, 0))
+            if v4 {
+              $evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
+            }
+            let v5 := $__NewtypeByPlaceEffectArg_recv_0_0(v1, v0)
+            $return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f(v5)
           }
           default {
             $evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()

--- a/crates/codegen/tests/fixtures/newtype_storage_field_mut_method_call.snap
+++ b/crates/codegen/tests/fixtures/newtype_storage_field_mut_method_call.snap
@@ -6,10 +6,18 @@ input_file: tests/fixtures/newtype_storage_field_mut_method_call.fe
 object "NewtypeStorageFieldMutMethodCall" {
   code {
     function $__NewtypeStorageFieldMutMethodCall_init() {
-      let v0 := dataoffset("NewtypeStorageFieldMutMethodCall_deployed")
-      let v1 := datasize("NewtypeStorageFieldMutMethodCall_deployed")
-      codecopy(0, v0, v1)
-      return(0, v1)
+      let v0 := callvalue()
+      let v1 := iszero(eq(v0, 0))
+      if v1 {
+        $evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
+      }
+      let v2 := dataoffset("NewtypeStorageFieldMutMethodCall_deployed")
+      let v3 := datasize("NewtypeStorageFieldMutMethodCall_deployed")
+      codecopy(0, v2, v3)
+      return(0, v3)
+    }
+    function $evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort() {
+      revert(0, 0)
     }
     $__NewtypeStorageFieldMutMethodCall_init()
   }
@@ -28,8 +36,13 @@ object "NewtypeStorageFieldMutMethodCall" {
         let v2 := $runtime_selector__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f__e4e3f8d20b3805a2()
         switch v2
           case 1 {
-            let v3 := $__NewtypeStorageFieldMutMethodCall_recv_0_0(v1)
-            $return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f(v3)
+            let v3 := callvalue()
+            let v4 := iszero(eq(v3, 0))
+            if v4 {
+              $evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
+            }
+            let v5 := $__NewtypeStorageFieldMutMethodCall_recv_0_0(v1)
+            $return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f(v5)
           }
           default {
             $evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()

--- a/crates/codegen/tests/fixtures/sonatina_ir/by_ref_trait_provider_storage_bug.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/by_ref_trait_provider_storage_bug.snap
@@ -50,12 +50,22 @@ func private %__ByRefTraitProviderStorageBug_recv_0_0(v0.i256) -> i256 {
 
 func private %__ByRefTraitProviderStorageBug_init() {
     block0:
-        v0.i256 = sym_addr &__ByRefTraitProviderStorageBug_runtime;
-        v1.i256 = sym_size &__ByRefTraitProviderStorageBug_runtime;
-        v3.i256 = call %init_field__Evm_hef0af3106e109414_Pair_h956dff41e88ee341__18f2eb617f185785 0.i256;
-        call %__ByRefTraitProviderStorageBug_init_contract v3;
-        evm_code_copy 0.i256 v0 v1;
-        evm_return 0.i256 v1;
+        v0.i256 = evm_call_value;
+        v2.i1 = eq v0 0.i256;
+        v3.i1 = is_zero v2;
+        br v3 block1 block2;
+
+    block1:
+        call %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort;
+        evm_invalid;
+
+    block2:
+        v4.i256 = sym_addr &__ByRefTraitProviderStorageBug_runtime;
+        v5.i256 = sym_size &__ByRefTraitProviderStorageBug_runtime;
+        v6.i256 = call %init_field__Evm_hef0af3106e109414_Pair_h956dff41e88ee341__18f2eb617f185785 0.i256;
+        call %__ByRefTraitProviderStorageBug_init_contract v6;
+        evm_code_copy 0.i256 v4 v5;
+        evm_return 0.i256 v5;
 }
 
 func private %__ByRefTraitProviderStorageBug_runtime() {
@@ -69,8 +79,18 @@ func private %__ByRefTraitProviderStorageBug_runtime() {
         evm_invalid;
 
     block2:
-        v5.i256 = call %__ByRefTraitProviderStorageBug_recv_0_0 v1;
-        call %return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f v5;
+        v4.i256 = evm_call_value;
+        v5.i1 = eq v4 0.i256;
+        v6.i1 = is_zero v5;
+        br v6 block3 block4;
+
+    block3:
+        call %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort;
+        evm_invalid;
+
+    block4:
+        v8.i256 = call %__ByRefTraitProviderStorageBug_recv_0_0 v1;
+        call %return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f v8;
         evm_invalid;
 }
 
@@ -78,6 +98,11 @@ func private %use_ctx_eff0_stor__Pair_h956dff41e88ee341__acec41afdc898140(v0.i25
     block0:
         v1.i256 = call %pair_h956dff41e88ee341_ctx_h4952b3c1f066f039_sum_stor v0;
         return v1;
+}
+
+func private %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort() {
+    block0:
+        evm_revert 0.i256 0.i256;
 }
 
 func private %init_field__Evm_hef0af3106e109414_Pair_h956dff41e88ee341__18f2eb617f185785(v0.i256) -> i256 {
@@ -107,11 +132,6 @@ func private %runtime_selector__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f__e4e
         v7.i256 = call %calldata_hf71d505b6ff5dc81_byteinput_hc4c2cb44299530ae_word_at v1 0.i256;
         v8.i32 = call %sol_hfd482bb803ad8c5f_abi_h2da9a2d0b1ddaeb7_selector_from_prefix v7;
         return v8;
-}
-
-func private %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort() {
-    block0:
-        evm_revert 0.i256 0.i256;
 }
 
 func private %return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f(v0.i256) {

--- a/crates/codegen/tests/fixtures/sonatina_ir/create_contract.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/create_contract.snap
@@ -25,37 +25,47 @@ func private %__Child_init_contract(v0.i256, v1.i256, v2.i256) {
 
 func private %__Child_init() {
     block0:
-        v0.i256 = sym_addr &__Child_runtime;
-        v1.i256 = sym_size &__Child_runtime;
-        v3.i256 = call %init_field__Evm_hef0af3106e109414_Pair_h956dff41e88ee341__18f2eb617f185785 0.i256;
-        v4.i256 = sym_size .;
-        v5.i256 = evm_code_size;
-        v6.i1 = lt v5 v4;
-        br v6 block1 block2;
+        v0.i256 = evm_call_value;
+        v2.i1 = eq v0 0.i256;
+        v3.i1 = is_zero v2;
+        br v3 block1 block2;
 
     block1:
         call %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort;
         evm_invalid;
 
     block2:
-        v9.i256 = sub v5 v4;
-        v10.i256 = sub v5 v4;
-        v11.*i8 = evm_malloc v10;
-        v12.i256 = ptr_to_int v11 i256;
-        v13.i256 = sub v5 v4;
-        evm_code_copy v12 v4 v13;
-        v14.objref<@__fe_obj_MemoryBytes_2> = obj.alloc @__fe_obj_MemoryBytes_2;
-        v15.objref<i256> = obj.proj v14 0.i256;
-        obj.store v15 v12;
-        v16.i256 = sub v5 v4;
-        v18.objref<i256> = obj.proj v14 1.i256;
-        obj.store v18 v16;
-        v19.objref<@__fe_obj_SolDecoder_4> = call %sol_hfd482bb803ad8c5f_abi_h2da9a2d0b1ddaeb7_decoder_new__MemoryBytes_h1e381015a9b0111b__59e0d528d54cca1b v14;
-        v20.i256 = call %u256_h3271ca15373d4483_decode_hb2fe2bf528775e55_decode__Sol_hfd482bb803ad8c5f_SolDecoder_MemoryBytes___a53dbc6192a658d6 v19;
-        v21.i256 = call %u256_h3271ca15373d4483_decode_hb2fe2bf528775e55_decode__Sol_hfd482bb803ad8c5f_SolDecoder_MemoryBytes___a53dbc6192a658d6 v19;
-        call %__Child_init_contract v20 v21 v3;
-        evm_code_copy 0.i256 v0 v1;
-        evm_return 0.i256 v1;
+        v4.i256 = sym_addr &__Child_runtime;
+        v5.i256 = sym_size &__Child_runtime;
+        v6.i256 = call %init_field__Evm_hef0af3106e109414_Pair_h956dff41e88ee341__18f2eb617f185785 0.i256;
+        v7.i256 = sym_size .;
+        v8.i256 = evm_code_size;
+        v9.i1 = lt v8 v7;
+        br v9 block3 block4;
+
+    block3:
+        call %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort;
+        evm_invalid;
+
+    block4:
+        v12.i256 = sub v8 v7;
+        v13.i256 = sub v8 v7;
+        v14.*i8 = evm_malloc v13;
+        v15.i256 = ptr_to_int v14 i256;
+        v16.i256 = sub v8 v7;
+        evm_code_copy v15 v7 v16;
+        v17.objref<@__fe_obj_MemoryBytes_2> = obj.alloc @__fe_obj_MemoryBytes_2;
+        v18.objref<i256> = obj.proj v17 0.i256;
+        obj.store v18 v15;
+        v19.i256 = sub v8 v7;
+        v21.objref<i256> = obj.proj v17 1.i256;
+        obj.store v21 v19;
+        v22.objref<@__fe_obj_SolDecoder_4> = call %sol_hfd482bb803ad8c5f_abi_h2da9a2d0b1ddaeb7_decoder_new__MemoryBytes_h1e381015a9b0111b__59e0d528d54cca1b v17;
+        v23.i256 = call %u256_h3271ca15373d4483_decode_hb2fe2bf528775e55_decode__Sol_hfd482bb803ad8c5f_SolDecoder_MemoryBytes___a53dbc6192a658d6 v22;
+        v24.i256 = call %u256_h3271ca15373d4483_decode_hb2fe2bf528775e55_decode__Sol_hfd482bb803ad8c5f_SolDecoder_MemoryBytes___a53dbc6192a658d6 v22;
+        call %__Child_init_contract v23 v24 v6;
+        evm_code_copy 0.i256 v4 v5;
+        evm_return 0.i256 v5;
 }
 
 func private %__Child_runtime() {
@@ -103,44 +113,74 @@ func private %__Factory_recv_0_1(v0.objref<@__fe_obj_Deploy2_1>) -> i256 {
 
 func private %__Factory_init() {
     block0:
-        v0.i256 = sym_addr &__Factory_runtime;
-        v1.i256 = sym_size &__Factory_runtime;
-        evm_code_copy 0.i256 v0 v1;
-        evm_return 0.i256 v1;
-}
-
-func private %__Factory_runtime() {
-    block0:
-        v0.i32 = call %runtime_selector__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f__e4e3f8d20b3805a2;
-        v1.objref<@__fe_obj_SolDecoder_7> = call %runtime_decoder__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f__e4e3f8d20b3805a2;
-        br_table v0 block1 (1.i32 block2) (2.i32 block3);
+        v0.i256 = evm_call_value;
+        v2.i1 = eq v0 0.i256;
+        v3.i1 = is_zero v2;
+        br v3 block1 block2;
 
     block1:
         call %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort;
         evm_invalid;
 
     block2:
-        v5.objref<@__fe_obj_Deploy_0> = call %deploy_h5c6b1804553edb1_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966 v1;
-        v6.i256 = call %__Factory_recv_0_0 v5;
-        call %return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_Address_h257056268eac7027__2d9a2ca106cd007c v6;
+        v4.i256 = sym_addr &__Factory_runtime;
+        v5.i256 = sym_size &__Factory_runtime;
+        evm_code_copy 0.i256 v4 v5;
+        evm_return 0.i256 v5;
+}
+
+func private %__Factory_runtime() {
+    block0:
+        v0.i32 = call %runtime_selector__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f__e4e3f8d20b3805a2;
+        v1.objref<@__fe_obj_SolDecoder_7> = call %runtime_decoder__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f__e4e3f8d20b3805a2;
+        br_table v0 block1 (1.i32 block2) (2.i32 block5);
+
+    block1:
+        call %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort;
         evm_invalid;
 
+    block2:
+        v4.i256 = evm_call_value;
+        v6.i1 = eq v4 0.i256;
+        v7.i1 = is_zero v6;
+        br v7 block3 block4;
+
     block3:
-        v8.objref<@__fe_obj_Deploy2_1> = call %deploy2_ha2b981aa2f8bf9fd_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966 v1;
-        v9.i256 = call %__Factory_recv_0_1 v8;
-        call %return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_Address_h257056268eac7027__2d9a2ca106cd007c v9;
+        call %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort;
         evm_invalid;
+
+    block4:
+        v9.objref<@__fe_obj_Deploy_0> = call %deploy_h5c6b1804553edb1_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966 v1;
+        v10.i256 = call %__Factory_recv_0_0 v9;
+        call %return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_Address_h257056268eac7027__2d9a2ca106cd007c v10;
+        evm_invalid;
+
+    block5:
+        v11.i256 = evm_call_value;
+        v12.i1 = eq v11 0.i256;
+        v13.i1 = is_zero v12;
+        br v13 block6 block7;
+
+    block6:
+        call %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort;
+        evm_invalid;
+
+    block7:
+        v15.objref<@__fe_obj_Deploy2_1> = call %deploy2_ha2b981aa2f8bf9fd_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966 v1;
+        v16.i256 = call %__Factory_recv_0_1 v15;
+        call %return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_Address_h257056268eac7027__2d9a2ca106cd007c v16;
+        evm_invalid;
+}
+
+func private %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort() {
+    block0:
+        evm_revert 0.i256 0.i256;
 }
 
 func private %init_field__Evm_hef0af3106e109414_Pair_h956dff41e88ee341__18f2eb617f185785(v0.i256) -> i256 {
     block0:
         v2.i256 = call %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_field__Pair_h956dff41e88ee341__acec41afdc898140 v0;
         return v2;
-}
-
-func private %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort() {
-    block0:
-        evm_revert 0.i256 0.i256;
 }
 
 func private %sol_hfd482bb803ad8c5f_abi_h2da9a2d0b1ddaeb7_decoder_new__MemoryBytes_h1e381015a9b0111b__59e0d528d54cca1b(v0.objref<@__fe_obj_MemoryBytes_2>) -> objref<@__fe_obj_SolDecoder_4> {

--- a/crates/codegen/tests/fixtures/sonatina_ir/effect_handle_field_deref.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/effect_handle_field_deref.snap
@@ -85,10 +85,20 @@ func private %__EffectHandleFieldDeref_recv_0_2(v0.i256, v1.i256) -> i256 {
 
 func private %__EffectHandleFieldDeref_init() {
     block0:
-        v0.i256 = sym_addr &__EffectHandleFieldDeref_runtime;
-        v1.i256 = sym_size &__EffectHandleFieldDeref_runtime;
-        evm_code_copy 0.i256 v0 v1;
-        evm_return 0.i256 v1;
+        v0.i256 = evm_call_value;
+        v2.i1 = eq v0 0.i256;
+        v3.i1 = is_zero v2;
+        br v3 block1 block2;
+
+    block1:
+        call %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort;
+        evm_invalid;
+
+    block2:
+        v4.i256 = sym_addr &__EffectHandleFieldDeref_runtime;
+        v5.i256 = sym_size &__EffectHandleFieldDeref_runtime;
+        evm_code_copy 0.i256 v4 v5;
+        evm_return 0.i256 v5;
 }
 
 func private %__EffectHandleFieldDeref_runtime() {
@@ -96,28 +106,58 @@ func private %__EffectHandleFieldDeref_runtime() {
         v1.i256 = call %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_field__Cell_hc7450704dd4a03d6__5989b97f954838c8 0.i256;
         v2.i32 = call %runtime_selector__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f__e4e3f8d20b3805a2;
         v3.objref<@__fe_obj_SolDecoder_3> = call %runtime_decoder__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f__e4e3f8d20b3805a2;
-        br_table v2 block1 (1.i32 block2) (2.i32 block3) (3.i32 block4);
+        br_table v2 block1 (1.i32 block2) (2.i32 block5) (3.i32 block8);
 
     block1:
         call %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort;
         evm_invalid;
 
     block2:
-        v8.objref<@__fe_obj_SeedSlot_1> = call %seedslot_h54140d6d3003b4fb_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966 v3;
-        v9.i256 = call %__EffectHandleFieldDeref_recv_0_0 v8;
-        call %return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f v9;
-        evm_invalid;
+        v7.i256 = evm_call_value;
+        v8.i1 = eq v7 0.i256;
+        v9.i1 = is_zero v8;
+        br v9 block3 block4;
 
     block3:
-        v11.i256 = call %readviaholder_h9a52c49def8cf7ae_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966 v3;
-        v12.i256 = call %__EffectHandleFieldDeref_recv_0_1 v11;
-        call %return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f v12;
+        call %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort;
         evm_invalid;
 
     block4:
-        v14.i256 = call %bumpmover_hdc9ecd58bf94824a_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966 v3;
-        v16.i256 = call %__EffectHandleFieldDeref_recv_0_2 v14 v1;
-        call %return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f v16;
+        v11.objref<@__fe_obj_SeedSlot_1> = call %seedslot_h54140d6d3003b4fb_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966 v3;
+        v12.i256 = call %__EffectHandleFieldDeref_recv_0_0 v11;
+        call %return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f v12;
+        evm_invalid;
+
+    block5:
+        v13.i256 = evm_call_value;
+        v14.i1 = eq v13 0.i256;
+        v15.i1 = is_zero v14;
+        br v15 block6 block7;
+
+    block6:
+        call %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort;
+        evm_invalid;
+
+    block7:
+        v17.i256 = call %readviaholder_h9a52c49def8cf7ae_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966 v3;
+        v18.i256 = call %__EffectHandleFieldDeref_recv_0_1 v17;
+        call %return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f v18;
+        evm_invalid;
+
+    block8:
+        v19.i256 = evm_call_value;
+        v20.i1 = eq v19 0.i256;
+        v21.i1 = is_zero v20;
+        br v21 block9 block10;
+
+    block9:
+        call %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort;
+        evm_invalid;
+
+    block10:
+        v23.i256 = call %bumpmover_hdc9ecd58bf94824a_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966 v3;
+        v25.i256 = call %__EffectHandleFieldDeref_recv_0_2 v23 v1;
+        call %return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f v25;
         evm_invalid;
 }
 
@@ -149,6 +189,11 @@ func private %cellmover_h6dc2778b4a1f6bf1_bump_stor_arg0_root_stor(v0.i256, v1.i
         return v7;
 }
 
+func private %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort() {
+    block0:
+        evm_revert 0.i256 0.i256;
+}
+
 func private %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_field__Cell_hc7450704dd4a03d6__5989b97f954838c8(v0.i256) -> i256 {
     block0:
         v2.i256 = call %stor_ptr__Evm_hef0af3106e109414_Cell_hc7450704dd4a03d6__db7aa8c50f26516a v0;
@@ -177,11 +222,6 @@ func private %runtime_decoder__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f__e4e3
         v1.i256 = call %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_input;
         v3.objref<@__fe_obj_SolDecoder_3> = call %sol_hfd482bb803ad8c5f_abi_h2da9a2d0b1ddaeb7_decoder_with_base__CallData_hf71d505b6ff5dc81__e6d5f05c3478f563 v1 4.i256;
         return v3;
-}
-
-func private %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort() {
-    block0:
-        evm_revert 0.i256 0.i256;
 }
 
 func private %seedslot_h54140d6d3003b4fb_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966(v0.objref<@__fe_obj_SolDecoder_3>) -> objref<@__fe_obj_SeedSlot_1> {

--- a/crates/codegen/tests/fixtures/sonatina_ir/erc20.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/erc20.snap
@@ -198,38 +198,48 @@ func private %__CoolCoin_recv_1_4(v0.objref<@__fe_obj_DecreaseAllowance_7>, v1.i
 
 func private %__CoolCoin_init() {
     block0:
-        v0.i256 = sym_addr &__CoolCoin_runtime;
-        v1.i256 = sym_size &__CoolCoin_runtime;
-        v3.i256 = call %init_field__Evm_hef0af3106e109414_TokenStore_0__1___db7d7c067dc14cc5 0.i256;
-        v5.i256 = call %init_field__Evm_hef0af3106e109414_AccessControl_3___1911f7c438797961 3.i256;
-        v6.i256 = sym_size .;
-        v7.i256 = evm_code_size;
-        v8.i1 = lt v7 v6;
-        br v8 block1 block2;
+        v0.i256 = evm_call_value;
+        v2.i1 = eq v0 0.i256;
+        v3.i1 = is_zero v2;
+        br v3 block1 block2;
 
     block1:
         call %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort;
         evm_invalid;
 
     block2:
-        v11.i256 = sub v7 v6;
-        v12.i256 = sub v7 v6;
-        v13.*i8 = evm_malloc v12;
-        v14.i256 = ptr_to_int v13 i256;
-        v15.i256 = sub v7 v6;
-        evm_code_copy v14 v6 v15;
-        v16.objref<@__fe_obj_MemoryBytes_9> = obj.alloc @__fe_obj_MemoryBytes_9;
-        v17.objref<i256> = obj.proj v16 0.i256;
-        obj.store v17 v14;
-        v18.i256 = sub v7 v6;
-        v20.objref<i256> = obj.proj v16 1.i256;
-        obj.store v20 v18;
-        v21.objref<@__fe_obj_SolDecoder_11> = call %sol_hfd482bb803ad8c5f_abi_h2da9a2d0b1ddaeb7_decoder_new__MemoryBytes_h1e381015a9b0111b__59e0d528d54cca1b v16;
-        v22.i256 = call %u256_h3271ca15373d4483_decode_hb2fe2bf528775e55_decode__Sol_hfd482bb803ad8c5f_SolDecoder_MemoryBytes___a53dbc6192a658d6 v21;
-        v23.i256 = call %address_h257056268eac7027_decode_hb2fe2bf528775e55_decode__Sol_hfd482bb803ad8c5f_SolDecoder_MemoryBytes___a53dbc6192a658d6 v21;
-        call %__CoolCoin_init_contract v22 v23 v3;
-        evm_code_copy 0.i256 v0 v1;
-        evm_return 0.i256 v1;
+        v4.i256 = sym_addr &__CoolCoin_runtime;
+        v5.i256 = sym_size &__CoolCoin_runtime;
+        v6.i256 = call %init_field__Evm_hef0af3106e109414_TokenStore_0__1___db7d7c067dc14cc5 0.i256;
+        v8.i256 = call %init_field__Evm_hef0af3106e109414_AccessControl_3___1911f7c438797961 3.i256;
+        v9.i256 = sym_size .;
+        v10.i256 = evm_code_size;
+        v11.i1 = lt v10 v9;
+        br v11 block3 block4;
+
+    block3:
+        call %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort;
+        evm_invalid;
+
+    block4:
+        v14.i256 = sub v10 v9;
+        v15.i256 = sub v10 v9;
+        v16.*i8 = evm_malloc v15;
+        v17.i256 = ptr_to_int v16 i256;
+        v18.i256 = sub v10 v9;
+        evm_code_copy v17 v9 v18;
+        v19.objref<@__fe_obj_MemoryBytes_9> = obj.alloc @__fe_obj_MemoryBytes_9;
+        v20.objref<i256> = obj.proj v19 0.i256;
+        obj.store v20 v17;
+        v21.i256 = sub v10 v9;
+        v23.objref<i256> = obj.proj v19 1.i256;
+        obj.store v23 v21;
+        v24.objref<@__fe_obj_SolDecoder_11> = call %sol_hfd482bb803ad8c5f_abi_h2da9a2d0b1ddaeb7_decoder_new__MemoryBytes_h1e381015a9b0111b__59e0d528d54cca1b v19;
+        v25.i256 = call %u256_h3271ca15373d4483_decode_hb2fe2bf528775e55_decode__Sol_hfd482bb803ad8c5f_SolDecoder_MemoryBytes___a53dbc6192a658d6 v24;
+        v26.i256 = call %address_h257056268eac7027_decode_hb2fe2bf528775e55_decode__Sol_hfd482bb803ad8c5f_SolDecoder_MemoryBytes___a53dbc6192a658d6 v24;
+        call %__CoolCoin_init_contract v25 v26 v6;
+        evm_code_copy 0.i256 v4 v5;
+        evm_return 0.i256 v5;
 }
 
 func private %__CoolCoin_runtime() {
@@ -238,90 +248,230 @@ func private %__CoolCoin_runtime() {
         v3.i256 = call %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_field__AccessControl_3___3633e113b859df5f 3.i256;
         v4.i32 = call %runtime_selector__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f__e4e3f8d20b3805a2;
         v5.objref<@__fe_obj_SolDecoder_13> = call %runtime_decoder__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f__e4e3f8d20b3805a2;
-        br_table v4 block1 (-1459249989.i32 block2) (157198259.i32 block3) (599290589.i32 block4) (1889567281.i32 block5) (-580719298.i32 block6) (404098525.i32 block7) (117300739.i32 block8) (-1780966591.i32 block9) (826074471.i32 block10) (1086394137.i32 block11) (1117154408.i32 block12) (2043438992.i32 block13) (961581905.i32 block14) (-1537752361.i32 block15);
+        br_table v4 block1 (-1459249989.i32 block2) (157198259.i32 block5) (599290589.i32 block8) (1889567281.i32 block11) (-580719298.i32 block14) (404098525.i32 block17) (117300739.i32 block20) (-1780966591.i32 block23) (826074471.i32 block26) (1086394137.i32 block29) (1117154408.i32 block32) (2043438992.i32 block35) (961581905.i32 block38) (-1537752361.i32 block41);
 
     block1:
         call %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort;
         evm_invalid;
 
     block2:
-        v21.objref<@__fe_obj_Transfer_0> = call %transfer_h13f5ec5985ebba60_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966 v5;
-        v23.i1 = call %__CoolCoin_recv_0_0 v21 v1;
-        call %return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_bool__397940bf296cce2a v23;
-        evm_invalid;
+        v20.i256 = evm_call_value;
+        v21.i1 = eq v20 0.i256;
+        v22.i1 = is_zero v21;
+        br v22 block3 block4;
 
     block3:
-        v25.objref<@__fe_obj_Approve_1> = call %approve_h90175fc19dafde67_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966 v5;
-        v27.i1 = call %__CoolCoin_recv_0_1 v25 v1;
-        call %return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_bool__397940bf296cce2a v27;
+        call %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort;
         evm_invalid;
 
     block4:
-        v29.objref<@__fe_obj_TransferFrom_2> = call %transferfrom_h939549e4bad999e8_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966 v5;
-        v31.i1 = call %__CoolCoin_recv_0_2 v29 v1;
-        call %return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_bool__397940bf296cce2a v31;
+        v24.objref<@__fe_obj_Transfer_0> = call %transfer_h13f5ec5985ebba60_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966 v5;
+        v26.i1 = call %__CoolCoin_recv_0_0 v24 v1;
+        call %return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_bool__397940bf296cce2a v26;
         evm_invalid;
 
     block5:
-        v33.i256 = call %balanceof_hf830ebedc81244a7_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966 v5;
-        v35.i256 = call %__CoolCoin_recv_0_3 v33 v1;
-        call %return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f v35;
-        evm_invalid;
+        v27.i256 = evm_call_value;
+        v28.i1 = eq v27 0.i256;
+        v29.i1 = is_zero v28;
+        br v29 block6 block7;
 
     block6:
-        v37.objref<@__fe_obj_Allowance_3> = call %allowance_h4bb1267f662bd2a8_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966 v5;
-        v39.i256 = call %__CoolCoin_recv_0_4 v37 v1;
-        call %return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f v39;
+        call %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort;
         evm_invalid;
 
     block7:
-        v41.i256 = call %__CoolCoin_recv_0_5 v1;
-        call %return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f v41;
+        v31.objref<@__fe_obj_Approve_1> = call %approve_h90175fc19dafde67_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966 v5;
+        v33.i1 = call %__CoolCoin_recv_0_1 v31 v1;
+        call %return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_bool__397940bf296cce2a v33;
         evm_invalid;
 
     block8:
-        v42.i256 = call %__CoolCoin_recv_0_6;
-        call %return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_String_32___7798a45a8b22b7ed v42;
-        evm_invalid;
+        v34.i256 = evm_call_value;
+        v35.i1 = eq v34 0.i256;
+        v36.i1 = is_zero v35;
+        br v36 block9 block10;
 
     block9:
-        v43.i256 = call %__CoolCoin_recv_0_7;
-        call %return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_String_8___99627a2b067a3b64 v43;
+        call %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort;
         evm_invalid;
 
     block10:
-        v44.i8 = call %__CoolCoin_recv_0_8;
-        call %return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u8__5f40d25b4a1c5efd v44;
+        v38.objref<@__fe_obj_TransferFrom_2> = call %transferfrom_h939549e4bad999e8_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966 v5;
+        v40.i1 = call %__CoolCoin_recv_0_2 v38 v1;
+        call %return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_bool__397940bf296cce2a v40;
         evm_invalid;
 
     block11:
-        v46.objref<@__fe_obj_Mint_4> = call %mint_ha2f94817be433a2e_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966 v5;
-        v48.i1 = call %__CoolCoin_recv_1_0 v46 v1;
-        call %return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_bool__397940bf296cce2a v48;
-        evm_invalid;
+        v41.i256 = evm_call_value;
+        v42.i1 = eq v41 0.i256;
+        v43.i1 = is_zero v42;
+        br v43 block12 block13;
 
     block12:
-        v50.i256 = call %burn_h25a61f4466d20eed_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966 v5;
-        v52.i1 = call %__CoolCoin_recv_1_1 v50 v1;
-        call %return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_bool__397940bf296cce2a v52;
+        call %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort;
         evm_invalid;
 
     block13:
-        v54.objref<@__fe_obj_BurnFrom_5> = call %burnfrom_ha9fb0972f143e40c_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966 v5;
-        v56.i1 = call %__CoolCoin_recv_1_2 v54 v1;
-        call %return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_bool__397940bf296cce2a v56;
+        v45.i256 = call %balanceof_hf830ebedc81244a7_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966 v5;
+        v47.i256 = call %__CoolCoin_recv_0_3 v45 v1;
+        call %return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f v47;
         evm_invalid;
 
     block14:
-        v58.objref<@__fe_obj_IncreaseAllowance_6> = call %increaseallowance_h9840135eaea36633_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966 v5;
-        v60.i1 = call %__CoolCoin_recv_1_3 v58 v1;
-        call %return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_bool__397940bf296cce2a v60;
-        evm_invalid;
+        v48.i256 = evm_call_value;
+        v49.i1 = eq v48 0.i256;
+        v50.i1 = is_zero v49;
+        br v50 block15 block16;
 
     block15:
-        v62.objref<@__fe_obj_DecreaseAllowance_7> = call %decreaseallowance_h635474f45639c83d_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966 v5;
-        v64.i1 = call %__CoolCoin_recv_1_4 v62 v1;
-        call %return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_bool__397940bf296cce2a v64;
+        call %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort;
+        evm_invalid;
+
+    block16:
+        v52.objref<@__fe_obj_Allowance_3> = call %allowance_h4bb1267f662bd2a8_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966 v5;
+        v54.i256 = call %__CoolCoin_recv_0_4 v52 v1;
+        call %return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f v54;
+        evm_invalid;
+
+    block17:
+        v55.i256 = evm_call_value;
+        v56.i1 = eq v55 0.i256;
+        v57.i1 = is_zero v56;
+        br v57 block18 block19;
+
+    block18:
+        call %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort;
+        evm_invalid;
+
+    block19:
+        v59.i256 = call %__CoolCoin_recv_0_5 v1;
+        call %return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f v59;
+        evm_invalid;
+
+    block20:
+        v60.i256 = evm_call_value;
+        v61.i1 = eq v60 0.i256;
+        v62.i1 = is_zero v61;
+        br v62 block21 block22;
+
+    block21:
+        call %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort;
+        evm_invalid;
+
+    block22:
+        v63.i256 = call %__CoolCoin_recv_0_6;
+        call %return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_String_32___7798a45a8b22b7ed v63;
+        evm_invalid;
+
+    block23:
+        v64.i256 = evm_call_value;
+        v65.i1 = eq v64 0.i256;
+        v66.i1 = is_zero v65;
+        br v66 block24 block25;
+
+    block24:
+        call %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort;
+        evm_invalid;
+
+    block25:
+        v67.i256 = call %__CoolCoin_recv_0_7;
+        call %return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_String_8___99627a2b067a3b64 v67;
+        evm_invalid;
+
+    block26:
+        v68.i256 = evm_call_value;
+        v69.i1 = eq v68 0.i256;
+        v70.i1 = is_zero v69;
+        br v70 block27 block28;
+
+    block27:
+        call %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort;
+        evm_invalid;
+
+    block28:
+        v71.i8 = call %__CoolCoin_recv_0_8;
+        call %return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u8__5f40d25b4a1c5efd v71;
+        evm_invalid;
+
+    block29:
+        v72.i256 = evm_call_value;
+        v73.i1 = eq v72 0.i256;
+        v74.i1 = is_zero v73;
+        br v74 block30 block31;
+
+    block30:
+        call %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort;
+        evm_invalid;
+
+    block31:
+        v76.objref<@__fe_obj_Mint_4> = call %mint_ha2f94817be433a2e_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966 v5;
+        v78.i1 = call %__CoolCoin_recv_1_0 v76 v1;
+        call %return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_bool__397940bf296cce2a v78;
+        evm_invalid;
+
+    block32:
+        v79.i256 = evm_call_value;
+        v80.i1 = eq v79 0.i256;
+        v81.i1 = is_zero v80;
+        br v81 block33 block34;
+
+    block33:
+        call %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort;
+        evm_invalid;
+
+    block34:
+        v83.i256 = call %burn_h25a61f4466d20eed_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966 v5;
+        v85.i1 = call %__CoolCoin_recv_1_1 v83 v1;
+        call %return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_bool__397940bf296cce2a v85;
+        evm_invalid;
+
+    block35:
+        v86.i256 = evm_call_value;
+        v87.i1 = eq v86 0.i256;
+        v88.i1 = is_zero v87;
+        br v88 block36 block37;
+
+    block36:
+        call %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort;
+        evm_invalid;
+
+    block37:
+        v90.objref<@__fe_obj_BurnFrom_5> = call %burnfrom_ha9fb0972f143e40c_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966 v5;
+        v92.i1 = call %__CoolCoin_recv_1_2 v90 v1;
+        call %return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_bool__397940bf296cce2a v92;
+        evm_invalid;
+
+    block38:
+        v93.i256 = evm_call_value;
+        v94.i1 = eq v93 0.i256;
+        v95.i1 = is_zero v94;
+        br v95 block39 block40;
+
+    block39:
+        call %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort;
+        evm_invalid;
+
+    block40:
+        v97.objref<@__fe_obj_IncreaseAllowance_6> = call %increaseallowance_h9840135eaea36633_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966 v5;
+        v99.i1 = call %__CoolCoin_recv_1_3 v97 v1;
+        call %return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_bool__397940bf296cce2a v99;
+        evm_invalid;
+
+    block41:
+        v100.i256 = evm_call_value;
+        v101.i1 = eq v100 0.i256;
+        v102.i1 = is_zero v101;
+        br v102 block42 block43;
+
+    block42:
+        call %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort;
+        evm_invalid;
+
+    block43:
+        v104.objref<@__fe_obj_DecreaseAllowance_7> = call %decreaseallowance_h635474f45639c83d_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966 v5;
+        v106.i1 = call %__CoolCoin_recv_1_4 v104 v1;
+        call %return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_bool__397940bf296cce2a v106;
         evm_invalid;
 }
 
@@ -542,6 +692,11 @@ func private %assert(v0.i1) {
         return;
 }
 
+func private %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort() {
+    block0:
+        evm_revert 0.i256 0.i256;
+}
+
 func private %init_field__Evm_hef0af3106e109414_TokenStore_0__1___db7d7c067dc14cc5(v0.i256) -> i256 {
     block0:
         v2.i256 = call %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_field__TokenStore_0__1___175215aa56127bde v0;
@@ -552,11 +707,6 @@ func private %init_field__Evm_hef0af3106e109414_AccessControl_3___1911f7c4387979
     block0:
         v2.i256 = call %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_field__AccessControl_3___3633e113b859df5f v0;
         return v2;
-}
-
-func private %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort() {
-    block0:
-        evm_revert 0.i256 0.i256;
 }
 
 func private %sol_hfd482bb803ad8c5f_abi_h2da9a2d0b1ddaeb7_decoder_new__MemoryBytes_h1e381015a9b0111b__59e0d528d54cca1b(v0.objref<@__fe_obj_MemoryBytes_9>) -> objref<@__fe_obj_SolDecoder_11> {

--- a/crates/codegen/tests/fixtures/sonatina_ir/high_level_contract.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/high_level_contract.snap
@@ -39,37 +39,47 @@ func private %__EchoContract_recv_0_2(v0.i256) -> i256 {
 
 func private %__EchoContract_init() {
     block0:
-        v0.i256 = sym_addr &__EchoContract_runtime;
-        v1.i256 = sym_size &__EchoContract_runtime;
-        v3.i256 = call %init_field__Evm_hef0af3106e109414_Foo_h6dbce71a6ea992b8__c09e6c6fc5a7b23d 0.i256;
-        v4.i256 = sym_size .;
-        v5.i256 = evm_code_size;
-        v6.i1 = lt v5 v4;
-        br v6 block1 block2;
+        v0.i256 = evm_call_value;
+        v2.i1 = eq v0 0.i256;
+        v3.i1 = is_zero v2;
+        br v3 block1 block2;
 
     block1:
         call %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort;
         evm_invalid;
 
     block2:
-        v9.i256 = sub v5 v4;
-        v10.i256 = sub v5 v4;
-        v11.*i8 = evm_malloc v10;
-        v12.i256 = ptr_to_int v11 i256;
-        v13.i256 = sub v5 v4;
-        evm_code_copy v12 v4 v13;
-        v14.objref<@__fe_obj_MemoryBytes_0> = obj.alloc @__fe_obj_MemoryBytes_0;
-        v15.objref<i256> = obj.proj v14 0.i256;
-        obj.store v15 v12;
-        v16.i256 = sub v5 v4;
-        v18.objref<i256> = obj.proj v14 1.i256;
-        obj.store v18 v16;
-        v19.objref<@__fe_obj_SolDecoder_2> = call %sol_hfd482bb803ad8c5f_abi_h2da9a2d0b1ddaeb7_decoder_new__MemoryBytes_h1e381015a9b0111b__59e0d528d54cca1b v14;
-        v20.i256 = call %u256_h3271ca15373d4483_decode_hb2fe2bf528775e55_decode__Sol_hfd482bb803ad8c5f_SolDecoder_MemoryBytes___a53dbc6192a658d6 v19;
-        v21.i256 = call %u256_h3271ca15373d4483_decode_hb2fe2bf528775e55_decode__Sol_hfd482bb803ad8c5f_SolDecoder_MemoryBytes___a53dbc6192a658d6 v19;
-        call %__EchoContract_init_contract v20 v21 v3;
-        evm_code_copy 0.i256 v0 v1;
-        evm_return 0.i256 v1;
+        v4.i256 = sym_addr &__EchoContract_runtime;
+        v5.i256 = sym_size &__EchoContract_runtime;
+        v6.i256 = call %init_field__Evm_hef0af3106e109414_Foo_h6dbce71a6ea992b8__c09e6c6fc5a7b23d 0.i256;
+        v7.i256 = sym_size .;
+        v8.i256 = evm_code_size;
+        v9.i1 = lt v8 v7;
+        br v9 block3 block4;
+
+    block3:
+        call %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort;
+        evm_invalid;
+
+    block4:
+        v12.i256 = sub v8 v7;
+        v13.i256 = sub v8 v7;
+        v14.*i8 = evm_malloc v13;
+        v15.i256 = ptr_to_int v14 i256;
+        v16.i256 = sub v8 v7;
+        evm_code_copy v15 v7 v16;
+        v17.objref<@__fe_obj_MemoryBytes_0> = obj.alloc @__fe_obj_MemoryBytes_0;
+        v18.objref<i256> = obj.proj v17 0.i256;
+        obj.store v18 v15;
+        v19.i256 = sub v8 v7;
+        v21.objref<i256> = obj.proj v17 1.i256;
+        obj.store v21 v19;
+        v22.objref<@__fe_obj_SolDecoder_2> = call %sol_hfd482bb803ad8c5f_abi_h2da9a2d0b1ddaeb7_decoder_new__MemoryBytes_h1e381015a9b0111b__59e0d528d54cca1b v17;
+        v23.i256 = call %u256_h3271ca15373d4483_decode_hb2fe2bf528775e55_decode__Sol_hfd482bb803ad8c5f_SolDecoder_MemoryBytes___a53dbc6192a658d6 v22;
+        v24.i256 = call %u256_h3271ca15373d4483_decode_hb2fe2bf528775e55_decode__Sol_hfd482bb803ad8c5f_SolDecoder_MemoryBytes___a53dbc6192a658d6 v22;
+        call %__EchoContract_init_contract v23 v24 v6;
+        evm_code_copy 0.i256 v4 v5;
+        evm_return 0.i256 v5;
 }
 
 func private %__EchoContract_runtime() {
@@ -77,38 +87,68 @@ func private %__EchoContract_runtime() {
         v1.i256 = call %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_field__Foo_h6dbce71a6ea992b8__21493237fe9c2c26 0.i256;
         v2.i32 = call %runtime_selector__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f__e4e3f8d20b3805a2;
         v3.objref<@__fe_obj_SolDecoder_4> = call %runtime_decoder__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f__e4e3f8d20b3805a2;
-        br_table v2 block1 (1.i32 block2) (2.i32 block3) (3.i32 block4);
+        br_table v2 block1 (1.i32 block2) (2.i32 block5) (3.i32 block8);
 
     block1:
         call %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort;
         evm_invalid;
 
     block2:
-        v7.i256 = call %__EchoContract_recv_0_0;
-        call %return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f v7;
-        evm_invalid;
+        v7.i256 = evm_call_value;
+        v8.i1 = eq v7 0.i256;
+        v9.i1 = is_zero v8;
+        br v9 block3 block4;
 
     block3:
-        v9.i256 = call %echo_h9f932a87feb06bd2_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966 v3;
-        v10.i256 = call %__EchoContract_recv_0_1 v9;
-        call %return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f v10;
+        call %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort;
         evm_invalid;
 
     block4:
-        v12.i256 = call %__EchoContract_recv_0_2 v1;
-        call %return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f v12;
+        v10.i256 = call %__EchoContract_recv_0_0;
+        call %return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f v10;
         evm_invalid;
+
+    block5:
+        v11.i256 = evm_call_value;
+        v12.i1 = eq v11 0.i256;
+        v13.i1 = is_zero v12;
+        br v13 block6 block7;
+
+    block6:
+        call %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort;
+        evm_invalid;
+
+    block7:
+        v15.i256 = call %echo_h9f932a87feb06bd2_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966 v3;
+        v16.i256 = call %__EchoContract_recv_0_1 v15;
+        call %return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f v16;
+        evm_invalid;
+
+    block8:
+        v17.i256 = evm_call_value;
+        v18.i1 = eq v17 0.i256;
+        v19.i1 = is_zero v18;
+        br v19 block9 block10;
+
+    block9:
+        call %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort;
+        evm_invalid;
+
+    block10:
+        v21.i256 = call %__EchoContract_recv_0_2 v1;
+        call %return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f v21;
+        evm_invalid;
+}
+
+func private %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort() {
+    block0:
+        evm_revert 0.i256 0.i256;
 }
 
 func private %init_field__Evm_hef0af3106e109414_Foo_h6dbce71a6ea992b8__c09e6c6fc5a7b23d(v0.i256) -> i256 {
     block0:
         v2.i256 = call %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_field__Foo_h6dbce71a6ea992b8__21493237fe9c2c26 v0;
         return v2;
-}
-
-func private %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort() {
-    block0:
-        evm_revert 0.i256 0.i256;
 }
 
 func private %sol_hfd482bb803ad8c5f_abi_h2da9a2d0b1ddaeb7_decoder_new__MemoryBytes_h1e381015a9b0111b__59e0d528d54cca1b(v0.objref<@__fe_obj_MemoryBytes_0>) -> objref<@__fe_obj_SolDecoder_2> {

--- a/crates/codegen/tests/fixtures/sonatina_ir/init_args_with_child_dep.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/init_args_with_child_dep.snap
@@ -13,10 +13,20 @@ type @__fe_obj_SolEncoder_4 = {i256, i256, i256};
 
 func private %__Child_init() {
     block0:
-        v0.i256 = sym_addr &__Child_runtime;
-        v1.i256 = sym_size &__Child_runtime;
-        evm_code_copy 0.i256 v0 v1;
-        evm_return 0.i256 v1;
+        v0.i256 = evm_call_value;
+        v2.i1 = eq v0 0.i256;
+        v3.i1 = is_zero v2;
+        br v3 block1 block2;
+
+    block1:
+        call %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort;
+        evm_invalid;
+
+    block2:
+        v4.i256 = sym_addr &__Child_runtime;
+        v5.i256 = sym_size &__Child_runtime;
+        evm_code_copy 0.i256 v4 v5;
+        evm_return 0.i256 v5;
 }
 
 func private %__Child_runtime() {
@@ -42,35 +52,45 @@ func private %__Parent_init_contract(v0.i256) {
 
 func private %__Parent_init() {
     block0:
-        v0.i256 = sym_addr &__Parent_runtime;
-        v1.i256 = sym_size &__Parent_runtime;
-        v2.i256 = sym_size .;
-        v3.i256 = evm_code_size;
-        v4.i1 = lt v3 v2;
-        br v4 block1 block2;
+        v0.i256 = evm_call_value;
+        v2.i1 = eq v0 0.i256;
+        v3.i1 = is_zero v2;
+        br v3 block1 block2;
 
     block1:
         call %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort;
         evm_invalid;
 
     block2:
-        v7.i256 = sub v3 v2;
-        v8.i256 = sub v3 v2;
-        v9.*i8 = evm_malloc v8;
-        v10.i256 = ptr_to_int v9 i256;
-        v11.i256 = sub v3 v2;
-        evm_code_copy v10 v2 v11;
-        v12.objref<@__fe_obj_MemoryBytes_1> = obj.alloc @__fe_obj_MemoryBytes_1;
-        v14.objref<i256> = obj.proj v12 0.i256;
-        obj.store v14 v10;
-        v15.i256 = sub v3 v2;
-        v17.objref<i256> = obj.proj v12 1.i256;
-        obj.store v17 v15;
-        v18.objref<@__fe_obj_SolDecoder_3> = call %sol_hfd482bb803ad8c5f_abi_h2da9a2d0b1ddaeb7_decoder_new__MemoryBytes_h1e381015a9b0111b__59e0d528d54cca1b v12;
-        v19.i256 = call %u256_h3271ca15373d4483_decode_hb2fe2bf528775e55_decode__Sol_hfd482bb803ad8c5f_SolDecoder_MemoryBytes___a53dbc6192a658d6 v18;
-        call %__Parent_init_contract v19;
-        evm_code_copy 0.i256 v0 v1;
-        evm_return 0.i256 v1;
+        v4.i256 = sym_addr &__Parent_runtime;
+        v5.i256 = sym_size &__Parent_runtime;
+        v6.i256 = sym_size .;
+        v7.i256 = evm_code_size;
+        v8.i1 = lt v7 v6;
+        br v8 block3 block4;
+
+    block3:
+        call %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort;
+        evm_invalid;
+
+    block4:
+        v11.i256 = sub v7 v6;
+        v12.i256 = sub v7 v6;
+        v13.*i8 = evm_malloc v12;
+        v14.i256 = ptr_to_int v13 i256;
+        v15.i256 = sub v7 v6;
+        evm_code_copy v14 v6 v15;
+        v16.objref<@__fe_obj_MemoryBytes_1> = obj.alloc @__fe_obj_MemoryBytes_1;
+        v17.objref<i256> = obj.proj v16 0.i256;
+        obj.store v17 v14;
+        v18.i256 = sub v7 v6;
+        v20.objref<i256> = obj.proj v16 1.i256;
+        obj.store v20 v18;
+        v21.objref<@__fe_obj_SolDecoder_3> = call %sol_hfd482bb803ad8c5f_abi_h2da9a2d0b1ddaeb7_decoder_new__MemoryBytes_h1e381015a9b0111b__59e0d528d54cca1b v16;
+        v22.i256 = call %u256_h3271ca15373d4483_decode_hb2fe2bf528775e55_decode__Sol_hfd482bb803ad8c5f_SolDecoder_MemoryBytes___a53dbc6192a658d6 v21;
+        call %__Parent_init_contract v22;
+        evm_code_copy 0.i256 v4 v5;
+        evm_return 0.i256 v5;
 }
 
 func private %__Parent_runtime() {
@@ -81,6 +101,11 @@ func private %__Parent_runtime() {
     block1:
         call %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort;
         evm_invalid;
+}
+
+func private %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort() {
+    block0:
+        evm_revert 0.i256 0.i256;
 }
 
 func private %runtime_selector__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f__e4e3f8d20b3805a2() -> i32 {
@@ -98,11 +123,6 @@ func private %runtime_selector__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f__e4e
         v7.i256 = call %calldata_hf71d505b6ff5dc81_byteinput_hc4c2cb44299530ae_word_at v1 0.i256;
         v8.i32 = call %sol_hfd482bb803ad8c5f_abi_h2da9a2d0b1ddaeb7_selector_from_prefix v7;
         return v8;
-}
-
-func private %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort() {
-    block0:
-        evm_revert 0.i256 0.i256;
 }
 
 func private %create_stor_arg0_root_stor__Evm_hef0af3106e109414_Child_hdfa2e9d62e9c9ad3__8303e18f50f8d8ed(v0.i256, v1.objref<@__fe_obj_tuple_0>) -> i256 {

--- a/crates/codegen/tests/fixtures/sonatina_ir/newtype_storage_byplace_effect_arg.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/newtype_storage_byplace_effect_arg.snap
@@ -40,10 +40,20 @@ func private %__NewtypeByPlaceEffectArg_recv_0_0(v0.i256, v1.i256) -> i256 {
 
 func private %__NewtypeByPlaceEffectArg_init() {
     block0:
-        v0.i256 = sym_addr &__NewtypeByPlaceEffectArg_runtime;
-        v1.i256 = sym_size &__NewtypeByPlaceEffectArg_runtime;
-        evm_code_copy 0.i256 v0 v1;
-        evm_return 0.i256 v1;
+        v0.i256 = evm_call_value;
+        v2.i1 = eq v0 0.i256;
+        v3.i1 = is_zero v2;
+        br v3 block1 block2;
+
+    block1:
+        call %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort;
+        evm_invalid;
+
+    block2:
+        v4.i256 = sym_addr &__NewtypeByPlaceEffectArg_runtime;
+        v5.i256 = sym_size &__NewtypeByPlaceEffectArg_runtime;
+        evm_code_copy 0.i256 v4 v5;
+        evm_return 0.i256 v5;
 }
 
 func private %__NewtypeByPlaceEffectArg_runtime() {
@@ -58,9 +68,24 @@ func private %__NewtypeByPlaceEffectArg_runtime() {
         evm_invalid;
 
     block2:
-        v8.i256 = call %__NewtypeByPlaceEffectArg_recv_0_0 v3 v1;
-        call %return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f v8;
+        v6.i256 = evm_call_value;
+        v7.i1 = eq v6 0.i256;
+        v8.i1 = is_zero v7;
+        br v8 block3 block4;
+
+    block3:
+        call %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort;
         evm_invalid;
+
+    block4:
+        v11.i256 = call %__NewtypeByPlaceEffectArg_recv_0_0 v3 v1;
+        call %return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f v11;
+        evm_invalid;
+}
+
+func private %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort() {
+    block0:
+        evm_revert 0.i256 0.i256;
 }
 
 func private %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_field__u256__3271ca15373d4483(v0.i256) -> i256 {
@@ -90,11 +115,6 @@ func private %runtime_selector__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f__e4e
         v7.i256 = call %calldata_hf71d505b6ff5dc81_byteinput_hc4c2cb44299530ae_word_at v1 0.i256;
         v8.i32 = call %sol_hfd482bb803ad8c5f_abi_h2da9a2d0b1ddaeb7_selector_from_prefix v7;
         return v8;
-}
-
-func private %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort() {
-    block0:
-        evm_revert 0.i256 0.i256;
 }
 
 func private %return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f(v0.i256) {

--- a/crates/codegen/tests/fixtures/sonatina_ir/newtype_storage_field_mut_method_call.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/newtype_storage_field_mut_method_call.snap
@@ -33,10 +33,20 @@ func private %__NewtypeStorageFieldMutMethodCall_recv_0_0(v0.i256) -> i256 {
 
 func private %__NewtypeStorageFieldMutMethodCall_init() {
     block0:
-        v0.i256 = sym_addr &__NewtypeStorageFieldMutMethodCall_runtime;
-        v1.i256 = sym_size &__NewtypeStorageFieldMutMethodCall_runtime;
-        evm_code_copy 0.i256 v0 v1;
-        evm_return 0.i256 v1;
+        v0.i256 = evm_call_value;
+        v2.i1 = eq v0 0.i256;
+        v3.i1 = is_zero v2;
+        br v3 block1 block2;
+
+    block1:
+        call %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort;
+        evm_invalid;
+
+    block2:
+        v4.i256 = sym_addr &__NewtypeStorageFieldMutMethodCall_runtime;
+        v5.i256 = sym_size &__NewtypeStorageFieldMutMethodCall_runtime;
+        evm_code_copy 0.i256 v4 v5;
+        evm_return 0.i256 v5;
 }
 
 func private %__NewtypeStorageFieldMutMethodCall_runtime() {
@@ -51,8 +61,18 @@ func private %__NewtypeStorageFieldMutMethodCall_runtime() {
         evm_invalid;
 
     block2:
-        v7.i256 = call %__NewtypeStorageFieldMutMethodCall_recv_0_0 v3;
-        call %return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f v7;
+        v6.i256 = evm_call_value;
+        v7.i1 = eq v6 0.i256;
+        v8.i1 = is_zero v7;
+        br v8 block3 block4;
+
+    block3:
+        call %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort;
+        evm_invalid;
+
+    block4:
+        v10.i256 = call %__NewtypeStorageFieldMutMethodCall_recv_0_0 v3;
+        call %return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f v10;
         evm_invalid;
 }
 
@@ -68,6 +88,11 @@ func private %wrap_haf9e70905fcbd513_bump_stor_arg0_root_stor(v0.i256) {
     block2:
         evm_sstore v0 v3;
         return;
+}
+
+func private %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort() {
+    block0:
+        evm_revert 0.i256 0.i256;
 }
 
 func private %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_field__u256__3271ca15373d4483(v0.i256) -> i256 {
@@ -97,11 +122,6 @@ func private %runtime_selector__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f__e4e
         v7.i256 = call %calldata_hf71d505b6ff5dc81_byteinput_hc4c2cb44299530ae_word_at v1 0.i256;
         v8.i32 = call %sol_hfd482bb803ad8c5f_abi_h2da9a2d0b1ddaeb7_selector_from_prefix v7;
         return v8;
-}
-
-func private %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort() {
-    block0:
-        evm_revert 0.i256 0.i256;
 }
 
 func private %return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f(v0.i256) {

--- a/crates/codegen/tests/fixtures/sonatina_ir/tstor_ptr_contract.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/tstor_ptr_contract.snap
@@ -36,13 +36,23 @@ func private %__GuardContract_recv_0_0(v0.i256, v1.i256) -> i1 {
 
 func private %__GuardContract_init() {
     block0:
-        v0.i256 = sym_addr &__GuardContract_runtime;
-        v1.i256 = sym_size &__GuardContract_runtime;
-        v3.i256 = call %init_field__Evm_hef0af3106e109414_u256__3b1b0af5b20737f9 0.i256;
-        v4.i256 = call %tstorptr_t__hb73db5b342ccdc03_effecthandle_hfc52f915596f993a_from_raw__bool__947c0c03c59c6f07 0.i256;
-        call %__GuardContract_init_contract v4;
-        evm_code_copy 0.i256 v0 v1;
-        evm_return 0.i256 v1;
+        v0.i256 = evm_call_value;
+        v2.i1 = eq v0 0.i256;
+        v3.i1 = is_zero v2;
+        br v3 block1 block2;
+
+    block1:
+        call %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort;
+        evm_invalid;
+
+    block2:
+        v4.i256 = sym_addr &__GuardContract_runtime;
+        v5.i256 = sym_size &__GuardContract_runtime;
+        v6.i256 = call %init_field__Evm_hef0af3106e109414_u256__3b1b0af5b20737f9 0.i256;
+        v7.i256 = call %tstorptr_t__hb73db5b342ccdc03_effecthandle_hfc52f915596f993a_from_raw__bool__947c0c03c59c6f07 0.i256;
+        call %__GuardContract_init_contract v7;
+        evm_code_copy 0.i256 v4 v5;
+        evm_return 0.i256 v5;
 }
 
 func private %__GuardContract_runtime() {
@@ -57,9 +67,24 @@ func private %__GuardContract_runtime() {
         evm_invalid;
 
     block2:
-        v7.i1 = call %__GuardContract_recv_0_0 v2 v1;
-        call %return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_bool__397940bf296cce2a v7;
+        v5.i256 = evm_call_value;
+        v6.i1 = eq v5 0.i256;
+        v7.i1 = is_zero v6;
+        br v7 block3 block4;
+
+    block3:
+        call %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort;
         evm_invalid;
+
+    block4:
+        v10.i1 = call %__GuardContract_recv_0_0 v2 v1;
+        call %return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_bool__397940bf296cce2a v10;
+        evm_invalid;
+}
+
+func private %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort() {
+    block0:
+        evm_revert 0.i256 0.i256;
 }
 
 func private %init_field__Evm_hef0af3106e109414_u256__3b1b0af5b20737f9(v0.i256) -> i256 {
@@ -94,11 +119,6 @@ func private %runtime_selector__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f__e4e
         v7.i256 = call %calldata_hf71d505b6ff5dc81_byteinput_hc4c2cb44299530ae_word_at v1 0.i256;
         v8.i32 = call %sol_hfd482bb803ad8c5f_abi_h2da9a2d0b1ddaeb7_selector_from_prefix v7;
         return v8;
-}
-
-func private %evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort() {
-    block0:
-        evm_revert 0.i256 0.i256;
 }
 
 func private %return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_bool__397940bf296cce2a(v0.i1) {

--- a/crates/codegen/tests/fixtures/tstor_ptr_contract.snap
+++ b/crates/codegen/tests/fixtures/tstor_ptr_contract.snap
@@ -6,17 +6,25 @@ input_file: tests/fixtures/tstor_ptr_contract.fe
 object "GuardContract" {
   code {
     function $__GuardContract_init() {
-      let v0 := dataoffset("GuardContract_deployed")
-      let v1 := datasize("GuardContract_deployed")
-      let v2 := $init_field__Evm_hef0af3106e109414_u256__3b1b0af5b20737f9(0)
-      let v3 := $tstorptr_t__hb73db5b342ccdc03_effecthandle_hfc52f915596f993a_from_raw__bool__947c0c03c59c6f07(0)
-      $__GuardContract_init_contract(v3)
-      codecopy(0, v0, v1)
-      return(0, v1)
+      let v0 := callvalue()
+      let v1 := iszero(eq(v0, 0))
+      if v1 {
+        $evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
+      }
+      let v2 := dataoffset("GuardContract_deployed")
+      let v3 := datasize("GuardContract_deployed")
+      let v4 := $init_field__Evm_hef0af3106e109414_u256__3b1b0af5b20737f9(0)
+      let v5 := $tstorptr_t__hb73db5b342ccdc03_effecthandle_hfc52f915596f993a_from_raw__bool__947c0c03c59c6f07(0)
+      $__GuardContract_init_contract(v5)
+      codecopy(0, v2, v3)
+      return(0, v3)
     }
     function $__GuardContract_init_contract($block_reentrance) {
       tstore($block_reentrance, iszero(iszero(0)))
       leave
+    }
+    function $evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort() {
+      revert(0, 0)
     }
     function $evm_hef0af3106e109414_contracthost_h57111e7eb283a125_field__u256__3271ca15373d4483($slot) -> ret {
       let v0 := $stor_ptr__Evm_hef0af3106e109414_u256__3b1b0af5b20737f9($slot)
@@ -62,8 +70,13 @@ object "GuardContract" {
         let v2 := $runtime_selector__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f__e4e3f8d20b3805a2()
         switch v2
           case 1 {
-            let v3 := $__GuardContract_recv_0_0(v1, v0)
-            $return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_bool__397940bf296cce2a(v3)
+            let v3 := callvalue()
+            let v4 := iszero(eq(v3, 0))
+            if v4 {
+              $evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
+            }
+            let v5 := $__GuardContract_recv_0_0(v1, v0)
+            $return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_bool__397940bf296cce2a(v5)
           }
           default {
             $evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()

--- a/crates/common/src/diagnostics.rs
+++ b/crates/common/src/diagnostics.rs
@@ -174,6 +174,7 @@ pub enum DiagnosticPass {
     MsgLower,
     EventLower,
     ArithmeticAttr,
+    PayableAttr,
 
     NameResolution,
 
@@ -196,6 +197,7 @@ impl DiagnosticPass {
             Self::MsgLower => 9,
             Self::EventLower => 10,
             Self::ArithmeticAttr => 12,
+            Self::PayableAttr => 13,
             Self::NameResolution => 2,
             Self::TypeDefinition => 3,
             Self::TraitDefinition => 4,

--- a/crates/contract-harness/src/lib.rs
+++ b/crates/contract-harness/src/lib.rs
@@ -755,15 +755,26 @@ impl RuntimeInstance {
     /// This is useful for tests that need the contract to send ETH
     /// via internal calls (e.g. `evm.call(value: 1, ...)`).
     pub fn fund_contract(&mut self, amount: U256) {
-        let db = &mut self.evm.ctx.journaled_state.database;
-        let mut info = db
+        let address = self.address;
+        let js = &mut self.evm.ctx.journaled_state;
+
+        // Update the underlying DB cache so future loads see the balance.
+        let mut info = js
+            .database
             .cache
             .accounts
-            .get(&self.address)
+            .get(&address)
             .map(|a| a.info.clone())
             .unwrap_or_default();
         info.balance = info.balance.saturating_add(amount);
-        db.insert_account_info(self.address, info);
+        js.database.insert_account_info(address, info.clone());
+
+        // Also update the live journal state — after deploy the account is
+        // already loaded there, and value transfers read from the journal
+        // rather than reloading from the DB cache.
+        if let Some(account) = js.state.get_mut(&address) {
+            account.info.balance = info.balance;
+        }
     }
 
     fn effective_nonce(&mut self, options: ExecutionOptions) -> u64 {

--- a/crates/driver/src/db.rs
+++ b/crates/driver/src/db.rs
@@ -11,6 +11,7 @@ use common::{
 use hir::analysis::{
     analysis_pass::{
         AnalysisPassManager, ArithmeticAttrPass, EventLowerPass, MsgLowerPass, ParsingPass,
+        PayableAttrPass,
     },
     diagnostics::DiagnosticVoucher,
     name_resolution::ImportAnalysisPass,
@@ -157,6 +158,7 @@ fn initialize_analysis_pass() -> AnalysisPassManager {
     let mut pass_manager = AnalysisPassManager::new();
     pass_manager.add_module_pass("Parsing", Box::new(ParsingPass {}));
     pass_manager.add_module_pass("ArithmeticAttr", Box::new(ArithmeticAttrPass {}));
+    pass_manager.add_module_pass("PayableAttr", Box::new(PayableAttrPass {}));
     pass_manager.add_module_pass("MsgLower", Box::new(MsgLowerPass {}));
     pass_manager.add_module_pass("EventLower", Box::new(EventLowerPass {}));
     pass_manager.add_module_pass("MsgSelector", Box::new(MsgSelectorAnalysisPass {}));

--- a/crates/fe/src/test/mod.rs
+++ b/crates/fe/src/test/mod.rs
@@ -23,7 +23,7 @@ use common::{
     config::{Config, WorkspaceMemberSelection},
     ingot::Ingot,
 };
-use contract_harness::{CallGasProfile, EvmTraceOptions, ExecutionOptions, RuntimeInstance};
+use contract_harness::{CallGasProfile, EvmTraceOptions, ExecutionOptions, RuntimeInstance, U256};
 use crossbeam_channel::{Receiver, Sender, TryRecvError};
 use driver::DriverDataBase;
 use hir::hir_def::{HirIngot, TopLevelMod, item::ItemKind};
@@ -2796,6 +2796,21 @@ pub(super) fn compile_and_run_test(
         ));
     }
 
+    let initial_balance = match case
+        .initial_balance
+        .as_deref()
+        .map(be_bytes_to_u256)
+        .transpose()
+    {
+        Ok(balance) => balance,
+        Err(err) => {
+            return failure(format!(
+                "invalid initial balance for test `{}`: {err}",
+                case.display_name
+            ));
+        }
+    };
+
     if backend == "sonatina" {
         if case.bytecode.is_empty() {
             return failure(format!("missing test bytecode for `{}`", case.display_name));
@@ -2816,6 +2831,7 @@ pub(super) fn compile_and_run_test(
             evm_trace,
             call_trace,
             collect_step_count,
+            initial_balance,
         );
         return TestOutcome {
             result,
@@ -2860,6 +2876,7 @@ pub(super) fn compile_and_run_test(
         evm_trace,
         call_trace,
         collect_step_count,
+        initial_balance,
     );
     TestOutcome {
         result,
@@ -3025,6 +3042,18 @@ fn write_report_manifest(
 /// * `show_logs` - Whether to execute with log collection enabled.
 ///
 /// Returns the test result and any emitted logs.
+fn be_bytes_to_u256(bytes: &[u8]) -> Result<U256, &'static str> {
+    if bytes.len() > 32 {
+        return Err("initial balance exceeds u256");
+    }
+    let mut buf = [0u8; 32];
+    // Pad on the left (big-endian): short value goes into the low bytes.
+    let start = 32 - bytes.len();
+    buf[start..].copy_from_slice(bytes);
+    Ok(U256::from_be_bytes(buf))
+}
+
+#[allow(clippy::too_many_arguments)]
 fn execute_test(
     name: &str,
     bytecode_hex: &str,
@@ -3033,6 +3062,7 @@ fn execute_test(
     evm_trace: Option<&EvmTraceOptions>,
     call_trace: bool,
     collect_step_count: bool,
+    initial_balance: Option<U256>,
 ) -> (
     TestResult,
     Vec<String>,
@@ -3061,6 +3091,11 @@ fn execute_test(
             );
         }
     };
+    // Optionally seed the test contract with ETH (opt-in via #[test(balance = N)]).
+    if let Some(balance) = initial_balance {
+        instance.fund_contract(balance);
+    }
+
     instance.set_trace_options(evm_trace.cloned());
 
     // Execute the test (empty calldata since test functions take no args)

--- a/crates/fe/tests/cli_output.rs
+++ b/crates/fe/tests/cli_output.rs
@@ -625,6 +625,80 @@ fn test_fe_test_both_backends_call_trace() {
     }
 }
 
+#[test]
+fn test_fe_test_rejects_oversized_balance_literal() {
+    let temp = tempdir().expect("tempdir");
+    let path = temp.path().join("oversized_balance.fe");
+    fs::write(
+        &path,
+        r#"
+#[test(balance = 0x10000000000000000000000000000000000000000000000000000000000000000)]
+fn too_big_balance() {}
+"#,
+    )
+    .expect("write fixture");
+    let path = path
+        .to_str()
+        .unwrap_or_else(|| panic!("fixture path is not utf-8: {}", path.display()));
+
+    for backend in ["sonatina", "yul"] {
+        let (output, exit_code) = run_fe_main(&["test", "--backend", backend, path]);
+        assert_ne!(
+            exit_code, 0,
+            "expected fe test to reject oversized #[test(balance = ...)] for backend {backend}:\n{output}"
+        );
+        assert!(
+            output.contains(
+                "invalid #[test] function `too_big_balance`: #[test(balance = ...)] must fit in u256"
+            ),
+            "expected oversized balance error for backend {backend}, got:\n{output}"
+        );
+    }
+}
+
+#[test]
+fn test_fe_test_rejects_malformed_balance_literal() {
+    let temp = tempdir().expect("tempdir");
+    let cases = [
+        (
+            "missing_balance_value",
+            r#"
+#[test(balance)]
+fn missing_balance_value() {}
+"#,
+            "invalid #[test] function `missing_balance_value`: #[test(balance = ...)] expects an integer literal",
+        ),
+        (
+            "non_integer_balance_value",
+            r#"
+#[test(balance = true)]
+fn non_integer_balance_value() {}
+"#,
+            "invalid #[test] function `non_integer_balance_value`: #[test(balance = ...)] expects an integer literal",
+        ),
+    ];
+
+    for (filename, source, expected) in cases {
+        let path = temp.path().join(format!("{filename}.fe"));
+        fs::write(&path, source).expect("write fixture");
+        let path = path
+            .to_str()
+            .unwrap_or_else(|| panic!("fixture path is not utf-8: {}", path.display()));
+
+        for backend in ["sonatina", "yul"] {
+            let (output, exit_code) = run_fe_main(&["test", "--backend", backend, path]);
+            assert_ne!(
+                exit_code, 0,
+                "expected fe test to reject malformed #[test(balance = ...)] for backend {backend}:\n{output}"
+            );
+            assert!(
+                output.contains(expected),
+                "expected malformed balance error for backend {backend}, got:\n{output}"
+            );
+        }
+    }
+}
+
 #[allow(clippy::print_stderr)]
 fn assert_fe_test_backends_agree(path: &str, call_trace: bool) {
     let mut yul_args = vec!["test", "--backend", "yul", path];

--- a/crates/fe/tests/fixtures/fe_test/payable.fe
+++ b/crates/fe/tests/fixtures/fe_test/payable.fe
@@ -1,0 +1,129 @@
+use std::evm::{Evm, Address}
+use std::abi::sol
+
+pub contract PayableBox {
+    #[payable]
+    init() {}
+
+    recv PayableMsg {
+        #[payable]
+        Fund {} {}
+
+        GetBalance {} -> u256 {
+            0
+        }
+    }
+}
+
+pub contract NonPayableBox {
+    init() {}
+
+    recv NonPayableMsg {
+        Ping {} -> u256 {
+            1
+        }
+    }
+}
+
+pub contract NoInitBox {
+    recv NoInitMsg {
+        Ping {} -> u256 {
+            7
+        }
+    }
+}
+
+msg PayableMsg {
+    #[selector = sol("fund()")]
+    Fund,
+
+    #[selector = sol("getBalance()")]
+    GetBalance -> u256,
+}
+
+msg NonPayableMsg {
+    #[selector = sol("ping()")]
+    Ping -> u256,
+}
+
+msg NoInitMsg {
+    #[selector = sol("ping()")]
+    Ping -> u256,
+}
+
+// Test: non-payable recv arm works with zero value
+#[test]
+fn test_non_payable_zero_value() uses (evm: mut Evm) {
+    let addr = evm.create2<NonPayableBox>(value: 0, args: (), salt: 0)
+    assert(addr.inner != 0)
+
+    let result: u256 = evm.call(addr: addr, gas: 100000, value: 0, message: NonPayableMsg::Ping {})
+    assert(result == 1)
+}
+
+// Test: non-payable recv arm reverts when ETH is sent
+#[test(should_revert, balance = 1000000000)]
+fn test_non_payable_rejects_value() uses (evm: mut Evm) {
+    let addr = evm.create2<NonPayableBox>(value: 0, args: (), salt: 0)
+    assert(addr.inner != 0)
+
+    // This should revert because Ping is not #[payable]
+    evm.call(addr: addr, gas: 100000, value: 1, message: NonPayableMsg::Ping {})
+}
+
+// Test: payable recv arm works with zero value
+#[test]
+fn test_payable_zero_value() uses (evm: mut Evm) {
+    let addr = evm.create2<PayableBox>(value: 0, args: (), salt: 0)
+    assert(addr.inner != 0)
+
+    // Fund is #[payable], should work with zero value too
+    evm.call(addr: addr, gas: 100000, value: 0, message: PayableMsg::Fund {})
+}
+
+// Test: payable init creates contract successfully
+#[test]
+fn test_payable_init() uses (evm: mut Evm) {
+    let addr = evm.create2<PayableBox>(value: 0, args: (), salt: 0)
+    assert(addr.inner != 0)
+}
+
+// Test: non-payable init reverts when ETH is sent during deployment
+#[test(should_revert, balance = 1000000000)]
+fn test_non_payable_init_rejects_value() uses (evm: mut Evm) {
+    // NonPayableBox init is not #[payable], deploying with value should revert
+    evm.create2<NonPayableBox>(value: 1, args: (), salt: 0)
+}
+
+// Test: contract without init deploys with zero value
+#[test]
+fn test_no_init_zero_value() uses (evm: mut Evm) {
+    let addr = evm.create2<NoInitBox>(value: 0, args: (), salt: 0)
+    assert(addr.inner != 0)
+
+    let result: u256 = evm.call(addr: addr, gas: 100000, value: 0, message: NoInitMsg::Ping {})
+    assert(result == 7)
+}
+
+// Test: contract without init rejects ETH during deployment
+#[test(should_revert, balance = 1000000000)]
+fn test_no_init_rejects_value() uses (evm: mut Evm) {
+    evm.create2<NoInitBox>(value: 1, args: (), salt: 0)
+}
+
+// Test: payable recv arm accepts non-zero ETH
+#[test(balance = 1000000000)]
+fn test_payable_accepts_value() uses (evm: mut Evm) {
+    let addr = evm.create2<PayableBox>(value: 0, args: (), salt: 0)
+    assert(addr.inner != 0)
+
+    // Fund is #[payable], should succeed with non-zero value
+    evm.call(addr: addr, gas: 100000, value: 1, message: PayableMsg::Fund {})
+}
+
+// Test: payable init accepts ETH at deployment
+#[test(balance = 1000000000)]
+fn test_payable_init_accepts_value() uses (evm: mut Evm) {
+    let addr = evm.create2<PayableBox>(value: 1, args: (), salt: 0)
+    assert(addr.inner != 0)
+}

--- a/crates/fmt/src/ast/items.rs
+++ b/crates/fmt/src/ast/items.rs
@@ -921,6 +921,8 @@ impl ToDoc for ast::ContractInit {
 
         token_doc_item_like_if_comments!(self, ctx);
 
+        let attrs = attrs_doc(self, ctx);
+
         let params_doc = self
             .params()
             .map(|params| params.to_doc(ctx))
@@ -936,8 +938,8 @@ impl ToDoc for ast::ContractInit {
             .map(|b| alloc.line().append(b.to_doc(ctx)))
             .unwrap_or_else(|| alloc.nil());
 
-        alloc
-            .text("init")
+        attrs
+            .append(alloc.text("init"))
             .append(params_doc)
             .append(uses_doc)
             .append(body_doc)
@@ -951,6 +953,8 @@ impl ToDoc for ast::ContractRecv {
 
         token_doc_item_like_if_comments!(self, ctx);
 
+        let attrs = attrs_doc(self, ctx);
+
         let path_doc = self
             .path()
             .map(|p| alloc.text(" ").append(p.to_doc(ctx)))
@@ -961,7 +965,10 @@ impl ToDoc for ast::ContractRecv {
             .map(|arms| alloc.text(" ").append(arms.to_doc(ctx)))
             .unwrap_or_else(|| alloc.text(" {}"));
 
-        alloc.text("recv").append(path_doc).append(arms_doc)
+        attrs
+            .append(alloc.text("recv"))
+            .append(path_doc)
+            .append(arms_doc)
     }
 }
 
@@ -976,6 +983,8 @@ impl ToDoc for ast::RecvArm {
         let alloc = &ctx.alloc;
 
         token_doc_item_like_if_comments!(self, ctx);
+
+        let attrs = attrs_doc(self, ctx);
 
         let pat_doc = self
             .pat()
@@ -1026,7 +1035,11 @@ impl ToDoc for ast::RecvArm {
             })
             .unwrap_or_else(|| alloc.nil());
 
-        pat_doc.append(ret_ty_doc).append(uses_doc).append(body_doc)
+        attrs
+            .append(pat_doc)
+            .append(ret_ty_doc)
+            .append(uses_doc)
+            .append(body_doc)
     }
 }
 

--- a/crates/hir/src/analysis/analysis_pass.rs
+++ b/crates/hir/src/analysis/analysis_pass.rs
@@ -1,6 +1,6 @@
 use crate::analysis::{HirAnalysisDb, diagnostics::DiagnosticVoucher};
 use crate::{
-    ArithmeticAttrError, EventError, ParserError, SelectorError,
+    ArithmeticAttrError, EventError, ParserError, PayableError, SelectorError,
     hir_def::{ModuleTree, TopLevelMod},
     lower::{parse_file_impl, scope_graph_impl},
 };
@@ -124,6 +124,22 @@ impl ModuleAnalysisPass for ArithmeticAttrPass {
         top_mod: TopLevelMod<'db>,
     ) -> Vec<Box<dyn DiagnosticVoucher>> {
         scope_graph_impl::accumulated::<ArithmeticAttrError>(db, top_mod)
+            .into_iter()
+            .map(|d| Box::new(d.clone()) as _)
+            .collect::<Vec<_>>()
+    }
+}
+
+/// Analysis pass that collects payable attribute validation errors.
+pub struct PayableAttrPass {}
+
+impl ModuleAnalysisPass for PayableAttrPass {
+    fn run_on_module<'db>(
+        &mut self,
+        db: &'db dyn HirAnalysisDb,
+        top_mod: TopLevelMod<'db>,
+    ) -> Vec<Box<dyn DiagnosticVoucher>> {
+        scope_graph_impl::accumulated::<PayableError>(db, top_mod)
             .into_iter()
             .map(|d| Box::new(d.clone()) as _)
             .collect::<Vec<_>>()

--- a/crates/hir/src/analysis/diagnostics.rs
+++ b/crates/hir/src/analysis/diagnostics.rs
@@ -437,6 +437,61 @@ impl DiagnosticVoucher for crate::ArithmeticAttrError {
     }
 }
 
+impl DiagnosticVoucher for crate::PayableError {
+    fn to_complete(&self, _db: &dyn SpannedHirAnalysisDb) -> CompleteDiagnostic {
+        let span = Span::new(self.file, self.primary_range, SpanKind::Original);
+        let (local_code, message, label) = match &self.kind {
+            crate::PayableErrorKind::PayableAttrOnUnsupportedItem { item_kind } => (
+                1,
+                format!(
+                    "`#[payable]` is only valid on `init` blocks and `recv` arms (found on {item_kind})"
+                ),
+                "move this attribute to an `init` block or `recv` arm".to_string(),
+            ),
+            crate::PayableErrorKind::PayableAttrOnMsgVariant => (
+                3,
+                "`#[payable]` must be placed on the corresponding `recv` arm, not the `msg` variant"
+                    .to_string(),
+                "move this attribute to the matching `recv` arm".to_string(),
+            ),
+            crate::PayableErrorKind::InvalidPayableAttrForm => (
+                2,
+                "invalid `#[payable]` attribute form".to_string(),
+                "expected `#[payable]` with no arguments".to_string(),
+            ),
+            crate::PayableErrorKind::UnknownAttrOnContractEntry {
+                attr_name,
+                entry_kind,
+            } => {
+                if *entry_kind == "recv block" {
+                    (
+                        4,
+                        format!("unknown attribute `#[{attr_name}]` on recv block"),
+                        "remove this attribute; `recv` blocks do not support normal attributes"
+                            .to_string(),
+                    )
+                } else {
+                    (
+                        4,
+                        format!(
+                            "unknown attribute `#[{attr_name}]` on {entry_kind} (only `#[payable]` is allowed)"
+                        ),
+                        "remove this attribute or use `#[payable]`".to_string(),
+                    )
+                }
+            }
+        };
+
+        CompleteDiagnostic::new(
+            Severity::Error,
+            message,
+            vec![SubDiagnostic::new(LabelStyle::Primary, label, Some(span))],
+            vec![],
+            GlobalErrorCode::new(DiagnosticPass::PayableAttr, local_code),
+        )
+    }
+}
+
 impl DiagnosticVoucher for crate::SelectorError {
     fn to_complete(&self, _db: &dyn SpannedHirAnalysisDb) -> CompleteDiagnostic {
         use crate::SelectorErrorKind;

--- a/crates/hir/src/core/hir_def/attr.rs
+++ b/crates/hir/src/core/hir_def/attr.rs
@@ -42,6 +42,23 @@ impl<'db> AttrListId<'db> {
         })
     }
 
+    /// Returns true if this attribute list contains a marker attribute with the given name.
+    ///
+    /// Marker attributes have no arguments in lowered HIR, for example `#[payable]`.
+    pub fn has_marker_attr(self, db: &'db dyn HirDb, name: &str) -> bool {
+        self.data(db).iter().any(|attr| {
+            if let Attr::Normal(normal_attr) = attr
+                && normal_attr.args.is_empty()
+                && let Some(path) = normal_attr.path.to_opt()
+                && let Some(ident) = path.as_ident(db)
+            {
+                ident.data(db) == name
+            } else {
+                false
+            }
+        })
+    }
+
     /// Returns the attribute with the given name, if present.
     pub fn get_attr(self, db: &'db dyn HirDb, name: &str) -> Option<&'db NormalAttr<'db>> {
         self.data(db).iter().find_map(|attr| {

--- a/crates/hir/src/core/hir_def/item.rs
+++ b/crates/hir/src/core/hir_def/item.rs
@@ -827,6 +827,7 @@ pub struct ContractInit<'db> {
     #[id]
     id: TrackedItemId<'db>,
 
+    pub attributes: AttrListId<'db>,
     pub params: FuncParamListId<'db>,
     pub effects: EffectParamListId<'db>,
     pub body: Body<'db>,
@@ -834,6 +835,13 @@ pub struct ContractInit<'db> {
 
     #[return_ref]
     pub(crate) origin: HirOrigin<ast::ContractInit>,
+}
+
+impl<'db> ContractInit<'db> {
+    /// Returns `true` if this init block is marked `#[payable]`.
+    pub fn is_payable(self, db: &'db dyn HirDb) -> bool {
+        self.attributes(db).has_marker_attr(db, "payable")
+    }
 }
 
 #[salsa::interned]
@@ -862,6 +870,7 @@ pub struct ContractRecvArm<'db> {
     pub ret_ty: Option<TypeId<'db>>,
     pub effects: EffectParamListId<'db>,
     pub body: Body<'db>,
+    pub attributes: AttrListId<'db>,
 }
 
 impl<'db> ContractRecvArm<'db> {
@@ -880,6 +889,11 @@ impl<'db> ContractRecvArm<'db> {
             | Pat::Record(Partial::Present(path), ..) => Some(*path),
             _ => None,
         }
+    }
+
+    /// Returns `true` if this recv arm is marked `#[payable]`.
+    pub fn is_payable(&self, db: &'db dyn HirDb) -> bool {
+        self.attributes.has_marker_attr(db, "payable")
     }
 }
 

--- a/crates/hir/src/core/lower/contract.rs
+++ b/crates/hir/src/core/lower/contract.rs
@@ -43,12 +43,16 @@ impl<'db> ContractRecvArm<'db> {
         let body = body_ctxt.build(body_ast.as_ref(), body_expr, BodyKind::FuncBody);
         let ret_ty = ast.ret_ty().map(|ty| TypeId::lower_ast(ctxt, ty));
         let effects = lower_uses_clause_opt(ctxt, ast.uses_clause());
+        super::payable::validate_payable_attr_form(ctxt, ast.attr_list());
+        super::payable::report_unknown_attrs_on_contract_entry(ctxt, ast.attr_list(), "recv arm");
+        let attributes = super::payable::lower_contract_entry_attrs_opt(ctxt, ast.attr_list());
 
         ContractRecvArm {
             pat,
             ret_ty,
             effects,
             body,
+            attributes,
         }
     }
 }
@@ -73,6 +77,16 @@ impl<'db> Contract<'db> {
         let recvs = {
             let mut data = Vec::new();
             for (recv_idx, r) in ast.recvs().enumerate() {
+                super::payable::report_payable_attr_on_unsupported_item(
+                    ctxt,
+                    r.attr_list(),
+                    "recv block",
+                );
+                super::payable::report_unknown_attrs_on_contract_entry(
+                    ctxt,
+                    r.attr_list(),
+                    "recv block",
+                );
                 let msg_path = r.path().map(|p| crate::hir_def::PathId::lower_ast(ctxt, p));
                 let arms = r
                     .arms()
@@ -121,6 +135,7 @@ fn lower_contract_field_def<'db>(
     ctxt: &mut FileLowerCtxt<'db>,
     ast: ast::RecordFieldDef,
 ) -> FieldDef<'db> {
+    super::payable::report_payable_attr_on_unsupported_item(ctxt, ast.attr_list(), "field");
     let attributes = AttrListId::lower_ast_opt(ctxt, ast.attr_list());
     let name = IdentId::lower_token_partial(ctxt, ast.name());
     let type_ref = TypeId::lower_ast_partial(ctxt, ast.ty());
@@ -139,6 +154,13 @@ fn lower_contract_init<'db>(
 ) -> ContractInit<'db> {
     let db = ctxt.db();
 
+    super::payable::validate_payable_attr_form(ctxt, init_ast.attr_list());
+    super::payable::report_unknown_attrs_on_contract_entry(
+        ctxt,
+        init_ast.attr_list(),
+        "init block",
+    );
+    let attributes = super::payable::lower_contract_entry_attrs_opt(ctxt, init_ast.attr_list());
     let id = ctxt.joined_id(TrackedItemVariant::ContractInit);
     let params = init_ast
         .params()
@@ -156,5 +178,14 @@ fn lower_contract_init<'db>(
     );
     let origin = HirOrigin::raw(&init_ast);
 
-    ContractInit::new(db, id, params, effects, body, ctxt.top_mod(), origin)
+    ContractInit::new(
+        db,
+        id,
+        attributes,
+        params,
+        effects,
+        body,
+        ctxt.top_mod(),
+        origin,
+    )
 }

--- a/crates/hir/src/core/lower/item.rs
+++ b/crates/hir/src/core/lower/item.rs
@@ -56,15 +56,30 @@ impl<'db> ItemKind<'db> {
             ast::ItemKind::Mod(mod_) => {
                 super::arithmetic::report_invalid_mod_arithmetic_attrs(ctxt, mod_.attr_list());
                 super::event::report_event_attr_on_non_struct_item(ctxt, mod_.attr_list(), "mod");
+                super::payable::report_payable_attr_on_unsupported_item(
+                    ctxt,
+                    mod_.attr_list(),
+                    "mod",
+                );
                 Mod::lower_ast(ctxt, mod_);
             }
             ast::ItemKind::Func(fn_) => {
                 super::arithmetic::report_invalid_function_arithmetic_attrs(ctxt, &fn_);
                 super::event::report_event_attr_on_non_struct_item(ctxt, fn_.attr_list(), "fn");
+                super::payable::report_payable_attr_on_unsupported_item(
+                    ctxt,
+                    fn_.attr_list(),
+                    "fn",
+                );
                 Func::lower_ast(ctxt, fn_);
             }
             ast::ItemKind::Struct(struct_) => {
                 super::arithmetic::report_arithmetic_attr_on_unsupported_item(
+                    ctxt,
+                    struct_.attr_list(),
+                    "struct",
+                );
+                super::payable::report_payable_attr_on_unsupported_item(
                     ctxt,
                     struct_.attr_list(),
                     "struct",
@@ -82,6 +97,11 @@ impl<'db> ItemKind<'db> {
                     contract.attr_list(),
                     "contract",
                 );
+                super::payable::report_payable_attr_on_unsupported_item(
+                    ctxt,
+                    contract.attr_list(),
+                    "contract",
+                );
                 Contract::lower_ast(ctxt, contract);
             }
             ast::ItemKind::Enum(enum_) => {
@@ -91,6 +111,11 @@ impl<'db> ItemKind<'db> {
                     "enum",
                 );
                 super::event::report_event_attr_on_non_struct_item(ctxt, enum_.attr_list(), "enum");
+                super::payable::report_payable_attr_on_unsupported_item(
+                    ctxt,
+                    enum_.attr_list(),
+                    "enum",
+                );
                 Enum::lower_ast(ctxt, enum_);
             }
             ast::ItemKind::Msg(msg) => {
@@ -100,6 +125,11 @@ impl<'db> ItemKind<'db> {
                     "msg",
                 );
                 super::event::report_event_attr_on_non_struct_item(ctxt, msg.attr_list(), "msg");
+                super::payable::report_payable_attr_on_unsupported_item(
+                    ctxt,
+                    msg.attr_list(),
+                    "msg",
+                );
                 lower_msg_as_mod(ctxt, msg);
             }
             ast::ItemKind::TypeAlias(alias) => {
@@ -113,6 +143,11 @@ impl<'db> ItemKind<'db> {
                     alias.attr_list(),
                     "type alias",
                 );
+                super::payable::report_payable_attr_on_unsupported_item(
+                    ctxt,
+                    alias.attr_list(),
+                    "type alias",
+                );
                 TypeAlias::lower_ast(ctxt, alias);
             }
             ast::ItemKind::Impl(impl_) => {
@@ -122,6 +157,11 @@ impl<'db> ItemKind<'db> {
                     "impl",
                 );
                 super::event::report_event_attr_on_non_struct_item(ctxt, impl_.attr_list(), "impl");
+                super::payable::report_payable_attr_on_unsupported_item(
+                    ctxt,
+                    impl_.attr_list(),
+                    "impl",
+                );
                 Impl::lower_ast(ctxt, impl_);
             }
             ast::ItemKind::Trait(trait_) => {
@@ -131,6 +171,11 @@ impl<'db> ItemKind<'db> {
                     "trait",
                 );
                 super::event::report_event_attr_on_non_struct_item(
+                    ctxt,
+                    trait_.attr_list(),
+                    "trait",
+                );
+                super::payable::report_payable_attr_on_unsupported_item(
                     ctxt,
                     trait_.attr_list(),
                     "trait",
@@ -148,6 +193,11 @@ impl<'db> ItemKind<'db> {
                     impl_trait.attr_list(),
                     "impl trait",
                 );
+                super::payable::report_payable_attr_on_unsupported_item(
+                    ctxt,
+                    impl_trait.attr_list(),
+                    "impl trait",
+                );
                 ImplTrait::lower_ast(ctxt, impl_trait);
             }
             ast::ItemKind::Const(const_) => {
@@ -161,6 +211,11 @@ impl<'db> ItemKind<'db> {
                     const_.attr_list(),
                     "const",
                 );
+                super::payable::report_payable_attr_on_unsupported_item(
+                    ctxt,
+                    const_.attr_list(),
+                    "const",
+                );
                 Const::lower_ast(ctxt, const_);
             }
             ast::ItemKind::Use(use_) => {
@@ -170,6 +225,11 @@ impl<'db> ItemKind<'db> {
                     "use",
                 );
                 super::event::report_event_attr_on_non_struct_item(ctxt, use_.attr_list(), "use");
+                super::payable::report_payable_attr_on_unsupported_item(
+                    ctxt,
+                    use_.attr_list(),
+                    "use",
+                );
                 Use::lower_ast(ctxt, use_);
             }
             ast::ItemKind::Extern(extern_) => {
@@ -183,6 +243,11 @@ impl<'db> ItemKind<'db> {
                     extern_.attr_list(),
                     "extern",
                 );
+                super::payable::report_payable_attr_on_unsupported_item(
+                    ctxt,
+                    extern_.attr_list(),
+                    "extern",
+                );
                 if let Some(extern_block) = extern_.extern_block() {
                     for fn_ in extern_block {
                         super::arithmetic::report_arithmetic_attr_on_unsupported_item(
@@ -191,6 +256,11 @@ impl<'db> ItemKind<'db> {
                             "extern fn",
                         );
                         super::event::report_event_attr_on_non_struct_item(
+                            ctxt,
+                            fn_.attr_list(),
+                            "extern fn",
+                        );
+                        super::payable::report_payable_attr_on_unsupported_item(
                             ctxt,
                             fn_.attr_list(),
                             "extern fn",
@@ -214,6 +284,11 @@ impl<'db> Mod<'db> {
         super::arithmetic::report_invalid_mod_arithmetic_attrs(
             ctxt,
             ast.items().and_then(|items| items.inner_attr_list()),
+        );
+        super::payable::report_payable_attr_on_unsupported_item(
+            ctxt,
+            ast.items().and_then(|items| items.inner_attr_list()),
+            "module",
         );
         let attributes = AttrListId::lower_ast_merged(
             ctxt,
@@ -425,6 +500,11 @@ impl<'db> Impl<'db> {
 
         if let Some(item_list) = ast.item_list() {
             for impl_item in item_list {
+                super::payable::report_payable_attr_on_unsupported_item(
+                    ctxt,
+                    impl_item.attr_list(),
+                    "fn",
+                );
                 Func::lower_ast(ctxt, impl_item);
             }
         }
@@ -470,10 +550,27 @@ impl<'db> Trait<'db> {
             for impl_item in item_list {
                 match impl_item.kind() {
                     ast::TraitItemKind::Func(func) => {
+                        super::payable::report_payable_attr_on_unsupported_item(
+                            ctxt,
+                            func.attr_list(),
+                            "fn",
+                        );
                         Func::lower_ast(ctxt, func);
                     }
-                    ast::TraitItemKind::Type(t) => types.push(AssocTyDecl::lower_ast(ctxt, t)),
+                    ast::TraitItemKind::Type(t) => {
+                        super::payable::report_payable_attr_on_unsupported_item(
+                            ctxt,
+                            t.attr_list(),
+                            "type",
+                        );
+                        types.push(AssocTyDecl::lower_ast(ctxt, t));
+                    }
                     ast::TraitItemKind::Const(c) => {
+                        super::payable::report_payable_attr_on_unsupported_item(
+                            ctxt,
+                            c.attr_list(),
+                            "const",
+                        );
                         consts.push(AssocConstDecl::lower_ast(ctxt, c));
                     }
                 };
@@ -544,10 +641,27 @@ impl<'db> ImplTrait<'db> {
             for impl_item in item_list {
                 match impl_item.kind() {
                     ast::TraitItemKind::Func(func) => {
+                        super::payable::report_payable_attr_on_unsupported_item(
+                            ctxt,
+                            func.attr_list(),
+                            "fn",
+                        );
                         Func::lower_ast(ctxt, func);
                     }
-                    ast::TraitItemKind::Type(t) => types.push(AssocTyDef::lower_ast(ctxt, t)),
+                    ast::TraitItemKind::Type(t) => {
+                        super::payable::report_payable_attr_on_unsupported_item(
+                            ctxt,
+                            t.attr_list(),
+                            "type",
+                        );
+                        types.push(AssocTyDef::lower_ast(ctxt, t));
+                    }
                     ast::TraitItemKind::Const(c) => {
+                        super::payable::report_payable_attr_on_unsupported_item(
+                            ctxt,
+                            c.attr_list(),
+                            "const",
+                        );
                         consts.push(AssocConstDef::lower_ast(ctxt, c));
                     }
                 };
@@ -657,6 +771,7 @@ impl<'db> FieldDefListId<'db> {
 
 impl<'db> FieldDef<'db> {
     pub(super) fn lower_ast(ctxt: &mut FileLowerCtxt<'db>, ast: ast::RecordFieldDef) -> Self {
+        super::payable::report_payable_attr_on_unsupported_item(ctxt, ast.attr_list(), "field");
         let attributes = AttrListId::lower_ast_opt(ctxt, ast.attr_list());
         let name = IdentId::lower_token_partial(ctxt, ast.name());
         let type_ref = TypeId::lower_ast_partial(ctxt, ast.ty());
@@ -687,6 +802,7 @@ impl<'db> VariantDefListId<'db> {
 
 impl<'db> VariantDef<'db> {
     fn lower_ast(ctxt: &mut FileLowerCtxt<'db>, ast: ast::VariantDef) -> Self {
+        super::payable::report_payable_attr_on_unsupported_item(ctxt, ast.attr_list(), "variant");
         let attributes = AttrListId::lower_ast_opt(ctxt, ast.attr_list());
         let name = IdentId::lower_token_partial(ctxt, ast.name());
         let kind = match ast.kind() {

--- a/crates/hir/src/core/lower/mod.rs
+++ b/crates/hir/src/core/lower/mod.rs
@@ -24,6 +24,7 @@ pub use arithmetic::{ArithmeticAttrError, ArithmeticAttrErrorKind};
 pub use event::{EventError, EventErrorKind};
 pub use item::{SelectorError, SelectorErrorKind};
 pub use parse::parse_file_impl;
+pub use payable::{PayableError, PayableErrorKind};
 
 pub(crate) mod parse;
 
@@ -39,6 +40,7 @@ mod msg;
 mod params;
 mod pat;
 mod path;
+mod payable;
 mod scope_builder;
 mod stmt;
 mod types;
@@ -106,6 +108,11 @@ pub(crate) fn scope_graph_impl<'db>(
 
     if let Some(items) = ast.items() {
         arithmetic::report_invalid_top_mod_arithmetic_attrs(&mut ctxt, items.inner_attr_list());
+        payable::report_payable_attr_on_unsupported_item(
+            &mut ctxt,
+            items.inner_attr_list(),
+            "module",
+        );
         lower_module_items(&mut ctxt, items);
     }
     ctxt.leave_item_scope(top_mod);

--- a/crates/hir/src/core/lower/msg.rs
+++ b/crates/hir/src/core/lower/msg.rs
@@ -212,7 +212,8 @@ fn lower_msg_variant_struct<'db>(
     variant: &ast::MsgVariant,
 ) -> Struct<'db> {
     let name = IdentId::lower_token_partial(builder.ctxt(), variant.name());
-    let attributes = filter_selector_attr(builder.ctxt(), variant.attr_list());
+    super::payable::report_payable_attr_on_msg_variant(builder.ctxt(), variant.attr_list());
+    let attributes = filter_msg_variant_attrs(builder.ctxt(), variant.attr_list());
     let fields = lower_msg_variant_fields(builder.ctxt(), variant.params());
     builder.pub_struct(name, attributes, fields)
 }
@@ -228,6 +229,11 @@ fn lower_msg_variant_fields<'db>(
             let fields = params
                 .into_iter()
                 .map(|field| {
+                    super::payable::report_payable_attr_on_unsupported_item(
+                        ctxt,
+                        field.attr_list(),
+                        "field",
+                    );
                     let attributes = AttrListId::lower_ast_opt(ctxt, field.attr_list());
                     let name = IdentId::lower_token_partial(ctxt, field.name());
                     let type_ref = TypeId::lower_ast_partial(ctxt, field.ty());
@@ -444,9 +450,9 @@ fn parse_selector_attr<'db>(
     None
 }
 
-/// Filters out the #[selector] attribute from an attribute list.
-/// Returns an AttrListId containing all attributes except selector.
-fn filter_selector_attr<'db>(
+/// Filters out msg-variant attributes that are handled specially during lowering.
+/// Currently this removes `#[selector]` and invalid `#[payable]`.
+fn filter_msg_variant_attrs<'db>(
     ctxt: &mut FileLowerCtxt<'db>,
     attr_list: Option<ast::AttrList>,
 ) -> AttrListId<'db> {
@@ -463,7 +469,8 @@ fn filter_selector_attr<'db>(
             if let ast::AttrKind::Normal(normal_attr) = attr.kind()
                 && let Some(path) = normal_attr.path()
             {
-                return path.text() != "selector";
+                let text = path.text();
+                return text != "selector" && text != "payable";
             }
             true
         })

--- a/crates/hir/src/core/lower/payable.rs
+++ b/crates/hir/src/core/lower/payable.rs
@@ -1,0 +1,181 @@
+use parser::ast::{self, prelude::AstNode as _};
+use salsa::Accumulator as _;
+
+use super::FileLowerCtxt;
+use crate::hir_def::{AttrListId, attr::Attr};
+
+/// Payable-related errors accumulated during lowering / validation.
+#[salsa::accumulator]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct PayableError {
+    pub kind: PayableErrorKind,
+    pub file: common::file::File,
+    pub primary_range: parser::TextRange,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum PayableErrorKind {
+    /// `#[payable]` placed on an item that doesn't support it.
+    PayableAttrOnUnsupportedItem { item_kind: &'static str },
+    /// `#[payable]` placed on a msg variant instead of the corresponding recv arm.
+    PayableAttrOnMsgVariant,
+    /// `#[payable]` used with arguments or value, e.g. `#[payable(foo)]` or `#[payable = 1]`.
+    InvalidPayableAttrForm,
+    /// Unknown attribute on an `init` block or `recv` arm (only `#[payable]` is allowed).
+    UnknownAttrOnContractEntry {
+        attr_name: String,
+        entry_kind: &'static str,
+    },
+}
+
+/// Report an error if `#[payable]` appears on an item that doesn't support it
+/// (anything other than a recv arm or init block).
+pub(super) fn report_payable_attr_on_unsupported_item<'db>(
+    ctxt: &mut FileLowerCtxt<'db>,
+    attrs: Option<ast::AttrList>,
+    item_kind: &'static str,
+) {
+    let Some(attrs) = attrs else { return };
+    let db = ctxt.db();
+    let file = ctxt.top_mod().file(db);
+
+    for attr in attrs {
+        let ast::AttrKind::Normal(normal) = attr.kind() else {
+            continue;
+        };
+        let is_payable = normal.path().is_some_and(|p| p.text() == "payable");
+        if !is_payable {
+            continue;
+        }
+
+        PayableError {
+            kind: PayableErrorKind::PayableAttrOnUnsupportedItem { item_kind },
+            file,
+            primary_range: attr.syntax().text_range(),
+        }
+        .accumulate(db);
+    }
+}
+
+/// Report a targeted error if `#[payable]` appears on a msg variant.
+pub(super) fn report_payable_attr_on_msg_variant<'db>(
+    ctxt: &mut FileLowerCtxt<'db>,
+    attrs: Option<ast::AttrList>,
+) {
+    let Some(attrs) = attrs else { return };
+    let db = ctxt.db();
+    let file = ctxt.top_mod().file(db);
+
+    for attr in attrs {
+        let ast::AttrKind::Normal(normal) = attr.kind() else {
+            continue;
+        };
+        let is_payable = normal.path().is_some_and(|p| p.text() == "payable");
+        if !is_payable {
+            continue;
+        }
+
+        PayableError {
+            kind: PayableErrorKind::PayableAttrOnMsgVariant,
+            file,
+            primary_range: attr.syntax().text_range(),
+        }
+        .accumulate(db);
+    }
+}
+
+/// Report an error for any non-`#[payable]` normal attribute on an `init` block
+/// or `recv` arm.  Only `#[payable]` (and doc comments) are valid here.
+pub(super) fn report_unknown_attrs_on_contract_entry<'db>(
+    ctxt: &mut FileLowerCtxt<'db>,
+    attrs: Option<ast::AttrList>,
+    entry_kind: &'static str,
+) {
+    let Some(attrs) = attrs else { return };
+    let db = ctxt.db();
+    let file = ctxt.top_mod().file(db);
+
+    for attr in attrs {
+        let ast::AttrKind::Normal(normal) = attr.kind() else {
+            // Doc comments are always allowed.
+            continue;
+        };
+        let attr_name = normal
+            .path()
+            .map(|p| p.text().to_string())
+            .unwrap_or_default();
+        if attr_name == "payable" {
+            continue;
+        }
+
+        PayableError {
+            kind: PayableErrorKind::UnknownAttrOnContractEntry {
+                attr_name,
+                entry_kind,
+            },
+            file,
+            primary_range: attr.syntax().text_range(),
+        }
+        .accumulate(db);
+    }
+}
+
+/// Validate that a `#[payable]` attribute on an init block or recv arm has the
+/// correct form (no arguments, no value).
+pub(super) fn validate_payable_attr_form<'db>(
+    ctxt: &mut FileLowerCtxt<'db>,
+    attrs: Option<ast::AttrList>,
+) {
+    let Some(attrs) = attrs else { return };
+    let db = ctxt.db();
+    let file = ctxt.top_mod().file(db);
+
+    for attr in attrs {
+        let ast::AttrKind::Normal(normal) = attr.kind() else {
+            continue;
+        };
+        let is_payable = normal.path().is_some_and(|p| p.text() == "payable");
+        if !is_payable {
+            continue;
+        }
+
+        // #[payable] must have no arguments and no value
+        let has_args = normal.args().is_some();
+        let has_value = normal.value().is_some();
+        if has_args || has_value {
+            PayableError {
+                kind: PayableErrorKind::InvalidPayableAttrForm,
+                file,
+                primary_range: attr.syntax().text_range(),
+            }
+            .accumulate(db);
+        }
+    }
+}
+
+/// Lower contract-entry attributes while dropping malformed `#[payable]` forms
+/// so they do not affect downstream payability semantics.
+pub(super) fn lower_contract_entry_attrs_opt<'db>(
+    ctxt: &mut FileLowerCtxt<'db>,
+    attrs: Option<ast::AttrList>,
+) -> AttrListId<'db> {
+    let Some(attrs) = attrs else {
+        return AttrListId::new(ctxt.db(), vec![]);
+    };
+
+    let attrs: Vec<_> = attrs
+        .into_iter()
+        .filter(|attr| !is_malformed_payable_attr(attr))
+        .map(|attr| Attr::lower_ast(ctxt, attr))
+        .collect();
+    AttrListId::new(ctxt.db(), attrs)
+}
+
+fn is_malformed_payable_attr(attr: &ast::Attr) -> bool {
+    let ast::AttrKind::Normal(normal) = attr.kind() else {
+        return false;
+    };
+
+    normal.path().is_some_and(|p| p.text() == "payable")
+        && (normal.args().is_some() || normal.value().is_some())
+}

--- a/crates/hir/src/core/lower/stmt.rs
+++ b/crates/hir/src/core/lower/stmt.rs
@@ -18,6 +18,11 @@ impl<'db> Stmt<'db> {
                 (Stmt::Let(pat, ty, init), HirOrigin::raw(&ast))
             }
             ast::StmtKind::For(for_) => {
+                super::payable::report_payable_attr_on_unsupported_item(
+                    ctxt.f_ctxt,
+                    for_.attr_list(),
+                    "for statement",
+                );
                 let bind = Pat::lower_ast_opt(ctxt, for_.pat());
                 let iter = Expr::push_to_body_opt(ctxt, for_.iterable());
                 let body = Expr::push_to_body_opt(

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -1,7 +1,7 @@
 use common::InputDb;
 pub use core::lower::{
-    ArithmeticAttrError, ArithmeticAttrErrorKind, EventError, EventErrorKind, SelectorError,
-    SelectorErrorKind, parse::ParserError,
+    ArithmeticAttrError, ArithmeticAttrErrorKind, EventError, EventErrorKind, PayableError,
+    PayableErrorKind, SelectorError, SelectorErrorKind, parse::ParserError,
 };
 
 pub mod analysis;

--- a/crates/hir/src/test_db.rs
+++ b/crates/hir/src/test_db.rs
@@ -9,7 +9,9 @@ use std::collections::BTreeMap;
 use std::ops::Range;
 
 use crate::analysis::{
-    analysis_pass::{AnalysisPassManager, EventLowerPass, MsgLowerPass, ParsingPass},
+    analysis_pass::{
+        AnalysisPassManager, EventLowerPass, MsgLowerPass, ParsingPass, PayableAttrPass,
+    },
     diagnostics::{DiagnosticVoucher, SpannedHirAnalysisDb},
     name_resolution::ImportAnalysisPass,
     ty::{
@@ -311,6 +313,7 @@ impl Default for HirPropertyFormatter<'_> {
 pub fn initialize_analysis_pass() -> AnalysisPassManager {
     let mut pass_manager = AnalysisPassManager::new();
     pass_manager.add_module_pass("Parsing", Box::new(ParsingPass {}));
+    pass_manager.add_module_pass("PayableAttr", Box::new(PayableAttrPass {}));
     pass_manager.add_module_pass("MsgLower", Box::new(MsgLowerPass {}));
     pass_manager.add_module_pass("EventLower", Box::new(EventLowerPass {}));
     pass_manager.add_module_pass("MsgSelector", Box::new(MsgSelectorAnalysisPass {}));

--- a/crates/language-server/src/lsp_diagnostics.rs
+++ b/crates/language-server/src/lsp_diagnostics.rs
@@ -9,7 +9,8 @@ use common::{
 use driver::{DriverDataBase, MirDiagnosticsMode};
 use hir::Ingot;
 use hir::analysis::analysis_pass::{
-    AnalysisPassManager, EventLowerPass, MsgLowerPass, ParsingPass,
+    AnalysisPassManager, ArithmeticAttrPass, EventLowerPass, MsgLowerPass, ParsingPass,
+    PayableAttrPass,
 };
 use hir::analysis::name_resolution::ImportAnalysisPass;
 use hir::analysis::ty::{
@@ -207,6 +208,8 @@ impl<'a> cs_files::Files<'a> for LspDb<'a> {
 fn initialize_analysis_pass() -> AnalysisPassManager {
     let mut pass_manager = AnalysisPassManager::new();
     pass_manager.add_module_pass("Parsing", Box::new(ParsingPass {}));
+    pass_manager.add_module_pass("ArithmeticAttr", Box::new(ArithmeticAttrPass {}));
+    pass_manager.add_module_pass("PayableAttr", Box::new(PayableAttrPass {}));
     pass_manager.add_module_pass("MsgLower", Box::new(MsgLowerPass {}));
     pass_manager.add_module_pass("EventLower", Box::new(EventLowerPass {}));
     pass_manager.add_module_pass("MsgSelector", Box::new(MsgSelectorAnalysisPass {}));

--- a/crates/language-server/src/mock_client_tests.rs
+++ b/crates/language-server/src/mock_client_tests.rs
@@ -363,6 +363,7 @@ async fn mock_lsp_scenarios() {
     scenario_format_during_generic_struct_keystroke_sequence(&mut client, &uri).await;
     scenario_diagnostics_published_for_broken_code(&mut client).await;
     scenario_contract_analysis_reports_errors(&mut client, &uri).await;
+    scenario_payable_attr_reports_errors(&mut client, &uri).await;
     scenario_errors_reported_after_panic_recovery(&mut client, &uri).await;
 
     client.shutdown().await;
@@ -604,6 +605,36 @@ pub contract Broken {
         found,
         "expected error 8-0051 (unresolved effect in contract init) — \
          ContractAnalysisPass must be registered in initialize_analysis_pass(); \
+         got: {:?}",
+        client.diagnostics_for_uri(uri),
+    );
+}
+
+/// Regression test: PayableAttrPass was absent from initialize_analysis_pass().
+/// Invalid `#[payable]` usages must be reported by the LSP, not just by `fe check`.
+async fn scenario_payable_attr_reports_errors(client: &mut MockLspClient, uri: &Url) {
+    client.clear_diagnostics();
+    // `#[payable(foo)]` is invalid — the attribute takes no arguments (error 13-0002).
+    client.did_change(
+        uri,
+        850,
+        r#"struct Store { value: u256 }
+
+pub contract BadPayable {
+    mut store: Store
+
+    #[payable(foo)]
+    init() {
+        store.value = 0
+    }
+}"#,
+    );
+
+    let found = client.wait_for_diagnostic_code(uri, "13-0002").await;
+    assert!(
+        found,
+        "expected error 13-0002 (invalid #[payable] form) — \
+         PayableAttrPass must be registered in initialize_analysis_pass(); \
          got: {:?}",
         client.diagnostics_for_uri(uri),
     );

--- a/crates/mir/src/analysis/escape.rs
+++ b/crates/mir/src/analysis/escape.rs
@@ -788,6 +788,7 @@ fn intrinsic_arg_may_escape(op: IntrinsicOp, arg_idx: usize) -> bool {
         | IntrinsicOp::Addmod
         | IntrinsicOp::Mulmod
         | IntrinsicOp::Caller
+        | IntrinsicOp::Callvalue
         | IntrinsicOp::Alloc => false,
     }
 }

--- a/crates/mir/src/fmt.rs
+++ b/crates/mir/src/fmt.rs
@@ -465,5 +465,6 @@ fn format_intrinsic(op: IntrinsicOp) -> &'static str {
         IntrinsicOp::Mulmod => "mulmod",
         IntrinsicOp::Revert => "revert",
         IntrinsicOp::Caller => "caller",
+        IntrinsicOp::Callvalue => "callvalue",
     }
 }

--- a/crates/mir/src/ir.rs
+++ b/crates/mir/src/ir.rs
@@ -1192,6 +1192,8 @@ pub enum IntrinsicOp {
     Revert,
     /// `caller()`
     Caller,
+    /// `callvalue()`
+    Callvalue,
     /// `alloc(size)` - allocate `size` bytes of dynamic raw EVM memory and return the base
     /// address.
     Alloc,
@@ -1216,6 +1218,7 @@ impl IntrinsicOp {
                 | IntrinsicOp::Addmod
                 | IntrinsicOp::Mulmod
                 | IntrinsicOp::Caller
+                | IntrinsicOp::Callvalue
                 | IntrinsicOp::Alloc
         )
     }

--- a/crates/mir/src/lower/contracts.rs
+++ b/crates/mir/src/lower/contracts.rs
@@ -646,6 +646,50 @@ impl<'db, 'a> ContractMirCx<'db, 'a> {
             .value
     }
 
+    /// Emit a CALLVALUE != 0 guard that reverts via host_abort.
+    ///
+    /// Inserts a branch: if `callvalue() != 0`, jump to an abort block;
+    /// otherwise continue in a new block.  The builder cursor is left on
+    /// the continuation block.
+    fn emit_callvalue_guard(
+        &self,
+        builder: &mut BodyBuilder<'db>,
+        label: impl Into<String>,
+        zero_u256: ValueId,
+        root_value: ValueId,
+    ) {
+        let db = self.db;
+        let callvalue = self.assign_runtime_local(
+            builder,
+            label,
+            TyId::u256(db),
+            false,
+            AddressSpaceKind::Memory,
+            Rvalue::Intrinsic {
+                op: IntrinsicOp::Callvalue,
+                args: vec![],
+            },
+        );
+        let is_nonzero = builder.alloc_value(
+            TyId::bool(db),
+            ValueOrigin::Binary {
+                op: BinOp::Comp(CompBinOp::NotEq),
+                lhs: callvalue,
+                rhs: zero_u256,
+            },
+            ValueRepr::Word,
+        );
+        let abort_block = builder.make_block();
+        let cont_block = builder.make_block();
+        builder.branch(is_nonzero, abort_block, cont_block);
+        builder.move_to_block(abort_block);
+        builder.terminate_current(Terminator::TerminatingCall {
+            source: SourceInfoId::SYNTHETIC,
+            call: TerminatingCall::Call(self.host_abort(root_value)),
+        });
+        builder.move_to_block(cont_block);
+    }
+
     fn host_abort(&self, root_value: ValueId) -> CallOrigin<'db> {
         self.call_hir(
             CallableDef::Func(self.host.abort_fn),
@@ -1267,6 +1311,12 @@ fn lower_init_entrypoint<'db>(
     let root_value = builder.unit_value(target.host.root_effect_ty);
     let zero_u256 = builder.const_int_value(TyId::u256(db), BigUint::from(0u8));
 
+    // CALLVALUE guard: revert if ETH is sent to a non-payable init.
+    let init_is_payable = contract.init(db).is_some_and(|init| init.is_payable(db));
+    if !init_is_payable {
+        cx.emit_callvalue_guard(&mut builder, "callvalue_init", zero_u256, root_value);
+    }
+
     // Code region queries for the runtime entrypoint are shared by init-input decoding and
     // contract creation.
     let runtime_func_item = builder.func_item_value(
@@ -1552,6 +1602,18 @@ fn lower_runtime_entrypoint<'db>(
             });
 
             builder.move_to_block(block);
+
+            // CALLVALUE guard: revert if ETH is sent to a non-payable arm.
+            let is_payable = arm.arm(db).is_some_and(|a| a.is_payable(db));
+            if !is_payable {
+                cx.emit_callvalue_guard(
+                    &mut builder,
+                    format!("callvalue_{recv_idx}_{arm_idx}"),
+                    zero_u256,
+                    root_value,
+                );
+            }
+
             let args_value = (!abi_payload_is_empty(db, abi_info.args_ty)).then(|| {
                 cx.emit_decode_or_unit(
                     &mut builder,

--- a/crates/mir/src/lower/intrinsics.rs
+++ b/crates/mir/src/lower/intrinsics.rs
@@ -111,6 +111,7 @@ impl<'db, 'a> MirBuilder<'db, 'a> {
             "addmod" => Some(IntrinsicOp::Addmod),
             "mulmod" => Some(IntrinsicOp::Mulmod),
             "caller" => Some(IntrinsicOp::Caller),
+            "callvalue" => Some(IntrinsicOp::Callvalue),
             _ => None,
         }
     }

--- a/crates/mir/src/transform.rs
+++ b/crates/mir/src/transform.rs
@@ -3026,7 +3026,8 @@ pub contract RedundantZeroInit {
                                 op:
                                     IntrinsicOp::CodeRegionOffset
                                     | IntrinsicOp::CodeRegionLen
-                                    | IntrinsicOp::Codecopy,
+                                    | IntrinsicOp::Codecopy
+                                    | IntrinsicOp::Callvalue,
                                 ..
                             },
                         ..

--- a/crates/mir/tests/fixtures/const_hole_storage_map_contract_defaults.mir.snap
+++ b/crates/mir/tests/fixtures/const_hole_storage_map_contract_defaults.mir.snap
@@ -25,27 +25,42 @@ fn __BalanceMap_recv_0_1(v0: Get, v1: u256) -> u256:
 
 fn __BalanceMap_init() -> ():
   bb0:
-    v0: u256 = code_region_offset(func_item(__BalanceMap_runtime))
-    v1: u256 = code_region_len(func_item(__BalanceMap_runtime))
-    eval codecopy(0, v0, v1)
-    terminate return_data(0, v1)
+    v0: u256 = callvalue()
+    br (v0 != 0) bb1 bb2
+  bb1:
+    terminate evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
+  bb2:
+    v1: u256 = code_region_offset(func_item(__BalanceMap_runtime))
+    v2: u256 = code_region_len(func_item(__BalanceMap_runtime))
+    eval codecopy(0, v1, v2)
+    terminate return_data(0, v2)
 
 fn __BalanceMap_runtime() -> ():
   bb0:
     v0: u256 = evm_hef0af3106e109414_contracthost_h57111e7eb283a125_field__Store_0__1___2a5ced58fcfdee44(0)
     v1: u32 = runtime_selector__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f__e4e3f8d20b3805a2()
     v2: SolDecoder<CallData> = runtime_decoder__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f__e4e3f8d20b3805a2()
-    switch v1 [1 => bb2, 2 => bb3] else bb1
+    switch v1 [1 => bb2, 2 => bb5] else bb1
   bb1:
     terminate evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
   bb2:
-    v3: Set = set_h931227dcdf0da20f_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966(v2)
-    eval __BalanceMap_recv_0_0(v3)
-    terminate return_unit__Evm_hef0af3106e109414__3af54274b2985741()
+    v3: u256 = callvalue()
+    br (v3 != 0) bb3 bb4
   bb3:
-    v4: Get = get_hffdc4ce7dcd289bd_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966(v2)
-    v5: u256 = __BalanceMap_recv_0_1(v4)
-    terminate return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f(v5)
+    terminate evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
+  bb4:
+    v4: Set = set_h931227dcdf0da20f_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966(v2)
+    eval __BalanceMap_recv_0_0(v4)
+    terminate return_unit__Evm_hef0af3106e109414__3af54274b2985741()
+  bb5:
+    v5: u256 = callvalue()
+    br (v5 != 0) bb6 bb7
+  bb6:
+    terminate evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
+  bb7:
+    v6: Get = get_hffdc4ce7dcd289bd_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966(v2)
+    v7: u256 = __BalanceMap_recv_0_1(v6)
+    terminate return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f(v7)
 
 fn storagemap_k__v__const_salt__u256__h5955888dd44c2a19_set_stor__u256_u256_0__6a346ad3c930d971(v0: StorageMap<u256, u256, 0>, v1: u256, v2: u256) -> ():
   ; runtime_abi values=[v1: u256, v2: u256] effects=[]
@@ -75,6 +90,11 @@ fn storagemap_k__v__const_salt__u256__h5955888dd44c2a19_get_stor__u256_u256_1__3
     v3: u256 = u256_h3271ca15373d4483_wordrepr_h7483d41ac8178d88_from_word(v2)
     ret v3
 
+fn evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort(v0: Evm) -> !:
+  ; runtime_abi values=[] effects=[]
+  bb0:
+    terminate revert(0, 0)
+
 fn evm_hef0af3106e109414_contracthost_h57111e7eb283a125_field__Store_0__1___2a5ced58fcfdee44(v0: mut Evm, v1: u256) -> StorPtr<Store<0, 1>>:
   ; runtime_abi values=[v1: u256] effects=[]
   bb0:
@@ -101,11 +121,6 @@ fn runtime_decoder__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f__e4e3f8d20b3805a
     v2: CallData = evm_hef0af3106e109414_contracthost_h57111e7eb283a125_input()
     v3: SolDecoder<CallData> = sol_hfd482bb803ad8c5f_abi_h2da9a2d0b1ddaeb7_decoder_with_base__CallData_hf71d505b6ff5dc81__e6d5f05c3478f563(v2, 4)
     ret v3
-
-fn evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort(v0: Evm) -> !:
-  ; runtime_abi values=[] effects=[]
-  bb0:
-    terminate revert(0, 0)
 
 fn set_h931227dcdf0da20f_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966(v0: mut SolDecoder<CallData>) -> Set:
   bb0:

--- a/crates/mir/tests/fixtures/contract_field_layout_slots_const_hole.mir.snap
+++ b/crates/mir/tests/fixtures/contract_field_layout_slots_const_hole.mir.snap
@@ -25,10 +25,15 @@ fn __LayoutHoles_recv_0_1(v0: Get, v1: u256, v2: u256) -> u256:
 
 fn __LayoutHoles_init() -> ():
   bb0:
-    v0: u256 = code_region_offset(func_item(__LayoutHoles_runtime))
-    v1: u256 = code_region_len(func_item(__LayoutHoles_runtime))
-    eval codecopy(0, v0, v1)
-    terminate return_data(0, v1)
+    v0: u256 = callvalue()
+    br (v0 != 0) bb1 bb2
+  bb1:
+    terminate evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
+  bb2:
+    v1: u256 = code_region_offset(func_item(__LayoutHoles_runtime))
+    v2: u256 = code_region_len(func_item(__LayoutHoles_runtime))
+    eval codecopy(0, v1, v2)
+    terminate return_data(0, v2)
 
 fn __LayoutHoles_runtime() -> ():
   bb0:
@@ -38,17 +43,27 @@ fn __LayoutHoles_runtime() -> ():
     v3: u256 = evm_hef0af3106e109414_contracthost_h57111e7eb283a125_field__StorageMap_u256__u256__4___173e98e83ba93f89(4)
     v4: u32 = runtime_selector__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f__e4e3f8d20b3805a2()
     v5: SolDecoder<CallData> = runtime_decoder__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f__e4e3f8d20b3805a2()
-    switch v4 [1 => bb2, 2 => bb3] else bb1
+    switch v4 [1 => bb2, 2 => bb5] else bb1
   bb1:
     terminate evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
   bb2:
-    v6: Set = set_hc90b8ea7f5d56426_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966(v5)
-    eval __LayoutHoles_recv_0_0(v6)
-    terminate return_unit__Evm_hef0af3106e109414__3af54274b2985741()
+    v6: u256 = callvalue()
+    br (v6 != 0) bb3 bb4
   bb3:
-    v7: Get = get_h7c52564759be682_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966(v5)
-    v8: u256 = __LayoutHoles_recv_0_1(v7)
-    terminate return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f(v8)
+    terminate evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
+  bb4:
+    v7: Set = set_hc90b8ea7f5d56426_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966(v5)
+    eval __LayoutHoles_recv_0_0(v7)
+    terminate return_unit__Evm_hef0af3106e109414__3af54274b2985741()
+  bb5:
+    v8: u256 = callvalue()
+    br (v8 != 0) bb6 bb7
+  bb6:
+    terminate evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
+  bb7:
+    v9: Get = get_h7c52564759be682_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966(v5)
+    v10: u256 = __LayoutHoles_recv_0_1(v9)
+    terminate return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f(v10)
 
 fn storagemap_k__v__const_salt__u256__h5955888dd44c2a19_set_stor__u256_u256_2__7d7bd47f3e4876cc(v0: StorageMap<u256, u256, 2>, v1: u256, v2: u256) -> ():
   ; runtime_abi values=[v1: u256, v2: u256] effects=[]
@@ -77,6 +92,11 @@ fn storagemap_k__v__const_salt__u256__h5955888dd44c2a19_get_stor__u256_u256_4__3
     v2: u256 = storagemap_get_word_with_salt__u256__3271ca15373d4483(v1, 4)
     v3: u256 = u256_h3271ca15373d4483_wordrepr_h7483d41ac8178d88_from_word(v2)
     ret v3
+
+fn evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort(v0: Evm) -> !:
+  ; runtime_abi values=[] effects=[]
+  bb0:
+    terminate revert(0, 0)
 
 fn evm_hef0af3106e109414_contracthost_h57111e7eb283a125_field___u256__u256___f8fb67624e92e2b2(v0: mut Evm, v1: u256) -> StorPtr<(u256, u256)>:
   ; runtime_abi values=[v1: u256] effects=[]
@@ -122,11 +142,6 @@ fn runtime_decoder__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f__e4e3f8d20b3805a
     v2: CallData = evm_hef0af3106e109414_contracthost_h57111e7eb283a125_input()
     v3: SolDecoder<CallData> = sol_hfd482bb803ad8c5f_abi_h2da9a2d0b1ddaeb7_decoder_with_base__CallData_hf71d505b6ff5dc81__e6d5f05c3478f563(v2, 4)
     ret v3
-
-fn evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort(v0: Evm) -> !:
-  ; runtime_abi values=[] effects=[]
-  bb0:
-    terminate revert(0, 0)
 
 fn set_hc90b8ea7f5d56426_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966(v0: mut SolDecoder<CallData>) -> Set:
   bb0:

--- a/crates/mir/tests/fixtures/create2_zero_arg_cleanup.mir.snap
+++ b/crates/mir/tests/fixtures/create2_zero_arg_cleanup.mir.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/mir/tests/lowering_snapshots.rs
-assertion_line: 26
 expression: mir_output
 ---
 fn create2_zero_arg_cleanup__StorPtr_Evm___207f35a85ac4062e(v0: u256) -> ():
@@ -13,10 +12,15 @@ fn create2_zero_arg_cleanup__StorPtr_Evm___207f35a85ac4062e(v0: u256) -> ():
 
 fn __Counter_init() -> ():
   bb0:
-    v0: u256 = code_region_offset(func_item(__Counter_runtime))
-    v1: u256 = code_region_len(func_item(__Counter_runtime))
-    eval codecopy(0, v0, v1)
-    terminate return_data(0, v1)
+    v0: u256 = callvalue()
+    br (v0 != 0) bb1 bb2
+  bb1:
+    terminate evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
+  bb2:
+    v1: u256 = code_region_offset(func_item(__Counter_runtime))
+    v2: u256 = code_region_len(func_item(__Counter_runtime))
+    eval codecopy(0, v1, v2)
+    terminate return_data(0, v2)
 
 fn __Counter_runtime() -> ():
   bb0:
@@ -63,6 +67,11 @@ fn assert(v0: bool) -> ():
   bb2:
     ret
 
+fn evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort(v0: Evm) -> !:
+  ; runtime_abi values=[] effects=[]
+  bb0:
+    terminate revert(0, 0)
+
 fn runtime_selector__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f__e4e3f8d20b3805a2(v0: Evm) -> u32:
   ; runtime_abi values=[] effects=[]
   bb0:
@@ -76,11 +85,6 @@ fn runtime_selector__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f__e4e3f8d20b3805
     v4: u256 = calldata_hf71d505b6ff5dc81_byteinput_hc4c2cb44299530ae_word_at(v1, 0)
     v5: u32 = sol_hfd482bb803ad8c5f_abi_h2da9a2d0b1ddaeb7_selector_from_prefix(v4)
     ret v5
-
-fn evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort(v0: Evm) -> !:
-  ; runtime_abi values=[] effects=[]
-  bb0:
-    terminate revert(0, 0)
 
 fn __Counter_init_code_len() -> u256:
   bb0:

--- a/crates/mir/tests/fixtures/echo.mir.snap
+++ b/crates/mir/tests/fixtures/echo.mir.snap
@@ -24,57 +24,77 @@ fn __EchoContract_recv_0_2(v0: u256) -> u256:
 
 fn __EchoContract_init() -> ():
   bb0:
-    v0: u256 = code_region_offset(func_item(__EchoContract_runtime))
-    v1: u256 = code_region_len(func_item(__EchoContract_runtime))
-    v2: u256 = init_field__Evm_hef0af3106e109414_Foo_h6dbce71a6ea992b8__c09e6c6fc5a7b23d(0)
-    v3: u256 = current_code_region_len()
-    v4: u256 = codesize()
-    br (v4 < v3) bb1 bb2
+    v0: u256 = callvalue()
+    br (v0 != 0) bb1 bb2
   bb1:
     terminate evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
   bb2:
-    bind (v4 - v3)
-    v5: u256 = alloc((v4 - v3))
-    eval codecopy(v5, v3, (v4 - v3))
-    v6: MemoryBytes = alloc mem
-    store mem[v6].0 = v5
-    store mem[v6].1 = (v4 - v3)
-    v7: SolDecoder<MemoryBytes> = sol_hfd482bb803ad8c5f_abi_h2da9a2d0b1ddaeb7_decoder_new__MemoryBytes_h1e381015a9b0111b__59e0d528d54cca1b(v6)
-    v8: u256 = u256_h3271ca15373d4483_decode_hb2fe2bf528775e55_decode__Sol_hfd482bb803ad8c5f_SolDecoder_MemoryBytes___a53dbc6192a658d6(v7)
-    v9: u256 = u256_h3271ca15373d4483_decode_hb2fe2bf528775e55_decode__Sol_hfd482bb803ad8c5f_SolDecoder_MemoryBytes___a53dbc6192a658d6(v7)
-    eval __EchoContract_init_contract(v8, v9, v2)
-    eval codecopy(0, v0, v1)
-    terminate return_data(0, v1)
+    v1: u256 = code_region_offset(func_item(__EchoContract_runtime))
+    v2: u256 = code_region_len(func_item(__EchoContract_runtime))
+    v3: u256 = init_field__Evm_hef0af3106e109414_Foo_h6dbce71a6ea992b8__c09e6c6fc5a7b23d(0)
+    v4: u256 = current_code_region_len()
+    v5: u256 = codesize()
+    br (v5 < v4) bb3 bb4
+  bb3:
+    terminate evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
+  bb4:
+    bind (v5 - v4)
+    v6: u256 = alloc((v5 - v4))
+    eval codecopy(v6, v4, (v5 - v4))
+    v7: MemoryBytes = alloc mem
+    store mem[v7].0 = v6
+    store mem[v7].1 = (v5 - v4)
+    v8: SolDecoder<MemoryBytes> = sol_hfd482bb803ad8c5f_abi_h2da9a2d0b1ddaeb7_decoder_new__MemoryBytes_h1e381015a9b0111b__59e0d528d54cca1b(v7)
+    v9: u256 = u256_h3271ca15373d4483_decode_hb2fe2bf528775e55_decode__Sol_hfd482bb803ad8c5f_SolDecoder_MemoryBytes___a53dbc6192a658d6(v8)
+    v10: u256 = u256_h3271ca15373d4483_decode_hb2fe2bf528775e55_decode__Sol_hfd482bb803ad8c5f_SolDecoder_MemoryBytes___a53dbc6192a658d6(v8)
+    eval __EchoContract_init_contract(v9, v10, v3)
+    eval codecopy(0, v1, v2)
+    terminate return_data(0, v2)
 
 fn __EchoContract_runtime() -> ():
   bb0:
     v0: u256 = evm_hef0af3106e109414_contracthost_h57111e7eb283a125_field__Foo_h6dbce71a6ea992b8__21493237fe9c2c26(0)
     v1: u32 = runtime_selector__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f__e4e3f8d20b3805a2()
     v2: SolDecoder<CallData> = runtime_decoder__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f__e4e3f8d20b3805a2()
-    switch v1 [1 => bb2, 2 => bb3, 3 => bb4] else bb1
+    switch v1 [1 => bb2, 2 => bb5, 3 => bb8] else bb1
   bb1:
     terminate evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
   bb2:
-    v3: u256 = __EchoContract_recv_0_0()
-    terminate return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f(v3)
+    v3: u256 = callvalue()
+    br (v3 != 0) bb3 bb4
   bb3:
-    v4: Echo = echo_h9f932a87feb06bd2_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966(v2)
-    v5: u256 = __EchoContract_recv_0_1(v4)
-    terminate return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f(v5)
+    terminate evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
   bb4:
-    v6: u256 = __EchoContract_recv_0_2(v0)
-    terminate return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f(v6)
+    v4: u256 = __EchoContract_recv_0_0()
+    terminate return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f(v4)
+  bb5:
+    v5: u256 = callvalue()
+    br (v5 != 0) bb6 bb7
+  bb6:
+    terminate evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
+  bb7:
+    v6: Echo = echo_h9f932a87feb06bd2_decode_h624c3cd8c996d995_decode__SolDecoder_CallData___c1e4510fd444b966(v2)
+    v7: u256 = __EchoContract_recv_0_1(v6)
+    terminate return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f(v7)
+  bb8:
+    v8: u256 = callvalue()
+    br (v8 != 0) bb9 bb10
+  bb9:
+    terminate evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
+  bb10:
+    v9: u256 = __EchoContract_recv_0_2(v0)
+    terminate return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f(v9)
+
+fn evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort(v0: Evm) -> !:
+  ; runtime_abi values=[] effects=[]
+  bb0:
+    terminate revert(0, 0)
 
 fn init_field__Evm_hef0af3106e109414_Foo_h6dbce71a6ea992b8__c09e6c6fc5a7b23d(v0: mut Evm, v1: u256) -> StorPtr<Foo>:
   ; runtime_abi values=[v1: u256] effects=[]
   bb0:
     v2: StorPtr<Foo> = evm_hef0af3106e109414_contracthost_h57111e7eb283a125_field__Foo_h6dbce71a6ea992b8__21493237fe9c2c26(v1)
     ret v2
-
-fn evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort(v0: Evm) -> !:
-  ; runtime_abi values=[] effects=[]
-  bb0:
-    terminate revert(0, 0)
 
 fn sol_hfd482bb803ad8c5f_abi_h2da9a2d0b1ddaeb7_decoder_new__MemoryBytes_h1e381015a9b0111b__59e0d528d54cca1b(v0: MemoryBytes) -> SolDecoder<MemoryBytes>:
   bb0:

--- a/crates/mir/tests/fixtures/payable_guards.fe
+++ b/crates/mir/tests/fixtures/payable_guards.fe
@@ -1,0 +1,27 @@
+use std::abi::sol
+
+contract PayableInitAndRecv {
+    #[payable]
+    init() {}
+
+    recv Msg {
+        #[payable]
+        Fund {} {}
+
+        Ping {} {}
+    }
+}
+
+contract NoInitContract {
+    recv Msg {
+        Ping {} {}
+    }
+}
+
+msg Msg {
+    #[selector = sol("fund()")]
+    Fund,
+
+    #[selector = sol("ping()")]
+    Ping,
+}

--- a/crates/mir/tests/fixtures/payable_guards.mir.snap
+++ b/crates/mir/tests/fixtures/payable_guards.mir.snap
@@ -1,0 +1,137 @@
+---
+source: crates/mir/tests/lowering_snapshots.rs
+expression: mir_output
+---
+fn __PayableInitAndRecv_recv_0_0() -> ():
+  bb0:
+    ret
+
+fn __PayableInitAndRecv_recv_0_1() -> ():
+  bb0:
+    ret
+
+fn __PayableInitAndRecv_init() -> ():
+  bb0:
+    v0: u256 = code_region_offset(func_item(__PayableInitAndRecv_runtime))
+    v1: u256 = code_region_len(func_item(__PayableInitAndRecv_runtime))
+    eval codecopy(0, v0, v1)
+    terminate return_data(0, v1)
+
+fn __PayableInitAndRecv_runtime() -> ():
+  bb0:
+    v0: u32 = runtime_selector__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f__e4e3f8d20b3805a2()
+    switch v0 [3054322312 => bb2, 1547088262 => bb3] else bb1
+  bb1:
+    terminate evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
+  bb2:
+    eval __PayableInitAndRecv_recv_0_0()
+    terminate return_unit__Evm_hef0af3106e109414__3af54274b2985741()
+  bb3:
+    v1: u256 = callvalue()
+    br (v1 != 0) bb4 bb5
+  bb4:
+    terminate evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
+  bb5:
+    eval __PayableInitAndRecv_recv_0_1()
+    terminate return_unit__Evm_hef0af3106e109414__3af54274b2985741()
+
+fn __NoInitContract_recv_0_0() -> ():
+  bb0:
+    ret
+
+fn __NoInitContract_init() -> ():
+  bb0:
+    v0: u256 = callvalue()
+    br (v0 != 0) bb1 bb2
+  bb1:
+    terminate evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
+  bb2:
+    v1: u256 = code_region_offset(func_item(__NoInitContract_runtime))
+    v2: u256 = code_region_len(func_item(__NoInitContract_runtime))
+    eval codecopy(0, v1, v2)
+    terminate return_data(0, v2)
+
+fn __NoInitContract_runtime() -> ():
+  bb0:
+    v0: u32 = runtime_selector__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f__e4e3f8d20b3805a2()
+    switch v0 [1547088262 => bb2] else bb1
+  bb1:
+    terminate evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
+  bb2:
+    v1: u256 = callvalue()
+    br (v1 != 0) bb3 bb4
+  bb3:
+    terminate evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
+  bb4:
+    eval __NoInitContract_recv_0_0()
+    terminate return_unit__Evm_hef0af3106e109414__3af54274b2985741()
+
+fn runtime_selector__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f__e4e3f8d20b3805a2(v0: Evm) -> u32:
+  ; runtime_abi values=[] effects=[]
+  bb0:
+    v1: CallData = evm_hef0af3106e109414_contracthost_h57111e7eb283a125_input()
+    v2: u256 = calldata_hf71d505b6ff5dc81_byteinput_hc4c2cb44299530ae_len(v1)
+    v3: bool = u256_h3271ca15373d4483_ord_h264f6d6d75097a_lt(v2, 4)
+    br v3 bb1 bb2
+  bb1:
+    terminate evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
+  bb2:
+    v4: u256 = calldata_hf71d505b6ff5dc81_byteinput_hc4c2cb44299530ae_word_at(v1, 0)
+    v5: u32 = sol_hfd482bb803ad8c5f_abi_h2da9a2d0b1ddaeb7_selector_from_prefix(v4)
+    ret v5
+
+fn evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort(v0: Evm) -> !:
+  ; runtime_abi values=[] effects=[]
+  bb0:
+    terminate revert(0, 0)
+
+fn return_unit__Evm_hef0af3106e109414__3af54274b2985741(v0: Evm) -> !:
+  ; runtime_abi values=[] effects=[]
+  bb0:
+    terminate evm_hef0af3106e109414_contracthost_h57111e7eb283a125_return_bytes(0, 0)
+
+fn evm_hef0af3106e109414_contracthost_h57111e7eb283a125_input(v0: Evm) -> CallData:
+  ; runtime_abi values=[] effects=[]
+  bb0:
+    ret 0
+
+fn calldata_hf71d505b6ff5dc81_byteinput_hc4c2cb44299530ae_len(v0: CallData) -> u256:
+  bb0:
+    v1: u256 = calldatasize()
+    v2: u256 = checked_sub<u256>(v1, v0)
+    ret v2
+
+fn u256_h3271ca15373d4483_ord_h264f6d6d75097a_lt(v0: u256, v1: u256) -> bool:
+  bb0:
+    v2: bool = __lt_u256(v0, v1)
+    ret v2
+
+fn calldata_hf71d505b6ff5dc81_byteinput_hc4c2cb44299530ae_word_at(v0: CallData, v1: u256) -> u256:
+  bb0:
+    bind (v0 + v1)
+    v2: u256 = calldataload((v0 + v1))
+    ret v2
+
+fn sol_hfd482bb803ad8c5f_abi_h2da9a2d0b1ddaeb7_selector_from_prefix(v0: u256) -> u32:
+  bb0:
+    v1: u32 = s_h33f7c3322e562590_intdowncast_hf946d58b157999e1_downcast_unchecked__u256_u32__6e3637cd3e911b35((v0 >> 224))
+    ret v1
+
+fn evm_hef0af3106e109414_contracthost_h57111e7eb283a125_return_bytes(v0: Evm, v1: u256, v2: u256) -> !:
+  ; runtime_abi values=[v1: u256, v2: u256] effects=[]
+  bb0:
+    terminate return_data(v1, v2)
+
+fn s_h33f7c3322e562590_intdowncast_hf946d58b157999e1_downcast_unchecked__u256_u32__6e3637cd3e911b35(v0: u256) -> u32:
+  bb0:
+    v1: u256 = u256_h3271ca15373d4483_intword_h9a147c8c32b1323c_to_word(v0)
+    v2: u32 = u32_h20aa0c10687491ad_intword_h9a147c8c32b1323c_from_word(v1)
+    ret v2
+
+fn u256_h3271ca15373d4483_intword_h9a147c8c32b1323c_to_word(v0: u256) -> u256:
+  bb0:
+    ret v0
+
+fn u32_h20aa0c10687491ad_intword_h9a147c8c32b1323c_from_word(v0: u256) -> u32:
+  bb0:
+    ret v0

--- a/crates/mir/tests/fixtures/payable_invalid_form_guards.fe
+++ b/crates/mir/tests/fixtures/payable_invalid_form_guards.fe
@@ -1,0 +1,22 @@
+use std::abi::sol
+
+contract InvalidPayableForms {
+    #[payable = 1]
+    init() {}
+
+    recv Msg {
+        #[payable(foo)]
+        Fund {} {}
+
+        #[payable]
+        Ping {} {}
+    }
+}
+
+msg Msg {
+    #[selector = sol("fund()")]
+    Fund,
+
+    #[selector = sol("ping()")]
+    Ping,
+}

--- a/crates/mir/tests/fixtures/payable_invalid_form_guards.mir.snap
+++ b/crates/mir/tests/fixtures/payable_invalid_form_guards.mir.snap
@@ -1,0 +1,112 @@
+---
+source: crates/mir/tests/lowering_snapshots.rs
+assertion_line: 26
+expression: mir_output
+---
+fn __InvalidPayableForms_recv_0_0() -> ():
+  bb0:
+    ret
+
+fn __InvalidPayableForms_recv_0_1() -> ():
+  bb0:
+    ret
+
+fn __InvalidPayableForms_init() -> ():
+  bb0:
+    v0: u256 = callvalue()
+    br (v0 != 0) bb1 bb2
+  bb1:
+    terminate evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
+  bb2:
+    v1: u256 = code_region_offset(func_item(__InvalidPayableForms_runtime))
+    v2: u256 = code_region_len(func_item(__InvalidPayableForms_runtime))
+    eval codecopy(0, v1, v2)
+    terminate return_data(0, v2)
+
+fn __InvalidPayableForms_runtime() -> ():
+  bb0:
+    v0: u32 = runtime_selector__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f__e4e3f8d20b3805a2()
+    switch v0 [3054322312 => bb2, 1547088262 => bb5] else bb1
+  bb1:
+    terminate evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
+  bb2:
+    v1: u256 = callvalue()
+    br (v1 != 0) bb3 bb4
+  bb3:
+    terminate evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
+  bb4:
+    eval __InvalidPayableForms_recv_0_0()
+    terminate return_unit__Evm_hef0af3106e109414__3af54274b2985741()
+  bb5:
+    eval __InvalidPayableForms_recv_0_1()
+    terminate return_unit__Evm_hef0af3106e109414__3af54274b2985741()
+
+fn evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort(v0: Evm) -> !:
+  ; runtime_abi values=[] effects=[]
+  bb0:
+    terminate revert(0, 0)
+
+fn runtime_selector__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f__e4e3f8d20b3805a2(v0: Evm) -> u32:
+  ; runtime_abi values=[] effects=[]
+  bb0:
+    v1: CallData = evm_hef0af3106e109414_contracthost_h57111e7eb283a125_input()
+    v2: u256 = calldata_hf71d505b6ff5dc81_byteinput_hc4c2cb44299530ae_len(v1)
+    v3: bool = u256_h3271ca15373d4483_ord_h264f6d6d75097a_lt(v2, 4)
+    br v3 bb1 bb2
+  bb1:
+    terminate evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
+  bb2:
+    v4: u256 = calldata_hf71d505b6ff5dc81_byteinput_hc4c2cb44299530ae_word_at(v1, 0)
+    v5: u32 = sol_hfd482bb803ad8c5f_abi_h2da9a2d0b1ddaeb7_selector_from_prefix(v4)
+    ret v5
+
+fn return_unit__Evm_hef0af3106e109414__3af54274b2985741(v0: Evm) -> !:
+  ; runtime_abi values=[] effects=[]
+  bb0:
+    terminate evm_hef0af3106e109414_contracthost_h57111e7eb283a125_return_bytes(0, 0)
+
+fn evm_hef0af3106e109414_contracthost_h57111e7eb283a125_input(v0: Evm) -> CallData:
+  ; runtime_abi values=[] effects=[]
+  bb0:
+    ret 0
+
+fn calldata_hf71d505b6ff5dc81_byteinput_hc4c2cb44299530ae_len(v0: CallData) -> u256:
+  bb0:
+    v1: u256 = calldatasize()
+    v2: u256 = checked_sub<u256>(v1, v0)
+    ret v2
+
+fn u256_h3271ca15373d4483_ord_h264f6d6d75097a_lt(v0: u256, v1: u256) -> bool:
+  bb0:
+    v2: bool = __lt_u256(v0, v1)
+    ret v2
+
+fn calldata_hf71d505b6ff5dc81_byteinput_hc4c2cb44299530ae_word_at(v0: CallData, v1: u256) -> u256:
+  bb0:
+    bind (v0 + v1)
+    v2: u256 = calldataload((v0 + v1))
+    ret v2
+
+fn sol_hfd482bb803ad8c5f_abi_h2da9a2d0b1ddaeb7_selector_from_prefix(v0: u256) -> u32:
+  bb0:
+    v1: u32 = s_h33f7c3322e562590_intdowncast_hf946d58b157999e1_downcast_unchecked__u256_u32__6e3637cd3e911b35((v0 >> 224))
+    ret v1
+
+fn evm_hef0af3106e109414_contracthost_h57111e7eb283a125_return_bytes(v0: Evm, v1: u256, v2: u256) -> !:
+  ; runtime_abi values=[v1: u256, v2: u256] effects=[]
+  bb0:
+    terminate return_data(v1, v2)
+
+fn s_h33f7c3322e562590_intdowncast_hf946d58b157999e1_downcast_unchecked__u256_u32__6e3637cd3e911b35(v0: u256) -> u32:
+  bb0:
+    v1: u256 = u256_h3271ca15373d4483_intword_h9a147c8c32b1323c_to_word(v0)
+    v2: u32 = u32_h20aa0c10687491ad_intword_h9a147c8c32b1323c_from_word(v1)
+    ret v2
+
+fn u256_h3271ca15373d4483_intword_h9a147c8c32b1323c_to_word(v0: u256) -> u256:
+  bb0:
+    ret v0
+
+fn u32_h20aa0c10687491ad_intword_h9a147c8c32b1323c_from_word(v0: u256) -> u32:
+  bb0:
+    ret v0

--- a/crates/mir/tests/fixtures/transient_field_effects.mir.snap
+++ b/crates/mir/tests/fixtures/transient_field_effects.mir.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/mir/tests/lowering_snapshots.rs
-assertion_line: 26
 expression: mir_output
 ---
 fn bump_lock__StorPtr_u256___64779554cfbf0358(v0: u256) -> ():
@@ -22,12 +21,17 @@ fn __Guard_recv_0_0(v0: u256) -> ():
 
 fn __Guard_init() -> ():
   bb0:
-    v0: u256 = code_region_offset(func_item(__Guard_runtime))
-    v1: u256 = code_region_len(func_item(__Guard_runtime))
-    v2: u256 = tstorptr_t__hb73db5b342ccdc03_effecthandle_hfc52f915596f993a_from_raw__u256__3271ca15373d4483(0)
-    eval __Guard_init_contract(v2)
-    eval codecopy(0, v0, v1)
-    terminate return_data(0, v1)
+    v0: u256 = callvalue()
+    br (v0 != 0) bb1 bb2
+  bb1:
+    terminate evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
+  bb2:
+    v1: u256 = code_region_offset(func_item(__Guard_runtime))
+    v2: u256 = code_region_len(func_item(__Guard_runtime))
+    v3: u256 = tstorptr_t__hb73db5b342ccdc03_effecthandle_hfc52f915596f993a_from_raw__u256__3271ca15373d4483(0)
+    eval __Guard_init_contract(v3)
+    eval codecopy(0, v1, v2)
+    terminate return_data(0, v2)
 
 fn __Guard_runtime() -> ():
   bb0:
@@ -37,6 +41,11 @@ fn __Guard_runtime() -> ():
   bb1:
     terminate evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
   bb2:
+    v2: u256 = callvalue()
+    br (v2 != 0) bb3 bb4
+  bb3:
+    terminate evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
+  bb4:
     eval __Guard_recv_0_0(v0)
     terminate return_unit__Evm_hef0af3106e109414__3af54274b2985741()
 
@@ -46,6 +55,11 @@ fn bump_lock__TStorPtr_u256___e67d09080c0f1393(v0: u256) -> ():
     v2: u256 = checked_add<u256>(v1, 1)
     store tstor[v0] = v2
     ret
+
+fn evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort(v0: Evm) -> !:
+  ; runtime_abi values=[] effects=[]
+  bb0:
+    terminate revert(0, 0)
 
 fn tstorptr_t__hb73db5b342ccdc03_effecthandle_hfc52f915596f993a_from_raw__u256__3271ca15373d4483(v0: u256) -> TStorPtr<u256>:
   bb0:
@@ -64,11 +78,6 @@ fn runtime_selector__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f__e4e3f8d20b3805
     v4: u256 = calldata_hf71d505b6ff5dc81_byteinput_hc4c2cb44299530ae_word_at(v1, 0)
     v5: u32 = sol_hfd482bb803ad8c5f_abi_h2da9a2d0b1ddaeb7_selector_from_prefix(v4)
     ret v5
-
-fn evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort(v0: Evm) -> !:
-  ; runtime_abi values=[] effects=[]
-  bb0:
-    terminate revert(0, 0)
 
 fn return_unit__Evm_hef0af3106e109414__3af54274b2985741(v0: Evm) -> !:
   ; runtime_abi values=[] effects=[]

--- a/crates/mir/tests/fixtures/zero_payload_contract_args.mir.snap
+++ b/crates/mir/tests/fixtures/zero_payload_contract_args.mir.snap
@@ -8,10 +8,15 @@ fn __ZeroPayloadContractArgs_recv_0_0() -> u256:
 
 fn __ZeroPayloadContractArgs_init() -> ():
   bb0:
-    v0: u256 = code_region_offset(func_item(__ZeroPayloadContractArgs_runtime))
-    v1: u256 = code_region_len(func_item(__ZeroPayloadContractArgs_runtime))
-    eval codecopy(0, v0, v1)
-    terminate return_data(0, v1)
+    v0: u256 = callvalue()
+    br (v0 != 0) bb1 bb2
+  bb1:
+    terminate evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
+  bb2:
+    v1: u256 = code_region_offset(func_item(__ZeroPayloadContractArgs_runtime))
+    v2: u256 = code_region_len(func_item(__ZeroPayloadContractArgs_runtime))
+    eval codecopy(0, v1, v2)
+    terminate return_data(0, v2)
 
 fn __ZeroPayloadContractArgs_runtime() -> ():
   bb0:
@@ -20,8 +25,18 @@ fn __ZeroPayloadContractArgs_runtime() -> ():
   bb1:
     terminate evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
   bb2:
-    v1: u256 = __ZeroPayloadContractArgs_recv_0_0()
-    terminate return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f(v1)
+    v1: u256 = callvalue()
+    br (v1 != 0) bb3 bb4
+  bb3:
+    terminate evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort()
+  bb4:
+    v2: u256 = __ZeroPayloadContractArgs_recv_0_0()
+    terminate return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f(v2)
+
+fn evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort(v0: Evm) -> !:
+  ; runtime_abi values=[] effects=[]
+  bb0:
+    terminate revert(0, 0)
 
 fn runtime_selector__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f__e4e3f8d20b3805a2(v0: Evm) -> u32:
   ; runtime_abi values=[] effects=[]
@@ -36,11 +51,6 @@ fn runtime_selector__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f__e4e3f8d20b3805
     v4: u256 = calldata_hf71d505b6ff5dc81_byteinput_hc4c2cb44299530ae_word_at(v1, 0)
     v5: u32 = sol_hfd482bb803ad8c5f_abi_h2da9a2d0b1ddaeb7_selector_from_prefix(v4)
     ret v5
-
-fn evm_hef0af3106e109414_contracthost_h57111e7eb283a125_abort(v0: Evm) -> !:
-  ; runtime_abi values=[] effects=[]
-  bb0:
-    terminate revert(0, 0)
 
 fn return_value__Evm_hef0af3106e109414_Sol_hfd482bb803ad8c5f_u256__c4b26908c66ef75f(v0: mut Evm, v1: u256) -> !:
   ; runtime_abi values=[v1: u256] effects=[]

--- a/crates/parser/src/ast/item.rs
+++ b/crates/parser/src/ast/item.rs
@@ -199,6 +199,7 @@ ast_node! {
     pub struct ContractInit,
     SK::ContractInit,
 }
+impl super::AttrListOwner for ContractInit {}
 impl ContractInit {
     pub fn params(&self) -> Option<super::FuncParamList> {
         support::child(self.syntax())
@@ -218,6 +219,7 @@ ast_node! {
     pub struct ContractRecv,
     SK::ContractRecv,
 }
+impl super::AttrListOwner for ContractRecv {}
 impl ContractRecv {
     /// Optional root message type path (`recv Type { ... }`).
     pub fn path(&self) -> Option<super::Path> {
@@ -242,6 +244,7 @@ ast_node! {
     pub struct RecvArm,
     SK::RecvArm,
 }
+impl super::AttrListOwner for RecvArm {}
 impl RecvArm {
     /// The pattern being matched (e.g., `Transfer { to, amount }`).
     pub fn pat(&self) -> Option<super::Pat> {

--- a/crates/parser/src/parser/item.rs
+++ b/crates/parser/src/parser/item.rs
@@ -274,17 +274,30 @@ impl super::Parse for ContractScope {
 
             parser.parse(ContractFieldsScope::default())?;
 
-            // Optional `init` block
+            // Optional `init` block (possibly preceded by attributes). If the
+            // leading attributes actually belong to the first `recv` block, we
+            // must reuse the same checkpoint instead of dropping it here.
+            let mut checkpoint = parse_attr_list(parser)?;
             if parser.is_ident("init") {
-                parser.parse(ContractInitScope::default())?;
+                parser.parse_cp(ContractInitScope::default(), checkpoint)?;
+                checkpoint = parse_attr_list(parser)?;
             }
 
-            // Zero or more `recv` blocks
+            // Zero or more `recv` blocks (each possibly preceded by attributes)
             loop {
-                if !parser.is_ident("recv") {
+                if parser.is_ident("recv") {
+                    parser.parse_cp(ContractRecvScope::default(), checkpoint)?;
+                    checkpoint = parse_attr_list(parser)?;
+                } else {
                     break;
                 }
-                parser.parse(ContractRecvScope::default())?;
+            }
+
+            // If trailing attributes were consumed but no init/recv follows,
+            // emit a parse error so they don't silently vanish.
+            if checkpoint.is_some() {
+                let _ =
+                    parser.error_msg_on_current_token("expected `init` or `recv` after attribute");
             }
 
             parser.bump_or_recover(
@@ -309,6 +322,18 @@ impl super::Parse for ContractFieldsScope {
             // Stop conditions
             match parser.current_kind() {
                 Some(SyntaxKind::RBrace) | None => break,
+                Some(SyntaxKind::Pound) | Some(SyntaxKind::DocComment) => {
+                    // Lookahead: break only if the attribute/doc comment is followed by
+                    // `init` or `recv`, otherwise it's a field attribute
+                    // (e.g. `#[field_attr] total: u256`).
+                    let is_init_or_recv_attr = parser.dry_run(|p| {
+                        let _ = attr::parse_attr_list(p);
+                        p.is_ident("init") || p.is_ident("recv")
+                    });
+                    if is_init_or_recv_attr {
+                        break;
+                    }
+                }
                 Some(SyntaxKind::Ident)
                     if matches!(parser.current_token().unwrap().text(), "init" | "recv") =>
                 {
@@ -399,6 +424,8 @@ impl super::Parse for RecvArmScope {
     type Error = Recovery<ErrProof>;
 
     fn parse<S: TokenStream>(&mut self, parser: &mut Parser<S>) -> Result<(), Self::Error> {
+        parse_attr_list(parser)?;
+
         parser.set_newline_as_trivia(false);
 
         parse_recv_arm_pat(parser)?;

--- a/crates/parser/test_files/syntax_node/items/contract_doc_comment_init_recv.fe
+++ b/crates/parser/test_files/syntax_node/items/contract_doc_comment_init_recv.fe
@@ -1,0 +1,13 @@
+contract Foo {
+    x: i32
+
+    /// Initializes the contract.
+    init() {}
+
+    /// Handles Erc20 messages.
+    recv Erc20 {
+        Balance { addr } -> u256 {
+            0
+        }
+    }
+}

--- a/crates/parser/test_files/syntax_node/items/contract_doc_comment_init_recv.snap
+++ b/crates/parser/test_files/syntax_node/items/contract_doc_comment_init_recv.snap
@@ -1,0 +1,100 @@
+---
+source: crates/parser/tests/syntax_node.rs
+expression: node
+input_file: test_files/syntax_node/items/contract_doc_comment_init_recv.fe
+---
+Root@0..192
+  ItemList@0..191
+    Item@0..191
+      Contract@0..191
+        ContractKw@0..8 "contract"
+        WhiteSpace@8..9 " "
+        Ident@9..12 "Foo"
+        WhiteSpace@12..13 " "
+        LBrace@13..14 "{"
+        Newline@14..15 "\n"
+        WhiteSpace@15..19 "    "
+        ContractFields@19..25
+          RecordFieldDef@19..25
+            Ident@19..20 "x"
+            Colon@20..21 ":"
+            WhiteSpace@21..22 " "
+            PathType@22..25
+              Path@22..25
+                PathSegment@22..25
+                  Ident@22..25 "i32"
+        Newline@25..27 "\n\n"
+        WhiteSpace@27..31 "    "
+        ContractInit@31..74
+          AttrList@31..61
+            DocCommentAttr@31..60
+              DocComment@31..60 "/// Initializes the c ..."
+            Newline@60..61 "\n"
+          WhiteSpace@61..65 "    "
+          Ident@65..69 "init"
+          FuncParamList@69..71
+            LParen@69..70 "("
+            RParen@70..71 ")"
+          WhiteSpace@71..72 " "
+          BlockExpr@72..74
+            LBrace@72..73 "{"
+            RBrace@73..74 "}"
+        Newline@74..76 "\n\n"
+        WhiteSpace@76..80 "    "
+        ContractRecv@80..189
+          AttrList@80..108
+            DocCommentAttr@80..107
+              DocComment@80..107 "/// Handles Erc20 mes ..."
+            Newline@107..108 "\n"
+          WhiteSpace@108..112 "    "
+          Ident@112..116 "recv"
+          WhiteSpace@116..117 " "
+          Path@117..122
+            PathSegment@117..122
+              Ident@117..122 "Erc20"
+          WhiteSpace@122..123 " "
+          RecvArmList@123..189
+            LBrace@123..124 "{"
+            Newline@124..125 "\n"
+            WhiteSpace@125..133 "        "
+            RecvArm@133..183
+              RecordPat@133..149
+                Path@133..140
+                  PathSegment@133..140
+                    Ident@133..140 "Balance"
+                WhiteSpace@140..141 " "
+                RecordPatFieldList@141..149
+                  LBrace@141..142 "{"
+                  WhiteSpace@142..143 " "
+                  RecordPatField@143..147
+                    PathPat@143..147
+                      Path@143..147
+                        PathSegment@143..147
+                          Ident@143..147 "addr"
+                  WhiteSpace@147..148 " "
+                  RBrace@148..149 "}"
+              WhiteSpace@149..150 " "
+              Arrow@150..152 "->"
+              WhiteSpace@152..153 " "
+              PathType@153..157
+                Path@153..157
+                  PathSegment@153..157
+                    Ident@153..157 "u256"
+              WhiteSpace@157..158 " "
+              BlockExpr@158..183
+                LBrace@158..159 "{"
+                Newline@159..160 "\n"
+                WhiteSpace@160..172 "            "
+                ExprStmt@172..173
+                  LitExpr@172..173
+                    Lit@172..173
+                      Int@172..173 "0"
+                Newline@173..174 "\n"
+                WhiteSpace@174..182 "        "
+                RBrace@182..183 "}"
+            Newline@183..184 "\n"
+            WhiteSpace@184..188 "    "
+            RBrace@188..189 "}"
+        Newline@189..190 "\n"
+        RBrace@190..191 "}"
+  Newline@191..192 "\n"

--- a/crates/uitest/fixtures/ty_check/payable_invalid_form.fe
+++ b/crates/uitest/fixtures/ty_check/payable_invalid_form.fe
@@ -1,0 +1,9 @@
+contract C {
+    #[payable(foo)]
+    init() {}
+}
+
+contract D {
+    #[payable = 1]
+    init() {}
+}

--- a/crates/uitest/fixtures/ty_check/payable_invalid_form.snap
+++ b/crates/uitest/fixtures/ty_check/payable_invalid_form.snap
@@ -1,0 +1,16 @@
+---
+source: crates/uitest/tests/ty_check.rs
+expression: diags
+input_file: fixtures/ty_check/payable_invalid_form.fe
+---
+error[13-0002]: invalid `#[payable]` attribute form
+  ┌─ payable_invalid_form.fe:2:5
+  │
+2 │     #[payable(foo)]
+  │     ^^^^^^^^^^^^^^^ expected `#[payable]` with no arguments
+
+error[13-0002]: invalid `#[payable]` attribute form
+  ┌─ payable_invalid_form.fe:7:5
+  │
+7 │     #[payable = 1]
+  │     ^^^^^^^^^^^^^^ expected `#[payable]` with no arguments

--- a/crates/uitest/fixtures/ty_check/payable_on_for_stmt.fe
+++ b/crates/uitest/fixtures/ty_check/payable_on_for_stmt.fe
@@ -1,0 +1,5 @@
+fn f() {
+    #[payable]
+    for i in 0..1 {
+    }
+}

--- a/crates/uitest/fixtures/ty_check/payable_on_for_stmt.snap
+++ b/crates/uitest/fixtures/ty_check/payable_on_for_stmt.snap
@@ -1,0 +1,10 @@
+---
+source: crates/uitest/tests/ty_check.rs
+expression: diags
+input_file: fixtures/ty_check/payable_on_for_stmt.fe
+---
+error[13-0001]: `#[payable]` is only valid on `init` blocks and `recv` arms (found on for statement)
+  ┌─ payable_on_for_stmt.fe:2:5
+  │
+2 │     #[payable]
+  │     ^^^^^^^^^^ move this attribute to an `init` block or `recv` arm

--- a/crates/uitest/fixtures/ty_check/payable_on_inner_mod_attrs.fe
+++ b/crates/uitest/fixtures/ty_check/payable_on_inner_mod_attrs.fe
@@ -1,0 +1,9 @@
+#![payable]
+
+fn top_level() {}
+
+mod nested {
+    #![payable]
+
+    fn inner() {}
+}

--- a/crates/uitest/fixtures/ty_check/payable_on_inner_mod_attrs.snap
+++ b/crates/uitest/fixtures/ty_check/payable_on_inner_mod_attrs.snap
@@ -1,0 +1,16 @@
+---
+source: crates/uitest/tests/ty_check.rs
+expression: diags
+input_file: fixtures/ty_check/payable_on_inner_mod_attrs.fe
+---
+error[13-0001]: `#[payable]` is only valid on `init` blocks and `recv` arms (found on module)
+  ┌─ payable_on_inner_mod_attrs.fe:1:1
+  │
+1 │ #![payable]
+  │ ^^^^^^^^^^^ move this attribute to an `init` block or `recv` arm
+
+error[13-0001]: `#[payable]` is only valid on `init` blocks and `recv` arms (found on module)
+  ┌─ payable_on_inner_mod_attrs.fe:6:5
+  │
+6 │     #![payable]
+  │     ^^^^^^^^^^^ move this attribute to an `init` block or `recv` arm

--- a/crates/uitest/fixtures/ty_check/payable_on_msg_variant.fe
+++ b/crates/uitest/fixtures/ty_check/payable_on_msg_variant.fe
@@ -1,0 +1,13 @@
+use std::abi::sol
+
+msg M {
+    #[payable]
+    #[selector = sol("ping()")]
+    Ping,
+}
+
+contract C {
+    recv M {
+        Ping {} {}
+    }
+}

--- a/crates/uitest/fixtures/ty_check/payable_on_msg_variant.snap
+++ b/crates/uitest/fixtures/ty_check/payable_on_msg_variant.snap
@@ -1,0 +1,10 @@
+---
+source: crates/uitest/tests/ty_check.rs
+expression: diags
+input_file: fixtures/ty_check/payable_on_msg_variant.fe
+---
+error[13-0003]: `#[payable]` must be placed on the corresponding `recv` arm, not the `msg` variant
+  ┌─ payable_on_msg_variant.fe:4:5
+  │
+4 │     #[payable]
+  │     ^^^^^^^^^^ move this attribute to the matching `recv` arm

--- a/crates/uitest/fixtures/ty_check/payable_on_nested_items.fe
+++ b/crates/uitest/fixtures/ty_check/payable_on_nested_items.fe
@@ -1,0 +1,21 @@
+struct Foo {
+    #[payable]
+    x: u256,
+}
+
+enum Bar {
+    #[payable]
+    A
+}
+
+impl Foo {
+    #[payable]
+    fn baz(self) -> u256 {
+        self.x
+    }
+}
+
+trait MyTrait {
+    #[payable]
+    fn do_thing(self)
+}

--- a/crates/uitest/fixtures/ty_check/payable_on_nested_items.snap
+++ b/crates/uitest/fixtures/ty_check/payable_on_nested_items.snap
@@ -1,0 +1,28 @@
+---
+source: crates/uitest/tests/ty_check.rs
+expression: diags
+input_file: fixtures/ty_check/payable_on_nested_items.fe
+---
+error[13-0001]: `#[payable]` is only valid on `init` blocks and `recv` arms (found on field)
+  ┌─ payable_on_nested_items.fe:2:5
+  │
+2 │     #[payable]
+  │     ^^^^^^^^^^ move this attribute to an `init` block or `recv` arm
+
+error[13-0001]: `#[payable]` is only valid on `init` blocks and `recv` arms (found on variant)
+  ┌─ payable_on_nested_items.fe:7:5
+  │
+7 │     #[payable]
+  │     ^^^^^^^^^^ move this attribute to an `init` block or `recv` arm
+
+error[13-0001]: `#[payable]` is only valid on `init` blocks and `recv` arms (found on fn)
+   ┌─ payable_on_nested_items.fe:12:5
+   │
+12 │     #[payable]
+   │     ^^^^^^^^^^ move this attribute to an `init` block or `recv` arm
+
+error[13-0001]: `#[payable]` is only valid on `init` blocks and `recv` arms (found on fn)
+   ┌─ payable_on_nested_items.fe:19:5
+   │
+19 │     #[payable]
+   │     ^^^^^^^^^^ move this attribute to an `init` block or `recv` arm

--- a/crates/uitest/fixtures/ty_check/payable_on_recv_block.fe
+++ b/crates/uitest/fixtures/ty_check/payable_on_recv_block.fe
@@ -1,0 +1,13 @@
+use std::abi::sol
+
+msg M {
+    #[selector = sol("ping()")]
+    Ping,
+}
+
+contract C {
+    #[payable]
+    recv M {
+        Ping {} {}
+    }
+}

--- a/crates/uitest/fixtures/ty_check/payable_on_recv_block.snap
+++ b/crates/uitest/fixtures/ty_check/payable_on_recv_block.snap
@@ -1,0 +1,10 @@
+---
+source: crates/uitest/tests/ty_check.rs
+expression: diags
+input_file: fixtures/ty_check/payable_on_recv_block.fe
+---
+error[13-0001]: `#[payable]` is only valid on `init` blocks and `recv` arms (found on recv block)
+  ┌─ payable_on_recv_block.fe:9:5
+  │
+9 │     #[payable]
+  │     ^^^^^^^^^^ move this attribute to an `init` block or `recv` arm

--- a/crates/uitest/fixtures/ty_check/payable_on_unsupported_items.fe
+++ b/crates/uitest/fixtures/ty_check/payable_on_unsupported_items.fe
@@ -1,0 +1,16 @@
+#[payable]
+fn foo() {}
+
+#[payable]
+struct Bar {}
+
+#[payable]
+enum Baz { A }
+
+#[payable]
+const X: u32 = 1
+
+extern {
+    #[payable]
+    pub unsafe fn ext()
+}

--- a/crates/uitest/fixtures/ty_check/payable_on_unsupported_items.snap
+++ b/crates/uitest/fixtures/ty_check/payable_on_unsupported_items.snap
@@ -1,0 +1,34 @@
+---
+source: crates/uitest/tests/ty_check.rs
+expression: diags
+input_file: fixtures/ty_check/payable_on_unsupported_items.fe
+---
+error[13-0001]: `#[payable]` is only valid on `init` blocks and `recv` arms (found on fn)
+  ┌─ payable_on_unsupported_items.fe:1:1
+  │
+1 │ #[payable]
+  │ ^^^^^^^^^^ move this attribute to an `init` block or `recv` arm
+
+error[13-0001]: `#[payable]` is only valid on `init` blocks and `recv` arms (found on struct)
+  ┌─ payable_on_unsupported_items.fe:4:1
+  │
+4 │ #[payable]
+  │ ^^^^^^^^^^ move this attribute to an `init` block or `recv` arm
+
+error[13-0001]: `#[payable]` is only valid on `init` blocks and `recv` arms (found on enum)
+  ┌─ payable_on_unsupported_items.fe:7:1
+  │
+7 │ #[payable]
+  │ ^^^^^^^^^^ move this attribute to an `init` block or `recv` arm
+
+error[13-0001]: `#[payable]` is only valid on `init` blocks and `recv` arms (found on const)
+   ┌─ payable_on_unsupported_items.fe:10:1
+   │
+10 │ #[payable]
+   │ ^^^^^^^^^^ move this attribute to an `init` block or `recv` arm
+
+error[13-0001]: `#[payable]` is only valid on `init` blocks and `recv` arms (found on extern fn)
+   ┌─ payable_on_unsupported_items.fe:14:5
+   │
+14 │     #[payable]
+   │     ^^^^^^^^^^ move this attribute to an `init` block or `recv` arm

--- a/crates/uitest/fixtures/ty_check/payable_unknown_attr_on_init_recv.fe
+++ b/crates/uitest/fixtures/ty_check/payable_unknown_attr_on_init_recv.fe
@@ -1,0 +1,17 @@
+struct Store { value: u256 }
+
+pub contract Foo {
+    mut store: Store
+
+    #[payble]
+    init() {
+        store.value = 0
+    }
+
+    #[bar]
+    recv {
+        #[foo]
+        Ping {} {
+        }
+    }
+}

--- a/crates/uitest/fixtures/ty_check/payable_unknown_attr_on_init_recv.snap
+++ b/crates/uitest/fixtures/ty_check/payable_unknown_attr_on_init_recv.snap
@@ -1,0 +1,29 @@
+---
+source: crates/uitest/tests/ty_check.rs
+assertion_line: 27
+expression: diags
+input_file: fixtures/ty_check/payable_unknown_attr_on_init_recv.fe
+---
+error[13-0004]: unknown attribute `#[payble]` on init block (only `#[payable]` is allowed)
+  ┌─ payable_unknown_attr_on_init_recv.fe:6:5
+  │
+6 │     #[payble]
+  │     ^^^^^^^^^ remove this attribute or use `#[payable]`
+
+error[13-0004]: unknown attribute `#[bar]` on recv block
+   ┌─ payable_unknown_attr_on_init_recv.fe:11:5
+   │
+11 │     #[bar]
+   │     ^^^^^^ remove this attribute; `recv` blocks do not support normal attributes
+
+error[13-0004]: unknown attribute `#[foo]` on recv arm (only `#[payable]` is allowed)
+   ┌─ payable_unknown_attr_on_init_recv.fe:13:9
+   │
+13 │         #[foo]
+   │         ^^^^^^ remove this attribute or use `#[payable]`
+
+error[8-0012]: undefined variable
+  ┌─ payable_unknown_attr_on_init_recv.fe:8:9
+  │
+8 │         store.value = 0
+  │         ^^^^^ undefined variable `store`

--- a/crates/uitest/fixtures/ty_check/payable_unknown_attr_on_recv_block.fe
+++ b/crates/uitest/fixtures/ty_check/payable_unknown_attr_on_recv_block.fe
@@ -1,0 +1,13 @@
+use std::abi::sol
+
+msg M {
+    #[selector = sol("ping()")]
+    Ping,
+}
+
+contract C {
+    #[payble]
+    recv M {
+        Ping {} {}
+    }
+}

--- a/crates/uitest/fixtures/ty_check/payable_unknown_attr_on_recv_block.snap
+++ b/crates/uitest/fixtures/ty_check/payable_unknown_attr_on_recv_block.snap
@@ -1,0 +1,11 @@
+---
+source: crates/uitest/tests/ty_check.rs
+assertion_line: 27
+expression: diags
+input_file: fixtures/ty_check/payable_unknown_attr_on_recv_block.fe
+---
+error[13-0004]: unknown attribute `#[payble]` on recv block
+  ┌─ payable_unknown_attr_on_recv_block.fe:9:5
+  │
+9 │     #[payble]
+  │     ^^^^^^^^^ remove this attribute; `recv` blocks do not support normal attributes


### PR DESCRIPTION
 ## Summary

  This PR adds a `#[payable]` attribute for contract `init` blocks and `recv` arms, addressing two problems:

  **Safety:** Fe contracts currently accept ETH silently on all entrypoints. Users can lose funds by sending ETH to functions that don't handle it. With `#[payable]`, the compiler injects a `CALLVALUE` check that
   reverts non-payable calls.

  **ABI correctness:** Without an explicit payable signal, JSON ABI generation (planned in a follow-up) would have to mark every function as `"stateMutability": "payable"` — even pure views and read-only
  accessors — since the compiler couldn't distinguish intent. With `#[payable]`, the ABI can correctly derive `"payable"`, `"nonpayable"`, `"view"`, and `"pure"`, which is required for proper integration with
  wallets, block explorers, and tools like Foundry or ethers.js.

  ### What's included

  - **Parser:** Attribute lists are now parsed before `init` blocks and `recv` arms/blocks, with lookahead to distinguish field attributes from init/recv attributes
  - **HIR:** `attributes` field propagated on `ContractInit` and `ContractRecvArm` with `is_payable()` helpers
  - **MIR:** New `IntrinsicOp::Callvalue` wired through ir, fmt, escape analysis, intrinsics mapping, and both codegen backends (Sonatina + Yul)
  - **MIR lowering:** `CALLVALUE != 0 → revert` guards emitted in both `lower_init_entrypoint` and `lower_runtime_entrypoint` for non-payable entrypoints
  - **Formatter:** `fe fmt` preserves `#[payable]` placement on init and recv arms
  - **Validation:** Full diagnostic pipeline (`PayableError` → `PayableAttrPass` → `DiagnosticVoucher`) rejects `#[payable]` on unsupported items (fn, struct, enum, msg variant, recv block, const, extern fn,
  etc.) and malformed forms like `#[payable(foo)]` or `#[payable = 1]`
  - **Test harness:** `RuntimeInstance::fund_contract()` gives deployed test contracts ETH balance so tests can exercise payable semantics with non-zero value

  ### Example

  ```fe
  pub contract Vault {
      #[payable]
      init() {}

      recv VaultMsg {
          #[payable]
          Deposit {} { ... }          // accepts ETH → ABI: "payable"

          GetBalance {} -> u256 { 0 } // reverts if ETH sent → ABI: "pure"
      }
  }

  Test plan

  - Non-payable recv arm works with zero value
  - Non-payable recv arm reverts with non-zero value (should_revert)
  - Payable recv arm works with zero value
  - Payable recv arm accepts non-zero ETH
  - Non-payable init reverts with non-zero value (should_revert)
  - Payable init accepts non-zero ETH
  - Contract without init deploys with zero value
  - Contract without init reverts with non-zero value (should_revert)
  - MIR snapshot verifies CALLVALUE guards present/absent as expected
  - UI tests for #[payable] on unsupported items (fn, struct, enum, const, extern fn)
  - UI tests for #[payable] on msg variant (targeted error message)
  - UI tests for #[payable] on recv block (targeted error message)
  - UI tests for malformed #[payable(foo)] and #[payable = 1]
  - All existing tests pass (cargo test --workspace)
