### PR TITLE
Implement JSON ABI generation for contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2173,6 +2173,7 @@ dependencies = [
  "similar",
  "smol_str 0.1.24",
  "tempfile",
+ "tiny-keccak",
  "tokio",
  "toml",
  "tracing",

--- a/crates/fe/Cargo.toml
+++ b/crates/fe/Cargo.toml
@@ -33,6 +33,7 @@ solc-runner = { path = "../solc-runner", package = "fe-solc-runner" }
 fe-web = { path = "../fe-web" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
+tiny-keccak = { version = "2.0.2", features = ["keccak"] }
 fmt.workspace = true
 walkdir = "2"
 similar = "2"

--- a/crates/fe/src/abi.rs
+++ b/crates/fe/src/abi.rs
@@ -1,0 +1,1681 @@
+use std::collections::HashSet;
+
+use common::ingot::IngotKind;
+use driver::DriverDataBase;
+use hir::{
+    analysis::{
+        name_resolution::{PathRes, resolve_path},
+        ty::{
+            adt_def::AdtRef,
+            binder::Binder,
+            const_ty::{ConstTyData, EvaluatedConstTy},
+            fold::{AssocTySubst, TyFoldable},
+            trait_def::TraitInstId,
+            trait_resolution::PredicateListId,
+            ty_def::{PrimTy, TyBase, TyData, TyId},
+        },
+    },
+    hir_def::{
+        FieldDefListId, Func, IdentId, PathId, Struct, TopLevelMod, Trait, scope_graph::ScopeId,
+    },
+};
+use serde::Serialize;
+use tiny_keccak::{Hasher, Keccak};
+
+#[derive(Serialize)]
+pub struct AbiEntry {
+    #[serde(rename = "type")]
+    pub entry_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub inputs: Option<Vec<AbiParam>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub outputs: Option<Vec<AbiParam>>,
+    #[serde(rename = "stateMutability", skip_serializing_if = "Option::is_none")]
+    pub state_mutability: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub anonymous: Option<bool>,
+}
+
+#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
+pub struct AbiParam {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub ty: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub indexed: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub components: Option<Vec<AbiParam>>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct AbiTypeDesc {
+    abi_type: String,
+    canonical_type: String,
+    components: Option<Vec<AbiParam>>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct NamedAbiParamDesc {
+    name: String,
+    indexed: Option<bool>,
+    desc: AbiTypeDesc,
+}
+
+impl AbiTypeDesc {
+    fn simple(ty: &str) -> Self {
+        Self {
+            abi_type: ty.to_string(),
+            canonical_type: ty.to_string(),
+            components: None,
+        }
+    }
+
+    fn tuple(components: Vec<AbiParam>, canonical_type: String) -> Self {
+        Self {
+            abi_type: "tuple".to_string(),
+            canonical_type,
+            components: Some(components),
+        }
+    }
+
+    fn array(self, len: &str) -> Self {
+        Self {
+            abi_type: format!("{}[{len}]", self.abi_type),
+            canonical_type: format!("{}[{len}]", self.canonical_type),
+            components: self.components,
+        }
+    }
+}
+
+impl NamedAbiParamDesc {
+    fn into_param(self) -> AbiParam {
+        AbiParam {
+            name: self.name,
+            ty: self.desc.abi_type,
+            indexed: self.indexed,
+            components: self.desc.components,
+        }
+    }
+}
+
+pub struct AbiResult {
+    pub json: String,
+    pub entry_count: usize,
+    pub warnings: Vec<String>,
+}
+
+enum RecvArmAbiEmission {
+    Emit(AbiEntry),
+    Skip(String),
+}
+
+/// Generate an Ethereum-compatible JSON ABI for a given contract inside `top_mod`.
+///
+/// Returns `Ok(None)` if the contract is not found in this module (useful for
+/// ingot builds where a contract may live in a different module).
+pub fn generate_contract_abi(
+    db: &DriverDataBase,
+    top_mod: TopLevelMod<'_>,
+    contract_name: &str,
+) -> Result<Option<AbiResult>, String> {
+    let Some(contract) = top_mod
+        .all_contracts(db)
+        .iter()
+        .find(|c| {
+            c.name(db)
+                .to_opt()
+                .map(|n| n.data(db).as_str() == contract_name)
+                .unwrap_or(false)
+        })
+        .copied()
+    else {
+        return Ok(None);
+    };
+
+    let mut entries = Vec::new();
+    let mut warnings = Vec::new();
+
+    if let Some(init) = contract.init(db) {
+        let inputs = init_params_to_abi_params(db, contract)?
+            .into_iter()
+            .map(NamedAbiParamDesc::into_param)
+            .collect();
+        let state_mutability = if init.is_payable(db) {
+            "payable"
+        } else {
+            "nonpayable"
+        };
+        entries.push(AbiEntry {
+            entry_type: "constructor".to_string(),
+            name: None,
+            inputs: Some(inputs),
+            outputs: None,
+            state_mutability: Some(state_mutability.to_string()),
+            anonymous: None,
+        });
+    }
+
+    let sol_ty = resolve_sol_abi_ty(db, contract.scope())?;
+    for recv in contract.recv_views(db) {
+        for arm_view in recv.arms(db) {
+            match recv_arm_to_abi_entry(db, arm_view, sol_ty) {
+                Ok(RecvArmAbiEmission::Emit(entry)) => entries.push(entry),
+                Ok(RecvArmAbiEmission::Skip(warning)) => warnings.push(warning),
+                Err(e) => return Err(e),
+            }
+        }
+    }
+
+    for struct_ in collect_contract_event_structs(db, contract) {
+        entries.push(event_struct_to_abi_entry(db, struct_)?);
+    }
+
+    let entry_count = entries.len();
+    let json = serde_json::to_string_pretty(&entries)
+        .map_err(|e| format!("JSON serialization error: {e}"))?;
+    Ok(Some(AbiResult {
+        json,
+        entry_count,
+        warnings,
+    }))
+}
+
+fn recv_arm_to_abi_entry(
+    db: &DriverDataBase,
+    arm_view: hir::semantic::RecvArmView<'_>,
+    sol_ty: TyId<'_>,
+) -> Result<RecvArmAbiEmission, String> {
+    arm_view
+        .arm(db)
+        .ok_or_else(|| "missing recv arm during ABI generation".to_string())?;
+    let variant_ty = arm_view.variant_ty(db);
+    let variant_struct = struct_from_ty(db, variant_ty).ok_or_else(|| {
+        format!(
+            "recv arm type `{}` is not a struct",
+            variant_ty.pretty_print(db)
+        )
+    })?;
+    let variant_name = variant_struct
+        .name(db)
+        .to_opt()
+        .map(|name| name.data(db).to_string())
+        .unwrap_or_else(|| "<unknown>".to_string());
+    if !variant_has_canonical_json_abi_shape(db, variant_struct) {
+        return Ok(RecvArmAbiEmission::Skip(format!(
+            "skipping recv arm `{variant_name}`: ABI shape is not compiler-known for manual `MsgVariant` impls; only `msg`-generated variants are emitted"
+        )));
+    }
+    let abi_info = arm_view.abi_info(db, sol_ty);
+    let Some(selector_signature) = abi_info.selector_signature.as_deref() else {
+        return Ok(RecvArmAbiEmission::Skip(format!(
+            "skipping recv arm `{variant_name}`: selector signature is unknown; \
+             use `#[selector = sol(\"name(types)\")]` to include it in the ABI"
+        )));
+    };
+
+    let input_descs = struct_ty_to_abi_param_descs(db, variant_struct, variant_ty, |_| None)?;
+    let outputs = match abi_info.ret_ty {
+        Some(ret_ty) => {
+            let desc = semantic_ty_to_abi_desc(db, ret_ty)?;
+            vec![
+                NamedAbiParamDesc {
+                    name: String::new(),
+                    indexed: None,
+                    desc,
+                }
+                .into_param(),
+            ]
+        }
+        None => Vec::new(),
+    };
+
+    let selector_value = abi_info.selector_value.ok_or_else(|| {
+        format!(
+            "cannot emit JSON ABI for `{selector_signature}`: selector value could not be resolved"
+        )
+    })?;
+    let parsed_signature = parse_function_signature(selector_signature)?;
+    ensure_selector_matches_signature(
+        selector_signature,
+        &parsed_signature,
+        &input_descs,
+        selector_value,
+    )?;
+
+    Ok(RecvArmAbiEmission::Emit(AbiEntry {
+        entry_type: "function".to_string(),
+        name: Some(parsed_signature.name),
+        inputs: Some(
+            input_descs
+                .into_iter()
+                .map(NamedAbiParamDesc::into_param)
+                .collect(),
+        ),
+        outputs: Some(outputs),
+        state_mutability: Some(derive_state_mutability(db, arm_view)),
+        anonymous: None,
+    }))
+}
+
+fn event_struct_to_abi_entry(db: &DriverDataBase, struct_: Struct<'_>) -> Result<AbiEntry, String> {
+    let event_name = struct_
+        .name(db)
+        .to_opt()
+        .map(|name| name.data(db).to_string())
+        .ok_or_else(|| "event struct is missing a name".to_string())?;
+    let field_tys: Vec<_> = struct_
+        .field_tys(db)
+        .into_iter()
+        .map(|ty| ty.instantiate_identity())
+        .collect();
+    let inputs = named_field_param_descs(db, struct_.hir_fields(db), &field_tys, |field| {
+        Some(field.attributes.has_attr(db, "indexed"))
+    })?
+    .into_iter()
+    .map(NamedAbiParamDesc::into_param)
+    .collect();
+
+    Ok(AbiEntry {
+        entry_type: "event".to_string(),
+        name: Some(event_name),
+        inputs: Some(inputs),
+        outputs: None,
+        state_mutability: None,
+        anonymous: None,
+    })
+}
+
+fn collect_contract_event_structs<'db>(
+    db: &'db DriverDataBase,
+    contract: hir::hir_def::Contract<'db>,
+) -> Vec<Struct<'db>> {
+    let mut events = Vec::new();
+    let mut seen = HashSet::new();
+    let mut visited_funcs = HashSet::new();
+    let emit_traits = resolve_event_emit_traits(db, contract.scope());
+
+    if contract.init(db).is_some() {
+        let (_, typed_body) = hir::analysis::ty::ty_check::check_contract_init_body(db, contract);
+        collect_typed_body_event_structs(
+            db,
+            typed_body,
+            &emit_traits,
+            &mut events,
+            &mut seen,
+            &mut visited_funcs,
+        );
+    }
+
+    for recv in contract.recv_views(db) {
+        for arm in recv.arms(db) {
+            let (_, typed_body) = hir::analysis::ty::ty_check::check_contract_recv_arm_body(
+                db,
+                contract,
+                recv.index(db),
+                arm.index(db),
+            );
+            collect_typed_body_event_structs(
+                db,
+                typed_body,
+                &emit_traits,
+                &mut events,
+                &mut seen,
+                &mut visited_funcs,
+            );
+        }
+    }
+
+    events
+}
+
+fn collect_typed_body_event_structs<'db>(
+    db: &'db DriverDataBase,
+    typed_body: &hir::analysis::ty::ty_check::TypedBody<'db>,
+    emit_traits: &EventEmitTraits<'db>,
+    out: &mut Vec<Struct<'db>>,
+    seen: &mut HashSet<Struct<'db>>,
+    visited_funcs: &mut HashSet<VisitedFuncBody<'db>>,
+) {
+    let Some(body) = typed_body.body() else {
+        return;
+    };
+
+    for (expr_id, partial_expr) in body.exprs(db).iter() {
+        let hir::hir_def::Partial::Present(expr) = partial_expr else {
+            continue;
+        };
+        if let Some(struct_) = emitted_event_struct(db, typed_body, body, expr_id, emit_traits) {
+            push_event_struct(db, out, seen, struct_);
+        }
+
+        if matches!(
+            expr,
+            hir::hir_def::Expr::Call(..) | hir::hir_def::Expr::MethodCall(..)
+        ) && let Some(callable) = typed_body.callable_expr(expr_id)
+            && let hir::hir_def::CallableDef::Func(func) = callable.callable_def
+            && visited_funcs.insert(VisitedFuncBody::from_callable(func, callable))
+            && func.body(db).is_some()
+        {
+            let (_, func_typed_body) = hir::analysis::ty::ty_check::check_func_body(db, func);
+            let func_typed_body =
+                instantiate_callable_typed_body(db, func_typed_body.clone(), callable);
+            collect_typed_body_event_structs(
+                db,
+                &func_typed_body,
+                emit_traits,
+                out,
+                seen,
+                visited_funcs,
+            );
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct VisitedFuncBody<'db> {
+    func: Func<'db>,
+    generic_args: Vec<TyId<'db>>,
+    trait_inst: Option<TraitInstId<'db>>,
+}
+
+impl<'db> VisitedFuncBody<'db> {
+    fn from_callable(
+        func: Func<'db>,
+        callable: &hir::analysis::ty::ty_check::Callable<'db>,
+    ) -> Self {
+        Self {
+            func,
+            generic_args: callable.generic_args().to_vec(),
+            trait_inst: callable.trait_inst(),
+        }
+    }
+}
+
+fn instantiate_callable_typed_body<'db>(
+    db: &'db DriverDataBase,
+    typed_body: hir::analysis::ty::ty_check::TypedBody<'db>,
+    callable: &hir::analysis::ty::ty_check::Callable<'db>,
+) -> hir::analysis::ty::ty_check::TypedBody<'db> {
+    let mut typed_body = Binder::bind(typed_body).instantiate(db, callable.generic_args());
+    if let Some(trait_inst) = callable.trait_inst() {
+        let mut subst = AssocTySubst::new(trait_inst);
+        typed_body = typed_body.fold_with(db, &mut subst);
+    }
+    typed_body
+}
+
+struct EventEmitTraits<'db> {
+    log_trait: Option<Trait<'db>>,
+    event_trait: Option<Trait<'db>>,
+}
+
+fn resolve_event_emit_traits<'db>(
+    db: &'db DriverDataBase,
+    scope: ScopeId<'db>,
+) -> EventEmitTraits<'db> {
+    EventEmitTraits {
+        log_trait: resolve_lib_trait_path(db, scope, "std::evm::effects::Log"),
+        event_trait: resolve_lib_trait_path(db, scope, "std::evm::event::Event"),
+    }
+}
+
+fn emitted_event_struct<'db>(
+    db: &'db DriverDataBase,
+    typed_body: &hir::analysis::ty::ty_check::TypedBody<'db>,
+    body: hir::hir_def::Body<'db>,
+    expr_id: hir::hir_def::ExprId,
+    emit_traits: &EventEmitTraits<'db>,
+) -> Option<Struct<'db>> {
+    let hir::hir_def::Partial::Present(hir::hir_def::Expr::MethodCall(
+        receiver,
+        method_name,
+        _,
+        args,
+    )) = expr_id.data(db, body)
+    else {
+        return None;
+    };
+    let method_name = method_name.to_opt()?;
+    if method_name.data(db) != "emit" {
+        return None;
+    }
+
+    let callable = typed_body.callable_expr(expr_id)?;
+    let hir::hir_def::CallableDef::Func(func) = callable.callable_def else {
+        return None;
+    };
+    if func.name(db).to_opt()? != method_name {
+        return None;
+    }
+
+    let trait_def = callable.trait_inst()?.def(db);
+    if emit_traits
+        .log_trait
+        .is_some_and(|log_trait| trait_def == log_trait)
+    {
+        let event_expr = args.first()?.expr;
+        let struct_ = struct_from_ty(db, typed_body.expr_ty(db, event_expr))?;
+        return is_event_struct(db, struct_).then_some(struct_);
+    }
+    if emit_traits
+        .event_trait
+        .is_some_and(|event_trait| trait_def == event_trait)
+    {
+        let struct_ = struct_from_ty(db, typed_body.expr_ty(db, *receiver))?;
+        return is_event_struct(db, struct_).then_some(struct_);
+    }
+
+    None
+}
+
+fn push_event_struct<'db>(
+    db: &'db DriverDataBase,
+    out: &mut Vec<Struct<'db>>,
+    seen: &mut HashSet<Struct<'db>>,
+    struct_: Struct<'db>,
+) {
+    if !seen.insert(struct_) || !is_event_struct(db, struct_) {
+        return;
+    }
+    out.push(struct_);
+}
+
+fn is_event_struct(db: &DriverDataBase, struct_: Struct<'_>) -> bool {
+    matches!(
+        hir::span::struct_ast(db, struct_),
+        hir::span::HirOrigin::Desugared(hir::span::DesugaredOrigin::Event(_))
+    )
+}
+
+fn variant_has_canonical_json_abi_shape(db: &DriverDataBase, struct_: Struct<'_>) -> bool {
+    matches!(
+        hir::span::struct_ast(db, struct_),
+        hir::span::HirOrigin::Desugared(hir::span::DesugaredOrigin::Msg(_))
+    )
+}
+
+fn resolve_lib_trait_path<'db>(
+    db: &'db DriverDataBase,
+    scope: ScopeId<'db>,
+    path: &str,
+) -> Option<Trait<'db>> {
+    let mut segments = path.split("::");
+    let root = segments.next()?;
+
+    let ingot = scope.ingot(db);
+    let mut path = if (ingot.kind(db) == IngotKind::Std && root == "std")
+        || (ingot.kind(db) == IngotKind::Core && root == "core")
+    {
+        PathId::from_ident(db, IdentId::make_ingot(db))
+    } else {
+        PathId::from_str(db, root)
+    };
+
+    for segment in segments {
+        path = path.push_str(db, segment);
+    }
+
+    let assumptions = PredicateListId::empty_list(db);
+    match resolve_path(db, path, scope, assumptions, true).ok()? {
+        PathRes::Trait(inst) => Some(inst.def(db)),
+        _ => None,
+    }
+}
+
+fn init_params_to_abi_params(
+    db: &DriverDataBase,
+    contract: hir::hir_def::Contract<'_>,
+) -> Result<Vec<NamedAbiParamDesc>, String> {
+    let Some(init) = contract.init(db) else {
+        return Ok(Vec::new());
+    };
+
+    let params: Vec<_> = init
+        .params(db)
+        .data(db)
+        .iter()
+        .filter(|param| !param.is_self_param(db))
+        .collect();
+    let param_tys = contract.init_args_ty(db).field_types(db);
+
+    if params.len() != param_tys.len() {
+        return Err(format!(
+            "constructor parameter count mismatch: {} names vs {} semantic types",
+            params.len(),
+            param_tys.len()
+        ));
+    }
+
+    params
+        .into_iter()
+        .zip(param_tys)
+        .map(|(param, ty)| {
+            let name = param
+                .name()
+                .map(|ident| ident.data(db).to_string())
+                .unwrap_or_default();
+            Ok(NamedAbiParamDesc {
+                name,
+                indexed: None,
+                desc: semantic_ty_to_abi_desc(db, ty)?,
+            })
+        })
+        .collect()
+}
+
+fn struct_ty_to_abi_param_descs(
+    db: &DriverDataBase,
+    struct_: Struct<'_>,
+    ty: TyId<'_>,
+    indexed: impl Fn(&hir::hir_def::FieldDef<'_>) -> Option<bool>,
+) -> Result<Vec<NamedAbiParamDesc>, String> {
+    let field_tys = ty.field_types(db);
+    named_field_param_descs(db, struct_.hir_fields(db), &field_tys, indexed)
+}
+
+fn named_field_param_descs(
+    db: &DriverDataBase,
+    fields: FieldDefListId<'_>,
+    field_tys: &[TyId<'_>],
+    indexed: impl Fn(&hir::hir_def::FieldDef<'_>) -> Option<bool>,
+) -> Result<Vec<NamedAbiParamDesc>, String> {
+    let hir_fields = fields.data(db);
+    if hir_fields.len() != field_tys.len() {
+        return Err(format!(
+            "field count mismatch: {} HIR fields vs {} semantic fields",
+            hir_fields.len(),
+            field_tys.len()
+        ));
+    }
+
+    hir_fields
+        .iter()
+        .zip(field_tys.iter().copied())
+        .map(|(field, ty)| {
+            let name = field
+                .name
+                .to_opt()
+                .map(|ident| ident.data(db).to_string())
+                .unwrap_or_default();
+            Ok(NamedAbiParamDesc {
+                name,
+                indexed: indexed(field),
+                desc: semantic_ty_to_abi_desc(db, ty)?,
+            })
+        })
+        .collect()
+}
+
+fn semantic_ty_to_abi_desc(db: &DriverDataBase, ty: TyId<'_>) -> Result<AbiTypeDesc, String> {
+    if let Some((_, inner)) = ty.as_capability(db) {
+        return semantic_ty_to_abi_desc(db, inner);
+    }
+
+    if ty == TyId::unit(db) {
+        return Err("unit type is not a valid external ABI parameter".to_string());
+    }
+
+    if ty.is_tuple(db) {
+        let components = ty.field_types(db);
+        let component_descs: Vec<_> = components
+            .into_iter()
+            .map(|field_ty| semantic_ty_to_abi_desc(db, field_ty))
+            .collect::<Result<_, _>>()?;
+        return Ok(AbiTypeDesc::tuple(
+            component_descs
+                .iter()
+                .map(|desc| AbiParam {
+                    name: String::new(),
+                    ty: desc.abi_type.clone(),
+                    indexed: None,
+                    components: desc.components.clone(),
+                })
+                .collect(),
+            canonical_tuple_type(&component_descs),
+        ));
+    }
+
+    if ty.is_array(db) {
+        let (_, args) = ty.decompose_ty_app(db);
+        let elem_ty = args
+            .first()
+            .copied()
+            .ok_or_else(|| "array type is missing its element type".to_string())?;
+        let len_ty = args
+            .get(1)
+            .copied()
+            .ok_or_else(|| "array type is missing its length".to_string())?;
+        let elem_desc = semantic_ty_to_abi_desc(db, elem_ty)?;
+        let len = array_len_to_string(db, len_ty)?;
+        return Ok(elem_desc.array(&len));
+    }
+
+    if ty.is_string(db) {
+        return Ok(AbiTypeDesc::simple("string"));
+    }
+
+    match ty.base_ty(db).data(db) {
+        TyData::TyBase(TyBase::Prim(prim)) => match prim {
+            PrimTy::Bool => Ok(AbiTypeDesc::simple("bool")),
+            PrimTy::U8 => Ok(AbiTypeDesc::simple("uint8")),
+            PrimTy::U16 => Ok(AbiTypeDesc::simple("uint16")),
+            PrimTy::U32 => Ok(AbiTypeDesc::simple("uint32")),
+            PrimTy::U64 => Ok(AbiTypeDesc::simple("uint64")),
+            PrimTy::U128 => Ok(AbiTypeDesc::simple("uint128")),
+            PrimTy::U256 | PrimTy::Usize => Ok(AbiTypeDesc::simple("uint256")),
+            PrimTy::I8 => Ok(AbiTypeDesc::simple("int8")),
+            PrimTy::I16 => Ok(AbiTypeDesc::simple("int16")),
+            PrimTy::I32 => Ok(AbiTypeDesc::simple("int32")),
+            PrimTy::I64 => Ok(AbiTypeDesc::simple("int64")),
+            PrimTy::I128 => Ok(AbiTypeDesc::simple("int128")),
+            PrimTy::I256 | PrimTy::Isize => Ok(AbiTypeDesc::simple("int256")),
+            PrimTy::String | PrimTy::Array | PrimTy::Tuple(_) => unreachable!(),
+            PrimTy::Ptr | PrimTy::View | PrimTy::BorrowMut | PrimTy::BorrowRef => {
+                Err(format!("unsupported ABI type `{}`", ty.pretty_print(db)))
+            }
+        },
+        TyData::TyBase(TyBase::Adt(adt)) => {
+            let adt_ref = adt.adt_ref(db);
+            if is_std_address_ty(db, ty, adt_ref) {
+                return Ok(AbiTypeDesc::simple("address"));
+            }
+            if let Some(sol_type) = std_sol_compat_abi_type(db, ty, adt_ref) {
+                return Ok(AbiTypeDesc::simple(&sol_type));
+            }
+            match adt_ref {
+                AdtRef::Struct(struct_) => {
+                    let component_descs = struct_ty_to_abi_param_descs(db, struct_, ty, |_| None)?;
+                    let components: Vec<_> = component_descs
+                        .iter()
+                        .cloned()
+                        .map(NamedAbiParamDesc::into_param)
+                        .collect();
+                    let canonical = canonical_tuple_type(
+                        &component_descs
+                            .iter()
+                            .map(|param| param.desc.clone())
+                            .collect::<Vec<_>>(),
+                    );
+                    Ok(AbiTypeDesc::tuple(components, canonical))
+                }
+                AdtRef::Enum(_) => Err(format!(
+                    "unsupported ABI enum type `{}`",
+                    ty.pretty_print(db)
+                )),
+            }
+        }
+        TyData::Invalid(_) => Err(format!("unresolved ABI type `{}`", ty.pretty_print(db))),
+        _ => Err(format!("unsupported ABI type `{}`", ty.pretty_print(db))),
+    }
+}
+
+fn array_len_to_string(db: &DriverDataBase, ty: TyId<'_>) -> Result<String, String> {
+    match ty.data(db) {
+        TyData::ConstTy(const_ty) => match const_ty.data(db) {
+            ConstTyData::Evaluated(EvaluatedConstTy::LitInt(value), _) => {
+                Ok(value.data(db).to_string())
+            }
+            _ => Err(format!(
+                "array length `{}` is not a concrete integer",
+                ty.pretty_print(db)
+            )),
+        },
+        _ => Err(format!(
+            "array length `{}` is not represented as a const type",
+            ty.pretty_print(db)
+        )),
+    }
+}
+
+fn struct_from_ty<'db>(db: &'db DriverDataBase, ty: TyId<'db>) -> Option<Struct<'db>> {
+    if let Some((_, inner)) = ty.as_capability(db) {
+        return struct_from_ty(db, inner);
+    }
+    match ty.base_ty(db).data(db) {
+        TyData::TyBase(TyBase::Adt(adt)) => match adt.adt_ref(db) {
+            AdtRef::Struct(struct_) => Some(struct_),
+            AdtRef::Enum(_) => None,
+        },
+        TyData::QualifiedTy(trait_inst) => struct_from_ty(db, trait_inst.self_ty(db)),
+        _ => None,
+    }
+}
+
+fn is_std_address_ty(db: &DriverDataBase, ty: TyId<'_>, adt_ref: AdtRef<'_>) -> bool {
+    let Some(name) = adt_ref.name(db) else {
+        return false;
+    };
+    if name.data(db) != "Address" {
+        return false;
+    }
+    ty.ingot(db)
+        .is_some_and(|ingot| ingot.kind(db) == IngotKind::Std)
+}
+
+/// Recognise `std::abi::sol` SolCompat wrapper types like `Uint160` / `Int24`
+/// and return their Solidity ABI type string (e.g. `"uint160"`, `"int24"`).
+fn std_sol_compat_abi_type(
+    db: &DriverDataBase,
+    ty: TyId<'_>,
+    adt_ref: AdtRef<'_>,
+) -> Option<String> {
+    if !ty
+        .ingot(db)
+        .is_some_and(|ingot| ingot.kind(db) == IngotKind::Std)
+    {
+        return None;
+    }
+    let name = adt_ref.name(db)?.data(db).to_string();
+
+    // Match Uint{N} or Int{N} where N is a valid Solidity bit width (8..=256, multiple of 8)
+    let (prefix, digits) = if let Some(rest) = name.strip_prefix("Uint") {
+        ("uint", rest)
+    } else if let Some(rest) = name.strip_prefix("Int") {
+        ("int", rest)
+    } else {
+        return None;
+    };
+
+    let bits: u16 = digits.parse().ok()?;
+    if (8..=256).contains(&bits) && bits.is_multiple_of(8) {
+        Some(format!("{prefix}{bits}"))
+    } else {
+        None
+    }
+}
+
+fn canonical_tuple_type(component_descs: &[AbiTypeDesc]) -> String {
+    let mut out = String::from("(");
+    for (idx, desc) in component_descs.iter().enumerate() {
+        if idx > 0 {
+            out.push(',');
+        }
+        out.push_str(&desc.canonical_type);
+    }
+    out.push(')');
+    out
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ParsedFunctionSignature {
+    name: String,
+    arg_types: Vec<String>,
+}
+
+fn parse_function_signature(signature: &str) -> Result<ParsedFunctionSignature, String> {
+    let (name, args) = signature.split_once('(').ok_or_else(|| {
+        format!(
+            "cannot emit JSON ABI for `{signature}`: selector signature must be of the form `name(type,...)`"
+        )
+    })?;
+    let args = args.strip_suffix(')').ok_or_else(|| {
+        format!("cannot emit JSON ABI for `{signature}`: selector signature must end with `)`")
+    })?;
+    if name.is_empty() || name.trim() != name || name.chars().any(char::is_whitespace) {
+        return Err(format!(
+            "cannot emit JSON ABI for `{signature}`: selector function name must be a single identifier"
+        ));
+    }
+
+    Ok(ParsedFunctionSignature {
+        name: name.to_string(),
+        arg_types: split_signature_args(signature, args)?,
+    })
+}
+
+fn split_signature_args(signature: &str, args: &str) -> Result<Vec<String>, String> {
+    if args.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut arg_types = Vec::new();
+    let mut start = 0;
+    let mut tuple_depth = 0usize;
+    let mut array_depth = 0usize;
+
+    for (idx, ch) in args.char_indices() {
+        match ch {
+            '(' => tuple_depth += 1,
+            ')' => {
+                if tuple_depth == 0 {
+                    return Err(format!(
+                        "cannot emit JSON ABI for `{signature}`: unbalanced `)` in selector signature"
+                    ));
+                }
+                tuple_depth -= 1;
+            }
+            '[' => array_depth += 1,
+            ']' => {
+                if array_depth == 0 {
+                    return Err(format!(
+                        "cannot emit JSON ABI for `{signature}`: unbalanced `]` in selector signature"
+                    ));
+                }
+                array_depth -= 1;
+            }
+            ',' if tuple_depth == 0 && array_depth == 0 => {
+                let arg = args[start..idx].trim();
+                if arg.is_empty() {
+                    return Err(format!(
+                        "cannot emit JSON ABI for `{signature}`: empty selector argument type"
+                    ));
+                }
+                arg_types.push(arg.to_string());
+                start = idx + 1;
+            }
+            _ => {}
+        }
+    }
+
+    if tuple_depth != 0 || array_depth != 0 {
+        return Err(format!(
+            "cannot emit JSON ABI for `{signature}`: unbalanced selector argument list"
+        ));
+    }
+
+    let last = args[start..].trim();
+    if last.is_empty() {
+        return Err(format!(
+            "cannot emit JSON ABI for `{signature}`: empty selector argument type"
+        ));
+    }
+    arg_types.push(last.to_string());
+    Ok(arg_types)
+}
+
+fn ensure_selector_matches_signature(
+    source_signature: &str,
+    parsed_signature: &ParsedFunctionSignature,
+    inputs: &[NamedAbiParamDesc],
+    actual_selector: u32,
+) -> Result<(), String> {
+    if parsed_signature.arg_types.len() != inputs.len() {
+        return Err(format!(
+            "cannot emit JSON ABI for `{source_signature}`: selector arity {} does not match semantic arity {}",
+            parsed_signature.arg_types.len(),
+            inputs.len()
+        ));
+    }
+
+    for (selector_ty, input) in parsed_signature.arg_types.iter().zip(inputs) {
+        if selector_ty != &input.desc.canonical_type {
+            return Err(format!(
+                "cannot emit JSON ABI for `{source_signature}`: selector argument type `{selector_ty}` does not match semantic ABI type `{}`",
+                input.desc.canonical_type
+            ));
+        }
+    }
+
+    let canonical_signature = canonical_function_signature(&parsed_signature.name, inputs);
+    let expected_selector = selector_for_signature(&canonical_signature);
+    if actual_selector != expected_selector {
+        return Err(format!(
+            "cannot emit JSON ABI for `{source_signature}`: non-canonical selector 0x{actual_selector:08x} does not match canonical signature `{canonical_signature}` (0x{expected_selector:08x})"
+        ));
+    }
+    Ok(())
+}
+
+fn canonical_function_signature(fn_name: &str, inputs: &[NamedAbiParamDesc]) -> String {
+    let mut signature = String::new();
+    signature.push_str(fn_name);
+    signature.push('(');
+    for (idx, input) in inputs.iter().enumerate() {
+        if idx > 0 {
+            signature.push(',');
+        }
+        signature.push_str(&input.desc.canonical_type);
+    }
+    signature.push(')');
+    signature
+}
+
+fn selector_for_signature(signature: &str) -> u32 {
+    let mut hasher = Keccak::v256();
+    let mut output = [0u8; 32];
+    hasher.update(signature.as_bytes());
+    hasher.finalize(&mut output);
+    u32::from_be_bytes([output[0], output[1], output[2], output[3]])
+}
+
+fn resolve_sol_abi_ty<'db>(
+    db: &'db DriverDataBase,
+    scope: ScopeId<'db>,
+) -> Result<TyId<'db>, String> {
+    let ingot = scope.ingot(db);
+    let std_root = if ingot.kind(db) == IngotKind::Std {
+        IdentId::make_ingot(db)
+    } else {
+        IdentId::new(db, "std".to_string())
+    };
+
+    let sol_path = PathId::from_ident(db, std_root)
+        .push_ident(db, IdentId::new(db, "abi".to_string()))
+        .push_ident(db, IdentId::new(db, "Sol".to_string()));
+
+    let assumptions = PredicateListId::empty_list(db);
+    match resolve_path(db, sol_path, scope, assumptions, false) {
+        Ok(PathRes::Ty(ty) | PathRes::TyAlias(_, ty)) => Ok(ty),
+        Ok(other) => Err(format!(
+            "expected `std::abi::Sol` to resolve to a type, got `{other:?}`"
+        )),
+        Err(err) => Err(format!("failed to resolve `std::abi::Sol`: {err:?}")),
+    }
+}
+
+/// Derive ABI state mutability from the effective recv-arm effect set.
+fn derive_state_mutability(
+    db: &DriverDataBase,
+    arm_view: hir::semantic::RecvArmView<'_>,
+) -> String {
+    let arm = arm_view
+        .arm(db)
+        .expect("recv arm should exist during ABI generation");
+    if arm.is_payable(db) {
+        return "payable".to_string();
+    }
+
+    let effects = arm_view.effective_effect_bindings(db);
+    if effects.is_empty() {
+        "pure".to_string()
+    } else if effects.iter().any(|effect| effect.is_mut) {
+        "nonpayable".to_string()
+    } else {
+        "view".to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use common::InputDb;
+    use driver::DriverDataBase;
+    use serde_json::Value;
+
+    fn generate_test_abi_result(code: &str, contract_name: &str) -> Result<AbiResult, String> {
+        let temp = tempfile::tempdir().expect("create temp dir");
+        let file_path = temp.path().join("test.fe");
+        let url = url::Url::from_file_path(&file_path).expect("file path to url");
+        let mut db = DriverDataBase::default();
+        let file = db.workspace().touch(&mut db, url, Some(code.to_string()));
+        let top_mod = db.top_mod(file);
+        generate_contract_abi(&db, top_mod, contract_name)?
+            .ok_or_else(|| format!("contract `{contract_name}` not found"))
+    }
+
+    fn generate_test_abi(code: &str, contract_name: &str) -> Result<String, String> {
+        generate_test_abi_result(code, contract_name).map(|r| r.json)
+    }
+
+    fn abi_entries(code: &str, contract_name: &str) -> Vec<Value> {
+        let abi = generate_test_abi(code, contract_name).expect("generate abi");
+        serde_json::from_str(&abi).expect("parse abi json")
+    }
+
+    #[test]
+    fn hex_selector_skips_arm_with_warning() {
+        let code = r#"
+msg FooMsg {
+    #[selector = 0x12345678]
+    Ping -> u256,
+}
+
+pub contract Foo {
+    recv FooMsg {
+        Ping -> u256 {
+            return 1
+        }
+    }
+}
+"#;
+
+        let result = generate_test_abi_result(code, "Foo").expect("ABI generation should succeed");
+        let entries: Vec<Value> = serde_json::from_str(&result.json).expect("parse abi json");
+        assert!(
+            entries.iter().all(|e| e["type"] != "function"),
+            "hex-selector arm should be skipped"
+        );
+        assert_eq!(result.warnings.len(), 1);
+        assert!(
+            result.warnings[0].contains("selector signature is unknown"),
+            "unexpected warning: {}",
+            result.warnings[0]
+        );
+    }
+
+    #[test]
+    fn sol_selector_alias_uses_source_function_name() {
+        let code = r#"
+use std::abi::sol
+
+msg FooMsg {
+    #[selector = sol("foo(uint256)")]
+    Bar { value: u256 } -> u256,
+}
+
+pub contract Foo {
+    recv FooMsg {
+        Bar { value } -> u256 {
+            value
+        }
+    }
+}
+"#;
+
+        let entries = abi_entries(code, "Foo");
+        let function = entries
+            .iter()
+            .find(|entry| entry["type"] == "function")
+            .expect("function entry");
+
+        assert_eq!(function["name"], "foo");
+        assert_eq!(function["inputs"][0]["type"], "uint256");
+    }
+
+    #[test]
+    fn selector_const_alias_preserves_signature() {
+        let code = r#"
+use std::abi::sol
+
+const PING: u32 = sol("ping()")
+
+msg FooMsg {
+    #[selector = PING]
+    Ping,
+}
+
+pub contract Foo {
+    recv FooMsg {
+        Ping {}
+    }
+}
+"#;
+
+        let entries = abi_entries(code, "Foo");
+        let function = entries
+            .iter()
+            .find(|entry| entry["type"] == "function")
+            .expect("function entry");
+
+        assert_eq!(function["name"], "ping");
+    }
+
+    #[test]
+    fn selector_const_block_preserves_signature() {
+        let code = r#"
+use std::abi::sol
+
+const PING: u32 = { sol("ping()") }
+
+msg FooMsg {
+    #[selector = PING]
+    Ping,
+}
+
+pub contract Foo {
+    recv FooMsg {
+        Ping {}
+    }
+}
+"#;
+
+        let entries = abi_entries(code, "Foo");
+        let function = entries
+            .iter()
+            .find(|entry| entry["type"] == "function")
+            .expect("function entry");
+
+        assert_eq!(function["name"], "ping");
+    }
+
+    #[test]
+    fn selector_const_block_local_alias_preserves_signature() {
+        let code = r#"
+use std::abi::sol
+
+const PING: u32 = {
+    let x = sol("ping()");
+    x
+}
+
+msg FooMsg {
+    #[selector = PING]
+    Ping,
+}
+
+pub contract Foo {
+    recv FooMsg {
+        Ping {}
+    }
+}
+"#;
+
+        let entries = abi_entries(code, "Foo");
+        let function = entries
+            .iter()
+            .find(|entry| entry["type"] == "function")
+            .expect("function entry");
+
+        assert_eq!(function["name"], "ping");
+    }
+
+    #[test]
+    fn selector_const_block_local_alias_chain_preserves_signature() {
+        let code = r#"
+use std::abi::sol
+
+const PING: u32 = {
+    let x = sol("ping()");
+    let y = x;
+    y
+}
+
+msg FooMsg {
+    #[selector = PING]
+    Ping,
+}
+
+pub contract Foo {
+    recv FooMsg {
+        Ping {}
+    }
+}
+"#;
+
+        let entries = abi_entries(code, "Foo");
+        let function = entries
+            .iter()
+            .find(|entry| entry["type"] == "function")
+            .expect("function entry");
+
+        assert_eq!(function["name"], "ping");
+    }
+
+    #[test]
+    fn selector_const_fn_preserves_signature() {
+        let code = r#"
+use std::abi::sol
+
+const fn ping_selector() -> u32 { sol("ping()") }
+
+msg FooMsg {
+    #[selector = ping_selector()]
+    Ping,
+}
+
+pub contract Foo {
+    recv FooMsg {
+        Ping {}
+    }
+}
+"#;
+
+        let entries = abi_entries(code, "Foo");
+        let function = entries
+            .iter()
+            .find(|entry| entry["type"] == "function")
+            .expect("function entry");
+
+        assert_eq!(function["name"], "ping");
+    }
+
+    #[test]
+    fn sol_selector_preserves_source_casing() {
+        let code = r#"
+use std::abi::sol
+
+msg FooMsg {
+    #[selector = sol("urlValue()")]
+    URLValue,
+}
+
+pub contract Foo {
+    recv FooMsg {
+        URLValue {
+        }
+    }
+}
+"#;
+
+        let entries = abi_entries(code, "Foo");
+        let function = entries
+            .iter()
+            .find(|entry| entry["type"] == "function")
+            .expect("function entry");
+
+        assert_eq!(function["name"], "urlValue");
+        assert_eq!(
+            function["inputs"].as_array().expect("inputs array").len(),
+            0
+        );
+    }
+
+    #[test]
+    fn manual_generic_recv_variants_are_skipped_with_warning() {
+        let code = r#"
+use std::abi::sol
+
+struct GenericMsg<T> {
+    pub value: T,
+}
+
+impl<T> core::abi::Encode<std::abi::Sol> for GenericMsg<T>
+    where T: core::abi::Encode<std::abi::Sol>
+{
+    fn encode<E: core::abi::AbiEncoder<std::abi::Sol>>(own self, _ e: mut E) {
+        let Self { value } = self
+        value.encode(e)
+    }
+}
+
+impl<T> core::abi::Decode<std::abi::Sol> for GenericMsg<T>
+    where T: core::abi::Decode<std::abi::Sol>
+{
+    fn decode<D: core::abi::AbiDecoder<std::abi::Sol>>(_ d: mut D) -> Self {
+        let value = T::decode(d)
+        Self { value }
+    }
+}
+
+impl core::message::MsgVariant<std::abi::Sol> for GenericMsg<u8> {
+    const SELECTOR: u32 = sol("genericMsg(uint8)")
+    type Return = u8
+}
+
+impl core::message::MsgVariant<std::abi::Sol> for GenericMsg<u16> {
+    const SELECTOR: u32 = sol("genericMsg(uint16)")
+    type Return = u16
+}
+
+pub contract GenericRecvContract {
+    recv {
+        GenericMsg<u8> { value } -> u8 uses () {
+            value
+        }
+        GenericMsg<u16> { value } -> u16 uses () {
+            value
+        }
+    }
+}
+"#;
+
+        let result = generate_test_abi_result(code, "GenericRecvContract")
+            .expect("ABI generation should succeed");
+        let entries: Vec<Value> = serde_json::from_str(&result.json).expect("parse abi json");
+        assert!(
+            entries.iter().all(|entry| entry["type"] != "function"),
+            "manual generic MsgVariant impls should be skipped"
+        );
+        assert_eq!(result.warnings.len(), 2);
+        assert!(
+            result
+                .warnings
+                .iter()
+                .all(|warning| warning.contains("manual `MsgVariant` impls")),
+            "unexpected warnings: {:?}",
+            result.warnings
+        );
+    }
+
+    #[test]
+    fn manual_msg_variant_impls_are_skipped_with_warning() {
+        let code = r#"
+use std::abi::sol
+
+struct Weird {
+    pub amount: u64,
+    pub flag: bool,
+}
+
+impl core::abi::Encode<std::abi::Sol> for Weird {
+    fn encode<E: core::abi::AbiEncoder<std::abi::Sol>>(own self, _ e: mut E) {
+        self.flag.encode(e)
+        self.amount.encode(e)
+    }
+}
+
+impl core::abi::Decode<std::abi::Sol> for Weird {
+    fn decode<D: core::abi::AbiDecoder<std::abi::Sol>>(_ d: mut D) -> Self {
+        let flag = bool::decode(d)
+        let amount = u64::decode(d)
+        Self { amount, flag }
+    }
+}
+
+impl core::message::MsgVariant<std::abi::Sol> for Weird {
+    const SELECTOR: u32 = sol("foo(bool,uint64)")
+    type Return = ()
+}
+
+pub contract Foo {
+    recv {
+        Weird { amount, flag } uses () {
+            let _ = amount
+            let _ = flag
+        }
+    }
+}
+"#;
+
+        let result = generate_test_abi_result(code, "Foo").expect("ABI generation should succeed");
+        let entries: Vec<Value> = serde_json::from_str(&result.json).expect("parse abi json");
+        assert!(
+            entries.iter().all(|e| e["type"] != "function"),
+            "manual MsgVariant should be skipped"
+        );
+        assert_eq!(result.warnings.len(), 1);
+        assert!(
+            result.warnings[0].contains("manual `MsgVariant` impls"),
+            "unexpected warning: {}",
+            result.warnings[0]
+        );
+    }
+
+    #[test]
+    fn manual_module_msg_variants_are_skipped_with_warning() {
+        let code = r#"
+use std::abi::sol
+
+mod TokenMsg {
+    pub struct Transfer {
+        pub to: u64,
+        pub amount: u64,
+    }
+
+    impl core::abi::Encode<std::abi::Sol> for Transfer {
+        fn encode<E: core::abi::AbiEncoder<std::abi::Sol>>(own self, _ e: mut E) {
+            self.to.encode(e)
+            self.amount.encode(e)
+        }
+    }
+
+    impl core::abi::Decode<std::abi::Sol> for Transfer {
+        fn decode<D: core::abi::AbiDecoder<std::abi::Sol>>(_ d: mut D) -> Self {
+            let to = u64::decode(d)
+            let amount = u64::decode(d)
+            Self { to, amount }
+        }
+    }
+
+    impl core::message::MsgVariant<std::abi::Sol> for Transfer {
+        const SELECTOR: u32 = sol("transfer(uint64,uint64)")
+        type Return = bool
+    }
+}
+
+pub contract Foo {
+    recv TokenMsg {
+        Transfer { to, amount } -> bool uses () {
+            let _ = to
+            let _ = amount
+            true
+        }
+    }
+}
+"#;
+
+        let result = generate_test_abi_result(code, "Foo").expect("ABI generation should succeed");
+        let entries: Vec<Value> = serde_json::from_str(&result.json).expect("parse abi json");
+        assert!(
+            entries.iter().all(|e| e["type"] != "function"),
+            "manual MsgVariant module should be skipped"
+        );
+        assert_eq!(result.warnings.len(), 1);
+        assert!(
+            result.warnings[0].contains("manual `MsgVariant` impls"),
+            "unexpected warning: {}",
+            result.warnings[0]
+        );
+    }
+
+    #[test]
+    fn constructed_events_without_emit_are_not_included() {
+        let code = r#"
+use std::abi::sol
+
+#[event]
+struct Transfer {
+    value: u256,
+}
+
+msg FooMsg {
+    #[selector = sol("ping()")]
+    Ping,
+}
+
+pub contract Foo {
+    recv FooMsg {
+        Ping uses () {
+            helper()
+        }
+    }
+}
+
+fn helper() {
+    let _ = Transfer { value: 1 }
+}
+"#;
+
+        let entries = abi_entries(code, "Foo");
+        assert!(
+            entries
+                .iter()
+                .all(|entry| !(entry["type"] == "event" && entry["name"] == "Transfer")),
+            "constructed-but-not-emitted event should be absent: {entries:?}"
+        );
+    }
+
+    #[test]
+    fn recv_variant_resolution_survives_same_name_event_structs() {
+        let code = r#"
+use std::abi::sol
+
+msg Erc20 {
+    #[selector = sol("transfer(uint256,uint256)")]
+    Transfer { to: u256, amount: u256 } -> bool,
+}
+
+#[event]
+struct Transfer {
+    #[indexed]
+    from: u256,
+    #[indexed]
+    to: u256,
+    value: u256,
+}
+
+pub contract C {
+    recv Erc20 {
+        Transfer { to, amount } -> bool {
+            let _ = to
+            let _ = amount
+            true
+        }
+    }
+}
+"#;
+
+        let entries = abi_entries(code, "C");
+        let function = entries
+            .iter()
+            .find(|entry| entry["type"] == "function")
+            .expect("function entry");
+        assert_eq!(function["name"], "transfer");
+        assert_eq!(function["inputs"][0]["name"], "to");
+        assert_eq!(function["inputs"][1]["name"], "amount");
+    }
+
+    #[test]
+    fn tuple_and_fixed_array_types_emit_components_and_lengths() {
+        let code = r#"
+use std::abi::sol
+
+msg TupleMsg {
+    #[selector = sol("setPair((uint64,bool),uint256[2])")]
+    SetPair { pair: (u64, bool), values: [u256; 2] } -> (u64, bool),
+}
+
+pub contract TupleContract {
+    recv TupleMsg {
+        SetPair { pair, values } -> (u64, bool) uses () {
+            let _ = values
+            pair
+        }
+    }
+}
+"#;
+
+        let entries = abi_entries(code, "TupleContract");
+        let function = entries
+            .iter()
+            .find(|entry| entry["type"] == "function")
+            .expect("function entry");
+
+        assert_eq!(function["inputs"][0]["type"], "tuple");
+        assert_eq!(function["inputs"][0]["components"][0]["type"], "uint64");
+        assert_eq!(function["inputs"][0]["components"][1]["type"], "bool");
+        assert_eq!(function["inputs"][1]["type"], "uint256[2]");
+        assert_eq!(function["outputs"][0]["type"], "tuple");
+        assert_eq!(function["outputs"][0]["components"][0]["type"], "uint64");
+        assert_eq!(function["outputs"][0]["components"][1]["type"], "bool");
+    }
+
+    #[test]
+    fn recv_mutability_uses_effective_contract_scoped_bindings() {
+        let code = r#"
+use std::abi::sol
+use std::evm::{Address, Call, Ctx}
+
+msg FooMsg {
+    #[selector = sol("who()")]
+    Who -> u256,
+    #[selector = sol("ping(address)")]
+    Ping { b: Address },
+}
+
+msg BarMsg {
+    #[selector = sol("pong()")]
+    Pong,
+}
+
+pub contract Foo uses (ctx: Ctx, call: mut Call) {
+    recv FooMsg {
+        Who -> u256 uses (ctx) {
+            ctx.caller().inner
+        }
+
+        Ping { b } uses (call) {
+            call.call(addr: b, gas: 100000, value: 0, message: BarMsg::Pong {})
+        }
+    }
+}
+
+pub contract Bar {
+    recv BarMsg {
+        Pong {}
+    }
+}
+"#;
+
+        let entries = abi_entries(code, "Foo");
+        let who = entries
+            .iter()
+            .find(|entry| entry["type"] == "function" && entry["name"] == "who")
+            .expect("who entry");
+        let ping = entries
+            .iter()
+            .find(|entry| entry["type"] == "function" && entry["name"] == "ping")
+            .expect("ping entry");
+
+        assert_eq!(who["stateMutability"], "view");
+        assert_eq!(ping["stateMutability"], "nonpayable");
+    }
+
+    #[test]
+    fn generic_event_helpers_preserve_concrete_event_types() {
+        let code = r#"
+use std::abi::sol
+use std::evm::effects::Log
+use std::evm::event::Event
+
+#[event]
+struct Transfer {
+    value: u256,
+}
+
+#[event]
+struct Approval {
+    value: u256,
+}
+
+msg FooMsg {
+    #[selector = sol("ping()")]
+    Ping,
+}
+
+fn emit_event<E: Event>(event: E) uses (log: mut Log) {
+    log.emit(event)
+}
+
+pub contract Foo uses (log: mut Log) {
+    recv FooMsg {
+        Ping uses (mut log) {
+            emit_event(Transfer { value: 1 })
+            emit_event(Approval { value: 2 })
+        }
+    }
+}
+"#;
+
+        let entries = abi_entries(code, "Foo");
+        assert!(
+            entries
+                .iter()
+                .any(|entry| entry["type"] == "event" && entry["name"] == "Transfer"),
+            "generic helper should preserve Transfer event: {entries:?}"
+        );
+        assert!(
+            entries
+                .iter()
+                .any(|entry| entry["type"] == "event" && entry["name"] == "Approval"),
+            "generic helper should preserve Approval event: {entries:?}"
+        );
+    }
+
+    #[test]
+    fn sol_compat_wrapper_types_emit_correct_abi_type() {
+        let code = r#"
+use std::abi::sol
+use std::abi::sol::Uint160
+use std::abi::sol::Int24
+
+msg FooMsg {
+    #[selector = sol("set(uint160,int24)")]
+    Set { addr: Uint160, value: Int24 },
+}
+
+pub contract Foo {
+    recv FooMsg {
+        Set { addr, value } uses () {
+            let _ = addr
+            let _ = value
+        }
+    }
+}
+"#;
+
+        let entries = abi_entries(code, "Foo");
+        let function = entries
+            .iter()
+            .find(|entry| entry["type"] == "function")
+            .expect("function entry");
+
+        assert_eq!(function["name"], "set");
+        assert_eq!(function["inputs"][0]["type"], "uint160");
+        assert_eq!(function["inputs"][0]["name"], "addr");
+        assert_eq!(function["inputs"][1]["type"], "int24");
+        assert_eq!(function["inputs"][1]["name"], "value");
+    }
+}

--- a/crates/fe/src/build.rs
+++ b/crates/fe/src/build.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeMap, HashSet},
+    collections::{BTreeMap, BTreeSet, HashSet},
     fs,
 };
 
@@ -36,11 +36,18 @@ struct BuildReportContext {
     root_dir: Utf8PathBuf,
 }
 
+#[derive(Debug, Default)]
+struct IngotBuildAnalysis {
+    contract_names: Vec<String>,
+    abi_artifact_names: Vec<String>,
+}
+
 #[derive(Debug, Clone, Copy)]
 struct EmitSelection {
     bytecode: bool,
     runtime_bytecode: bool,
     ir: bool,
+    abi: bool,
 }
 
 impl EmitSelection {
@@ -49,12 +56,14 @@ impl EmitSelection {
             bytecode: false,
             runtime_bytecode: false,
             ir: false,
+            abi: false,
         };
         for emit in requested {
             match emit {
                 BuildEmit::Bytecode => selection.bytecode = true,
                 BuildEmit::RuntimeBytecode => selection.runtime_bytecode = true,
                 BuildEmit::Ir => selection.ir = true,
+                BuildEmit::Abi => selection.abi = true,
             }
         }
         selection
@@ -542,17 +551,27 @@ fn build_workspace(
         .cloned()
         .unwrap_or_else(|| workspace_root.join("out"));
 
+    let abi_collision_check_needs_filtering =
+        emit.abi && !emit.writes_any_bytecode() && contract.is_none();
     let mut contract_names_by_member = Vec::with_capacity(selected_member_paths.len());
+    let mut abi_artifact_names_by_member = Vec::with_capacity(selected_member_paths.len());
     for member in members {
         let member_path = workspace_root.join(member.path.as_str());
         if !selected_member_paths.contains(&member_path) {
             continue;
         }
-        let contract_names = match analyze_ingot_contract_names(db, &member.url) {
-            Ok(names) => names,
+        let analysis = match analyze_ingot_build_artifacts(
+            db,
+            &member.url,
+            abi_collision_check_needs_filtering,
+        ) {
+            Ok(analysis) => analysis,
             Err(()) => return true,
         };
-        contract_names_by_member.push((member, contract_names));
+        contract_names_by_member.push((member.clone(), analysis.contract_names));
+        if abi_collision_check_needs_filtering {
+            abi_artifact_names_by_member.push((member, analysis.abi_artifact_names));
+        }
     }
 
     if let Some(contract) = contract {
@@ -621,6 +640,11 @@ fn build_workspace(
     {
         return true;
     }
+    if abi_collision_check_needs_filtering
+        && let Err(()) = check_workspace_artifact_name_collisions(&abi_artifact_names_by_member)
+    {
+        return true;
+    }
     if emit.ir
         && let Err(()) = check_workspace_ir_output_name_collisions(&contract_names_by_member)
     {
@@ -660,10 +684,11 @@ fn build_workspace(
     had_errors
 }
 
-fn analyze_ingot_contract_names(
+fn analyze_ingot_build_artifacts(
     db: &mut DriverDataBase,
     ingot_url: &Url,
-) -> Result<Vec<String>, ()> {
+    include_abi_artifact_names: bool,
+) -> Result<IngotBuildAnalysis, ()> {
     let Some(ingot) = db.workspace().containing_ingot(db, ingot_url.clone()) else {
         eprintln!("Error: Could not resolve ingot from directory");
         return Err(());
@@ -684,7 +709,18 @@ fn analyze_ingot_contract_names(
         eprintln!("Error: Failed to analyze contracts: {err}");
     })?;
 
-    Ok(contract_names)
+    let abi_artifact_names = if include_abi_artifact_names {
+        collect_ingot_abi_artifact_names(db, ingot).map_err(|err| {
+            eprintln!("Error: Failed to analyze ABI artifacts: {err}");
+        })?
+    } else {
+        Vec::new()
+    };
+
+    Ok(IngotBuildAnalysis {
+        contract_names,
+        abi_artifact_names,
+    })
 }
 
 fn check_workspace_artifact_name_collisions(
@@ -902,97 +938,110 @@ fn build_ingot(
     let report_dir = report_dir.map(Utf8PathBuf::as_path);
 
     let mut had_errors = false;
-    match backend_kind {
-        BackendKind::Yul => {
-            let optimize = opt_level.yul_optimize();
-            let yul = match codegen::emit_ingot_yul(db, ingot) {
-                Ok(yul) => yul,
-                Err(err) => {
-                    eprintln!("Error: Failed to emit Yul: {err}");
-                    return BuildSummary { had_errors: true };
-                }
-            };
-            if let Some(dir) = report_dir {
-                let path = dir.join("ingot.yul");
-                let _ = std::fs::write(path.as_std_path(), &yul);
-                match lower_ingot(db, ingot) {
-                    Ok(mir) => {
-                        let path = dir.join("mir.txt");
-                        let _ =
-                            std::fs::write(path.as_std_path(), mir_fmt::format_module(db, &mir));
-                    }
+    if emit.ir || emit.writes_any_bytecode() {
+        match backend_kind {
+            BackendKind::Yul => {
+                let optimize = opt_level.yul_optimize();
+                let yul = match codegen::emit_ingot_yul(db, ingot) {
+                    Ok(yul) => yul,
                     Err(err) => {
-                        let path = dir.join("mir_error.txt");
-                        let _ = std::fs::write(path.as_std_path(), format!("{err}"));
-                    }
-                }
-            }
-            if emit.ir
-                && let Err(err) =
-                    write_named_ir_artifact(ir_out_dir, report_dir, ir_file_stem, "yul", &yul)
-            {
-                eprintln!("Error: {err}");
-                had_errors = true;
-            }
-            if emit.writes_any_bytecode() {
-                had_errors |= write_yul_bytecode_artifacts(
-                    &names_to_build,
-                    &yul,
-                    optimize,
-                    out_dir,
-                    report_dir,
-                    emit,
-                    solc,
-                );
-            }
-        }
-        BackendKind::Sonatina => {
-            if emit.ir {
-                let mir_module = match lower_ingot(db, ingot) {
-                    Ok(mir_module) => mir_module,
-                    Err(err) => {
-                        eprintln!("Error: Failed to compile Sonatina IR: {err}");
+                        eprintln!("Error: Failed to emit Yul: {err}");
                         return BuildSummary { had_errors: true };
                     }
                 };
-                let ir = match codegen::emit_mir_module_sonatina_ir_optimized(
-                    db,
-                    &mir_module,
-                    opt_level,
-                    contract,
-                ) {
-                    Ok(ir) => ir,
-                    Err(err) => {
-                        eprintln!("Error: Failed to compile Sonatina IR: {err}");
-                        return BuildSummary { had_errors: true };
+                if let Some(dir) = report_dir {
+                    let path = dir.join("ingot.yul");
+                    let _ = std::fs::write(path.as_std_path(), &yul);
+                    match lower_ingot(db, ingot) {
+                        Ok(mir) => {
+                            let path = dir.join("mir.txt");
+                            let _ = std::fs::write(
+                                path.as_std_path(),
+                                mir_fmt::format_module(db, &mir),
+                            );
+                        }
+                        Err(err) => {
+                            let path = dir.join("mir_error.txt");
+                            let _ = std::fs::write(path.as_std_path(), format!("{err}"));
+                        }
                     }
-                };
-                if let Err(err) =
-                    write_named_ir_artifact(ir_out_dir, report_dir, ir_file_stem, "sona", &ir)
+                }
+                if emit.ir
+                    && let Err(err) =
+                        write_named_ir_artifact(ir_out_dir, report_dir, ir_file_stem, "yul", &yul)
                 {
                     eprintln!("Error: {err}");
                     had_errors = true;
                 }
+                if emit.writes_any_bytecode() {
+                    had_errors |= write_yul_bytecode_artifacts(
+                        &names_to_build,
+                        &yul,
+                        optimize,
+                        out_dir,
+                        report_dir,
+                        emit,
+                        solc,
+                    );
+                }
             }
-            if emit.writes_any_bytecode() {
-                let bytecode =
-                    match codegen::emit_ingot_sonatina_bytecode(db, ingot, opt_level, contract) {
-                        Ok(bytecode) => bytecode,
+            BackendKind::Sonatina => {
+                if emit.ir {
+                    let mir_module = match lower_ingot(db, ingot) {
+                        Ok(mir_module) => mir_module,
                         Err(err) => {
-                            eprintln!("Error: Failed to compile Sonatina bytecode: {err}");
+                            eprintln!("Error: Failed to compile Sonatina IR: {err}");
                             return BuildSummary { had_errors: true };
                         }
                     };
-                had_errors |= write_sonatina_bytecode_artifacts(
-                    &names_to_build,
-                    &bytecode,
-                    out_dir,
-                    report_dir,
-                    emit,
-                );
+                    let ir = match codegen::emit_mir_module_sonatina_ir_optimized(
+                        db,
+                        &mir_module,
+                        opt_level,
+                        contract,
+                    ) {
+                        Ok(ir) => ir,
+                        Err(err) => {
+                            eprintln!("Error: Failed to compile Sonatina IR: {err}");
+                            return BuildSummary { had_errors: true };
+                        }
+                    };
+                    if let Err(err) =
+                        write_named_ir_artifact(ir_out_dir, report_dir, ir_file_stem, "sona", &ir)
+                    {
+                        eprintln!("Error: {err}");
+                        had_errors = true;
+                    }
+                }
+                if emit.writes_any_bytecode() {
+                    let bytecode =
+                        match codegen::emit_ingot_sonatina_bytecode(db, ingot, opt_level, contract)
+                        {
+                            Ok(bytecode) => bytecode,
+                            Err(err) => {
+                                eprintln!("Error: Failed to compile Sonatina bytecode: {err}");
+                                return BuildSummary { had_errors: true };
+                            }
+                        };
+                    had_errors |= write_sonatina_bytecode_artifacts(
+                        &names_to_build,
+                        &bytecode,
+                        out_dir,
+                        report_dir,
+                        emit,
+                    );
+                }
             }
         }
-    };
+    }
+
+    if emit.abi {
+        // For ingot builds, generate ABI from each top-level module
+        use hir::hir_def::HirIngot;
+        for top_mod in ingot.all_modules(db) {
+            had_errors |= write_abi_artifacts(db, *top_mod, &names_to_build, out_dir, report_dir);
+        }
+    }
 
     BuildSummary { had_errors }
 }
@@ -1037,88 +1086,96 @@ fn build_top_mod(
     let report_dir = report_dir.map(Utf8PathBuf::as_path);
 
     let mut had_errors = false;
-    match backend_kind {
-        BackendKind::Yul => {
-            let optimize = opt_level.yul_optimize();
-            let yul = match codegen::emit_module_yul(db, top_mod) {
-                Ok(yul) => yul,
-                Err(err) => {
-                    eprintln!("Error: Failed to emit Yul: {err}");
-                    return BuildSummary { had_errors: true };
-                }
-            };
-            if let Some(dir) = report_dir {
-                let path = dir.join("module.yul");
-                let _ = std::fs::write(path.as_std_path(), &yul);
-                match lower_module(db, top_mod) {
-                    Ok(mir) => {
-                        let path = dir.join("mir.txt");
-                        let _ =
-                            std::fs::write(path.as_std_path(), mir_fmt::format_module(db, &mir));
-                    }
+    if emit.ir || emit.writes_any_bytecode() {
+        match backend_kind {
+            BackendKind::Yul => {
+                let optimize = opt_level.yul_optimize();
+                let yul = match codegen::emit_module_yul(db, top_mod) {
+                    Ok(yul) => yul,
                     Err(err) => {
-                        let path = dir.join("mir_error.txt");
-                        let _ = std::fs::write(path.as_std_path(), format!("{err}"));
-                    }
-                }
-            }
-            if emit.ir
-                && let Err(err) =
-                    write_named_ir_artifact(ir_out_dir, report_dir, ir_file_stem, "yul", &yul)
-            {
-                eprintln!("Error: {err}");
-                had_errors = true;
-            }
-            if emit.writes_any_bytecode() {
-                had_errors |= write_yul_bytecode_artifacts(
-                    &names_to_build,
-                    &yul,
-                    optimize,
-                    out_dir,
-                    report_dir,
-                    emit,
-                    solc,
-                );
-            }
-        }
-        BackendKind::Sonatina => {
-            if emit.ir {
-                let ir = match codegen::emit_module_sonatina_ir_optimized(
-                    db, top_mod, opt_level, contract,
-                ) {
-                    Ok(ir) => ir,
-                    Err(err) => {
-                        eprintln!("Error: Failed to compile Sonatina IR: {err}");
+                        eprintln!("Error: Failed to emit Yul: {err}");
                         return BuildSummary { had_errors: true };
                     }
                 };
-                if let Err(err) =
-                    write_named_ir_artifact(ir_out_dir, report_dir, ir_file_stem, "sona", &ir)
+                if let Some(dir) = report_dir {
+                    let path = dir.join("module.yul");
+                    let _ = std::fs::write(path.as_std_path(), &yul);
+                    match lower_module(db, top_mod) {
+                        Ok(mir) => {
+                            let path = dir.join("mir.txt");
+                            let _ = std::fs::write(
+                                path.as_std_path(),
+                                mir_fmt::format_module(db, &mir),
+                            );
+                        }
+                        Err(err) => {
+                            let path = dir.join("mir_error.txt");
+                            let _ = std::fs::write(path.as_std_path(), format!("{err}"));
+                        }
+                    }
+                }
+                if emit.ir
+                    && let Err(err) =
+                        write_named_ir_artifact(ir_out_dir, report_dir, ir_file_stem, "yul", &yul)
                 {
                     eprintln!("Error: {err}");
                     had_errors = true;
                 }
+                if emit.writes_any_bytecode() {
+                    had_errors |= write_yul_bytecode_artifacts(
+                        &names_to_build,
+                        &yul,
+                        optimize,
+                        out_dir,
+                        report_dir,
+                        emit,
+                        solc,
+                    );
+                }
             }
-            if emit.writes_any_bytecode() {
-                let bytecode = match codegen::emit_module_sonatina_bytecode(
-                    db, top_mod, opt_level, contract,
-                ) {
-                    Ok(bytecode) => bytecode,
-                    Err(err) => {
-                        eprintln!("Error: Failed to compile Sonatina bytecode: {err}");
-                        return BuildSummary { had_errors: true };
+            BackendKind::Sonatina => {
+                if emit.ir {
+                    let ir = match codegen::emit_module_sonatina_ir_optimized(
+                        db, top_mod, opt_level, contract,
+                    ) {
+                        Ok(ir) => ir,
+                        Err(err) => {
+                            eprintln!("Error: Failed to compile Sonatina IR: {err}");
+                            return BuildSummary { had_errors: true };
+                        }
+                    };
+                    if let Err(err) =
+                        write_named_ir_artifact(ir_out_dir, report_dir, ir_file_stem, "sona", &ir)
+                    {
+                        eprintln!("Error: {err}");
+                        had_errors = true;
                     }
-                };
-                had_errors |= write_sonatina_bytecode_artifacts(
-                    &names_to_build,
-                    &bytecode,
-                    out_dir,
-                    report_dir,
-                    emit,
-                );
+                }
+                if emit.writes_any_bytecode() {
+                    let bytecode = match codegen::emit_module_sonatina_bytecode(
+                        db, top_mod, opt_level, contract,
+                    ) {
+                        Ok(bytecode) => bytecode,
+                        Err(err) => {
+                            eprintln!("Error: Failed to compile Sonatina bytecode: {err}");
+                            return BuildSummary { had_errors: true };
+                        }
+                    };
+                    had_errors |= write_sonatina_bytecode_artifacts(
+                        &names_to_build,
+                        &bytecode,
+                        out_dir,
+                        report_dir,
+                        emit,
+                    );
+                }
             }
         }
-    };
+    }
+
+    if emit.abi {
+        had_errors |= write_abi_artifacts(db, top_mod, &names_to_build, out_dir, report_dir);
+    }
 
     BuildSummary { had_errors }
 }
@@ -1143,6 +1200,34 @@ fn collect_ingot_contract_names(
     let mut names: Vec<_> = graph.contracts.keys().cloned().collect();
     names.sort();
     Ok(names)
+}
+
+fn collect_ingot_abi_artifact_names(
+    db: &DriverDataBase,
+    ingot: hir::Ingot<'_>,
+) -> Result<Vec<String>, String> {
+    use hir::hir_def::HirIngot;
+
+    let mut names = BTreeSet::new();
+    for top_mod in ingot.all_modules(db) {
+        for contract in top_mod.all_contracts(db) {
+            let Some(name) = contract
+                .name(db)
+                .to_opt()
+                .map(|name| name.data(db).to_string())
+            else {
+                continue;
+            };
+            let Some(result) = crate::abi::generate_contract_abi(db, *top_mod, &name)? else {
+                continue;
+            };
+            if result.entry_count > 0 {
+                names.insert(name);
+            }
+        }
+    }
+
+    Ok(names.into_iter().collect())
 }
 
 fn workspace_member_ir_out_dir(
@@ -1183,7 +1268,7 @@ fn ensure_output_dirs(
     out_dir: &Utf8Path,
     ir_out_dir: &Utf8Path,
 ) -> Result<(), String> {
-    if emit.writes_any_bytecode() {
+    if emit.writes_any_bytecode() || emit.abi {
         fs::create_dir_all(out_dir.as_std_path())
             .map_err(|err| format!("Failed to create output directory {out_dir}: {err}"))?;
     }
@@ -1192,6 +1277,64 @@ fn ensure_output_dirs(
             .map_err(|err| format!("Failed to create output directory {ir_out_dir}: {err}"))?;
     }
     Ok(())
+}
+
+fn write_abi_artifacts(
+    db: &DriverDataBase,
+    top_mod: TopLevelMod<'_>,
+    names_to_build: &[String],
+    out_dir: &Utf8Path,
+    report_dir: Option<&Utf8Path>,
+) -> bool {
+    let mut had_errors = false;
+    for name in names_to_build {
+        match crate::abi::generate_contract_abi(db, top_mod, name) {
+            Ok(Some(result)) => {
+                for warning in &result.warnings {
+                    eprintln!("Warning: {warning}");
+                }
+                let base = sanitize_filename(name);
+                let abi_path = out_dir.join(format!("{base}.abi.json"));
+                let report_path = report_dir.map(|dir| dir.join(format!("{base}.abi.json")));
+                if result.entry_count == 0 {
+                    if let Err(err) = remove_file_if_exists(&abi_path) {
+                        eprintln!("Error: Failed to remove stale ABI: {err}");
+                        had_errors = true;
+                    }
+                    if let Some(path) = report_path.as_ref()
+                        && let Err(err) = remove_file_if_exists(path)
+                    {
+                        eprintln!("Error: Failed to remove stale ABI from report dir: {err}");
+                        had_errors = true;
+                    }
+                    continue;
+                }
+                if let Err(err) = fs::write(abi_path.as_std_path(), &result.json) {
+                    eprintln!("Error: Failed to write ABI: {err}");
+                    had_errors = true;
+                } else {
+                    if let Some(path) = report_path.as_ref() {
+                        let _ = fs::write(path.as_std_path(), &result.json);
+                    }
+                    println!("Wrote {out_dir}/{base}.abi.json");
+                }
+            }
+            Ok(None) => {} // Contract not in this module, skip
+            Err(err) => {
+                eprintln!("Error: Failed to generate ABI for {name}: {err}");
+                had_errors = true;
+            }
+        }
+    }
+    had_errors
+}
+
+fn remove_file_if_exists(path: &Utf8Path) -> std::io::Result<()> {
+    match fs::remove_file(path.as_std_path()) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(err),
+    }
 }
 
 fn write_named_ir_artifact(
@@ -1311,6 +1454,9 @@ fn describe_emit_selection(emit: EmitSelection) -> String {
     if emit.ir {
         parts.push("ir");
     }
+    if emit.abi {
+        parts.push("abi");
+    }
     parts.join(",")
 }
 
@@ -1382,4 +1528,136 @@ fn ingot_has_source_files(db: &DriverDataBase, ingot: hir::Ingot<'_>) -> bool {
         .files(db)
         .iter()
         .any(|(_, file)| matches!(file.kind(db), Some(IngotFileKind::Source)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::Value;
+    use tempfile::tempdir;
+
+    #[test]
+    fn describe_emit_selection_lists_abi() {
+        let emit = EmitSelection {
+            bytecode: false,
+            runtime_bytecode: false,
+            ir: false,
+            abi: true,
+        };
+        assert_eq!(describe_emit_selection(emit), "abi");
+    }
+
+    #[test]
+    fn write_abi_artifacts_copies_into_report_dir() {
+        let code = include_str!("../tests/fixtures/cli_output/emit_abi/abi_contract.fe");
+
+        let temp_input = tempdir().expect("tempdir");
+        let file_path = temp_input.path().join("test.fe");
+        let url = Url::from_file_path(&file_path).expect("file path to url");
+        let mut db = DriverDataBase::default();
+        let file = db.workspace().touch(&mut db, url, Some(code.to_string()));
+        let top_mod = db.top_mod(file);
+        let temp = tempdir().expect("tempdir");
+        let out_dir =
+            Utf8PathBuf::from_path_buf(temp.path().join("out")).expect("utf8 output path");
+        let report_dir =
+            Utf8PathBuf::from_path_buf(temp.path().join("report")).expect("utf8 report path");
+        fs::create_dir_all(out_dir.as_std_path()).expect("create output dir");
+        fs::create_dir_all(report_dir.as_std_path()).expect("create report dir");
+
+        let names = vec!["Foo".to_string()];
+        let had_errors = write_abi_artifacts(&db, top_mod, &names, &out_dir, Some(&report_dir));
+        assert!(!had_errors, "unexpected ABI write error");
+
+        let out_abi = out_dir.join("Foo.abi.json");
+        let report_abi = report_dir.join("Foo.abi.json");
+        assert!(out_abi.exists(), "missing output ABI");
+        assert!(report_abi.exists(), "missing report ABI");
+
+        let out_json = fs::read_to_string(out_abi.as_std_path()).expect("read output ABI");
+        let report_json = fs::read_to_string(report_abi.as_std_path()).expect("read report ABI");
+        assert_eq!(out_json, report_json);
+
+        let abi: Value = serde_json::from_str(&out_json).expect("parse output ABI");
+        let function = abi
+            .as_array()
+            .expect("abi array")
+            .iter()
+            .find(|entry| entry["type"] == "function")
+            .expect("function entry");
+        assert_eq!(function["name"], "ping");
+    }
+
+    #[test]
+    fn write_abi_artifacts_removes_stale_empty_outputs() {
+        let temp_input = tempdir().expect("tempdir");
+        let file_path = temp_input.path().join("test.fe");
+        let url = Url::from_file_path(&file_path).expect("file path to url");
+        let temp = tempdir().expect("tempdir");
+        let out_dir =
+            Utf8PathBuf::from_path_buf(temp.path().join("out")).expect("utf8 output path");
+        let report_dir =
+            Utf8PathBuf::from_path_buf(temp.path().join("report")).expect("utf8 report path");
+        fs::create_dir_all(out_dir.as_std_path()).expect("create output dir");
+        fs::create_dir_all(report_dir.as_std_path()).expect("create report dir");
+
+        let mut first_db = DriverDataBase::default();
+        let first_code = include_str!("../tests/fixtures/cli_output/emit_abi/abi_contract.fe");
+        let first_file =
+            first_db
+                .workspace()
+                .touch(&mut first_db, url.clone(), Some(first_code.to_string()));
+        let first_top_mod = first_db.top_mod(first_file);
+        let names = vec!["Foo".to_string()];
+        let had_errors = write_abi_artifacts(
+            &first_db,
+            first_top_mod,
+            &names,
+            &out_dir,
+            Some(&report_dir),
+        );
+        assert!(!had_errors, "unexpected ABI write error");
+        assert!(out_dir.join("Foo.abi.json").exists(), "missing output ABI");
+        assert!(
+            report_dir.join("Foo.abi.json").exists(),
+            "missing report ABI"
+        );
+
+        let mut second_db = DriverDataBase::default();
+        let second_code = r#"
+msg FooMsg {
+    #[selector = 0x12345678]
+    Ping -> u256,
+}
+
+pub contract Foo {
+    recv FooMsg {
+        Ping -> u256 {
+            return 1
+        }
+    }
+}
+"#;
+        let second_file =
+            second_db
+                .workspace()
+                .touch(&mut second_db, url, Some(second_code.to_string()));
+        let second_top_mod = second_db.top_mod(second_file);
+        let had_errors = write_abi_artifacts(
+            &second_db,
+            second_top_mod,
+            &names,
+            &out_dir,
+            Some(&report_dir),
+        );
+        assert!(!had_errors, "unexpected ABI cleanup error");
+        assert!(
+            !out_dir.join("Foo.abi.json").exists(),
+            "stale output ABI should be removed"
+        );
+        assert!(
+            !report_dir.join("Foo.abi.json").exists(),
+            "stale report ABI should be removed"
+        );
+    }
 }

--- a/crates/fe/src/main.rs
+++ b/crates/fe/src/main.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::print_stderr, clippy::print_stdout)]
+mod abi;
 mod build;
 mod check;
 mod cli;
@@ -48,6 +49,7 @@ pub enum BuildEmit {
     Bytecode,
     RuntimeBytecode,
     Ir,
+    Abi,
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -115,7 +117,7 @@ pub enum Command {
             short = 'e',
             value_enum,
             value_delimiter = ',',
-            default_value = "bytecode,runtime-bytecode"
+            default_value = "bytecode,runtime-bytecode,abi"
         )]
         emit: Vec<BuildEmit>,
         /// Write a debugging report as a `.tar.gz` file (includes sources, IR, backend output, and bytecode artifacts).

--- a/crates/fe/tests/cli_output.rs
+++ b/crates/fe/tests/cli_output.rs
@@ -1,4 +1,5 @@
 use dir_test::{Fixture, dir_test};
+use serde_json::Value;
 use std::{fs, io::IsTerminal, path::Path, process::Command, sync::OnceLock};
 use tempfile::tempdir;
 use test_utils::{
@@ -432,6 +433,401 @@ fn test_cli_build_all_contracts_fake_solc_artifacts() {
         .expect("fixture should have parent")
         .join("multi_contract_build_all_fake_solc.case");
     snap_test!(snapshot, snapshot_path.to_str().unwrap());
+}
+
+#[test]
+fn test_cli_build_emit_abi_writes_json_artifact() {
+    let fixture_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/cli_output/emit_abi/abi_contract.fe");
+    let fixture_path_str = fixture_path.to_str().expect("fixture path utf8");
+
+    let temp = tempdir().expect("tempdir");
+    let out_dir = temp.path().join("out");
+    let out_dir_str = out_dir.to_string_lossy().to_string();
+
+    let (output, exit_code) = run_fe_main(&[
+        "build",
+        "--emit",
+        "abi",
+        "--contract",
+        "Foo",
+        "--out-dir",
+        out_dir_str.as_str(),
+        fixture_path_str,
+    ]);
+    assert_eq!(exit_code, 0, "fe build failed:\n{output}");
+
+    let abi_path = out_dir.join("Foo.abi.json");
+    assert!(abi_path.is_file(), "missing ABI artifact:\n{output}");
+    assert!(
+        !out_dir.join("Foo.bin").exists(),
+        "unexpected deploy artifact"
+    );
+    assert!(
+        !out_dir.join("Foo.runtime.bin").exists(),
+        "unexpected runtime artifact"
+    );
+
+    let abi: Value = serde_json::from_str(&fs::read_to_string(&abi_path).expect("read ABI"))
+        .expect("parse ABI JSON");
+    let function = abi
+        .as_array()
+        .expect("abi array")
+        .iter()
+        .find(|entry| entry["type"] == "function")
+        .expect("function entry");
+
+    assert!(
+        output.contains("Foo.abi.json"),
+        "unexpected output:\n{output}"
+    );
+    assert_eq!(function["name"], "ping");
+    assert_eq!(function["inputs"][0]["name"], "value");
+    assert_eq!(function["inputs"][0]["type"], "uint256");
+    assert_eq!(function["outputs"][0]["type"], "uint256");
+}
+
+#[test]
+fn test_cli_build_emit_abi_includes_imported_events() {
+    let temp = tempdir().expect("tempdir");
+    let src_dir = temp.path().join("src");
+    fs::create_dir_all(&src_dir).expect("create src dir");
+    fs::write(
+        temp.path().join("fe.toml"),
+        "[ingot]\nname = \"emit_abi_events\"\nversion = \"0.1.0\"\n",
+    )
+    .expect("write fe.toml");
+    fs::write(
+        src_dir.join("events.fe"),
+        r#"
+#[event]
+pub struct Transfer {
+    pub value: u256,
+}
+
+#[event]
+pub struct UnusedEvent {
+    pub value: u256,
+}
+"#,
+    )
+    .expect("write events.fe");
+    fs::write(
+        src_dir.join("helpers.fe"),
+        r#"
+use std::evm::Log
+use super::events::Transfer
+
+pub fn emit_transfer(value: u256) uses (log: mut Log) {
+    log.emit(Transfer { value })
+}
+"#,
+    )
+    .expect("write helpers.fe");
+    fs::write(
+        src_dir.join("lib.fe"),
+        r#"
+use std::abi::sol
+use std::evm::Log
+use helpers::emit_transfer
+
+msg FooMsg {
+    #[selector = sol("ping()")]
+    Ping,
+}
+
+pub contract Foo uses (log: mut Log) {
+    recv FooMsg {
+        Ping uses (mut log) {
+            emit_transfer(value: 1)
+        }
+    }
+}
+"#,
+    )
+    .expect("write lib.fe");
+
+    let out_dir = temp.path().join("out");
+    let out_dir_str = out_dir.to_string_lossy().to_string();
+    let project_path = temp.path().to_str().expect("project path utf8");
+
+    let (output, exit_code) = run_fe_main(&[
+        "build",
+        "--emit",
+        "abi",
+        "--contract",
+        "Foo",
+        "--out-dir",
+        out_dir_str.as_str(),
+        project_path,
+    ]);
+    assert_eq!(exit_code, 0, "fe build failed:\n{output}");
+
+    let abi_path = out_dir.join("Foo.abi.json");
+    let abi: Value = serde_json::from_str(&fs::read_to_string(&abi_path).expect("read ABI"))
+        .expect("parse ABI JSON");
+    let event = abi
+        .as_array()
+        .expect("abi array")
+        .iter()
+        .find(|entry| entry["type"] == "event" && entry["name"] == "Transfer")
+        .expect("event entry");
+
+    assert_eq!(event["inputs"][0]["name"], "value");
+    assert_eq!(event["inputs"][0]["type"], "uint256");
+    assert!(
+        abi.as_array()
+            .expect("abi array")
+            .iter()
+            .all(|entry| entry["name"] != "UnusedEvent"),
+        "unexpected unused event in ABI: {abi}"
+    );
+}
+
+#[test]
+fn test_cli_build_emit_abi_skips_hex_selectors_with_warning() {
+    let fixture_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/cli_output/build/simple_contract.fe");
+    let fixture_path_str = fixture_path.to_str().expect("fixture path utf8");
+
+    let temp = tempdir().expect("tempdir");
+    let out_dir = temp.path().join("out");
+    let out_dir_str = out_dir.to_string_lossy().to_string();
+
+    let (output, exit_code) = run_fe_main(&[
+        "build",
+        "--emit",
+        "abi",
+        "--contract",
+        "Foo",
+        "--out-dir",
+        out_dir_str.as_str(),
+        fixture_path_str,
+    ]);
+
+    assert_eq!(exit_code, 0, "ABI build should succeed:\n{output}");
+    assert!(
+        output.contains("selector signature is unknown"),
+        "expected warning about unknown selector:\n{output}"
+    );
+    assert!(
+        !out_dir.join("Foo.abi.json").exists(),
+        "empty ABI artifact should not be written"
+    );
+}
+
+#[test]
+fn test_cli_build_emit_abi_skips_manual_msgvariant_codecs() {
+    let temp = tempdir().expect("tempdir");
+    let src_dir = temp.path().join("src");
+    fs::create_dir_all(&src_dir).expect("create src dir");
+    fs::write(
+        temp.path().join("fe.toml"),
+        "[ingot]\nname = \"emit_abi_manual_msgvariant\"\nversion = \"0.1.0\"\n",
+    )
+    .expect("write fe.toml");
+    fs::write(
+        src_dir.join("lib.fe"),
+        r#"
+use std::abi::sol
+
+struct Weird {
+    pub amount: u64,
+    pub flag: bool,
+}
+
+impl core::abi::AbiSize for Weird {
+    const ENCODED_SIZE: u256 = 64
+}
+
+impl core::abi::Encode<std::abi::Sol> for Weird {
+    const DIRECT_ENCODE: bool = false
+
+    fn encode<E: core::abi::AbiEncoder<std::abi::Sol>>(own self, _ e: mut E) {
+        self.flag.encode(e)
+        self.amount.encode(e)
+    }
+
+    fn encode_to_ptr(own self, ptr: u256) {
+        std::abi::Sol::store_word(ptr, if self.flag { 1 } else { 0 })
+        std::abi::Sol::store_word(ptr + 32, self.amount as u256)
+    }
+}
+
+impl core::abi::Decode<std::abi::Sol> for Weird {
+    fn decode<D: core::abi::AbiDecoder<std::abi::Sol>>(_ d: mut D) -> Self {
+        let flag = bool::decode(d)
+        let amount = u64::decode(d)
+        Self { amount, flag }
+    }
+}
+
+impl core::message::MsgVariant<std::abi::Sol> for Weird {
+    const SELECTOR: u32 = sol("foo(bool,uint64)")
+    type Return = ()
+}
+
+pub contract Foo {
+    recv {
+        Weird { amount, flag } uses () {
+            let _ = amount
+            let _ = flag
+        }
+    }
+}
+"#,
+    )
+    .expect("write lib.fe");
+
+    let out_dir = temp.path().join("out");
+    let out_dir_str = out_dir.to_string_lossy().to_string();
+    let project_path = temp.path().to_str().expect("project path utf8");
+
+    let (output, exit_code) = run_fe_main(&[
+        "build",
+        "--emit",
+        "abi",
+        "--contract",
+        "Foo",
+        "--out-dir",
+        out_dir_str.as_str(),
+        project_path,
+    ]);
+
+    assert_eq!(exit_code, 0, "ABI build should succeed:\n{output}");
+    assert!(
+        output.contains("manual `MsgVariant` impls"),
+        "expected warning about manual MsgVariant codecs:\n{output}"
+    );
+    assert!(
+        !out_dir.join("Foo.abi.json").exists(),
+        "empty ABI artifact should not be written"
+    );
+}
+
+#[test]
+fn test_cli_build_default_emit_skips_empty_abi_artifact() {
+    let fixture_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/cli_output/build/simple_contract.fe");
+    let fixture_path_str = fixture_path.to_str().expect("fixture path utf8");
+
+    let temp = tempdir().expect("tempdir");
+    let out_dir = temp.path().join("out");
+    let out_dir_str = out_dir.to_string_lossy().to_string();
+
+    let (output, exit_code) = run_fe_main(&[
+        "build",
+        "--contract",
+        "Foo",
+        "--out-dir",
+        out_dir_str.as_str(),
+        fixture_path_str,
+    ]);
+
+    assert_eq!(exit_code, 0, "default build should succeed:\n{output}");
+    assert!(
+        output.contains("selector signature is unknown"),
+        "expected warning about unknown selector:\n{output}"
+    );
+    assert!(
+        !output.contains("Foo.abi.json"),
+        "empty ABI artifact should not be reported as written:\n{output}"
+    );
+    assert!(
+        !out_dir.join("Foo.abi.json").exists(),
+        "empty ABI artifact should not be written"
+    );
+}
+
+#[test]
+fn test_cli_build_default_emit_removes_stale_empty_abi_artifact() {
+    let temp = tempdir().expect("tempdir");
+    let src_dir = temp.path().join("src");
+    fs::create_dir_all(&src_dir).expect("create src dir");
+    fs::write(
+        temp.path().join("fe.toml"),
+        "[ingot]\nname = \"stale_empty_abi\"\nversion = \"0.1.0\"\n",
+    )
+    .expect("write fe.toml");
+    let out_dir = temp.path().join("out");
+    let out_dir_str = out_dir.to_string_lossy().to_string();
+    let project_path = temp.path().to_str().expect("project path utf8");
+
+    fs::write(
+        src_dir.join("lib.fe"),
+        r#"
+use std::abi::sol
+
+msg FooMsg {
+    #[selector = sol("ping()")]
+    Ping,
+}
+
+pub contract Foo {
+    recv FooMsg {
+        Ping {}
+    }
+}
+"#,
+    )
+    .expect("write initial lib.fe");
+
+    let (first_output, first_exit_code) = run_fe_main(&[
+        "build",
+        "--contract",
+        "Foo",
+        "--out-dir",
+        out_dir_str.as_str(),
+        project_path,
+    ]);
+
+    assert_eq!(
+        first_exit_code, 0,
+        "initial build should succeed:\n{first_output}"
+    );
+    assert!(
+        out_dir.join("Foo.abi.json").exists(),
+        "expected initial ABI artifact"
+    );
+
+    fs::write(
+        src_dir.join("lib.fe"),
+        r#"
+msg FooMsg {
+    #[selector = 0x12345678]
+    Ping,
+}
+
+pub contract Foo {
+    recv FooMsg {
+        Ping {}
+    }
+}
+"#,
+    )
+    .expect("write updated lib.fe");
+
+    let (second_output, second_exit_code) = run_fe_main(&[
+        "build",
+        "--contract",
+        "Foo",
+        "--out-dir",
+        out_dir_str.as_str(),
+        project_path,
+    ]);
+
+    assert_eq!(
+        second_exit_code, 0,
+        "second build should succeed:\n{second_output}"
+    );
+    assert!(
+        second_output.contains("selector signature is unknown"),
+        "expected warning about unknown selector:\n{second_output}"
+    );
+    assert!(
+        !out_dir.join("Foo.abi.json").exists(),
+        "stale ABI artifact should be removed after it becomes empty"
+    );
 }
 
 #[cfg(unix)]
@@ -1256,6 +1652,100 @@ fn test_cli_build_workspace_collisions_are_rejected() {
     let (output, exit_code) = run_fe_main_in_dir(&["build"], &root);
     assert_ne!(exit_code, 0, "expected non-zero exit code:\n{output}");
     snap_test!(output, snapshot_path.to_str().unwrap());
+}
+
+#[test]
+fn test_cli_build_emit_abi_workspace_empty_collisions_are_allowed() {
+    let root = workspace_fixture("build_contract_ambiguity");
+    let temp = tempdir().expect("tempdir");
+    let out_dir = temp.path().join("out");
+    let out_dir_str = out_dir.to_string_lossy().to_string();
+    let (output, exit_code) = run_fe_main_in_dir(
+        &["build", "--emit", "abi", "--out-dir", out_dir_str.as_str()],
+        &root,
+    );
+    assert_eq!(exit_code, 0, "expected zero exit code:\n{output}");
+    assert!(
+        !output.contains("Contract names collide"),
+        "unexpected collision error:\n{output}"
+    );
+    assert!(
+        !out_dir.join("Foo.abi.json").exists(),
+        "empty ABI-only workspace build should not write an ABI artifact"
+    );
+}
+
+#[test]
+fn test_cli_build_emit_abi_workspace_nonempty_collisions_are_rejected() {
+    let temp = tempdir().expect("tempdir");
+    let root = temp.path();
+    fs::create_dir_all(root.join("ingots/a/src")).expect("create ingot a");
+    fs::create_dir_all(root.join("ingots/b/src")).expect("create ingot b");
+    fs::write(
+        root.join("fe.toml"),
+        r#"[workspace]
+name = "emit_abi_workspace_collision"
+version = "0.1.0"
+members = [
+  { path = "ingots/a", name = "a" },
+  { path = "ingots/b", name = "b" },
+]
+"#,
+    )
+    .expect("write workspace fe.toml");
+    fs::write(
+        root.join("ingots/a/fe.toml"),
+        "[ingot]\nname = \"a\"\nversion = \"0.1.0\"\n",
+    )
+    .expect("write ingot a fe.toml");
+    fs::write(
+        root.join("ingots/b/fe.toml"),
+        "[ingot]\nname = \"b\"\nversion = \"0.1.0\"\n",
+    )
+    .expect("write ingot b fe.toml");
+    fs::write(
+        root.join("ingots/a/src/lib.fe"),
+        r#"
+use std::abi::sol
+
+msg FooMsg {
+    #[selector = sol("ping()")]
+    Ping,
+}
+
+pub contract Foo {
+    recv FooMsg {
+        Ping {}
+    }
+}
+"#,
+    )
+    .expect("write ingot a source");
+    fs::write(
+        root.join("ingots/b/src/lib.fe"),
+        r#"
+use std::abi::sol
+
+msg FooMsg {
+    #[selector = sol("pong()")]
+    Pong,
+}
+
+pub contract Foo {
+    recv FooMsg {
+        Pong {}
+    }
+}
+"#,
+    )
+    .expect("write ingot b source");
+
+    let (output, exit_code) = run_fe_main_in_dir(&["build", "--emit", "abi"], root);
+    assert_ne!(exit_code, 0, "expected non-zero exit code:\n{output}");
+    assert!(
+        output.contains("Contract names collide in a flat workspace output directory"),
+        "expected ABI collision error:\n{output}"
+    );
 }
 
 #[test]

--- a/crates/fe/tests/fixtures/cli_output/build/multi_contract_build_all_fake_solc.snap
+++ b/crates/fe/tests/fixtures/cli_output/build/multi_contract_build_all_fake_solc.snap
@@ -8,6 +8,10 @@ Wrote <out>/Bar.runtime.bin
 Wrote <out>/Foo.bin
 Wrote <out>/Foo.runtime.bin
 
+=== STDERR ===
+Warning: skipping recv arm `Pong`: selector signature is unknown; use `#[selector = sol("name(types)")]` to include it in the ABI
+Warning: skipping recv arm `Ping`: selector signature is unknown; use `#[selector = sol("name(types)")]` to include it in the ABI
+
 === EXIT CODE: 0 ===
 
 === ARTIFACTS ===

--- a/crates/fe/tests/fixtures/cli_output/build/multi_contract_build_fake_solc.snap
+++ b/crates/fe/tests/fixtures/cli_output/build/multi_contract_build_fake_solc.snap
@@ -6,6 +6,9 @@ expression: snapshot
 Wrote <out>/Foo.bin
 Wrote <out>/Foo.runtime.bin
 
+=== STDERR ===
+Warning: skipping recv arm `Ping`: selector signature is unknown; use `#[selector = sol("name(types)")]` to include it in the ABI
+
 === EXIT CODE: 0 ===
 
 === ARTIFACTS ===

--- a/crates/fe/tests/fixtures/cli_output/build/simple_contract_build_fake_solc.snap
+++ b/crates/fe/tests/fixtures/cli_output/build/simple_contract_build_fake_solc.snap
@@ -6,6 +6,9 @@ expression: snapshot
 Wrote <out>/Foo.bin
 Wrote <out>/Foo.runtime.bin
 
+=== STDERR ===
+Warning: skipping recv arm `Ping`: selector signature is unknown; use `#[selector = sol("name(types)")]` to include it in the ABI
+
 === EXIT CODE: 0 ===
 
 === ARTIFACTS ===

--- a/crates/fe/tests/fixtures/cli_output/build_ingots/multi_file/build_all_fake_solc.snap
+++ b/crates/fe/tests/fixtures/cli_output/build_ingots/multi_file/build_all_fake_solc.snap
@@ -8,6 +8,10 @@ Wrote <out>/Bar.runtime.bin
 Wrote <out>/Foo.bin
 Wrote <out>/Foo.runtime.bin
 
+=== STDERR ===
+Warning: skipping recv arm `Pong`: selector signature is unknown; use `#[selector = sol("name(types)")]` to include it in the ABI
+Warning: skipping recv arm `Ping`: selector signature is unknown; use `#[selector = sol("name(types)")]` to include it in the ABI
+
 === EXIT CODE: 0 ===
 
 === ARTIFACTS ===

--- a/crates/fe/tests/fixtures/cli_output/build_ingots/simple/build_fake_solc.snap
+++ b/crates/fe/tests/fixtures/cli_output/build_ingots/simple/build_fake_solc.snap
@@ -6,6 +6,9 @@ expression: snapshot
 Wrote <out>/Foo.bin
 Wrote <out>/Foo.runtime.bin
 
+=== STDERR ===
+Warning: skipping recv arm `Ping`: selector signature is unknown; use `#[selector = sol("name(types)")]` to include it in the ABI
+
 === EXIT CODE: 0 ===
 
 === ARTIFACTS ===

--- a/crates/fe/tests/fixtures/cli_output/emit_abi/abi_contract.fe
+++ b/crates/fe/tests/fixtures/cli_output/emit_abi/abi_contract.fe
@@ -1,0 +1,14 @@
+use std::abi::sol
+
+msg FooMsg {
+    #[selector = sol("ping(uint256)")]
+    Ping { value: u256 } -> u256,
+}
+
+pub contract Foo {
+    recv FooMsg {
+        Ping { value } -> u256 {
+            return value
+        }
+    }
+}

--- a/crates/fe/tests/fixtures/cli_output/workspaces/build_contract_ambiguity/build_contract_ambiguity_collisions-2.snap.new
+++ b/crates/fe/tests/fixtures/cli_output/workspaces/build_contract_ambiguity/build_contract_ambiguity_collisions-2.snap.new
@@ -1,0 +1,15 @@
+---
+source: crates/fe/tests/cli_output.rs
+assertion_line: 1538
+expression: output
+input_file: tests/fixtures/cli_output/workspaces/build_contract_ambiguity/build_contract_ambiguity_collisions.case
+---
+=== STDERR ===
+Error: Contract names collide in a flat workspace output directory
+Conflicts:
+  - Foo
+    - Foo in a (ingots/a)
+    - Foo in b (ingots/b)
+Hint: build a specific member by name or path instead.
+
+=== EXIT CODE: 1 ===

--- a/crates/fe/tests/fixtures/cli_output/workspaces/build_workspace_root/build_member_by_name_fake_solc.snap
+++ b/crates/fe/tests/fixtures/cli_output/workspaces/build_workspace_root/build_member_by_name_fake_solc.snap
@@ -7,6 +7,9 @@ input_file: tests/fixtures/cli_output/workspaces/build_workspace_root/build_memb
 Wrote <out>/Foo.bin
 Wrote <out>/Foo.runtime.bin
 
+=== STDERR ===
+Warning: skipping recv arm `Ping`: selector signature is unknown; use `#[selector = sol("name(types)")]` to include it in the ABI
+
 === EXIT CODE: 0 ===
 
 === ARTIFACTS ===

--- a/crates/fe/tests/fixtures/cli_output/workspaces/build_workspace_root/build_workspace_root_fake_solc.snap
+++ b/crates/fe/tests/fixtures/cli_output/workspaces/build_workspace_root/build_workspace_root_fake_solc.snap
@@ -8,6 +8,10 @@ Wrote <out>/Foo.runtime.bin
 Wrote <out>/Bar.bin
 Wrote <out>/Bar.runtime.bin
 
+=== STDERR ===
+Warning: skipping recv arm `Ping`: selector signature is unknown; use `#[selector = sol("name(types)")]` to include it in the ABI
+Warning: skipping recv arm `Pong`: selector signature is unknown; use `#[selector = sol("name(types)")]` to include it in the ABI
+
 === EXIT CODE: 0 ===
 
 === ARTIFACTS ===

--- a/crates/fe/tests/fixtures/cli_output/workspaces/build_workspace_root/build_workspace_root_filter_fake_solc.snap
+++ b/crates/fe/tests/fixtures/cli_output/workspaces/build_workspace_root/build_workspace_root_filter_fake_solc.snap
@@ -6,6 +6,9 @@ expression: snapshot
 Wrote <out>/Foo.bin
 Wrote <out>/Foo.runtime.bin
 
+=== STDERR ===
+Warning: skipping recv arm `Ping`: selector signature is unknown; use `#[selector = sol("name(types)")]` to include it in the ABI
+
 === EXIT CODE: 0 ===
 
 === ARTIFACTS ===

--- a/crates/fe/tests/fixtures/cli_output/workspaces/build_workspace_root_skips_library_member/build_workspace_root_skips_library_member_fake_solc.snap
+++ b/crates/fe/tests/fixtures/cli_output/workspaces/build_workspace_root_skips_library_member/build_workspace_root_skips_library_member_fake_solc.snap
@@ -8,6 +8,10 @@ Wrote <out>/Foo.runtime.bin
 Wrote <out>/Bar.bin
 Wrote <out>/Bar.runtime.bin
 
+=== STDERR ===
+Warning: skipping recv arm `Ping`: selector signature is unknown; use `#[selector = sol("name(types)")]` to include it in the ABI
+Warning: skipping recv arm `Pong`: selector signature is unknown; use `#[selector = sol("name(types)")]` to include it in the ABI
+
 === EXIT CODE: 0 ===
 
 === ARTIFACTS ===

--- a/crates/fe/tests/fixtures/cli_output/workspaces/dependency_scope/build_dependency_in_scope_file_path_fake_solc.snap
+++ b/crates/fe/tests/fixtures/cli_output/workspaces/dependency_scope/build_dependency_in_scope_file_path_fake_solc.snap
@@ -7,6 +7,9 @@ input_file: tests/fixtures/cli_output/workspaces/dependency_scope/build_dependen
 Wrote <out>/Foo.bin
 Wrote <out>/Foo.runtime.bin
 
+=== STDERR ===
+Warning: skipping recv arm `Ping`: selector signature is unknown; use `#[selector = sol("name(types)")]` to include it in the ABI
+
 === EXIT CODE: 0 ===
 
 === ARTIFACTS ===

--- a/crates/hir/src/analysis/ty/msg_selector.rs
+++ b/crates/hir/src/analysis/ty/msg_selector.rs
@@ -62,7 +62,12 @@ fn check_msg_mod<'db>(
             continue;
         };
 
-        let Some(selector) = eval_msg_variant_selector(db, struct_, ty_diags) else {
+        let variant_ty = crate::analysis::ty::ty_def::TyId::adt(
+            db,
+            crate::analysis::ty::adt_def::AdtRef::from(struct_).as_adt(db),
+        );
+        let Some(selector) = eval_msg_variant_selector(db, variant_ty, struct_.scope(), ty_diags)
+        else {
             continue;
         };
 

--- a/crates/hir/src/analysis/ty/ty_check/contract.rs
+++ b/crates/hir/src/analysis/ty/ty_check/contract.rs
@@ -531,7 +531,10 @@ pub fn check_contract_recv_blocks<'db>(
                 let variant_span: DynLazySpan<'db> = variant.span().name().into();
 
                 // Check selector conflicts
-                if let Some(selector) = eval_msg_variant_selector(db, variant, &mut diags) {
+                let variant_ty = TyId::adt(db, AdtRef::from(variant).as_adt(db));
+                if let Some(selector) =
+                    eval_msg_variant_selector(db, variant_ty, variant.scope(), &mut diags)
+                {
                     check_selector_conflict(
                         selector,
                         variant,
@@ -563,7 +566,7 @@ pub fn check_contract_recv_blocks<'db>(
 
                     // Check selector conflicts
                     if let Some(selector) =
-                        eval_msg_variant_selector(db, resolved.variant_struct, &mut diags)
+                        eval_msg_variant_selector(db, resolved.ty, contract.scope(), &mut diags)
                     {
                         check_selector_conflict(
                             selector,
@@ -637,17 +640,25 @@ fn check_handler_conflict<'db>(
 /// Evaluates a msg variant's `SELECTOR` associated const via CTFE.
 pub(crate) fn eval_msg_variant_selector<'db>(
     db: &'db dyn HirAnalysisDb,
-    struct_: Struct<'db>,
+    variant_ty: TyId<'db>,
+    scope: ScopeId<'db>,
     diags: &mut Vec<FuncBodyDiag<'db>>,
 ) -> Option<u32> {
-    let msg_variant_trait = resolve_core_trait(db, struct_.scope(), &["message", "MsgVariant"])?;
+    let msg_variant_trait = resolve_core_trait(db, scope, &["message", "MsgVariant"])?;
 
-    let canonical_ty = Canonical::new(db, TyId::adt(db, AdtRef::from(struct_).as_adt(db)));
-    let ingot = struct_.top_mod(db).ingot(db);
-    let impl_ = impls_for_ty(db, ingot, canonical_ty)
-        .iter()
-        .find(|impl_| impl_.skip_binder().trait_def(db) == msg_variant_trait)?
-        .skip_binder();
+    let canonical_ty = Canonical::new(db, variant_ty);
+    let scope_ingot = scope.ingot(db);
+    let search_ingots = [
+        Some(scope_ingot),
+        variant_ty.ingot(db).filter(|&ingot| ingot != scope_ingot),
+    ];
+    let implementor = search_ingots.into_iter().flatten().find_map(|ingot| {
+        impls_for_ty(db, ingot, canonical_ty)
+            .iter()
+            .find(|impl_| impl_.skip_binder().trait_def(db) == msg_variant_trait)
+            .copied()
+    })?;
+    let impl_ = implementor.skip_binder();
 
     let selector_name = IdentId::new(db, "SELECTOR".to_string());
     let selector_const = impl_

--- a/crates/hir/src/core/semantic/mod.rs
+++ b/crates/hir/src/core/semantic/mod.rs
@@ -32,7 +32,9 @@ pub use symbol::{
 
 use crate::HirDb;
 use crate::analysis::HirAnalysisDb;
-use crate::analysis::ty::corelib::{resolve_core_trait, resolve_lib_type_path};
+use crate::analysis::ty::corelib::{
+    resolve_core_trait, resolve_lib_func_path, resolve_lib_type_path,
+};
 use crate::analysis::ty::diagnostics::{ImplDiag, TyLowerDiag};
 use crate::analysis::ty::normalize::normalize_ty;
 use crate::analysis::ty::ty_def::Kind;
@@ -950,15 +952,14 @@ impl<'db> RecvArmView<'db> {
         let contract = recv.contract(db);
 
         let variant_ty = self.variant_ty(db);
-        let selector_value = variant_struct_from_ty(db, variant_ty)
-            .and_then(|s| get_variant_selector(db, s))
-            .unwrap_or_default();
+        let selector_info = get_variant_selector_info(db, variant_ty, contract.scope());
 
         let Some(msg_variant_trait) =
             resolve_core_trait(db, contract.scope(), &["message", "MsgVariant"])
         else {
             return RecvArmAbiInfo {
-                selector_value,
+                selector_value: selector_info.value,
+                selector_signature: selector_info.signature,
                 args_ty: variant_ty,
                 ret_ty: None,
             };
@@ -982,7 +983,8 @@ impl<'db> RecvArmView<'db> {
         let ret_ty = (variant_ret_ty != TyId::unit(db)).then_some(variant_ret_ty);
 
         RecvArmAbiInfo {
-            selector_value,
+            selector_value: selector_info.value,
+            selector_signature: selector_info.signature,
             args_ty,
             ret_ty,
         }
@@ -1123,9 +1125,16 @@ impl<'db> EffectEnvView<'db> {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Update)]
 pub struct RecvArmAbiInfo<'db> {
-    pub selector_value: u32,
+    pub selector_value: Option<u32>,
+    pub selector_signature: Option<String>,
     pub args_ty: TyId<'db>,
     pub ret_ty: Option<TyId<'db>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Update)]
+struct VariantSelectorInfo {
+    value: Option<u32>,
+    signature: Option<String>,
 }
 
 fn variant_struct_from_ty<'db>(db: &'db dyn HirAnalysisDb, ty: TyId<'db>) -> Option<Struct<'db>> {
@@ -1884,41 +1893,244 @@ fn resolve_sol_abi_ty<'db>(
     }
 }
 
-fn get_variant_selector<'db>(db: &'db dyn HirAnalysisDb, struct_: Struct<'db>) -> Option<u32> {
+fn get_variant_selector_info<'db>(
+    db: &'db dyn HirAnalysisDb,
+    variant_ty: TyId<'db>,
+    scope: ScopeId<'db>,
+) -> VariantSelectorInfo {
     use crate::analysis::ty::{
+        canonical::Canonical,
         const_eval::{ConstValue, try_eval_const_body},
+        corelib::resolve_core_trait,
+        trait_def::impls_for_ty,
         ty_def::{PrimTy, TyBase, TyData},
     };
     use num_traits::ToPrimitive;
 
-    let msg_variant_trait = resolve_core_trait(db, struct_.scope(), &["message", "MsgVariant"])?;
+    let Some(msg_variant_trait) = resolve_core_trait(db, scope, &["message", "MsgVariant"]) else {
+        return VariantSelectorInfo {
+            value: None,
+            signature: None,
+        };
+    };
+    let canonical_ty = Canonical::new(db, variant_ty);
+    let scope_ingot = scope.ingot(db);
+    let search_ingots = [
+        Some(scope_ingot),
+        variant_ty.ingot(db).filter(|&ingot| ingot != scope_ingot),
+    ];
 
-    let adt_def = crate::analysis::ty::adt_def::AdtRef::from(struct_).as_adt(db);
-    let ty = TyId::adt(db, adt_def);
-    let canonical_ty = crate::analysis::ty::canonical::Canonical::new(db, ty);
-    let ingot = struct_.top_mod(db).ingot(db);
-
-    let impl_ = crate::analysis::ty::trait_def::impls_for_ty(db, ingot, canonical_ty)
-        .iter()
-        .find(|impl_| impl_.skip_binder().trait_def(db).eq(&msg_variant_trait))?
-        .skip_binder();
+    let Some(implementor) = search_ingots.into_iter().flatten().find_map(|ingot| {
+        impls_for_ty(db, ingot, canonical_ty)
+            .iter()
+            .find(|impl_| impl_.skip_binder().trait_def(db).eq(&msg_variant_trait))
+            .copied()
+    }) else {
+        return VariantSelectorInfo {
+            value: None,
+            signature: None,
+        };
+    };
+    let impl_ = implementor.skip_binder();
 
     let selector_name = IdentId::new(db, "SELECTOR".to_string());
     let hir_impl = impl_.hir_impl_trait(db);
-    let selector_const = hir_impl
+    let Some(selector_const) = hir_impl
         .hir_consts(db)
         .iter()
-        .find(|c| c.name.to_opt() == Some(selector_name))?;
+        .find(|c| c.name.to_opt() == Some(selector_name))
+    else {
+        return VariantSelectorInfo {
+            value: None,
+            signature: None,
+        };
+    };
 
-    let body = selector_const.value.to_opt()?;
+    let Some(body) = selector_const.value.to_opt() else {
+        return VariantSelectorInfo {
+            value: None,
+            signature: None,
+        };
+    };
+    let signature = selector_signature_from_body(db, body, hir_impl.scope());
     let expected_ty = TyId::new(db, TyData::TyBase(TyBase::Prim(PrimTy::U32)));
-    match try_eval_const_body(db, body, expected_ty)? {
-        ConstValue::Int(value) => value.to_u32(),
-        ConstValue::Bool(_)
-        | ConstValue::Bytes(_)
-        | ConstValue::EnumVariant(_)
-        | ConstValue::ConstArray(_) => None,
+    let value = match try_eval_const_body(db, body, expected_ty) {
+        Some(ConstValue::Int(value)) => value.to_u32(),
+        Some(
+            ConstValue::Bool(_)
+            | ConstValue::Bytes(_)
+            | ConstValue::EnumVariant(_)
+            | ConstValue::ConstArray(_),
+        )
+        | None => None,
+    };
+
+    VariantSelectorInfo { value, signature }
+}
+
+fn selector_signature_from_body<'db>(
+    db: &'db dyn HirAnalysisDb,
+    body: Body<'db>,
+    scope: ScopeId<'db>,
+) -> Option<String> {
+    use crate::analysis::ty::ty_def::{PrimTy, TyBase, TyData};
+
+    let expected_ty = TyId::new(db, TyData::TyBase(TyBase::Prim(PrimTy::U32)));
+    let (_, typed_body) =
+        crate::analysis::ty::ty_check::check_anon_const_body(db, body, expected_ty);
+    let mut visited = SelectorSearchVisited::new();
+
+    selector_signature_from_typed_body(db, body, scope, typed_body, &mut visited)
+}
+
+/// Tracks already-visited items to prevent cycles when following const/fn references.
+struct SelectorSearchVisited<'db> {
+    consts: FxHashSet<Const<'db>>,
+    funcs: FxHashSet<Func<'db>>,
+    locals: FxHashSet<PatId>,
+}
+
+impl<'db> SelectorSearchVisited<'db> {
+    fn new() -> Self {
+        Self {
+            consts: FxHashSet::default(),
+            funcs: FxHashSet::default(),
+            locals: FxHashSet::default(),
+        }
     }
+}
+
+fn selector_signature_from_typed_body<'db>(
+    db: &'db dyn HirAnalysisDb,
+    body: Body<'db>,
+    scope: ScopeId<'db>,
+    typed_body: &crate::analysis::ty::ty_check::TypedBody<'db>,
+    visited: &mut SelectorSearchVisited<'db>,
+) -> Option<String> {
+    let expr_id = body.expr(db);
+    selector_signature_from_expr(db, body, scope, typed_body, visited, expr_id)
+}
+
+fn selector_signature_from_expr<'db>(
+    db: &'db dyn HirAnalysisDb,
+    body: Body<'db>,
+    scope: ScopeId<'db>,
+    typed_body: &crate::analysis::ty::ty_check::TypedBody<'db>,
+    visited: &mut SelectorSearchVisited<'db>,
+    expr_id: ExprId,
+) -> Option<String> {
+    match expr_id.data(db, body) {
+        Partial::Present(Expr::Call(_callee, args)) => {
+            if args.len() == 1
+                && args[0].label.is_none()
+                && let Partial::Present(Expr::Lit(LitKind::String(signature))) =
+                    args[0].expr.data(db, body)
+            {
+                let resolved_sol = resolve_lib_func_path(db, scope, "std::abi::sol")?;
+                if let crate::hir_def::CallableDef::Func(func) =
+                    typed_body.callable_expr(expr_id)?.callable_def
+                    && func == resolved_sol
+                {
+                    return Some(signature.data(db).to_string());
+                }
+            }
+
+            // Follow const fn calls
+            if let Some(callable) = typed_body.callable_expr(expr_id)
+                && let crate::hir_def::CallableDef::Func(func) = callable.callable_def
+                && func.is_const(db)
+                && visited.funcs.insert(func)
+            {
+                let (_, func_typed_body) = crate::analysis::ty::ty_check::check_func_body(db, func);
+                if let Some(func_body) = func_typed_body.body() {
+                    return selector_signature_from_typed_body(
+                        db,
+                        func_body,
+                        func.scope(),
+                        func_typed_body,
+                        visited,
+                    );
+                }
+            }
+        }
+        Partial::Present(Expr::Block(stmts)) => {
+            if let Some(last_stmt) = stmts.last()
+                && let Partial::Present(Stmt::Expr(inner_expr)) = last_stmt.data(db, body)
+            {
+                return selector_signature_from_expr(
+                    db,
+                    body,
+                    scope,
+                    typed_body,
+                    visited,
+                    *inner_expr,
+                );
+            }
+        }
+        _ => {}
+    }
+
+    if let Some(signature) =
+        selector_signature_from_local_binding(db, body, scope, typed_body, visited, expr_id)
+    {
+        return Some(signature);
+    }
+
+    match typed_body.expr_const_ref(expr_id)? {
+        crate::analysis::ty::ty_check::ConstRef::Const(const_) => {
+            if !visited.consts.insert(const_) {
+                return None;
+            }
+            let (_, const_typed_body) = crate::analysis::ty::ty_check::check_const_body(db, const_);
+            let const_body = const_typed_body.body()?;
+            selector_signature_from_typed_body(
+                db,
+                const_body,
+                const_.scope(),
+                const_typed_body,
+                visited,
+            )
+        }
+        crate::analysis::ty::ty_check::ConstRef::TraitConst { .. } => None,
+    }
+}
+
+fn selector_signature_from_local_binding<'db>(
+    db: &'db dyn HirAnalysisDb,
+    body: Body<'db>,
+    scope: ScopeId<'db>,
+    typed_body: &crate::analysis::ty::ty_check::TypedBody<'db>,
+    visited: &mut SelectorSearchVisited<'db>,
+    expr_id: ExprId,
+) -> Option<String> {
+    let crate::analysis::ty::ty_check::LocalBinding::Local { pat, .. } =
+        typed_body.expr_binding(expr_id)?
+    else {
+        return None;
+    };
+
+    if !visited.locals.insert(pat) {
+        return None;
+    }
+
+    let init_expr = selector_local_binding_init_expr(db, body, pat)?;
+    selector_signature_from_expr(db, body, scope, typed_body, visited, init_expr)
+}
+
+fn selector_local_binding_init_expr<'db>(
+    db: &'db dyn HirAnalysisDb,
+    body: Body<'db>,
+    pat: PatId,
+) -> Option<ExprId> {
+    for (_, stmt) in body.stmts(db).iter() {
+        if let Partial::Present(Stmt::Let(stmt_pat, _, Some(init_expr))) = stmt
+            && *stmt_pat == pat
+        {
+            return Some(*init_expr);
+        }
+    }
+
+    None
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Update)]

--- a/crates/mir/src/lower/contracts/plan.rs
+++ b/crates/mir/src/lower/contracts/plan.rs
@@ -280,11 +280,22 @@ impl<'db> ContractPlan<'db> {
         for recv in contract.recv_views(db) {
             for arm in recv.arms(db) {
                 let abi_info = arm.abi_info(db, target.abi.abi_ty);
+                let selector =
+                    abi_info
+                        .selector_value
+                        .ok_or_else(|| MirLowerError::Unsupported {
+                            func_name: "<contract lowering>".into(),
+                            message: format!(
+                                "contract `{display_name}` recv arm {}:{} has no resolved selector",
+                                recv.index(db),
+                                arm.index(db)
+                            ),
+                        })?;
                 arms.push(RuntimeDispatchArmPlan {
                     recv_idx: recv.index(db),
                     arm_idx: arm.index(db),
                     is_payable: arm.arm(db).is_some_and(|a| a.is_payable(db)),
-                    selector: abi_info.selector_value,
+                    selector,
                     call: RuntimeCallPlan {
                         callee: SyntheticId::ContractRecvArmHandler {
                             contract,


### PR DESCRIPTION
### Summary

  Adds Ethereum-compatible JSON ABI generation to the Fe compiler. ABI files (`<contract>.abi.json`) are now emitted by default alongside bytecode artifacts. The ABI is derived from the contract's semantic types,
   ensuring correctness even for generic msg variants.

  ### What it does

  **ABI entries are generated from:**
  - `recv` arms → `"function"` entries (name, inputs, outputs, stateMutability)
  - `init` blocks → `"constructor"` entries (inputs, stateMutability)
  - `#[event]` structs reachable from the contract → `"event"` entries (inputs with indexed flags)

  **Type mapping** uses the semantic type system (not HIR), so generic msg variants like `GenericMsg<u8>` correctly emit `uint8` rather than an unresolved type parameter.

  **Selector validation** ensures the ABI is consistent with on-chain behavior:
  - The function name and argument types are extracted from the `sol("name(types)")` selector signature
  - The canonical Keccak-256 selector is recomputed and verified against the declared selector value
  - Arity and type mismatches between the selector signature and semantic types are hard errors

  **Graceful handling of hex selectors:** Recv arms with raw hex selectors (`#[selector = 0x...]`) are skipped with a warning rather than failing the build, so the rest of the ABI can still be generated.

  **Event collection** is scope-aware: only event structs actually reachable from the contract's init/recv bodies (including transitively called functions) are included — unused events defined elsewhere in the
  ingot are excluded.

  **State mutability** is derived from effects: `#[payable]` → `"payable"`, no effects → `"pure"`, read-only → `"view"`, any mutation → `"nonpayable"`.

  **Default emit:** ABI is included in the default `--emit` set (`bytecode,runtime-bytecode,abi`), so `fe build` produces ABI files without extra flags.

  ### Test plan

  - [x] Unit tests: hex selector skipping with warning, `sol()` alias naming, const alias resolution, generic variant types, event/function name collisions, tuple/array type encoding
  - [x] CLI integration tests: artifact written to output + report dir, imported events included, unused events excluded, hex selector produces warning + partial ABI
  - [x] `cargo test -p fe` — all 57 tests pass

