### PR TITLE
feat(cli): include git hash in fe --version output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2054,6 +2054,7 @@ dependencies = [
  "fe-solc-runner",
  "fe-test-utils",
  "fe-web",
+ "gix",
  "glob",
  "hex",
  "petgraph",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ derive_more = { version = "1.0", default-features = false, features = [
 dir-test = "0.4"
 glob = "0.3.2"
 crossbeam-channel = "0.5.15"
+gix = { version = "0.83.0", default-features = false }
 rustc-hash = "2.1.0"
 num-bigint = "0.4"
 num-traits = "0.2"

--- a/crates/fe/Cargo.toml
+++ b/crates/fe/Cargo.toml
@@ -55,3 +55,6 @@ dir-test.workspace = true
 test-utils.workspace = true
 semantic-indexing.workspace = true
 sha2 = "0.10"
+
+[build-dependencies]
+gix = { workspace = true, features = ["sha1"] }

--- a/crates/fe/build.rs
+++ b/crates/fe/build.rs
@@ -1,4 +1,7 @@
-use std::{env, process::Command};
+use std::{
+    env,
+    path::{Path, PathBuf},
+};
 
 fn main() {
     println!("cargo:rerun-if-changed=tests/fixtures");
@@ -12,34 +15,33 @@ fn main() {
         return;
     }
 
-    let Some(hash) = git_output(&["rev-parse", "--short", "HEAD"]) else {
+    let Some(repo) = git_repo() else {
         return;
     };
 
-    emit_git_rerun_paths();
+    let Ok(head_id) = repo.head_id() else {
+        return;
+    };
+
+    emit_git_rerun_paths(&repo);
+    let hash = head_id.shorten_or_id();
     println!("cargo:rustc-env=FE_GIT_HASH={hash}");
 }
 
-fn emit_git_rerun_paths() {
-    for path in [
-        git_output(&["rev-parse", "--git-path", "HEAD"]),
-        git_output(&["symbolic-ref", "-q", "HEAD"])
-            .and_then(|branch| git_output(&["rev-parse", "--git-path", branch.as_str()])),
-        git_output(&["rev-parse", "--git-path", "packed-refs"]),
-    ]
-    .into_iter()
-    .flatten()
-    {
-        println!("cargo:rerun-if-changed={path}");
+fn git_repo() -> Option<gix::Repository> {
+    let manifest_dir = env::var_os("CARGO_MANIFEST_DIR").map(PathBuf::from)?;
+    gix::discover(manifest_dir).ok()
+}
+
+fn emit_git_rerun_paths(repo: &gix::Repository) {
+    emit_rerun_path(repo.git_dir().join("HEAD"));
+    emit_rerun_path(repo.common_dir().join("packed-refs"));
+
+    if let Ok(Some(head_ref)) = repo.head_ref() {
+        emit_rerun_path(repo.common_dir().join(head_ref.name().to_path()));
     }
 }
 
-fn git_output(args: &[&str]) -> Option<String> {
-    let output = Command::new("git").args(args).output().ok()?;
-    if !output.status.success() {
-        return None;
-    }
-
-    let output = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    (!output.is_empty()).then_some(output)
+fn emit_rerun_path(path: impl AsRef<Path>) {
+    println!("cargo:rerun-if-changed={}", path.as_ref().display());
 }

--- a/crates/fe/build.rs
+++ b/crates/fe/build.rs
@@ -30,7 +30,11 @@ fn main() {
 
 fn git_repo() -> Option<gix::Repository> {
     let manifest_dir = env::var_os("CARGO_MANIFEST_DIR").map(PathBuf::from)?;
-    gix::discover(manifest_dir).ok()
+    let workspace_root = manifest_dir.parent()?.parent()?;
+
+    // Open the expected Fe workspace root directly so source exports nested in
+    // another checkout do not inherit that checkout's HEAD.
+    gix::open(workspace_root).ok()
 }
 
 fn emit_git_rerun_paths(repo: &gix::Repository) {

--- a/crates/fe/build.rs
+++ b/crates/fe/build.rs
@@ -1,4 +1,45 @@
+use std::{env, process::Command};
+
 fn main() {
     println!("cargo:rerun-if-changed=tests/fixtures");
     println!("cargo:rerun-if-changed=tests/doc_fixtures");
+    println!("cargo:rerun-if-env-changed=FE_GIT_HASH");
+
+    if let Ok(override_hash) = env::var("FE_GIT_HASH")
+        && !override_hash.trim().is_empty()
+    {
+        println!("cargo:rustc-env=FE_GIT_HASH={}", override_hash.trim());
+        return;
+    }
+
+    let Some(hash) = git_output(&["rev-parse", "--short", "HEAD"]) else {
+        return;
+    };
+
+    emit_git_rerun_paths();
+    println!("cargo:rustc-env=FE_GIT_HASH={hash}");
+}
+
+fn emit_git_rerun_paths() {
+    for path in [
+        git_output(&["rev-parse", "--git-path", "HEAD"]),
+        git_output(&["symbolic-ref", "-q", "HEAD"])
+            .and_then(|branch| git_output(&["rev-parse", "--git-path", branch.as_str()])),
+        git_output(&["rev-parse", "--git-path", "packed-refs"]),
+    ]
+    .into_iter()
+    .flatten()
+    {
+        println!("cargo:rerun-if-changed={path}");
+    }
+}
+
+fn git_output(args: &[&str]) -> Option<String> {
+    let output = Command::new("git").args(args).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    let output = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!output.is_empty()).then_some(output)
 }

--- a/crates/fe/src/main.rs
+++ b/crates/fe/src/main.rs
@@ -14,6 +14,7 @@ mod tree;
 mod workspace_ingot;
 
 use std::fs;
+use std::sync::OnceLock;
 
 use build::build;
 use camino::Utf8PathBuf;
@@ -47,8 +48,18 @@ pub enum TestEmit {
     Rmir,
 }
 
+fn cli_version() -> &'static str {
+    static VERSION: OnceLock<String> = OnceLock::new();
+    VERSION
+        .get_or_init(|| match option_env!("FE_GIT_HASH") {
+            Some(hash) if !hash.is_empty() => format!("{} ({hash})", env!("CARGO_PKG_VERSION")),
+            _ => env!("CARGO_PKG_VERSION").to_string(),
+        })
+        .as_str()
+}
+
 #[derive(Debug, Clone, Parser)]
-#[command(version, about, long_about = None)]
+#[command(version = cli_version(), about, long_about = None)]
 pub struct Options {
     /// Control colored output (auto, always, never).
     #[arg(long, global = true, value_enum, default_value = "auto")]

--- a/crates/resolver/Cargo.toml
+++ b/crates/resolver/Cargo.toml
@@ -29,7 +29,7 @@ toml = "0.8"
 tempfile = "3.13"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-gix = { version = "0.83.0", default-features = false, features = [
+gix = { workspace = true, features = [
     "sha1",
     "worktree-mutation",
     "blocking-http-transport-reqwest-rust-tls",


### PR DESCRIPTION
## Summary

This PR resolves #1338 by adding the current git short hash to `fe --version`.

Before:
- `fe 26.0.0-alpha.7`

After:
- `fe 26.0.0-alpha.7 (6d15b3851)` (example)

## What changed

- Added `crates/fe/build.rs`:
  - Reads `git rev-parse --short HEAD` at build time.
  - Exposes it as `FE_GIT_HASH` via `cargo:rustc-env`.
  - Supports overriding via `FE_GIT_HASH` environment variable.
- Updated `crates/fe/src/main.rs`:
  - Added `cli_version()` to format version output.
  - Switched clap metadata from `#[command(version)]` to `#[command(version = cli_version())]`.

## Validation

- Ran:
  - `cargo run -q -p fe -- --version`
- Verified output now includes the git short hash.
