### PR TITLE
Expose missing Ctx APIs

### DIFF
--- a/crates/fe/tests/fixtures/fe_test/ctx.fe
+++ b/crates/fe/tests/fixtures/fe_test/ctx.fe
@@ -1,0 +1,204 @@
+use std::evm::{Evm, Ctx, Address}
+use std::abi::sol
+
+msg CtxMsg {
+    #[selector = 0x01]
+    GetOrigin -> u256,
+    #[selector = 0x02]
+    GetCoinbase -> u256,
+    #[selector = 0x03]
+    GetTimestamp -> u256,
+    #[selector = 0x04]
+    GetBlockNumber -> u256,
+    #[selector = 0x05]
+    GetPrevrandao -> u256,
+    #[selector = 0x06]
+    GetGaslimit -> u256,
+    #[selector = 0x07]
+    GetChainid -> u256,
+    #[selector = 0x08]
+    GetBasefee -> u256,
+    #[selector = 0x09]
+    GetBlockhash { block: u256 } -> u256,
+    #[selector = 0x0a]
+    GetAddress -> u256,
+    #[selector = 0x0b]
+    GetCaller -> u256,
+    #[selector = 0x0c]
+    GetGas -> u256,
+}
+
+pub contract CtxBox uses (ctx: Ctx) {
+    init() {}
+
+    recv CtxMsg {
+        GetOrigin {} -> u256
+            uses (ctx)
+        {
+            ctx.origin().inner
+        }
+
+        GetCoinbase {} -> u256
+            uses (ctx)
+        {
+            ctx.coinbase().inner
+        }
+
+        GetTimestamp {} -> u256
+            uses (ctx)
+        {
+            ctx.timestamp()
+        }
+
+        GetBlockNumber {} -> u256
+            uses (ctx)
+        {
+            ctx.block_number()
+        }
+
+        GetPrevrandao {} -> u256
+            uses (ctx)
+        {
+            ctx.prevrandao()
+        }
+
+        GetGaslimit {} -> u256
+            uses (ctx)
+        {
+            ctx.gaslimit()
+        }
+
+        GetChainid {} -> u256
+            uses (ctx)
+        {
+            ctx.chainid()
+        }
+
+        GetBasefee {} -> u256
+            uses (ctx)
+        {
+            ctx.basefee()
+        }
+
+        GetBlockhash { block } -> u256
+            uses (ctx)
+        {
+            ctx.blockhash(block)
+        }
+
+        GetAddress {} -> u256
+            uses (ctx)
+        {
+            ctx.address().inner
+        }
+
+        GetCaller {} -> u256
+            uses (ctx)
+        {
+            ctx.caller().inner
+        }
+
+        GetGas {} -> u256
+            uses (ctx)
+        {
+            ctx.gas()
+        }
+    }
+}
+
+// Test: ctx.origin() returns a value (may be zero in test env)
+#[test]
+fn test_origin() uses (evm: mut Evm) {
+    let addr = evm.create2<CtxBox>(value: 0, args: (), salt: 0)
+    let origin: u256 = evm.call(addr: addr, gas: 100000, value: 0, message: CtxMsg::GetOrigin {})
+    assert(origin == origin)
+}
+
+// Test: ctx.coinbase() returns a value (may be zero in test env)
+#[test]
+fn test_coinbase() uses (evm: mut Evm) {
+    let addr = evm.create2<CtxBox>(value: 0, args: (), salt: 0)
+    let coinbase: u256 = evm.call(addr: addr, gas: 100000, value: 0, message: CtxMsg::GetCoinbase {})
+    // coinbase may be zero in test environment, just verify the call succeeds
+    assert(coinbase == coinbase)
+}
+
+// Test: ctx.timestamp() returns a non-zero value
+#[test]
+fn test_timestamp() uses (evm: mut Evm) {
+    let addr = evm.create2<CtxBox>(value: 0, args: (), salt: 0)
+    let ts: u256 = evm.call(addr: addr, gas: 100000, value: 0, message: CtxMsg::GetTimestamp {})
+    assert(ts != 0)
+}
+
+// Test: ctx.block_number() returns a value
+#[test]
+fn test_block_number() uses (evm: mut Evm) {
+    let addr = evm.create2<CtxBox>(value: 0, args: (), salt: 0)
+    let num: u256 = evm.call(addr: addr, gas: 100000, value: 0, message: CtxMsg::GetBlockNumber {})
+    assert(num == num)
+}
+
+// Test: ctx.prevrandao() returns a value
+#[test]
+fn test_prevrandao() uses (evm: mut Evm) {
+    let addr = evm.create2<CtxBox>(value: 0, args: (), salt: 0)
+    let rand: u256 = evm.call(addr: addr, gas: 100000, value: 0, message: CtxMsg::GetPrevrandao {})
+    assert(rand == rand)
+}
+
+// Test: ctx.gaslimit() returns a non-zero value
+#[test]
+fn test_gaslimit() uses (evm: mut Evm) {
+    let addr = evm.create2<CtxBox>(value: 0, args: (), salt: 0)
+    let limit: u256 = evm.call(addr: addr, gas: 100000, value: 0, message: CtxMsg::GetGaslimit {})
+    assert(limit != 0)
+}
+
+// Test: ctx.chainid() returns a non-zero value
+#[test]
+fn test_chainid() uses (evm: mut Evm) {
+    let addr = evm.create2<CtxBox>(value: 0, args: (), salt: 0)
+    let id: u256 = evm.call(addr: addr, gas: 100000, value: 0, message: CtxMsg::GetChainid {})
+    assert(id != 0)
+}
+
+// Test: ctx.basefee() returns a value
+#[test]
+fn test_basefee() uses (evm: mut Evm) {
+    let addr = evm.create2<CtxBox>(value: 0, args: (), salt: 0)
+    let fee: u256 = evm.call(addr: addr, gas: 100000, value: 0, message: CtxMsg::GetBasefee {})
+    assert(fee == fee)
+}
+
+// Test: ctx.blockhash() returns a value for a given block
+#[test]
+fn test_blockhash() uses (evm: mut Evm) {
+    let addr = evm.create2<CtxBox>(value: 0, args: (), salt: 0)
+    let hash: u256 = evm.call(addr: addr, gas: 100000, value: 0, message: CtxMsg::GetBlockhash { block: 0 })
+    assert(hash == hash)
+}
+
+// Test: ctx.address() returns the contract's own address
+#[test]
+fn test_address() uses (evm: mut Evm) {
+    let addr = evm.create2<CtxBox>(value: 0, args: (), salt: 0)
+    let reported: u256 = evm.call(addr: addr, gas: 100000, value: 0, message: CtxMsg::GetAddress {})
+    assert(reported == addr.inner)
+}
+
+// Test: ctx.caller() returns the caller address
+#[test]
+fn test_caller() uses (evm: mut Evm) {
+    let addr = evm.create2<CtxBox>(value: 0, args: (), salt: 0)
+    let caller: u256 = evm.call(addr: addr, gas: 100000, value: 0, message: CtxMsg::GetCaller {})
+    assert(caller != 0)
+}
+
+// Test: ctx.gas() returns remaining gas (non-zero)
+#[test]
+fn test_gas() uses (evm: mut Evm) {
+    let addr = evm.create2<CtxBox>(value: 0, args: (), salt: 0)
+    let remaining: u256 = evm.call(addr: addr, gas: 100000, value: 0, message: CtxMsg::GetGas {})
+    assert(remaining != 0)
+}

--- a/crates/fe/tests/fixtures/fe_test/payable.fe
+++ b/crates/fe/tests/fixtures/fe_test/payable.fe
@@ -1,7 +1,7 @@
-use std::evm::{Evm, Address}
+use std::evm::{Evm, Ctx, Address}
 use std::abi::sol
 
-pub contract PayableBox {
+pub contract PayableBox uses (ctx: Ctx) {
     #[payable]
     init() {}
 
@@ -9,8 +9,10 @@ pub contract PayableBox {
         #[payable]
         Fund {} {}
 
-        GetBalance {} -> u256 {
-            0
+        GetBalance {} -> u256
+            uses (ctx)
+        {
+            ctx.selfbalance()
         }
     }
 }
@@ -126,4 +128,17 @@ fn test_payable_accepts_value() uses (evm: mut Evm) {
 fn test_payable_init_accepts_value() uses (evm: mut Evm) {
     let addr = evm.create2<PayableBox>(value: 1, args: (), salt: 0)
     assert(addr.inner != 0)
+}
+
+// Test: selfbalance reflects ETH sent to contract
+#[test(balance = 1000000000)]
+fn test_selfbalance() uses (evm: mut Evm) {
+    let addr = evm.create2<PayableBox>(value: 0, args: (), salt: 0)
+
+    // Fund the contract with 500 wei
+    evm.call(addr: addr, gas: 100000, value: 500, message: PayableMsg::Fund {})
+
+    // Query the balance via ctx.selfbalance()
+    let balance: u256 = evm.call(addr: addr, gas: 100000, value: 0, message: PayableMsg::GetBalance {})
+    assert(balance == 500)
 }

--- a/ingots/std/src/evm/effects.fe
+++ b/ingots/std/src/evm/effects.fe
@@ -146,9 +146,17 @@ impl<T> EffectRefMut<T> for TStorPtr<T> {}
 pub trait Ctx {
     fn address(self) -> Address
     fn caller(self) -> Address
+    fn origin(self) -> Address
+    fn coinbase(self) -> Address
     fn value(self) -> u256
     fn timestamp(self) -> u256
     fn block_number(self) -> u256
+    fn prevrandao(self) -> u256
+    fn gaslimit(self) -> u256
+    fn chainid(self) -> u256
+    fn basefee(self) -> u256
+    fn selfbalance(self) -> u256
+    fn blockhash(self, _: u256) -> u256
     fn gas(self) -> u256
 }
 
@@ -412,6 +420,12 @@ impl Ctx for Evm {
     fn caller(self) -> Address {
         Address { inner: ops::caller() }
     }
+    fn origin(self) -> Address {
+        Address { inner: ops::origin() }
+    }
+    fn coinbase(self) -> Address {
+        Address { inner: ops::coinbase() }
+    }
     fn value(self) -> u256 {
         ops::callvalue()
     }
@@ -420,6 +434,24 @@ impl Ctx for Evm {
     }
     fn block_number(self) -> u256 {
         ops::number()
+    }
+    fn prevrandao(self) -> u256 {
+        ops::prevrandao()
+    }
+    fn gaslimit(self) -> u256 {
+        ops::gaslimit()
+    }
+    fn chainid(self) -> u256 {
+        ops::chainid()
+    }
+    fn basefee(self) -> u256 {
+        ops::basefee()
+    }
+    fn selfbalance(self) -> u256 {
+        ops::selfbalance()
+    }
+    fn blockhash(self, _ block: u256) -> u256 {
+        ops::blockhash(block)
     }
     fn gas(self) -> u256 {
         ops::gas()


### PR DESCRIPTION
Since user code can't call `ops::*` directly anymore, we need to expose these APIs on `Ctx`