### PR TITLE
Fix `map` type unification

### DIFF
--- a/crates/fe/tests/fixtures/fe_test/result_map_chain_infers_independently.fe
+++ b/crates/fe/tests/fixtures/fe_test/result_map_chain_infers_independently.fe
@@ -1,0 +1,28 @@
+use core::functional::Fn
+use core::result::Result::{self, Ok}
+
+struct Wrap {
+    pub val: u256,
+}
+
+struct ToWrap {}
+impl Fn<u256, Wrap> for ToWrap {
+    fn call(self, _ x: own u256) -> Wrap {
+        Wrap { val: x }
+    }
+}
+
+struct FromWrap {}
+impl Fn<Wrap, u256> for FromWrap {
+    fn call(self, _ w: own Wrap) -> u256 {
+        w.val
+    }
+}
+
+#[test]
+fn result_map_chain_infers_independently() {
+    let r: Result<bool, u256> = Ok(42)
+    let value: u256 = r.map(ToWrap{}).map(FromWrap{}).unwrap()
+    let expected: u256 = 42
+    assert(value == expected)
+}

--- a/crates/hir/src/analysis/name_resolution/method_selection.rs
+++ b/crates/hir/src/analysis/name_resolution/method_selection.rs
@@ -124,19 +124,6 @@ fn receiver_is_ty_param_like<'db>(db: &'db dyn HirAnalysisDb, ty: TyId<'db>) -> 
     )
 }
 
-fn instantiate_to_receiver_kind<'db>(
-    db: &'db dyn HirAnalysisDb,
-    table: &mut UnificationTable<'db>,
-    candidate_self_ty: TyId<'db>,
-    receiver_ty: TyId<'db>,
-) -> TyId<'db> {
-    if receiver_ty.is_star_kind(db) {
-        table.instantiate_to_term(candidate_self_ty)
-    } else {
-        candidate_self_ty
-    }
-}
-
 impl<'db, 'a> CandidateAssembler<'db, 'a> {
     fn assemble(mut self) -> AssembledCandidates<'db> {
         if self.trait_.is_none() {
@@ -183,28 +170,30 @@ impl<'db, 'a> CandidateAssembler<'db, 'a> {
             }
         }
 
-        let mut table = UnificationTable::new(self.db);
-        let extracted_receiver_ty = self.receiver.extract_identity(&mut table);
+        self.receiver.with_materialized(self.db, |cx| {
+            let receiver = cx.query();
+            for &pred in self.assumptions.list(self.db) {
+                let snapshot = cx.snapshot();
+                // `*`-kind receivers need a fully applied self type before
+                // bound unification, otherwise abstract constructors can never
+                // match the concrete receiver term.
+                let self_ty = if receiver.is_star_kind(self.db) {
+                    cx.materialize_to_term(pred.self_ty(self.db))
+                } else {
+                    cx.materialize(pred.self_ty(self.db))
+                };
 
-        for &pred in self.assumptions.list(self.db) {
-            let snapshot = table.snapshot();
-            let self_ty = instantiate_to_receiver_kind(
-                self.db,
-                &mut table,
-                pred.self_ty(self.db),
-                extracted_receiver_ty,
-            );
-
-            if table.unify(extracted_receiver_ty, self_ty).is_ok() {
-                self.insert_trait_method_cand(pred);
-                for super_trait in pred.def(self.db).super_traits(self.db) {
-                    let super_trait = super_trait.instantiate(self.db, pred.args(self.db));
-                    self.insert_trait_method_cand(super_trait);
+                if cx.unify::<TyId<'db>>(receiver, self_ty).is_ok() {
+                    self.insert_trait_method_cand(pred);
+                    for super_trait in pred.def(self.db).super_traits(self.db) {
+                        let super_trait = super_trait.instantiate(self.db, pred.args(self.db));
+                        self.insert_trait_method_cand(super_trait);
+                    }
                 }
-            }
 
-            table.rollback_to(snapshot);
-        }
+                cx.rollback_to(snapshot);
+            }
+        });
     }
 
     fn allow_trait(&self, trait_def: Trait<'db>) -> bool {
@@ -408,7 +397,7 @@ impl<'db, 'a> MethodSelector<'db, 'a> {
         let mut table = UnificationTable::new(self.db);
         // Seed the table with receiver's canonical variables so that subsequent
         // canonicalization can safely probe them.
-        let _ = self.receiver.extract_identity(&mut table);
+        let _ = self.receiver.canonical().extract_identity(&mut table);
 
         // If the receiver is a type parameter (e.g. `D` in `fn f<D: Trait>(d: D)`),
         // prefer preserving any trait arguments coming from bounds rather than

--- a/crates/hir/src/analysis/name_resolution/method_selection.rs
+++ b/crates/hir/src/analysis/name_resolution/method_selection.rs
@@ -63,16 +63,26 @@ pub(crate) fn select_method_candidate<'db>(
     assumptions: PredicateListId<'db>,
     trait_: Option<Trait<'db>>,
 ) -> Result<MethodCandidate<'db>, MethodSelectionError<'db>> {
-    if receiver.value.is_ty_var(db) {
+    let mut table = UnificationTable::new(db);
+    let receiver_ty = receiver.extract_identity(&mut table);
+    if receiver_ty.is_ty_var(db) {
         return Err(MethodSelectionError::ReceiverTypeMustBeKnown);
     }
 
-    let candidates =
-        assemble_method_candidates(db, receiver, method_name, scope, assumptions, trait_);
+    let candidates = assemble_method_candidates(
+        db,
+        receiver,
+        receiver_ty,
+        method_name,
+        scope,
+        assumptions,
+        trait_,
+    );
 
     let selector = MethodSelector {
         db,
         receiver,
+        receiver_ty,
         scope,
         candidates,
         assumptions,
@@ -84,6 +94,7 @@ pub(crate) fn select_method_candidate<'db>(
 fn assemble_method_candidates<'db>(
     db: &'db dyn HirAnalysisDb,
     receiver_ty: Canonical<TyId<'db>>,
+    raw_receiver_ty: TyId<'db>,
     method_name: IdentId<'db>,
     scope: ScopeId<'db>,
     assumptions: PredicateListId<'db>,
@@ -92,6 +103,7 @@ fn assemble_method_candidates<'db>(
     CandidateAssembler {
         db,
         receiver_ty,
+        raw_receiver_ty,
         method_name,
         scope,
         assumptions,
@@ -105,6 +117,7 @@ struct CandidateAssembler<'db> {
     db: &'db dyn HirAnalysisDb,
     /// The type that method is being called on.
     receiver_ty: Canonical<TyId<'db>>,
+    raw_receiver_ty: TyId<'db>,
     /// The name of the method being called.
     method_name: IdentId<'db>,
     /// The scope that candidates are being assembled in.
@@ -147,8 +160,7 @@ impl<'db> CandidateAssembler<'db> {
 
     fn assemble_inherent_method_candidates(&mut self) {
         let ingot = self
-            .receiver_ty
-            .value
+            .raw_receiver_ty
             .ingot(self.db)
             .unwrap_or_else(|| self.scope.ingot(self.db));
         for &method in probe_method(self.db, ingot, self.receiver_ty, self.method_name) {
@@ -165,13 +177,12 @@ impl<'db> CandidateAssembler<'db> {
         //
         // In that case, rely on in-scope bounds (`assumptions`) to provide method
         // candidates.
-        let receiver_is_ty_param = receiver_is_ty_param_like(self.db, self.receiver_ty.value);
+        let receiver_is_ty_param = receiver_is_ty_param_like(self.db, self.raw_receiver_ty);
 
         if !receiver_is_ty_param {
             let search_ingots = [
                 Some(scope_ingot),
-                self.receiver_ty
-                    .value
+                self.raw_receiver_ty
                     .ingot(self.db)
                     .filter(|&ingot| ingot != scope_ingot),
             ];
@@ -224,6 +235,7 @@ impl<'db> CandidateAssembler<'db> {
 struct MethodSelector<'db> {
     db: &'db dyn HirAnalysisDb,
     receiver: Canonical<TyId<'db>>,
+    receiver_ty: TyId<'db>,
     scope: ScopeId<'db>,
     candidates: AssembledCandidates<'db>,
     assumptions: PredicateListId<'db>,
@@ -346,7 +358,7 @@ impl<'db> MethodSelector<'db> {
                     .filter_map(|(&cand, &is_confirmed)| is_confirmed.then_some(cand))
                     .collect();
                 if confirmed.len() == 1
-                    && (self.receiver.value.has_var(self.db)
+                    && (self.receiver_ty.has_var(self.db)
                         || selected
                             .iter()
                             .filter_map(|(&cand, &is_confirmed)| (!is_confirmed).then_some(cand))
@@ -367,7 +379,7 @@ impl<'db> MethodSelector<'db> {
         candidate: TraitMethodCand<'db>,
         confirmed: TraitMethodCand<'db>,
     ) -> bool {
-        let canonical_receiver = Canonicalized::new(self.db, self.receiver.value);
+        let canonical_receiver = Canonicalized::new(self.db, self.receiver_ty);
         let mut table = UnificationTable::new(self.db);
         let candidate_inst = canonical_receiver.extract_solution(&mut table, candidate.inst);
         let confirmed_inst = canonical_receiver.extract_solution(&mut table, confirmed.inst);
@@ -415,7 +427,7 @@ impl<'db> MethodSelector<'db> {
         // introducing fresh inference vars. Otherwise, unconstrained trait args
         // can trigger spurious "type annotation needed" diagnostics on method calls
         // whose signatures don't mention those args (e.g. `AbiDecoder<A>::read_word`).
-        let receiver_is_ty_param = receiver_is_ty_param_like(self.db, self.receiver.value);
+        let receiver_is_ty_param = receiver_is_ty_param_like(self.db, self.receiver_ty);
 
         let query = CanonicalGoalQuery::new(self.db, inst, self.assumptions);
         let inst = if receiver_is_ty_param {

--- a/crates/hir/src/analysis/name_resolution/method_selection.rs
+++ b/crates/hir/src/analysis/name_resolution/method_selection.rs
@@ -57,32 +57,23 @@ impl<'db> TraitMethodCand<'db> {
 
 pub(crate) fn select_method_candidate<'db>(
     db: &'db dyn HirAnalysisDb,
-    receiver: Canonical<TyId<'db>>,
+    receiver: &Canonicalized<'db, TyId<'db>>,
     method_name: IdentId<'db>,
     scope: ScopeId<'db>,
     assumptions: PredicateListId<'db>,
     trait_: Option<Trait<'db>>,
 ) -> Result<MethodCandidate<'db>, MethodSelectionError<'db>> {
-    let mut table = UnificationTable::new(db);
-    let receiver_ty = receiver.extract_identity(&mut table);
+    let receiver_ty = receiver.original();
     if receiver_ty.is_ty_var(db) {
         return Err(MethodSelectionError::ReceiverTypeMustBeKnown);
     }
 
-    let candidates = assemble_method_candidates(
-        db,
-        receiver,
-        receiver_ty,
-        method_name,
-        scope,
-        assumptions,
-        trait_,
-    );
+    let candidates =
+        assemble_method_candidates(db, receiver, method_name, scope, assumptions, trait_);
 
     let selector = MethodSelector {
         db,
         receiver,
-        receiver_ty,
         scope,
         candidates,
         assumptions,
@@ -93,8 +84,7 @@ pub(crate) fn select_method_candidate<'db>(
 
 fn assemble_method_candidates<'db>(
     db: &'db dyn HirAnalysisDb,
-    receiver_ty: Canonical<TyId<'db>>,
-    raw_receiver_ty: TyId<'db>,
+    receiver: &Canonicalized<'db, TyId<'db>>,
     method_name: IdentId<'db>,
     scope: ScopeId<'db>,
     assumptions: PredicateListId<'db>,
@@ -102,8 +92,7 @@ fn assemble_method_candidates<'db>(
 ) -> AssembledCandidates<'db> {
     CandidateAssembler {
         db,
-        receiver_ty,
-        raw_receiver_ty,
+        receiver,
         method_name,
         scope,
         assumptions,
@@ -113,11 +102,10 @@ fn assemble_method_candidates<'db>(
     .assemble()
 }
 
-struct CandidateAssembler<'db> {
+struct CandidateAssembler<'db, 'a> {
     db: &'db dyn HirAnalysisDb,
     /// The type that method is being called on.
-    receiver_ty: Canonical<TyId<'db>>,
-    raw_receiver_ty: TyId<'db>,
+    receiver: &'a Canonicalized<'db, TyId<'db>>,
     /// The name of the method being called.
     method_name: IdentId<'db>,
     /// The scope that candidates are being assembled in.
@@ -149,7 +137,7 @@ fn instantiate_to_receiver_kind<'db>(
     }
 }
 
-impl<'db> CandidateAssembler<'db> {
+impl<'db, 'a> CandidateAssembler<'db, 'a> {
     fn assemble(mut self) -> AssembledCandidates<'db> {
         if self.trait_.is_none() {
             self.assemble_inherent_method_candidates();
@@ -160,10 +148,11 @@ impl<'db> CandidateAssembler<'db> {
 
     fn assemble_inherent_method_candidates(&mut self) {
         let ingot = self
-            .raw_receiver_ty
+            .receiver
+            .original()
             .ingot(self.db)
             .unwrap_or_else(|| self.scope.ingot(self.db));
-        for &method in probe_method(self.db, ingot, self.receiver_ty, self.method_name) {
+        for &method in probe_method(self.db, ingot, self.receiver.canonical(), self.method_name) {
             self.candidates.insert_inherent_method(method);
         }
     }
@@ -177,24 +166,25 @@ impl<'db> CandidateAssembler<'db> {
         //
         // In that case, rely on in-scope bounds (`assumptions`) to provide method
         // candidates.
-        let receiver_is_ty_param = receiver_is_ty_param_like(self.db, self.raw_receiver_ty);
+        let receiver_is_ty_param = receiver_is_ty_param_like(self.db, self.receiver.original());
 
         if !receiver_is_ty_param {
             let search_ingots = [
                 Some(scope_ingot),
-                self.raw_receiver_ty
+                self.receiver
+                    .original()
                     .ingot(self.db)
                     .filter(|&ingot| ingot != scope_ingot),
             ];
             for ingot in search_ingots.into_iter().flatten() {
-                for &imp in impls_for_ty(self.db, ingot, self.receiver_ty) {
+                for &imp in impls_for_ty(self.db, ingot, self.receiver.canonical()) {
                     self.insert_trait_method_cand(imp.skip_binder().trait_(self.db));
                 }
             }
         }
 
         let mut table = UnificationTable::new(self.db);
-        let extracted_receiver_ty = self.receiver_ty.extract_identity(&mut table);
+        let extracted_receiver_ty = self.receiver.extract_identity(&mut table);
 
         for &pred in self.assumptions.list(self.db) {
             let snapshot = table.snapshot();
@@ -232,16 +222,15 @@ impl<'db> CandidateAssembler<'db> {
     }
 }
 
-struct MethodSelector<'db> {
+struct MethodSelector<'db, 'a> {
     db: &'db dyn HirAnalysisDb,
-    receiver: Canonical<TyId<'db>>,
-    receiver_ty: TyId<'db>,
+    receiver: &'a Canonicalized<'db, TyId<'db>>,
     scope: ScopeId<'db>,
     candidates: AssembledCandidates<'db>,
     assumptions: PredicateListId<'db>,
 }
 
-impl<'db> MethodSelector<'db> {
+impl<'db, 'a> MethodSelector<'db, 'a> {
     fn select(self) -> Result<MethodCandidate<'db>, MethodSelectionError<'db>> {
         if let Some(res) = self.select_inherent_method() {
             return res;
@@ -358,7 +347,7 @@ impl<'db> MethodSelector<'db> {
                     .filter_map(|(&cand, &is_confirmed)| is_confirmed.then_some(cand))
                     .collect();
                 if confirmed.len() == 1
-                    && (self.receiver_ty.has_var(self.db)
+                    && (self.receiver.original().has_var(self.db)
                         || selected
                             .iter()
                             .filter_map(|(&cand, &is_confirmed)| (!is_confirmed).then_some(cand))
@@ -379,10 +368,9 @@ impl<'db> MethodSelector<'db> {
         candidate: TraitMethodCand<'db>,
         confirmed: TraitMethodCand<'db>,
     ) -> bool {
-        let canonical_receiver = Canonicalized::new(self.db, self.receiver_ty);
         let mut table = UnificationTable::new(self.db);
-        let candidate_inst = canonical_receiver.extract_solution(&mut table, candidate.inst);
-        let confirmed_inst = canonical_receiver.extract_solution(&mut table, confirmed.inst);
+        let candidate_inst = self.receiver.extract_solution(&mut table, candidate.inst);
+        let confirmed_inst = self.receiver.extract_solution(&mut table, confirmed.inst);
         if candidate_inst.def(self.db) != confirmed_inst.def(self.db)
             || candidate.method.name(self.db) != confirmed.method.name(self.db)
         {
@@ -427,7 +415,7 @@ impl<'db> MethodSelector<'db> {
         // introducing fresh inference vars. Otherwise, unconstrained trait args
         // can trigger spurious "type annotation needed" diagnostics on method calls
         // whose signatures don't mention those args (e.g. `AbiDecoder<A>::read_word`).
-        let receiver_is_ty_param = receiver_is_ty_param_like(self.db, self.receiver_ty);
+        let receiver_is_ty_param = receiver_is_ty_param_like(self.db, self.receiver.original());
 
         let query = CanonicalGoalQuery::new(self.db, inst, self.assumptions);
         let inst = if receiver_is_ty_param {

--- a/crates/hir/src/analysis/name_resolution/path_resolver.rs
+++ b/crates/hir/src/analysis/name_resolution/path_resolver.rs
@@ -27,7 +27,7 @@ use crate::analysis::{
     ty::{
         adt_def::{AdtRef, adt_layout_hole_plan, adt_layout_hole_plan_with_explicit_args},
         binder::Binder,
-        canonical::{Canonical, Canonicalized},
+        canonical::Canonicalized,
         const_ty::{AppFrameId, HoleId, LayoutHoleArgSite, LocalFrameId, StructuralHoleOrigin},
         fold::TyFoldable,
         layout_holes::layout_hole_with_fallback_ty,
@@ -1111,7 +1111,7 @@ fn select_assoc_const_candidate<'db>(
         let mut matches: IndexSet<TraitInstId<'db>> = IndexSet::default();
 
         let mut table = UnificationTable::new(db);
-        let receiver = Canonical::new(db, receiver_ty);
+        let receiver = Canonicalized::new(db, receiver_ty);
         let extracted_receiver_ty = receiver.extract_identity(&mut table);
 
         for &pred in assumptions.list(db) {
@@ -1119,16 +1119,21 @@ fn select_assoc_const_candidate<'db>(
             let self_ty = table.instantiate_to_term(pred.self_ty(db));
 
             if table.unify(extracted_receiver_ty, self_ty).is_ok() {
-                if pred.def(db).const_(db, name).is_some() {
-                    matches.insert(pred);
-                }
+                let pred = pred.fold_with(db, &mut table);
+                if let Some(pred) =
+                    receiver.extract_existing_solution(&mut table, extracted_receiver_ty, pred)
+                {
+                    if pred.def(db).const_(db, name).is_some() {
+                        matches.insert(pred);
+                    }
 
-                // Include super-trait consts so `T::CONST` works through a `T: SubTrait` bound
-                // even when `assumptions` hasn't been transitively expanded.
-                for super_trait in pred.def(db).super_traits(db) {
-                    let super_inst = super_trait.instantiate(db, pred.args(db));
-                    if super_inst.def(db).const_(db, name).is_some() {
-                        matches.insert(super_inst);
+                    // Include super-trait consts so `T::CONST` works through a `T: SubTrait`
+                    // bound even when `assumptions` hasn't been transitively expanded.
+                    for super_trait in pred.def(db).super_traits(db) {
+                        let super_inst = super_trait.instantiate(db, pred.args(db));
+                        if super_inst.def(db).const_(db, name).is_some() {
+                            matches.insert(super_inst);
+                        }
                     }
                 }
             }
@@ -1153,6 +1158,15 @@ fn select_assoc_const_candidate<'db>(
                             Some(owner_self),
                         )
                     {
+                        let inst = inst.fold_with(db, &mut table);
+                        let Some(inst) = receiver.extract_existing_solution(
+                            &mut table,
+                            extracted_receiver_ty,
+                            inst,
+                        ) else {
+                            continue;
+                        };
+
                         if inst.def(db).const_(db, name).is_some() {
                             matches.insert(inst);
                         }

--- a/crates/hir/src/analysis/name_resolution/path_resolver.rs
+++ b/crates/hir/src/analysis/name_resolution/path_resolver.rs
@@ -919,7 +919,7 @@ where
                 let receiver_ty = Canonicalized::new(db, ty);
                 match select_method_candidate(
                     db,
-                    receiver_ty.canonical(),
+                    &receiver_ty,
                     ident,
                     parent_scope,
                     assumptions,

--- a/crates/hir/src/analysis/name_resolution/path_resolver.rs
+++ b/crates/hir/src/analysis/name_resolution/path_resolver.rs
@@ -29,7 +29,6 @@ use crate::analysis::{
         binder::Binder,
         canonical::Canonicalized,
         const_ty::{AppFrameId, HoleId, LayoutHoleArgSite, LocalFrameId, StructuralHoleOrigin},
-        fold::TyFoldable,
         layout_holes::layout_hole_with_fallback_ty,
         normalize::normalize_ty,
         trait_def::{TraitInstId, impls_for_ty_with_constraints},
@@ -40,7 +39,6 @@ use crate::analysis::{
             ConstDefaultCompletion, TyAlias, collect_generic_params, lower_generic_arg_list,
             lower_hir_ty, lower_type_alias,
         },
-        unify::UnificationTable,
     },
 };
 
@@ -1109,26 +1107,23 @@ fn select_assoc_const_candidate<'db>(
     );
     if receiver_is_ty_param {
         let mut matches: IndexSet<TraitInstId<'db>> = IndexSet::default();
-
-        let mut table = UnificationTable::new(db);
         let receiver = Canonicalized::new(db, receiver_ty);
-        let extracted_receiver_ty = receiver.extract_identity(&mut table);
+        receiver.with_materialized(db, |cx| {
+            let receiver = cx.query();
+            for &pred in assumptions.list(db) {
+                let snapshot = cx.snapshot();
+                let self_ty = cx.materialize_to_term(pred.self_ty(db));
 
-        for &pred in assumptions.list(db) {
-            let snapshot = table.snapshot();
-            let self_ty = table.instantiate_to_term(pred.self_ty(db));
-
-            if table.unify(extracted_receiver_ty, self_ty).is_ok() {
-                let pred = pred.fold_with(db, &mut table);
-                if let Some(pred) =
-                    receiver.extract_existing_solution(&mut table, extracted_receiver_ty, pred)
+                let pred = cx.materialize(pred);
+                if cx.unify::<TyId<'db>>(receiver, self_ty).is_ok()
+                    && let Some(pred) = cx.try_extract::<TraitInstId<'db>>(pred)
                 {
                     if pred.def(db).const_(db, name).is_some() {
                         matches.insert(pred);
                     }
 
-                    // Include super-trait consts so `T::CONST` works through a `T: SubTrait`
-                    // bound even when `assumptions` hasn't been transitively expanded.
+                    // `T::CONST` should also see constants inherited through a
+                    // super-trait bound such as `T: SubTrait`.
                     for super_trait in pred.def(db).super_traits(db) {
                         let super_inst = super_trait.instantiate(db, pred.args(db));
                         if super_inst.def(db).const_(db, name).is_some() {
@@ -1136,51 +1131,43 @@ fn select_assoc_const_candidate<'db>(
                         }
                     }
                 }
+
+                cx.rollback_to(snapshot);
             }
 
-            table.rollback_to(snapshot);
-        }
+            if let TyData::AssocTy(assoc_ty) = receiver_ty.data(db) {
+                let trait_ = assoc_ty.trait_.def(db);
+                let assoc_name = assoc_ty.name;
+                if let Some(decl) = trait_.assoc_ty(db, assoc_name) {
+                    // Bounds on the associated type are interpreted in the
+                    // owner trait's `Self` context, not the projected subject.
+                    let owner_self = cx.materialize(assoc_ty.trait_.self_ty(db));
+                    for bound in &decl.bounds {
+                        if let TypeBound::Trait(trait_ref) = *bound
+                            && let Ok(inst) = cx.lower_trait_ref(
+                                receiver,
+                                trait_ref,
+                                scope,
+                                assumptions,
+                                Some(owner_self),
+                            )
+                            && let Some(inst) = cx.try_extract::<TraitInstId<'db>>(inst)
+                        {
+                            if inst.def(db).const_(db, name).is_some() {
+                                matches.insert(inst);
+                            }
 
-        if let TyData::AssocTy(assoc_ty) = receiver_ty.data(db) {
-            let trait_ = assoc_ty.trait_.def(db);
-            let assoc_name = assoc_ty.name;
-            if let Some(decl) = trait_.assoc_ty(db, assoc_name) {
-                let subject = extracted_receiver_ty.fold_with(db, &mut table);
-                let owner_self = assoc_ty.trait_.self_ty(db);
-                for bound in &decl.bounds {
-                    if let TypeBound::Trait(trait_ref) = *bound
-                        && let Ok(inst) = crate::analysis::ty::trait_lower::lower_trait_ref(
-                            db,
-                            subject,
-                            trait_ref,
-                            scope,
-                            assumptions,
-                            Some(owner_self),
-                        )
-                    {
-                        let inst = inst.fold_with(db, &mut table);
-                        let Some(inst) = receiver.extract_existing_solution(
-                            &mut table,
-                            extracted_receiver_ty,
-                            inst,
-                        ) else {
-                            continue;
-                        };
-
-                        if inst.def(db).const_(db, name).is_some() {
-                            matches.insert(inst);
-                        }
-
-                        for super_trait in inst.def(db).super_traits(db) {
-                            let super_inst = super_trait.instantiate(db, inst.args(db));
-                            if super_inst.def(db).const_(db, name).is_some() {
-                                matches.insert(super_inst);
+                            for super_trait in inst.def(db).super_traits(db) {
+                                let super_inst = super_trait.instantiate(db, inst.args(db));
+                                if super_inst.def(db).const_(db, name).is_some() {
+                                    matches.insert(super_inst);
+                                }
                             }
                         }
                     }
                 }
             }
-        }
+        });
 
         return match matches.len() {
             0 => AssocConstSelection::NotFound,
@@ -1227,24 +1214,19 @@ pub(crate) fn find_associated_type<'db>(
 ) -> Result<SmallVec<(TraitInstId<'db>, TyId<'db>), 4>, FindAssociatedTypeError> {
     let canonical_ty = ty.canonical();
     let original_ty = ty.original();
-    let mut table = UnificationTable::new(db);
-    let lhs_ty = ty.extract_identity(&mut table);
 
     // Qualified type: `<A as T>::B`. Always construct the associated type projection
     // against the qualified trait instance; bindings (if any) will be handled downstream.
-    if let TyData::QualifiedTy(trait_inst) = lhs_ty.data(db) {
-        let proj = TyId::assoc_ty(db, *trait_inst, name);
-        let inst = ty.extract_existing_solution(&mut table, lhs_ty, *trait_inst);
-        let proj = ty.extract_existing_solution(&mut table, lhs_ty, proj);
-        return Ok(match (inst, proj) {
-            (Some(inst), Some(proj)) => smallvec![(inst, proj)],
-            _ => smallvec![],
-        });
+    if let TyData::QualifiedTy(trait_inst) = original_ty.data(db) {
+        return Ok(smallvec![(
+            *trait_inst,
+            TyId::assoc_ty(db, *trait_inst, name)
+        )]);
     }
 
     let scope_ingot = scope.ingot(db);
 
-    if let TyData::TyParam(param) = lhs_ty.data(db) {
+    if let TyData::TyParam(param) = original_ty.data(db) {
         // Trait self, in trait or impl trait. Associated type must be in this trait.
         if param.is_trait_self() {
             if let Some(trait_) = param.owner.resolve_to::<Trait>(db) {
@@ -1264,137 +1246,117 @@ pub(crate) fn find_associated_type<'db>(
     }
 
     let mut candidates = SmallVec::new();
-    // Check explicit bounds in assumptions that match `ty` only when `ty` is a type
-    // parameter (to avoid spurious ambiguities for concrete types that already have impls).
-    if let TyData::TyParam(_) = lhs_ty.data(db) {
-        for &trait_inst in assumptions.list(db) {
-            // `trait_inst` is a specific trait bound, e.g., `A: Abi` or `S<A>: SomeTrait`.
-            let snapshot = table.snapshot();
-            let pred_self_ty =
-                table.instantiate_with_fresh_vars(Binder::bind(trait_inst.self_ty(db)));
-
-            if table.unify(lhs_ty, pred_self_ty).is_ok()
-                && let Some(assoc_ty) = trait_inst.assoc_ty(db, name)
-            {
-                let folded_inst = trait_inst.fold_with(db, &mut table);
-                let folded_ty = assoc_ty.fold_with(db, &mut table);
-                if let (Some(folded_inst), Some(folded_ty)) = (
-                    ty.extract_existing_solution(&mut table, lhs_ty, folded_inst),
-                    ty.extract_existing_solution(&mut table, lhs_ty, folded_ty),
-                ) {
-                    candidates.push((folded_inst, folded_ty));
-                }
-            }
-            table.rollback_to(snapshot);
-        }
-    }
-
     let search_ingots = [
         Some(scope_ingot),
         original_ty.ingot(db).filter(|&ingot| ingot != scope_ingot),
     ];
 
-    // Check impls for `ty` across both the call-site ingot and `ty`'s defining ingot.
-    for ingot in search_ingots.into_iter().flatten() {
-        for impl_ in impls_for_ty_with_constraints(db, ingot, canonical_ty, assumptions) {
-            let snapshot = table.snapshot();
-            let impl_ = table.instantiate_with_fresh_vars(impl_);
+    ty.with_materialized(db, |cx| -> Result<(), FindAssociatedTypeError> {
+        let lhs_ty = cx.query();
 
-            if table.unify(lhs_ty, impl_.self_ty(db)).is_ok()
-                && let Some(assoc_ty) = impl_.assoc_ty(db, name)
-            {
-                let folded_inst = impl_.trait_(db).fold_with(db, &mut table);
-                let folded_ty = assoc_ty.fold_with(db, &mut table);
-                if let (Some(folded_inst), Some(folded_ty)) = (
-                    ty.extract_existing_solution(&mut table, lhs_ty, folded_inst),
-                    ty.extract_existing_solution(&mut table, lhs_ty, folded_ty),
-                ) {
-                    candidates.push((folded_inst, folded_ty));
-                }
-            }
-            table.rollback_to(snapshot);
-        }
-    }
+        // Only consult explicit bounds for type-parameter receivers; concrete
+        // receivers get their candidates from impl lookup to avoid spurious
+        // ambiguity between bounds and implementations.
+        if let TyData::TyParam(_) = original_ty.data(db) {
+            for &trait_inst in assumptions.list(db) {
+                let snapshot = cx.snapshot();
+                let pred_self_ty =
+                    cx.instantiate_with_fresh_vars(Binder::bind(trait_inst.self_ty(db)));
 
-    // Case 3: The LHS `ty` is an associated type (e.g., `T::Encoder` in `T::Encoder::Output`).
-    // We need to look at the trait bound on the associated type.
-    if let TyData::AssocTy(assoc_ty) = lhs_ty.data(db) {
-        let mut assoc_table = UnificationTable::new(db);
-
-        // Extract the canonical type's substitutions into the unification table
-        // This ensures we maintain any type parameter bindings from the outer context
-        let ty_with_subst = ty.extract_identity(&mut assoc_table);
-
-        // First, check if there are trait bounds on this associated type in the assumptions
-        // (e.g., from where clauses like `T::Assoc: Level1`).
-        for &trait_inst in assumptions.list(db) {
-            let snapshot = assoc_table.snapshot();
-            // Allow unification to account for type variables in either side
-            if assoc_table
-                .unify(ty_with_subst, trait_inst.self_ty(db))
-                .is_ok()
-                && let Some(assoc_ty) = trait_inst.assoc_ty(db, name)
-            {
-                let folded_inst = trait_inst.fold_with(db, &mut assoc_table);
-                let folded_ty = assoc_ty.fold_with(db, &mut assoc_table);
-                if let (Some(folded_inst), Some(folded_ty)) = (
-                    ty.extract_existing_solution(&mut assoc_table, ty_with_subst, folded_inst),
-                    ty.extract_existing_solution(&mut assoc_table, ty_with_subst, folded_ty),
-                ) {
-                    candidates.push((folded_inst, folded_ty));
-                }
-            }
-            assoc_table.rollback_to(snapshot);
-        }
-
-        // Also check bounds defined on the associated type in the trait definition.
-        // We need to use the calling context's scope/assumptions (not the trait's) so that
-        // path resolution works correctly.
-        let trait_ = assoc_ty.trait_.def(db);
-        let assoc_name = assoc_ty.name;
-        if let Some(decl) = trait_.assoc_ty(db, assoc_name) {
-            let subject = ty_with_subst.fold_with(db, &mut assoc_table);
-            // owner_self is used to substitute `Self` in bounds like `type Assoc: Encode<Self>`
-            let owner_self = assoc_ty.trait_.self_ty(db);
-            for bound in &decl.bounds {
-                let TypeBound::Trait(trait_ref) = *bound else {
-                    continue;
-                };
-
-                let inst = match crate::analysis::ty::trait_lower::lower_trait_ref(
-                    db,
-                    subject,
-                    trait_ref,
-                    scope,
-                    assumptions,
-                    Some(owner_self),
-                ) {
-                    Ok(inst) => inst,
-                    Err(TraitRefLowerError::Cycle) => {
-                        return Err(FindAssociatedTypeError::InfiniteBoundRecursion);
-                    }
-                    Err(TraitRefLowerError::PathResError(err))
-                        if err.is_infinite_bound_recursion() =>
+                if cx.unify::<TyId<'db>>(lhs_ty, pred_self_ty).is_ok() {
+                    let trait_inst = cx.materialize(trait_inst);
+                    if let Some(assoc_ty) = trait_inst.assoc_ty(db, name)
+                        && let (Some(inst), Some(assoc_ty)) = (
+                            cx.try_extract::<TraitInstId<'db>>(trait_inst),
+                            cx.try_extract::<TyId<'db>>(assoc_ty),
+                        )
                     {
-                        return Err(FindAssociatedTypeError::InfiniteBoundRecursion);
+                        candidates.push((inst, assoc_ty));
                     }
-                    Err(_) => continue,
-                };
+                }
+                cx.rollback_to(snapshot);
+            }
+        }
 
-                if inst.def(db).assoc_ty(db, name).is_some() {
-                    let assoc_ty = TyId::assoc_ty(db, inst, name);
-                    let folded_inst = inst.fold_with(db, &mut assoc_table);
-                    let folded_ty = assoc_ty.fold_with(db, &mut assoc_table);
-                    if let (Some(folded_inst), Some(folded_ty)) = (
-                        ty.extract_existing_solution(&mut assoc_table, ty_with_subst, folded_inst),
-                        ty.extract_existing_solution(&mut assoc_table, ty_with_subst, folded_ty),
+        // Search both the call-site ingot and the receiver's ingot so local
+        // traits on external types and external traits on local types are both visible.
+        for ingot in search_ingots.into_iter().flatten() {
+            for impl_ in impls_for_ty_with_constraints(db, ingot, canonical_ty, assumptions) {
+                if let Some(Some((inst, assoc_ty))) =
+                    cx.with_impl_assoc_ty(impl_, lhs_ty, name, |cx, inst, assoc_ty| {
+                        Some((
+                            cx.try_extract::<TraitInstId<'db>>(inst)?,
+                            cx.try_extract::<TyId<'db>>(assoc_ty)?,
+                        ))
+                    })
+                {
+                    candidates.push((inst, assoc_ty));
+                }
+            }
+        }
+
+        // Projections such as `T::Assoc::Item` can be resolved either from an
+        // explicit bound on `T::Assoc` or from the bounds declared on the
+        // associated type itself.
+        if let TyData::AssocTy(assoc_ty) = original_ty.data(db) {
+            for &trait_inst in assumptions.list(db) {
+                let snapshot = cx.snapshot();
+                let trait_inst = cx.materialize(trait_inst);
+                if cx
+                    .unify::<TyId<'db>>(lhs_ty, trait_inst.self_ty(db))
+                    .is_ok()
+                    && let Some(assoc_ty) = trait_inst.assoc_ty(db, name)
+                    && let (Some(inst), Some(assoc_ty)) = (
+                        cx.try_extract::<TraitInstId<'db>>(trait_inst),
+                        cx.try_extract::<TyId<'db>>(assoc_ty),
+                    )
+                {
+                    candidates.push((inst, assoc_ty));
+                }
+                cx.rollback_to(snapshot);
+            }
+
+            let trait_ = assoc_ty.trait_.def(db);
+            let assoc_name = assoc_ty.name;
+            if let Some(decl) = trait_.assoc_ty(db, assoc_name) {
+                // Bounds like `type Assoc: Encode<Self>` are lowered in the
+                // owner trait's `Self` environment.
+                let owner_self = cx.materialize(assoc_ty.trait_.self_ty(db));
+                for bound in &decl.bounds {
+                    let TypeBound::Trait(trait_ref) = *bound else {
+                        continue;
+                    };
+
+                    let inst = match cx.lower_trait_ref(
+                        lhs_ty,
+                        trait_ref,
+                        scope,
+                        assumptions,
+                        Some(owner_self),
                     ) {
-                        candidates.push((folded_inst, folded_ty));
+                        Ok(inst) => inst,
+                        Err(TraitRefLowerError::Cycle) => {
+                            return Err(FindAssociatedTypeError::InfiniteBoundRecursion);
+                        }
+                        Err(TraitRefLowerError::PathResError(err))
+                            if err.is_infinite_bound_recursion() =>
+                        {
+                            return Err(FindAssociatedTypeError::InfiniteBoundRecursion);
+                        }
+                        Err(_) => continue,
+                    };
+
+                    if inst.def(db).assoc_ty(db, name).is_some()
+                        && let Some(inst) = cx.try_extract::<TraitInstId<'db>>(inst)
+                    {
+                        candidates.push((inst, TyId::assoc_ty(db, inst, name)));
                     }
                 }
             }
         }
-    }
+
+        Ok(())
+    })?;
 
     Ok(candidates)
 }

--- a/crates/hir/src/analysis/name_resolution/path_resolver.rs
+++ b/crates/hir/src/analysis/name_resolution/path_resolver.rs
@@ -35,7 +35,7 @@ use crate::analysis::{
         trait_def::{TraitInstId, impls_for_ty_with_constraints},
         trait_lower::{TraitArgError, TraitRefLowerError, lower_trait_ref, lower_trait_ref_impl},
         trait_resolution::PredicateListId,
-        ty_def::{InvalidCause, Kind, TyData, TyId, inference_keys},
+        ty_def::{InvalidCause, Kind, TyData, TyId},
         ty_lower::{
             ConstDefaultCompletion, TyAlias, collect_generic_params, lower_generic_arg_list,
             lower_hir_ty, lower_type_alias,
@@ -1214,16 +1214,18 @@ pub(crate) fn find_associated_type<'db>(
     let canonical_ty = ty.canonical();
     let original_ty = ty.original();
     let mut table = UnificationTable::new(db);
-    let lhs_ty = canonical_ty.extract_identity(&mut table);
-    let lhs_keys = inference_keys(db, &lhs_ty);
+    let lhs_ty = ty.extract_identity(&mut table);
 
     // Qualified type: `<A as T>::B`. Always construct the associated type projection
     // against the qualified trait instance; bindings (if any) will be handled downstream.
     if let TyData::QualifiedTy(trait_inst) = lhs_ty.data(db) {
         let proj = TyId::assoc_ty(db, *trait_inst, name);
-        let proj = ty.decanonicalize(db, proj);
-        let inst = ty.decanonicalize(db, *trait_inst);
-        return Ok(smallvec![(inst, proj)]);
+        let inst = ty.extract_existing_solution(&mut table, lhs_ty, *trait_inst);
+        let proj = ty.extract_existing_solution(&mut table, lhs_ty, proj);
+        return Ok(match (inst, proj) {
+            (Some(inst), Some(proj)) => smallvec![(inst, proj)],
+            _ => smallvec![],
+        });
     }
 
     let scope_ingot = scope.ingot(db);
@@ -1262,13 +1264,11 @@ pub(crate) fn find_associated_type<'db>(
             {
                 let folded_inst = trait_inst.fold_with(db, &mut table);
                 let folded_ty = assoc_ty.fold_with(db, &mut table);
-                let folded_inst_keys = inference_keys(db, &folded_inst);
-                let folded_ty_keys = inference_keys(db, &folded_ty);
-                if folded_inst_keys.is_subset(&lhs_keys) && folded_ty_keys.is_subset(&lhs_keys) {
-                    candidates.push((
-                        ty.decanonicalize(db, folded_inst),
-                        ty.decanonicalize(db, folded_ty),
-                    ));
+                if let (Some(folded_inst), Some(folded_ty)) = (
+                    ty.extract_existing_solution(&mut table, lhs_ty, folded_inst),
+                    ty.extract_existing_solution(&mut table, lhs_ty, folded_ty),
+                ) {
+                    candidates.push((folded_inst, folded_ty));
                 }
             }
             table.rollback_to(snapshot);
@@ -1291,13 +1291,11 @@ pub(crate) fn find_associated_type<'db>(
             {
                 let folded_inst = impl_.trait_(db).fold_with(db, &mut table);
                 let folded_ty = assoc_ty.fold_with(db, &mut table);
-                let folded_inst_keys = inference_keys(db, &folded_inst);
-                let folded_ty_keys = inference_keys(db, &folded_ty);
-                if folded_inst_keys.is_subset(&lhs_keys) && folded_ty_keys.is_subset(&lhs_keys) {
-                    candidates.push((
-                        ty.decanonicalize(db, folded_inst),
-                        ty.decanonicalize(db, folded_ty),
-                    ));
+                if let (Some(folded_inst), Some(folded_ty)) = (
+                    ty.extract_existing_solution(&mut table, lhs_ty, folded_inst),
+                    ty.extract_existing_solution(&mut table, lhs_ty, folded_ty),
+                ) {
+                    candidates.push((folded_inst, folded_ty));
                 }
             }
             table.rollback_to(snapshot);
@@ -1311,8 +1309,7 @@ pub(crate) fn find_associated_type<'db>(
 
         // Extract the canonical type's substitutions into the unification table
         // This ensures we maintain any type parameter bindings from the outer context
-        let ty_with_subst = canonical_ty.extract_identity(&mut assoc_table);
-        let assoc_lhs_keys = inference_keys(db, &ty_with_subst);
+        let ty_with_subst = ty.extract_identity(&mut assoc_table);
 
         // First, check if there are trait bounds on this associated type in the assumptions
         // (e.g., from where clauses like `T::Assoc: Level1`).
@@ -1326,15 +1323,11 @@ pub(crate) fn find_associated_type<'db>(
             {
                 let folded_inst = trait_inst.fold_with(db, &mut assoc_table);
                 let folded_ty = assoc_ty.fold_with(db, &mut assoc_table);
-                let folded_inst_keys = inference_keys(db, &folded_inst);
-                let folded_ty_keys = inference_keys(db, &folded_ty);
-                if folded_inst_keys.is_subset(&assoc_lhs_keys)
-                    && folded_ty_keys.is_subset(&assoc_lhs_keys)
-                {
-                    candidates.push((
-                        ty.decanonicalize(db, folded_inst),
-                        ty.decanonicalize(db, folded_ty),
-                    ));
+                if let (Some(folded_inst), Some(folded_ty)) = (
+                    ty.extract_existing_solution(&mut assoc_table, ty_with_subst, folded_inst),
+                    ty.extract_existing_solution(&mut assoc_table, ty_with_subst, folded_ty),
+                ) {
+                    candidates.push((folded_inst, folded_ty));
                 }
             }
             assoc_table.rollback_to(snapshot);
@@ -1378,15 +1371,11 @@ pub(crate) fn find_associated_type<'db>(
                     let assoc_ty = TyId::assoc_ty(db, inst, name);
                     let folded_inst = inst.fold_with(db, &mut assoc_table);
                     let folded_ty = assoc_ty.fold_with(db, &mut assoc_table);
-                    let folded_inst_keys = inference_keys(db, &folded_inst);
-                    let folded_ty_keys = inference_keys(db, &folded_ty);
-                    if folded_inst_keys.is_subset(&assoc_lhs_keys)
-                        && folded_ty_keys.is_subset(&assoc_lhs_keys)
-                    {
-                        candidates.push((
-                            ty.decanonicalize(db, folded_inst),
-                            ty.decanonicalize(db, folded_ty),
-                        ));
+                    if let (Some(folded_inst), Some(folded_ty)) = (
+                        ty.extract_existing_solution(&mut assoc_table, ty_with_subst, folded_inst),
+                        ty.extract_existing_solution(&mut assoc_table, ty_with_subst, folded_ty),
+                    ) {
+                        candidates.push((folded_inst, folded_ty));
                     }
                 }
             }

--- a/crates/hir/src/analysis/name_resolution/path_resolver.rs
+++ b/crates/hir/src/analysis/name_resolution/path_resolver.rs
@@ -919,7 +919,7 @@ where
                 let receiver_ty = Canonicalized::new(db, ty);
                 match select_method_candidate(
                     db,
-                    receiver_ty.value,
+                    receiver_ty.canonical(),
                     ident,
                     parent_scope,
                     assumptions,
@@ -1175,7 +1175,7 @@ fn select_assoc_const_candidate<'db>(
         };
     }
 
-    let canonical_receiver = Canonicalized::new(db, receiver_ty).value;
+    let canonical_receiver = Canonicalized::new(db, receiver_ty).canonical();
     let scope_ingot = scope.ingot(db);
 
     // Find trait impls for the receiver type that define the associated const, searching both:
@@ -1211,12 +1211,15 @@ pub(crate) fn find_associated_type<'db>(
     name: IdentId<'db>,
     assumptions: PredicateListId<'db>,
 ) -> Result<SmallVec<(TraitInstId<'db>, TyId<'db>), 4>, FindAssociatedTypeError> {
-    let canonical_ty = ty.value;
-    let original_ty = ty.decanonicalize(db, canonical_ty.value);
+    let canonical_ty = ty.canonical();
+    let original_ty = ty.original();
+    let mut table = UnificationTable::new(db);
+    let lhs_ty = canonical_ty.extract_identity(&mut table);
+    let lhs_keys = inference_keys(db, &lhs_ty);
 
     // Qualified type: `<A as T>::B`. Always construct the associated type projection
     // against the qualified trait instance; bindings (if any) will be handled downstream.
-    if let TyData::QualifiedTy(trait_inst) = canonical_ty.value.data(db) {
+    if let TyData::QualifiedTy(trait_inst) = lhs_ty.data(db) {
         let proj = TyId::assoc_ty(db, *trait_inst, name);
         let proj = ty.decanonicalize(db, proj);
         let inst = ty.decanonicalize(db, *trait_inst);
@@ -1224,13 +1227,8 @@ pub(crate) fn find_associated_type<'db>(
     }
 
     let scope_ingot = scope.ingot(db);
-    // Use a single unification table and snapshots to preserve outer
-    // substitutions while isolating per-candidate attempts.
-    let mut table = UnificationTable::new(db);
-    let lhs_ty = canonical_ty.extract_identity(&mut table);
-    let lhs_keys = inference_keys(db, &lhs_ty);
 
-    if let TyData::TyParam(param) = canonical_ty.value.data(db) {
+    if let TyData::TyParam(param) = lhs_ty.data(db) {
         // Trait self, in trait or impl trait. Associated type must be in this trait.
         if param.is_trait_self() {
             if let Some(trait_) = param.owner.resolve_to::<Trait>(db) {
@@ -1252,7 +1250,7 @@ pub(crate) fn find_associated_type<'db>(
     let mut candidates = SmallVec::new();
     // Check explicit bounds in assumptions that match `ty` only when `ty` is a type
     // parameter (to avoid spurious ambiguities for concrete types that already have impls).
-    if let TyData::TyParam(_) = canonical_ty.value.data(db) {
+    if let TyData::TyParam(_) = lhs_ty.data(db) {
         for &trait_inst in assumptions.list(db) {
             // `trait_inst` is a specific trait bound, e.g., `A: Abi` or `S<A>: SomeTrait`.
             let snapshot = table.snapshot();
@@ -1308,7 +1306,7 @@ pub(crate) fn find_associated_type<'db>(
 
     // Case 3: The LHS `ty` is an associated type (e.g., `T::Encoder` in `T::Encoder::Output`).
     // We need to look at the trait bound on the associated type.
-    if let TyData::AssocTy(assoc_ty) = canonical_ty.value.data(db) {
+    if let TyData::AssocTy(assoc_ty) = lhs_ty.data(db) {
         let mut assoc_table = UnificationTable::new(db);
 
         // Extract the canonical type's substitutions into the unification table

--- a/crates/hir/src/analysis/ty/canonical.rs
+++ b/crates/hir/src/analysis/ty/canonical.rs
@@ -6,7 +6,7 @@ use super::{
     fold::{TyFoldable, TyFolder},
     ty_def::{TyData, TyFlags, TyId, TyVar},
     unify::{InferenceKey, UnificationStore, UnificationTableBase},
-    visitor::{TyVisitable, collect_flags},
+    visitor::{TyVisitable, TyVisitor, collect_flags, walk_const_ty, walk_ty},
 };
 use crate::analysis::{HirAnalysisDb, ty::ty_def::collect_variables};
 
@@ -25,18 +25,16 @@ where
         Canonical { value }
     }
 
-    /// Extracts the identity from the canonical value.
-    ///
-    /// This method initializes the unification table with new variables
-    /// based on the canonical value and then returns the canonical value
-    /// itself.
+    /// Materializes the canonical value into the provided table's inference
+    /// universe.
     ///
     /// # Parameters
-    /// - `table`: The unification table to be initialized with new variables.
+    /// - `table`: The unification table that receives fresh vars corresponding
+    ///   to the canonical vars in `self`.
     ///
     /// # Returns
-    /// The canonical value after initializing the unification table.
-    ///
+    /// A copy of the canonical value where each canonical var has been
+    /// re-materialized as a fresh var in `table`.
     pub fn extract_identity<S>(self, table: &mut UnificationTableBase<'db, S>) -> T
     where
         S: UnificationStore<'db>,
@@ -190,30 +188,95 @@ where
         solution.value.fold_with(db, &mut extractor)
     }
 
-    /// Substitute canonical variables back to the original variables.
+    /// Extracts a value produced in a scratch table seeded from this
+    /// canonicalized input back into the original inference environment.
     ///
-    /// This is useful when you want to run unification in a canonicalized
-    /// environment (e.g. to avoid mixing inference keys from different tables)
-    /// but need to return a result in the original environment.
-    pub fn decanonicalize<U>(&self, db: &'db dyn HirAnalysisDb, value: U) -> U
+    /// `query` must be the materialized identity previously returned by
+    /// [`Canonicalized::extract_identity`] for this canonicalized input in the
+    /// same `table`.
+    ///
+    /// Returns `None` when `value` still contains scratch-local vars that do
+    /// not originate from this canonical query.
+    pub fn extract_existing_solution<U, S>(
+        &self,
+        table: &mut UnificationTableBase<'db, S>,
+        query: T,
+        value: U,
+    ) -> Option<U>
     where
-        U: TyFoldable<'db>,
+        S: UnificationStore<'db>,
+        T: TyVisitable<'db>,
+        U: TyFoldable<'db> + TyVisitable<'db> + Update,
     {
-        struct Decanonicalizer<'a, 'db> {
+        let db = table.db;
+        let value = value.fold_with(db, table);
+        let mut canonicalizer = Canonicalizer {
+            subst: collect_variable_tys(db, &query)
+                .into_iter()
+                .zip(collect_variable_tys(db, &self.canonical.value))
+                .collect(),
+        };
+        let solution = Solution {
+            value: value.fold_with(db, &mut canonicalizer),
+        };
+        self.solution_uses_only_original_canonical_vars(db, &solution.value)
+            .then(|| self.extract_solution(table, solution))
+    }
+
+    fn solution_uses_only_original_canonical_vars<U>(
+        &self,
+        db: &'db dyn HirAnalysisDb,
+        value: &U,
+    ) -> bool
+    where
+        U: TyVisitable<'db>,
+    {
+        struct QueryVarChecker<'a, 'db> {
+            db: &'db dyn HirAnalysisDb,
             subst: &'a FxHashMap<TyId<'db>, TyId<'db>>,
+            is_valid: bool,
         }
 
-        impl<'db> TyFolder<'db> for Decanonicalizer<'_, 'db> {
-            fn fold_ty(&mut self, db: &'db dyn HirAnalysisDb, ty: TyId<'db>) -> TyId<'db> {
-                if let Some(&ty) = self.subst.get(&ty) {
-                    return ty;
+        impl<'db> TyVisitor<'db> for QueryVarChecker<'_, 'db> {
+            fn db(&self) -> &'db dyn HirAnalysisDb {
+                self.db
+            }
+
+            fn visit_ty(&mut self, ty: TyId<'db>) {
+                if !self.is_valid {
+                    return;
                 }
-                ty.super_fold_with(db, self)
+
+                match ty.data(self.db) {
+                    TyData::TyVar(_) => {
+                        self.is_valid &= self.subst.contains_key(&ty);
+                    }
+                    _ => walk_ty(self, ty),
+                }
+            }
+
+            fn visit_const_ty(&mut self, const_ty: &ConstTyId<'db>) {
+                if !self.is_valid {
+                    return;
+                }
+
+                match const_ty.data(self.db) {
+                    ConstTyData::TyVar(var, const_ty_ty) => {
+                        let ty = TyId::const_ty_var(self.db, *const_ty_ty, var.key);
+                        self.is_valid &= self.subst.contains_key(&ty);
+                    }
+                    _ => walk_const_ty(self, const_ty),
+                }
             }
         }
 
-        let mut folder = Decanonicalizer { subst: &self.subst };
-        value.fold_with(db, &mut folder)
+        let mut checker = QueryVarChecker {
+            db,
+            subst: &self.subst,
+            is_valid: true,
+        };
+        value.visit_with(&mut checker);
+        checker.is_valid
     }
 }
 
@@ -342,5 +405,88 @@ where
 
             _ => ty.super_fold_with(db, self),
         }
+    }
+}
+
+fn collect_variable_tys<'db, V>(db: &'db dyn HirAnalysisDb, value: &V) -> Vec<TyId<'db>>
+where
+    V: TyVisitable<'db>,
+{
+    struct VariableCollector<'db> {
+        db: &'db dyn HirAnalysisDb,
+        vars: Vec<TyId<'db>>,
+    }
+
+    impl<'db> TyVisitor<'db> for VariableCollector<'db> {
+        fn db(&self) -> &'db dyn HirAnalysisDb {
+            self.db
+        }
+
+        fn visit_ty(&mut self, ty: TyId<'db>) {
+            match ty.data(self.db) {
+                TyData::TyVar(_) => self.vars.push(ty),
+                _ => walk_ty(self, ty),
+            }
+        }
+
+        fn visit_const_ty(&mut self, const_ty: &ConstTyId<'db>) {
+            match const_ty.data(self.db) {
+                ConstTyData::TyVar(var, const_ty_ty) => {
+                    self.vars
+                        .push(TyId::const_ty_var(self.db, *const_ty_ty, var.key));
+                }
+                _ => walk_const_ty(self, const_ty),
+            }
+        }
+    }
+
+    let mut collector = VariableCollector { db, vars: vec![] };
+    value.visit_with(&mut collector);
+    collector.vars
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Canonicalized;
+    use crate::{
+        analysis::ty::{
+            ty_def::{Kind, TyVarSort},
+            unify::UnificationTable,
+        },
+        test_db::HirAnalysisTestDb,
+    };
+
+    #[test]
+    fn extract_existing_solution_handles_preseeded_tables() {
+        let db = HirAnalysisTestDb::default();
+        let mut original_table = UnificationTable::new(&db);
+        let original = original_table.new_var(TyVarSort::General, &Kind::Star);
+        let canonicalized = Canonicalized::new(&db, original);
+
+        let mut scratch = UnificationTable::new(&db);
+        let _ = scratch.new_var(TyVarSort::General, &Kind::Star);
+        let extracted = canonicalized.extract_identity(&mut scratch);
+
+        assert_eq!(
+            canonicalized.extract_existing_solution(&mut scratch, extracted, extracted),
+            Some(original)
+        );
+    }
+
+    #[test]
+    fn extract_existing_solution_rejects_scratch_only_vars() {
+        let db = HirAnalysisTestDb::default();
+        let mut original_table = UnificationTable::new(&db);
+        let original = original_table.new_var(TyVarSort::General, &Kind::Star);
+        let canonicalized = Canonicalized::new(&db, original);
+
+        let mut scratch = UnificationTable::new(&db);
+        let extracted = canonicalized.extract_identity(&mut scratch);
+        let extra = scratch.new_var(TyVarSort::General, &Kind::Star);
+
+        assert_eq!(
+            canonicalized.extract_existing_solution(&mut scratch, extracted, extra),
+            None
+        );
     }
 }

--- a/crates/hir/src/analysis/ty/canonical.rs
+++ b/crates/hir/src/analysis/ty/canonical.rs
@@ -6,7 +6,7 @@ use super::{
     fold::{TyFoldable, TyFolder},
     ty_def::{TyData, TyFlags, TyId, TyVar},
     unify::{InferenceKey, UnificationStore, UnificationTableBase},
-    visitor::{TyVisitable, TyVisitor, collect_flags, walk_const_ty, walk_ty},
+    visitor::{TyVisitable, collect_flags},
 };
 use crate::analysis::{HirAnalysisDb, ty::ty_def::collect_variables};
 
@@ -51,6 +51,13 @@ where
         T: TyVisitable<'db>,
     {
         collect_flags(db, self.value)
+    }
+
+    pub(crate) fn value(self) -> T
+    where
+        T: Copy,
+    {
+        self.value
     }
 
     /// Canonicalize a new solution that corresponds to the canonical query.
@@ -142,13 +149,6 @@ where
         self.canonical
     }
 
-    pub fn extract_identity<S>(&self, table: &mut UnificationTableBase<'db, S>) -> T
-    where
-        S: UnificationStore<'db>,
-    {
-        self.canonical.extract_identity(table)
-    }
-
     pub fn canonicalize_solution<S, U>(
         &self,
         db: &'db dyn HirAnalysisDb,
@@ -160,6 +160,10 @@ where
         U: TyFoldable<'db> + Clone + Update,
     {
         self.canonical.canonicalize_solution(db, table, solution)
+    }
+
+    pub(crate) fn subst(&self) -> &FxHashMap<TyId<'db>, TyId<'db>> {
+        &self.subst
     }
 
     /// Extracts the solution from the canonicalized query.
@@ -186,97 +190,6 @@ where
         let db = table.db;
         let mut extractor = SolutionExtractor::new(table, map);
         solution.value.fold_with(db, &mut extractor)
-    }
-
-    /// Extracts a value produced in a scratch table seeded from this
-    /// canonicalized input back into the original inference environment.
-    ///
-    /// `query` must be the materialized identity previously returned by
-    /// [`Canonicalized::extract_identity`] for this canonicalized input in the
-    /// same `table`.
-    ///
-    /// Returns `None` when `value` still contains scratch-local vars that do
-    /// not originate from this canonical query.
-    pub fn extract_existing_solution<U, S>(
-        &self,
-        table: &mut UnificationTableBase<'db, S>,
-        query: T,
-        value: U,
-    ) -> Option<U>
-    where
-        S: UnificationStore<'db>,
-        T: TyVisitable<'db>,
-        U: TyFoldable<'db> + TyVisitable<'db> + Update,
-    {
-        let db = table.db;
-        let value = value.fold_with(db, table);
-        let mut canonicalizer = Canonicalizer {
-            subst: collect_variable_tys(db, &query)
-                .into_iter()
-                .zip(collect_variable_tys(db, &self.canonical.value))
-                .collect(),
-        };
-        let solution = Solution {
-            value: value.fold_with(db, &mut canonicalizer),
-        };
-        self.solution_uses_only_original_canonical_vars(db, &solution.value)
-            .then(|| self.extract_solution(table, solution))
-    }
-
-    fn solution_uses_only_original_canonical_vars<U>(
-        &self,
-        db: &'db dyn HirAnalysisDb,
-        value: &U,
-    ) -> bool
-    where
-        U: TyVisitable<'db>,
-    {
-        struct QueryVarChecker<'a, 'db> {
-            db: &'db dyn HirAnalysisDb,
-            subst: &'a FxHashMap<TyId<'db>, TyId<'db>>,
-            is_valid: bool,
-        }
-
-        impl<'db> TyVisitor<'db> for QueryVarChecker<'_, 'db> {
-            fn db(&self) -> &'db dyn HirAnalysisDb {
-                self.db
-            }
-
-            fn visit_ty(&mut self, ty: TyId<'db>) {
-                if !self.is_valid {
-                    return;
-                }
-
-                match ty.data(self.db) {
-                    TyData::TyVar(_) => {
-                        self.is_valid &= self.subst.contains_key(&ty);
-                    }
-                    _ => walk_ty(self, ty),
-                }
-            }
-
-            fn visit_const_ty(&mut self, const_ty: &ConstTyId<'db>) {
-                if !self.is_valid {
-                    return;
-                }
-
-                match const_ty.data(self.db) {
-                    ConstTyData::TyVar(var, const_ty_ty) => {
-                        let ty = TyId::const_ty_var(self.db, *const_ty_ty, var.key);
-                        self.is_valid &= self.subst.contains_key(&ty);
-                    }
-                    _ => walk_const_ty(self, const_ty),
-                }
-            }
-        }
-
-        let mut checker = QueryVarChecker {
-            db,
-            subst: &self.subst,
-            is_valid: true,
-        };
-        value.visit_with(&mut checker);
-        checker.is_valid
     }
 }
 
@@ -354,7 +267,7 @@ impl<'db> TyFolder<'db> for Canonicalizer<'db> {
     }
 }
 
-struct SolutionExtractor<'a, 'db, S>
+pub(super) struct SolutionExtractor<'a, 'db, S>
 where
     S: UnificationStore<'db>,
 {
@@ -368,7 +281,7 @@ impl<'a, 'db, S> SolutionExtractor<'a, 'db, S>
 where
     S: UnificationStore<'db>,
 {
-    fn new(
+    pub(super) fn new(
         table: &'a mut UnificationTableBase<'db, S>,
         subst: FxHashMap<TyId<'db>, TyId<'db>>,
     ) -> Self {
@@ -408,149 +321,25 @@ where
     }
 }
 
-fn collect_variable_tys<'db, V>(db: &'db dyn HirAnalysisDb, value: &V) -> Vec<TyId<'db>>
-where
-    V: TyVisitable<'db>,
-{
-    struct VariableCollector<'db> {
-        db: &'db dyn HirAnalysisDb,
-        vars: Vec<TyId<'db>>,
-    }
-
-    impl<'db> TyVisitor<'db> for VariableCollector<'db> {
-        fn db(&self) -> &'db dyn HirAnalysisDb {
-            self.db
-        }
-
-        fn visit_ty(&mut self, ty: TyId<'db>) {
-            match ty.data(self.db) {
-                TyData::TyVar(_) => self.vars.push(ty),
-                _ => walk_ty(self, ty),
-            }
-        }
-
-        fn visit_const_ty(&mut self, const_ty: &ConstTyId<'db>) {
-            match const_ty.data(self.db) {
-                ConstTyData::TyVar(var, const_ty_ty) => {
-                    self.vars
-                        .push(TyId::const_ty_var(self.db, *const_ty_ty, var.key));
-                }
-                _ => walk_const_ty(self, const_ty),
-            }
-        }
-    }
-
-    let mut collector = VariableCollector { db, vars: vec![] };
-    value.visit_with(&mut collector);
-    collector.vars
-}
-
 #[cfg(test)]
 mod tests {
-    use salsa::Update;
-
-    use super::Canonicalized;
-    use crate::analysis::ty::ty_def::TyId;
-    use crate::{
-        analysis::HirAnalysisDb,
-        analysis::ty::{
-            fold::{TyFoldable, TyFolder},
-            ty_def::{Kind, TyVarSort},
-            unify::UnificationTable,
-            visitor::{TyVisitable, TyVisitor},
-        },
-        test_db::HirAnalysisTestDb,
+    use super::Canonical;
+    use crate::analysis::ty::{
+        ty_def::{Kind, TyVarSort},
+        unify::UnificationTable,
     };
-
-    #[derive(Debug, Clone, Copy, PartialEq, Eq, Update)]
-    struct RepeatedAndConstVars<'db> {
-        lhs: TyId<'db>,
-        rhs: TyId<'db>,
-        const_arg: TyId<'db>,
-    }
-
-    impl<'db> TyFoldable<'db> for RepeatedAndConstVars<'db> {
-        fn super_fold_with<F>(self, db: &'db dyn HirAnalysisDb, folder: &mut F) -> Self
-        where
-            F: TyFolder<'db>,
-        {
-            Self {
-                lhs: self.lhs.fold_with(db, folder),
-                rhs: self.rhs.fold_with(db, folder),
-                const_arg: self.const_arg.fold_with(db, folder),
-            }
-        }
-    }
-
-    impl<'db> TyVisitable<'db> for RepeatedAndConstVars<'db> {
-        fn visit_with<V>(&self, visitor: &mut V)
-        where
-            V: TyVisitor<'db> + ?Sized,
-        {
-            self.lhs.visit_with(visitor);
-            self.rhs.visit_with(visitor);
-            self.const_arg.visit_with(visitor);
-        }
-    }
+    use crate::test_db::HirAnalysisTestDb;
 
     #[test]
-    fn extract_existing_solution_handles_preseeded_tables() {
+    fn canonical_extract_identity_handles_preseeded_tables() {
         let db = HirAnalysisTestDb::default();
-        let mut original_table = UnificationTable::new(&db);
-        let original = original_table.new_var(TyVarSort::General, &Kind::Star);
-        let canonicalized = Canonicalized::new(&db, original);
+        let mut table = UnificationTable::new(&db);
+        let original = table.new_var(TyVarSort::General, &Kind::Star);
+        let canonical = Canonical::new(&db, original);
 
         let mut scratch = UnificationTable::new(&db);
         let _ = scratch.new_var(TyVarSort::General, &Kind::Star);
-        let extracted = canonicalized.extract_identity(&mut scratch);
 
-        assert_eq!(
-            canonicalized.extract_existing_solution(&mut scratch, extracted, extracted),
-            Some(original)
-        );
-    }
-
-    #[test]
-    fn extract_existing_solution_rejects_scratch_only_vars() {
-        let db = HirAnalysisTestDb::default();
-        let mut original_table = UnificationTable::new(&db);
-        let original = original_table.new_var(TyVarSort::General, &Kind::Star);
-        let canonicalized = Canonicalized::new(&db, original);
-
-        let mut scratch = UnificationTable::new(&db);
-        let extracted = canonicalized.extract_identity(&mut scratch);
-        let extra = scratch.new_var(TyVarSort::General, &Kind::Star);
-
-        assert_eq!(
-            canonicalized.extract_existing_solution(&mut scratch, extracted, extra),
-            None
-        );
-    }
-
-    #[test]
-    fn extract_existing_solution_handles_repeated_and_const_vars() {
-        let db = HirAnalysisTestDb::default();
-        let mut original_table = UnificationTable::new(&db);
-        let repeated = original_table.new_var(TyVarSort::General, &Kind::Star);
-        let const_arg = TyId::const_ty_var(
-            &db,
-            TyId::u256(&db),
-            original_table.new_key(&Kind::Star, TyVarSort::General),
-        );
-        let original = RepeatedAndConstVars {
-            lhs: repeated,
-            rhs: repeated,
-            const_arg,
-        };
-        let canonicalized = Canonicalized::new(&db, original);
-
-        let mut scratch = UnificationTable::new(&db);
-        let _ = scratch.new_var(TyVarSort::General, &Kind::Star);
-        let extracted = canonicalized.extract_identity(&mut scratch);
-
-        assert_eq!(
-            canonicalized.extract_existing_solution(&mut scratch, extracted, extracted),
-            Some(original)
-        );
+        assert!(canonical.extract_identity(&mut scratch).is_ty_var(&db));
     }
 }

--- a/crates/hir/src/analysis/ty/canonical.rs
+++ b/crates/hir/src/analysis/ty/canonical.rs
@@ -4,14 +4,15 @@ use salsa::Update;
 use super::{
     const_ty::{ConstTyData, ConstTyId},
     fold::{TyFoldable, TyFolder},
-    ty_def::{TyData, TyId, TyVar},
+    ty_def::{TyData, TyFlags, TyId, TyVar},
     unify::{InferenceKey, UnificationStore, UnificationTableBase},
+    visitor::{TyVisitable, collect_flags},
 };
 use crate::analysis::{HirAnalysisDb, ty::ty_def::collect_variables};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Canonical<T> {
-    pub value: T,
+    value: T,
 }
 
 impl<'db, T> Canonical<T>
@@ -45,6 +46,13 @@ where
         let db = table.db;
         let mut extractor = SolutionExtractor::new(table, FxHashMap::default());
         self.value.fold_with(db, &mut extractor)
+    }
+
+    pub fn flags(self, db: &'db dyn HirAnalysisDb) -> TyFlags
+    where
+        T: TyVisitable<'db>,
+    {
+        collect_flags(db, self.value)
     }
 
     /// Canonicalize a new solution that corresponds to the canonical query.
@@ -103,27 +111,37 @@ where
 /// [`Solution`] that corresponds to [`Canonical`] query.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Canonicalized<'db, T> {
-    pub value: Canonical<T>,
+    original: T,
+    canonical: Canonical<T>,
     // A substitution from canonical type variables to original type variables.
     subst: FxHashMap<TyId<'db>, TyId<'db>>,
 }
 
 impl<'db, T> Canonicalized<'db, T>
 where
-    T: TyFoldable<'db>,
+    T: TyFoldable<'db> + Copy,
 {
     pub fn new(db: &'db dyn HirAnalysisDb, value: T) -> Self {
         let mut canonicalizer = Canonicalizer::default();
-        let value = value.fold_with(db, &mut canonicalizer);
+        let canonical = value.fold_with(db, &mut canonicalizer);
         let map = canonicalizer
             .subst
             .into_iter()
             .map(|(orig_var, canonical_var)| (canonical_var, orig_var))
             .collect();
         Canonicalized {
-            value: Canonical { value },
+            original: value,
+            canonical: Canonical { value: canonical },
             subst: map,
         }
+    }
+
+    pub fn original(&self) -> T {
+        self.original
+    }
+
+    pub fn canonical(&self) -> Canonical<T> {
+        self.canonical
     }
 
     /// Extracts the solution from the canonicalized query.

--- a/crates/hir/src/analysis/ty/canonical.rs
+++ b/crates/hir/src/analysis/ty/canonical.rs
@@ -447,14 +447,51 @@ where
 
 #[cfg(test)]
 mod tests {
+    use salsa::Update;
+
     use super::Canonicalized;
+    use crate::analysis::ty::ty_def::TyId;
     use crate::{
+        analysis::HirAnalysisDb,
         analysis::ty::{
+            fold::{TyFoldable, TyFolder},
             ty_def::{Kind, TyVarSort},
             unify::UnificationTable,
+            visitor::{TyVisitable, TyVisitor},
         },
         test_db::HirAnalysisTestDb,
     };
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Update)]
+    struct RepeatedAndConstVars<'db> {
+        lhs: TyId<'db>,
+        rhs: TyId<'db>,
+        const_arg: TyId<'db>,
+    }
+
+    impl<'db> TyFoldable<'db> for RepeatedAndConstVars<'db> {
+        fn super_fold_with<F>(self, db: &'db dyn HirAnalysisDb, folder: &mut F) -> Self
+        where
+            F: TyFolder<'db>,
+        {
+            Self {
+                lhs: self.lhs.fold_with(db, folder),
+                rhs: self.rhs.fold_with(db, folder),
+                const_arg: self.const_arg.fold_with(db, folder),
+            }
+        }
+    }
+
+    impl<'db> TyVisitable<'db> for RepeatedAndConstVars<'db> {
+        fn visit_with<V>(&self, visitor: &mut V)
+        where
+            V: TyVisitor<'db> + ?Sized,
+        {
+            self.lhs.visit_with(visitor);
+            self.rhs.visit_with(visitor);
+            self.const_arg.visit_with(visitor);
+        }
+    }
 
     #[test]
     fn extract_existing_solution_handles_preseeded_tables() {
@@ -487,6 +524,33 @@ mod tests {
         assert_eq!(
             canonicalized.extract_existing_solution(&mut scratch, extracted, extra),
             None
+        );
+    }
+
+    #[test]
+    fn extract_existing_solution_handles_repeated_and_const_vars() {
+        let db = HirAnalysisTestDb::default();
+        let mut original_table = UnificationTable::new(&db);
+        let repeated = original_table.new_var(TyVarSort::General, &Kind::Star);
+        let const_arg = TyId::const_ty_var(
+            &db,
+            TyId::u256(&db),
+            original_table.new_key(&Kind::Star, TyVarSort::General),
+        );
+        let original = RepeatedAndConstVars {
+            lhs: repeated,
+            rhs: repeated,
+            const_arg,
+        };
+        let canonicalized = Canonicalized::new(&db, original);
+
+        let mut scratch = UnificationTable::new(&db);
+        let _ = scratch.new_var(TyVarSort::General, &Kind::Star);
+        let extracted = canonicalized.extract_identity(&mut scratch);
+
+        assert_eq!(
+            canonicalized.extract_existing_solution(&mut scratch, extracted, extracted),
+            Some(original)
         );
     }
 }

--- a/crates/hir/src/analysis/ty/canonical.rs
+++ b/crates/hir/src/analysis/ty/canonical.rs
@@ -144,6 +144,26 @@ where
         self.canonical
     }
 
+    pub fn extract_identity<S>(&self, table: &mut UnificationTableBase<'db, S>) -> T
+    where
+        S: UnificationStore<'db>,
+    {
+        self.canonical.extract_identity(table)
+    }
+
+    pub fn canonicalize_solution<S, U>(
+        &self,
+        db: &'db dyn HirAnalysisDb,
+        table: &mut UnificationTableBase<'db, S>,
+        solution: U,
+    ) -> Solution<U>
+    where
+        S: UnificationStore<'db>,
+        U: TyFoldable<'db> + Clone + Update,
+    {
+        self.canonical.canonicalize_solution(db, table, solution)
+    }
+
     /// Extracts the solution from the canonicalized query.
     ///
     /// This method takes a unification table and a solution, and returns the

--- a/crates/hir/src/analysis/ty/mod.rs
+++ b/crates/hir/src/analysis/ty/mod.rs
@@ -46,6 +46,7 @@ pub mod method_table;
 pub mod normalize;
 pub mod pattern_analysis;
 pub mod pattern_ir;
+pub(crate) mod scratch;
 pub mod trait_def;
 pub mod trait_lower;
 pub mod trait_resolution; // This line was previously 'pub mod name_resolution;'

--- a/crates/hir/src/analysis/ty/normalize.rs
+++ b/crates/hir/src/analysis/ty/normalize.rs
@@ -14,10 +14,9 @@ use super::{
     canonical::Canonical,
     canonical::Canonicalized,
     fold::{TyFoldable, TyFolder},
-    trait_def::impls_for_ty_with_constraints,
+    trait_def::{TraitInstId, impls_for_ty_with_constraints},
     trait_resolution::{PredicateListId, TraitSolveCx},
     ty_def::{AssocTy, TyData, TyId, TyParam},
-    unify::UnificationTable,
     visitor::{TyVisitable, TyVisitor},
 };
 use crate::analysis::{
@@ -51,13 +50,16 @@ pub struct TypeNormalizer<'db> {
 }
 
 #[derive(Clone, Copy)]
-struct AssumptionUnifyInput<'db> {
-    lhs_self: TyId<'db>,
-    rhs_self: TyId<'db>,
-    bound: TyId<'db>,
+pub(crate) struct AssumptionUnifyInput<T> {
+    pub(crate) lhs_self: T,
+    pub(crate) rhs_self: T,
+    pub(crate) bound: T,
 }
 
-impl<'db> TyFoldable<'db> for AssumptionUnifyInput<'db> {
+impl<'db, T> TyFoldable<'db> for AssumptionUnifyInput<T>
+where
+    T: TyFoldable<'db> + Copy,
+{
     fn super_fold_with<F>(self, db: &'db dyn HirAnalysisDb, folder: &mut F) -> Self
     where
         F: TyFolder<'db>,
@@ -70,7 +72,10 @@ impl<'db> TyFoldable<'db> for AssumptionUnifyInput<'db> {
     }
 }
 
-impl<'db> TyVisitable<'db> for AssumptionUnifyInput<'db> {
+impl<'db, T> TyVisitable<'db> for AssumptionUnifyInput<T>
+where
+    T: TyVisitable<'db> + Copy,
+{
     fn visit_with<V>(&self, visitor: &mut V)
     where
         V: TyVisitor<'db> + ?Sized,
@@ -165,21 +170,18 @@ impl<'db> TypeNormalizer<'db> {
                 },
             );
 
-            let mut table = UnificationTable::new(self.db);
-            let materialized_input = canonical_input.extract_identity(&mut table);
-            let AssumptionUnifyInput {
-                lhs_self,
-                rhs_self,
-                bound,
-            } = materialized_input;
-
-            if table.unify(lhs_self, rhs_self).is_ok() {
-                let resolved = bound.fold_with(self.db, &mut table);
-                return canonical_input.extract_existing_solution(
-                    &mut table,
-                    materialized_input,
-                    resolved,
-                );
+            if let Some(resolved) = canonical_input.with_materialized(self.db, |cx| {
+                let input = cx.query();
+                if cx
+                    .unify::<TyId<'db>>(input.lhs_self, input.rhs_self)
+                    .is_ok()
+                {
+                    let resolved = cx.resolve::<TyId<'db>>(input.bound);
+                    return cx.try_extract::<TyId<'db>>(resolved);
+                }
+                None
+            }) {
+                return Some(resolved);
             }
         }
 
@@ -247,49 +249,40 @@ impl<'db> TypeNormalizer<'db> {
         // Canonicalize the target trait instance so we can unify against it in a
         // fresh table without mixing inference keys from other tables.
         let canonical_target = Canonicalized::new(self.db, trait_inst);
+        canonical_target.with_materialized(self.db, |cx| {
+            let target_inst = cx.query();
+            for ingot in search_ingots.into_iter().flatten() {
+                for implementor in impls_for_ty_with_constraints(
+                    self.db,
+                    ingot,
+                    canonical_self_ty,
+                    self.assumptions,
+                ) {
+                    if implementor.skip_binder().trait_def(self.db) != trait_def {
+                        continue;
+                    }
 
-        let mut table = UnificationTable::new(self.db);
-        let target_inst = canonical_target.extract_identity(&mut table);
+                    let candidate = cx.with_impl_assoc_ty(
+                        implementor,
+                        target_inst.self_ty(self.db),
+                        assoc.name,
+                        |cx, inst, assoc_ty| {
+                            cx.unify::<TraitInstId<'db>>(inst, target_inst).ok()?;
+                            let assoc_ty = cx.resolve::<TyId<'db>>(assoc_ty);
+                            cx.try_extract::<TyId<'db>>(assoc_ty)
+                        },
+                    );
 
-        for ingot in search_ingots.into_iter().flatten() {
-            for implementor in
-                impls_for_ty_with_constraints(self.db, ingot, canonical_self_ty, self.assumptions)
-            {
-                let snapshot = table.snapshot();
-                let implementor = table.instantiate_with_fresh_vars(implementor);
-
-                // Filter by trait before unifying (cheap early out).
-                if implementor.trait_def(self.db) != trait_def {
-                    table.rollback_to(snapshot);
-                    continue;
+                    // Extract into the caller's inference environment before
+                    // continuing normalization, so scratch-local vars never
+                    // leak into the cache.
+                    if let Some(Some(folded)) = candidate {
+                        let norm = self.fold_ty(self.db, folded);
+                        dedup.entry(norm).or_insert(());
+                    }
                 }
-
-                if table
-                    .unify(implementor.trait_(self.db), target_inst)
-                    .is_err()
-                {
-                    table.rollback_to(snapshot);
-                    continue;
-                }
-
-                let Some(assoc_ty) = implementor.assoc_ty(self.db, assoc.name) else {
-                    table.rollback_to(snapshot);
-                    continue;
-                };
-
-                // Map scratch-table solutions back into the caller's inference
-                // environment before further normalization.
-                let folded = assoc_ty.fold_with(self.db, &mut table);
-                if let Some(folded) =
-                    canonical_target.extract_existing_solution(&mut table, target_inst, folded)
-                {
-                    let norm = self.fold_ty(self.db, folded);
-                    dedup.entry(norm).or_insert(());
-                }
-
-                table.rollback_to(snapshot);
             }
-        }
+        });
 
         match dedup.len() {
             0 => None,

--- a/crates/hir/src/analysis/ty/normalize.rs
+++ b/crates/hir/src/analysis/ty/normalize.rs
@@ -170,7 +170,7 @@ impl<'db> TypeNormalizer<'db> {
                 lhs_self,
                 rhs_self,
                 bound,
-            } = canonical_input.canonical().extract_identity(&mut table);
+            } = canonical_input.extract_identity(&mut table);
 
             if table.unify(lhs_self, rhs_self).is_ok() {
                 let resolved = bound.fold_with(self.db, &mut table);

--- a/crates/hir/src/analysis/ty/normalize.rs
+++ b/crates/hir/src/analysis/ty/normalize.rs
@@ -16,7 +16,7 @@ use super::{
     fold::{TyFoldable, TyFolder},
     trait_def::impls_for_ty_with_constraints,
     trait_resolution::{PredicateListId, TraitSolveCx},
-    ty_def::{AssocTy, TyData, TyId, TyParam, inference_keys},
+    ty_def::{AssocTy, TyData, TyId, TyParam},
     unify::UnificationTable,
     visitor::{TyVisitable, TyVisitor},
 };
@@ -166,15 +166,20 @@ impl<'db> TypeNormalizer<'db> {
             );
 
             let mut table = UnificationTable::new(self.db);
+            let materialized_input = canonical_input.extract_identity(&mut table);
             let AssumptionUnifyInput {
                 lhs_self,
                 rhs_self,
                 bound,
-            } = canonical_input.extract_identity(&mut table);
+            } = materialized_input;
 
             if table.unify(lhs_self, rhs_self).is_ok() {
                 let resolved = bound.fold_with(self.db, &mut table);
-                return Some(canonical_input.decanonicalize(self.db, resolved));
+                return canonical_input.extract_existing_solution(
+                    &mut table,
+                    materialized_input,
+                    resolved,
+                );
             }
         }
 
@@ -242,11 +247,9 @@ impl<'db> TypeNormalizer<'db> {
         // Canonicalize the target trait instance so we can unify against it in a
         // fresh table without mixing inference keys from other tables.
         let canonical_target = Canonicalized::new(self.db, trait_inst);
-        let canonical_inst = canonical_target.canonical();
 
         let mut table = UnificationTable::new(self.db);
-        let target_inst = canonical_inst.extract_identity(&mut table);
-        let target_keys = inference_keys(self.db, &target_inst);
+        let target_inst = canonical_target.extract_identity(&mut table);
 
         for ingot in search_ingots.into_iter().flatten() {
             for implementor in
@@ -274,20 +277,15 @@ impl<'db> TypeNormalizer<'db> {
                     continue;
                 };
 
-                // Apply substitutions, then decanonicalize back to the original
-                // inference vars before further normalization.
+                // Map scratch-table solutions back into the caller's inference
+                // environment before further normalization.
                 let folded = assoc_ty.fold_with(self.db, &mut table);
-                let folded_keys = inference_keys(self.db, &folded);
-                if !folded_keys.is_subset(&target_keys) {
-                    // This candidate left unconstrained snapshot-local vars in
-                    // the projected associated type. Skipping avoids leaking
-                    // rollback-invalid keys into later analysis.
-                    table.rollback_to(snapshot);
-                    continue;
+                if let Some(folded) =
+                    canonical_target.extract_existing_solution(&mut table, target_inst, folded)
+                {
+                    let norm = self.fold_ty(self.db, folded);
+                    dedup.entry(norm).or_insert(());
                 }
-                let folded = canonical_target.decanonicalize(self.db, folded);
-                let norm = self.fold_ty(self.db, folded);
-                dedup.entry(norm).or_insert(());
 
                 table.rollback_to(snapshot);
             }

--- a/crates/hir/src/analysis/ty/normalize.rs
+++ b/crates/hir/src/analysis/ty/normalize.rs
@@ -170,7 +170,7 @@ impl<'db> TypeNormalizer<'db> {
                 lhs_self,
                 rhs_self,
                 bound,
-            } = canonical_input.value.extract_identity(&mut table);
+            } = canonical_input.canonical().extract_identity(&mut table);
 
             if table.unify(lhs_self, rhs_self).is_ok() {
                 let resolved = bound.fold_with(self.db, &mut table);
@@ -242,7 +242,7 @@ impl<'db> TypeNormalizer<'db> {
         // Canonicalize the target trait instance so we can unify against it in a
         // fresh table without mixing inference keys from other tables.
         let canonical_target = Canonicalized::new(self.db, trait_inst);
-        let canonical_inst = canonical_target.value;
+        let canonical_inst = canonical_target.canonical();
 
         let mut table = UnificationTable::new(self.db);
         let target_inst = canonical_inst.extract_identity(&mut table);

--- a/crates/hir/src/analysis/ty/scratch.rs
+++ b/crates/hir/src/analysis/ty/scratch.rs
@@ -1,0 +1,575 @@
+use std::marker::PhantomData;
+
+use rustc_hash::FxHashMap;
+use salsa::Update;
+
+use super::{
+    binder::Binder,
+    canonical::{Canonicalized, Solution},
+    const_ty::{ConstTyData, ConstTyId},
+    fold::{TyFoldable, TyFolder},
+    normalize::AssumptionUnifyInput,
+    trait_def::{ImplementorId, TraitInstId},
+    trait_lower::{TraitRefLowerError, lower_trait_ref},
+    trait_resolution::PredicateListId,
+    ty_def::{TyData, TyId},
+    unify::{Snapshot, Unifiable, UnificationResult, UnificationStore, UnificationTable},
+    visitor::{TyVisitable, TyVisitor, walk_const_ty, walk_ty},
+};
+use crate::{
+    analysis::HirAnalysisDb,
+    core::hir_def::{IdentId, TraitRefId, scope_graph::ScopeId},
+};
+
+pub(crate) trait ScratchRepr<'db>: Sized {
+    type Branded<'q>: Copy;
+}
+
+mod private {
+    use super::ScratchRepr;
+
+    pub(crate) trait ScratchOps<'db>: ScratchRepr<'db> {
+        fn brand<'q>(raw: Self) -> Self::Branded<'q>;
+        fn unbrand<'q>(value: Self::Branded<'q>) -> Self;
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct ScratchTy<'q, 'db> {
+    raw: TyId<'db>,
+    _brand: PhantomData<fn(&'q ()) -> &'q ()>,
+}
+
+impl<'q, 'db> ScratchTy<'q, 'db> {
+    pub(crate) fn is_star_kind(self, db: &'db dyn HirAnalysisDb) -> bool {
+        self.raw.is_star_kind(db)
+    }
+
+    const fn new(raw: TyId<'db>) -> Self {
+        Self {
+            raw,
+            _brand: PhantomData,
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct ScratchTraitInst<'q, 'db> {
+    raw: TraitInstId<'db>,
+    _brand: PhantomData<fn(&'q ()) -> &'q ()>,
+}
+
+impl<'q, 'db> ScratchTraitInst<'q, 'db> {
+    pub(crate) fn def(self, db: &'db dyn HirAnalysisDb) -> crate::hir_def::Trait<'db> {
+        self.raw.def(db)
+    }
+
+    pub(crate) fn self_ty(self, db: &'db dyn HirAnalysisDb) -> ScratchTy<'q, 'db> {
+        ScratchTy::new(self.raw.self_ty(db))
+    }
+
+    pub(crate) fn assoc_ty(
+        self,
+        db: &'db dyn HirAnalysisDb,
+        name: IdentId<'db>,
+    ) -> Option<ScratchTy<'q, 'db>> {
+        self.raw.assoc_ty(db, name).map(ScratchTy::new)
+    }
+
+    const fn new(raw: TraitInstId<'db>) -> Self {
+        Self {
+            raw,
+            _brand: PhantomData,
+        }
+    }
+}
+
+#[must_use]
+pub(crate) struct ScratchSnapshot<'q, 'db> {
+    raw: Snapshot<ena::unify::InPlace<super::unify::InferenceKey<'db>>>,
+    _brand: PhantomData<fn(&'q ()) -> &'q ()>,
+}
+
+pub(crate) struct MaterializedCx<'q, 'db, Q>
+where
+    Q: TyFoldable<'db> + Copy + ScratchRepr<'db>,
+{
+    db: &'db dyn HirAnalysisDb,
+    table: UnificationTable<'db>,
+    query_raw: Q,
+    local_to_canonical: FxHashMap<TyId<'db>, TyId<'db>>,
+    original_to_local: FxHashMap<TyId<'db>, TyId<'db>>,
+    canonical_to_original: FxHashMap<TyId<'db>, TyId<'db>>,
+    _brand: PhantomData<fn(&'q ()) -> &'q ()>,
+}
+
+impl<'q, 'db, Q> MaterializedCx<'q, 'db, Q>
+where
+    Q: TyFoldable<'db> + Copy + ScratchRepr<'db> + private::ScratchOps<'db>,
+{
+    pub(crate) fn query(&self) -> Q::Branded<'q> {
+        Q::brand(self.query_raw)
+    }
+
+    pub(crate) fn snapshot(&mut self) -> ScratchSnapshot<'q, 'db> {
+        ScratchSnapshot {
+            raw: self.table.snapshot(),
+            _brand: PhantomData,
+        }
+    }
+
+    pub(crate) fn rollback_to(&mut self, snapshot: ScratchSnapshot<'q, 'db>) {
+        self.table.rollback_to(snapshot.raw);
+    }
+
+    pub(crate) fn materialize<U>(&mut self, value: U) -> U::Branded<'q>
+    where
+        U: TyFoldable<'db> + ScratchRepr<'db> + private::ScratchOps<'db>,
+    {
+        let mut materializer =
+            ScratchMaterializer::new(&mut self.table, std::mem::take(&mut self.original_to_local));
+        let raw = value.fold_with(self.db, &mut materializer);
+        self.original_to_local = materializer.subst;
+        U::brand(raw)
+    }
+
+    pub(crate) fn resolve<U>(&mut self, value: U::Branded<'q>) -> U::Branded<'q>
+    where
+        U: TyFoldable<'db> + ScratchRepr<'db> + private::ScratchOps<'db>,
+    {
+        U::brand(U::unbrand(value).fold_with(self.db, &mut self.table))
+    }
+
+    pub(crate) fn instantiate_with_fresh_vars<U>(&mut self, binder: Binder<U>) -> U::Branded<'q>
+    where
+        U: TyFoldable<'db> + ScratchRepr<'db> + private::ScratchOps<'db>,
+    {
+        U::brand(self.table.instantiate_with_fresh_vars(binder))
+    }
+
+    pub(crate) fn materialize_to_term(&mut self, ty: TyId<'db>) -> ScratchTy<'q, 'db> {
+        let ty = self.materialize(ty);
+        self.instantiate_to_term(ty)
+    }
+
+    pub(crate) fn instantiate_to_term(&mut self, ty: ScratchTy<'q, 'db>) -> ScratchTy<'q, 'db> {
+        ScratchTy::new(self.table.instantiate_to_term(ty.raw))
+    }
+
+    pub(crate) fn unify<U>(&mut self, lhs: U::Branded<'q>, rhs: U::Branded<'q>) -> UnificationResult
+    where
+        U: Unifiable<'db> + ScratchRepr<'db> + private::ScratchOps<'db>,
+    {
+        self.table.unify(U::unbrand(lhs), U::unbrand(rhs))
+    }
+
+    pub(crate) fn try_extract<U>(&mut self, value: U::Branded<'q>) -> Option<U>
+    where
+        U: TyFoldable<'db>
+            + TyVisitable<'db>
+            + Update
+            + ScratchRepr<'db>
+            + private::ScratchOps<'db>,
+    {
+        let value = U::unbrand(value).fold_with(self.db, &mut self.table);
+        let mut remapper = RemapToCanonical {
+            db: self.db,
+            subst: &self.local_to_canonical,
+        };
+        let value = value.fold_with(self.db, &mut remapper);
+        uses_only_query_canonical_vars(self.db, &self.canonical_to_original, &value).then(|| {
+            let solution = Solution { value };
+            let mut extractor = super::canonical::SolutionExtractor::new(
+                &mut self.table,
+                self.canonical_to_original.clone(),
+            );
+            solution.value.fold_with(self.db, &mut extractor)
+        })
+    }
+
+    pub(crate) fn lower_trait_ref(
+        &mut self,
+        self_ty: ScratchTy<'q, 'db>,
+        trait_ref: TraitRefId<'db>,
+        scope: ScopeId<'db>,
+        assumptions: PredicateListId<'db>,
+        owner_self: Option<ScratchTy<'q, 'db>>,
+    ) -> Result<ScratchTraitInst<'q, 'db>, TraitRefLowerError<'db>> {
+        lower_trait_ref(
+            self.db,
+            self_ty.raw,
+            trait_ref,
+            scope,
+            assumptions,
+            owner_self.map(|owner| owner.raw),
+        )
+        .map(ScratchTraitInst::new)
+    }
+
+    pub(crate) fn with_impl_assoc_ty<R>(
+        &mut self,
+        implementor: Binder<ImplementorId<'db>>,
+        receiver: ScratchTy<'q, 'db>,
+        name: IdentId<'db>,
+        f: impl FnOnce(&mut Self, ScratchTraitInst<'q, 'db>, ScratchTy<'q, 'db>) -> R,
+    ) -> Option<R> {
+        let snapshot = self.snapshot();
+        let implementor = self.table.instantiate_with_fresh_vars(implementor);
+        let result = if self
+            .table
+            .unify(receiver.raw, implementor.self_ty(self.db))
+            .is_ok()
+        {
+            implementor.assoc_ty(self.db, name).map(|assoc_ty| {
+                let inst = ScratchTraitInst::new(
+                    implementor
+                        .trait_(self.db)
+                        .fold_with(self.db, &mut self.table),
+                );
+                let assoc_ty = ScratchTy::new(assoc_ty.fold_with(self.db, &mut self.table));
+                f(self, inst, assoc_ty)
+            })
+        } else {
+            None
+        };
+        self.rollback_to(snapshot);
+        result
+    }
+}
+
+#[allow(private_bounds)]
+impl<'db, Q> Canonicalized<'db, Q>
+where
+    Q: TyFoldable<'db> + Copy + ScratchRepr<'db> + private::ScratchOps<'db>,
+{
+    pub(crate) fn with_materialized<R>(
+        &self,
+        db: &'db dyn HirAnalysisDb,
+        f: impl for<'q> FnOnce(&mut MaterializedCx<'q, 'db, Q>) -> R,
+    ) -> R {
+        let mut table = UnificationTable::new(db);
+        let mut materializer = ScratchMaterializer::new(&mut table, FxHashMap::default());
+        let query_raw = self.canonical().value().fold_with(db, &mut materializer);
+        let canonical_to_local = materializer.subst;
+        let local_to_canonical = materializer.reverse_subst;
+        let mut original_to_local = FxHashMap::default();
+
+        for (canonical, original) in self.subst() {
+            if let Some(&local) = canonical_to_local.get(canonical) {
+                original_to_local.insert(*original, local);
+            }
+        }
+
+        let mut cx = MaterializedCx {
+            db,
+            table,
+            query_raw,
+            local_to_canonical,
+            original_to_local,
+            canonical_to_original: self.subst().clone(),
+            _brand: PhantomData,
+        };
+        f(&mut cx)
+    }
+}
+
+impl<'db> ScratchRepr<'db> for TyId<'db> {
+    type Branded<'q> = ScratchTy<'q, 'db>;
+}
+
+impl<'db> private::ScratchOps<'db> for TyId<'db> {
+    fn brand<'q>(raw: Self) -> Self::Branded<'q> {
+        ScratchTy::new(raw)
+    }
+
+    fn unbrand<'q>(value: Self::Branded<'q>) -> Self {
+        value.raw
+    }
+}
+
+impl<'db> ScratchRepr<'db> for TraitInstId<'db> {
+    type Branded<'q> = ScratchTraitInst<'q, 'db>;
+}
+
+impl<'db> private::ScratchOps<'db> for TraitInstId<'db> {
+    fn brand<'q>(raw: Self) -> Self::Branded<'q> {
+        ScratchTraitInst::new(raw)
+    }
+
+    fn unbrand<'q>(value: Self::Branded<'q>) -> Self {
+        value.raw
+    }
+}
+
+impl<'db> ScratchRepr<'db> for AssumptionUnifyInput<TyId<'db>> {
+    type Branded<'q> = AssumptionUnifyInput<ScratchTy<'q, 'db>>;
+}
+
+impl<'db> private::ScratchOps<'db> for AssumptionUnifyInput<TyId<'db>> {
+    fn brand<'q>(raw: Self) -> Self::Branded<'q> {
+        AssumptionUnifyInput {
+            lhs_self: ScratchTy::new(raw.lhs_self),
+            rhs_self: ScratchTy::new(raw.rhs_self),
+            bound: ScratchTy::new(raw.bound),
+        }
+    }
+
+    fn unbrand<'q>(value: Self::Branded<'q>) -> Self {
+        AssumptionUnifyInput {
+            lhs_self: value.lhs_self.raw,
+            rhs_self: value.rhs_self.raw,
+            bound: value.bound.raw,
+        }
+    }
+}
+
+struct ScratchMaterializer<'a, 'db, S>
+where
+    S: UnificationStore<'db>,
+{
+    table: &'a mut super::unify::UnificationTableBase<'db, S>,
+    subst: FxHashMap<TyId<'db>, TyId<'db>>,
+    reverse_subst: FxHashMap<TyId<'db>, TyId<'db>>,
+}
+
+impl<'a, 'db, S> ScratchMaterializer<'a, 'db, S>
+where
+    S: UnificationStore<'db>,
+{
+    fn new(
+        table: &'a mut super::unify::UnificationTableBase<'db, S>,
+        subst: FxHashMap<TyId<'db>, TyId<'db>>,
+    ) -> Self {
+        Self {
+            table,
+            subst,
+            reverse_subst: FxHashMap::default(),
+        }
+    }
+}
+
+impl<'db, S> TyFolder<'db> for ScratchMaterializer<'_, 'db, S>
+where
+    S: UnificationStore<'db>,
+{
+    fn fold_ty(&mut self, db: &'db dyn HirAnalysisDb, ty: TyId<'db>) -> TyId<'db> {
+        if let Some(&ty) = self.subst.get(&ty) {
+            return ty;
+        }
+
+        match ty.data(db) {
+            TyData::TyVar(var) => {
+                let new_ty = self.table.new_var(var.sort, &var.kind);
+                self.subst.insert(ty, new_ty);
+                self.reverse_subst.insert(new_ty, ty);
+                new_ty
+            }
+            TyData::ConstTy(const_ty) => {
+                if let ConstTyData::TyVar(var, const_ty_ty) = const_ty.data(db) {
+                    let new_ty = TyId::const_ty_var(
+                        db,
+                        *const_ty_ty,
+                        self.table.new_key(const_ty_ty.kind(db), var.sort),
+                    );
+                    self.subst.insert(ty, new_ty);
+                    self.reverse_subst.insert(new_ty, ty);
+                    new_ty
+                } else {
+                    ty.super_fold_with(db, self)
+                }
+            }
+            _ => ty.super_fold_with(db, self),
+        }
+    }
+}
+
+struct RemapToCanonical<'a, 'db> {
+    db: &'db dyn HirAnalysisDb,
+    subst: &'a FxHashMap<TyId<'db>, TyId<'db>>,
+}
+
+impl<'db> TyFolder<'db> for RemapToCanonical<'_, 'db> {
+    fn fold_ty(&mut self, db: &'db dyn HirAnalysisDb, ty: TyId<'db>) -> TyId<'db> {
+        if let Some(&canonical) = self.subst.get(&ty) {
+            return canonical;
+        }
+
+        match ty.data(self.db) {
+            TyData::TyVar(_) => ty,
+            TyData::ConstTy(const_ty) => {
+                if let ConstTyData::TyVar(..) = const_ty.data(self.db) {
+                    ty
+                } else {
+                    ty.super_fold_with(db, self)
+                }
+            }
+            _ => ty.super_fold_with(db, self),
+        }
+    }
+}
+
+fn uses_only_query_canonical_vars<'db, V>(
+    db: &'db dyn HirAnalysisDb,
+    subst: &FxHashMap<TyId<'db>, TyId<'db>>,
+    value: &V,
+) -> bool
+where
+    V: TyVisitable<'db>,
+{
+    struct QueryVarChecker<'a, 'db> {
+        db: &'db dyn HirAnalysisDb,
+        subst: &'a FxHashMap<TyId<'db>, TyId<'db>>,
+        is_valid: bool,
+    }
+
+    impl<'db> TyVisitor<'db> for QueryVarChecker<'_, 'db> {
+        fn db(&self) -> &'db dyn HirAnalysisDb {
+            self.db
+        }
+
+        fn visit_ty(&mut self, ty: TyId<'db>) {
+            if !self.is_valid {
+                return;
+            }
+
+            match ty.data(self.db) {
+                TyData::TyVar(_) => self.is_valid &= self.subst.contains_key(&ty),
+                _ => walk_ty(self, ty),
+            }
+        }
+
+        fn visit_const_ty(&mut self, const_ty: &ConstTyId<'db>) {
+            if !self.is_valid {
+                return;
+            }
+
+            match const_ty.data(self.db) {
+                ConstTyData::TyVar(var, const_ty_ty) => {
+                    let ty = TyId::const_ty_var(self.db, *const_ty_ty, var.key);
+                    self.is_valid &= self.subst.contains_key(&ty);
+                }
+                _ => walk_const_ty(self, const_ty),
+            }
+        }
+    }
+
+    let mut checker = QueryVarChecker {
+        db,
+        subst,
+        is_valid: true,
+    };
+    value.visit_with(&mut checker);
+    checker.is_valid
+}
+
+#[cfg(test)]
+mod tests {
+    use salsa::Update;
+
+    use super::{Canonicalized, ScratchRepr, private};
+    use crate::{
+        analysis::HirAnalysisDb,
+        analysis::ty::{
+            fold::{TyFoldable, TyFolder},
+            ty_def::{Kind, TyId, TyVarSort},
+            visitor::{TyVisitable, TyVisitor},
+        },
+        test_db::HirAnalysisTestDb,
+    };
+
+    #[test]
+    fn with_materialized_extracts_query_back_to_original() {
+        let db = HirAnalysisTestDb::default();
+        let mut table = super::UnificationTable::new(&db);
+        let original = table.new_var(TyVarSort::General, &Kind::Star);
+        let canonicalized = Canonicalized::new(&db, original);
+
+        canonicalized.with_materialized(&db, |cx| {
+            assert_eq!(cx.try_extract::<TyId<'_>>(cx.query()), Some(original));
+        });
+    }
+
+    #[test]
+    fn with_materialized_rejects_scratch_only_vars() {
+        let db = HirAnalysisTestDb::default();
+        let mut table = super::UnificationTable::new(&db);
+        let original = table.new_var(TyVarSort::General, &Kind::Star);
+        let canonicalized = Canonicalized::new(&db, original);
+
+        canonicalized.with_materialized(&db, |cx| {
+            let extra = super::ScratchTy::new(cx.table.new_var(TyVarSort::General, &Kind::Star));
+            assert_eq!(cx.try_extract::<TyId<'_>>(extra), None);
+        });
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Update)]
+    struct RepeatedAndConstVars<'db> {
+        lhs: TyId<'db>,
+        rhs: TyId<'db>,
+        const_arg: TyId<'db>,
+    }
+
+    impl<'db> TyFoldable<'db> for RepeatedAndConstVars<'db> {
+        fn super_fold_with<F>(self, db: &'db dyn HirAnalysisDb, folder: &mut F) -> Self
+        where
+            F: TyFolder<'db>,
+        {
+            Self {
+                lhs: self.lhs.fold_with(db, folder),
+                rhs: self.rhs.fold_with(db, folder),
+                const_arg: self.const_arg.fold_with(db, folder),
+            }
+        }
+    }
+
+    impl<'db> TyVisitable<'db> for RepeatedAndConstVars<'db> {
+        fn visit_with<V>(&self, visitor: &mut V)
+        where
+            V: TyVisitor<'db> + ?Sized,
+        {
+            self.lhs.visit_with(visitor);
+            self.rhs.visit_with(visitor);
+            self.const_arg.visit_with(visitor);
+        }
+    }
+
+    impl<'db> ScratchRepr<'db> for RepeatedAndConstVars<'db> {
+        type Branded<'q> = RepeatedAndConstVars<'db>;
+    }
+
+    impl<'db> private::ScratchOps<'db> for RepeatedAndConstVars<'db> {
+        fn brand<'q>(raw: Self) -> <Self as ScratchRepr<'db>>::Branded<'q> {
+            raw
+        }
+
+        fn unbrand<'q>(value: <Self as ScratchRepr<'db>>::Branded<'q>) -> Self {
+            value
+        }
+    }
+
+    #[test]
+    fn with_materialized_extracts_values_derived_from_query() {
+        let db = HirAnalysisTestDb::default();
+        let mut table = super::UnificationTable::new(&db);
+        let repeated = table.new_var(TyVarSort::General, &Kind::Star);
+        let const_arg = TyId::const_ty_var(
+            &db,
+            TyId::u256(&db),
+            table.new_key(&Kind::Star, TyVarSort::General),
+        );
+        let original = RepeatedAndConstVars {
+            lhs: repeated,
+            rhs: repeated,
+            const_arg,
+        };
+        let canonicalized = Canonicalized::new(&db, original);
+
+        canonicalized.with_materialized(&db, |cx| {
+            let query = cx.query();
+            assert_eq!(
+                cx.try_extract::<RepeatedAndConstVars<'_>>(query),
+                Some(original)
+            );
+        });
+    }
+}

--- a/crates/hir/src/analysis/ty/trait_def.rs
+++ b/crates/hir/src/analysis/ty/trait_def.rs
@@ -73,7 +73,8 @@ pub(crate) fn impls_for_trait_in_ingots<'db>(
     secondary: Option<Ingot<'db>>,
     trait_: Canonical<TraitInstId<'db>>,
 ) -> Vec<Binder<ImplementorId<'db>>> {
-    let trait_def = trait_.value.def(db);
+    let mut table = UnificationTable::new(db);
+    let trait_def = trait_.extract_identity(&mut table).def(db);
     let mut dedup: IndexSet<Binder<ImplementorId<'db>>> = IndexSet::default();
     dedup.extend(impls_for_trait_def(db, primary, trait_def).iter().copied());
     if let Some(secondary) = secondary {

--- a/crates/hir/src/analysis/ty/trait_resolution/mod.rs
+++ b/crates/hir/src/analysis/ty/trait_resolution/mod.rs
@@ -9,7 +9,6 @@ use crate::analysis::{
     ty::{
         trait_resolution::{constraint::ty_constraints, proof_forest::ProofForest},
         unify::UnificationTable,
-        visitor::collect_flags,
     },
 };
 use crate::{
@@ -56,7 +55,7 @@ impl<'db> CanonicalGoalQuery<'db> {
         let original = Canonicalized::new(db, raw);
         Self {
             raw,
-            canonical: original.value,
+            canonical: original.canonical(),
             original,
         }
     }
@@ -249,8 +248,7 @@ fn is_query_satisfiable<'db>(
     origin_ingot: Ingot<'db>,
     query: Canonical<TraitSolverQuery<'db>>,
 ) -> GoalSatisfiability<'db> {
-    let flags = collect_flags(db, query.value);
-    if flags.contains(TyFlags::HAS_INVALID) {
+    if query.flags(db).contains(TyFlags::HAS_INVALID) {
         return GoalSatisfiability::ContainsInvalid;
     };
 

--- a/crates/hir/src/analysis/ty/ty_check/expr.rs
+++ b/crates/hir/src/analysis/ty/ty_check/expr.rs
@@ -2208,7 +2208,7 @@ impl<'db> TyChecker<'db> {
             };
 
             Some(ProviderTargetResolution {
-                target_ty: Canonicalized::new(self.db, target_ty).value.value,
+                target_ty: Canonicalized::new(self.db, target_ty).original(),
                 target_seed_ty: target_assoc,
                 handle_proof: Some((effect_handle_inst, handle_solution)),
                 effect_ref_proof: Some((effect_ref_inst, effect_ref_solution)),
@@ -2728,7 +2728,7 @@ impl<'db> TyChecker<'db> {
         let mut canonical_r_ty = Canonicalized::new(self.db, selected_receiver_ty);
         let mut candidate = select_method_candidate(
             self.db,
-            canonical_r_ty.value,
+            canonical_r_ty.canonical(),
             method_name,
             self.env.scope(),
             method_assumptions,
@@ -2742,7 +2742,7 @@ impl<'db> TyChecker<'db> {
                 let fallback_canonical = Canonicalized::new(self.db, receiver_ty);
                 let fallback = select_method_candidate(
                     self.db,
-                    fallback_canonical.value,
+                    fallback_canonical.canonical(),
                     method_name,
                     self.env.scope(),
                     method_assumptions,
@@ -3817,7 +3817,7 @@ impl<'db> TyChecker<'db> {
         let mut c_lhs_ty = Canonicalized::new(self.db, selected_lhs_ty);
         let mut method_candidate = select_method_candidate(
             self.db,
-            c_lhs_ty.value,
+            c_lhs_ty.canonical(),
             op.trait_method(self.db),
             self.env.scope(),
             method_assumptions,
@@ -3831,7 +3831,7 @@ impl<'db> TyChecker<'db> {
                 let c_candidate_ty = Canonicalized::new(self.db, candidate_ty);
                 let fallback = select_method_candidate(
                     self.db,
-                    c_candidate_ty.value,
+                    c_candidate_ty.canonical(),
                     op.trait_method(self.db),
                     self.env.scope(),
                     method_assumptions,

--- a/crates/hir/src/analysis/ty/ty_check/expr.rs
+++ b/crates/hir/src/analysis/ty/ty_check/expr.rs
@@ -2728,7 +2728,7 @@ impl<'db> TyChecker<'db> {
         let mut canonical_r_ty = Canonicalized::new(self.db, selected_receiver_ty);
         let mut candidate = select_method_candidate(
             self.db,
-            canonical_r_ty.canonical(),
+            &canonical_r_ty,
             method_name,
             self.env.scope(),
             method_assumptions,
@@ -2742,7 +2742,7 @@ impl<'db> TyChecker<'db> {
                 let fallback_canonical = Canonicalized::new(self.db, receiver_ty);
                 let fallback = select_method_candidate(
                     self.db,
-                    fallback_canonical.canonical(),
+                    &fallback_canonical,
                     method_name,
                     self.env.scope(),
                     method_assumptions,
@@ -3817,7 +3817,7 @@ impl<'db> TyChecker<'db> {
         let mut c_lhs_ty = Canonicalized::new(self.db, selected_lhs_ty);
         let mut method_candidate = select_method_candidate(
             self.db,
-            c_lhs_ty.canonical(),
+            &c_lhs_ty,
             op.trait_method(self.db),
             self.env.scope(),
             method_assumptions,
@@ -3831,7 +3831,7 @@ impl<'db> TyChecker<'db> {
                 let c_candidate_ty = Canonicalized::new(self.db, candidate_ty);
                 let fallback = select_method_candidate(
                     self.db,
-                    c_candidate_ty.canonical(),
+                    &c_candidate_ty,
                     op.trait_method(self.db),
                     self.env.scope(),
                     method_assumptions,

--- a/crates/hir/src/analysis/ty/ty_check/expr.rs
+++ b/crates/hir/src/analysis/ty/ty_check/expr.rs
@@ -2208,7 +2208,7 @@ impl<'db> TyChecker<'db> {
             };
 
             Some(ProviderTargetResolution {
-                target_ty: Canonicalized::new(self.db, target_ty).original(),
+                target_ty,
                 target_seed_ty: target_assoc,
                 handle_proof: Some((effect_handle_inst, handle_solution)),
                 effect_ref_proof: Some((effect_ref_inst, effect_ref_solution)),

--- a/crates/hir/src/analysis/ty/ty_check/expr.rs
+++ b/crates/hir/src/analysis/ty/ty_check/expr.rs
@@ -2724,7 +2724,8 @@ impl<'db> TyChecker<'db> {
         let receiver_tys = self.capability_fallback_candidates(receiver_prop.ty);
         let method_assumptions = self.env.assumptions();
 
-        let mut canonical_r_ty = Canonicalized::new(self.db, receiver_tys[0]);
+        let mut selected_receiver_ty = receiver_tys[0];
+        let mut canonical_r_ty = Canonicalized::new(self.db, selected_receiver_ty);
         let mut candidate = select_method_candidate(
             self.db,
             canonical_r_ty.value,
@@ -2749,14 +2750,13 @@ impl<'db> TyChecker<'db> {
                 );
 
                 if fallback.is_ok() || !matches!(fallback, Err(MethodSelectionError::NotFound)) {
+                    selected_receiver_ty = receiver_ty;
                     canonical_r_ty = fallback_canonical;
                     candidate = fallback;
                     break;
                 }
             }
         }
-
-        let selected_receiver_ty = canonical_r_ty.value.value;
         let candidate = match candidate {
             Ok(candidate) => candidate,
             Err(err) => {
@@ -2795,10 +2795,7 @@ impl<'db> TyChecker<'db> {
                         let diag = body_diag_from_method_selection_err(
                             self.db,
                             err,
-                            Spanned::new(
-                                canonical_r_ty.value.value,
-                                receiver.span(self.body()).into(),
-                            ),
+                            Spanned::new(selected_receiver_ty, receiver.span(self.body()).into()),
                             Spanned::new(method_name, call_span.method_name().into()),
                         );
                         self.push_diag(diag);

--- a/crates/hir/src/analysis/ty/ty_check/path.rs
+++ b/crates/hir/src/analysis/ty/ty_check/path.rs
@@ -36,8 +36,6 @@ pub(super) enum ResolvedPathInBody<'db> {
     Reso(PathRes<'db>),
     Binding(LocalBinding<'db>),
     NewBinding(IdentId<'db>),
-
-    #[allow(dead_code)]
     Diag(FuncBodyDiag<'db>),
     Invalid,
 }

--- a/crates/hir/src/projection.rs
+++ b/crates/hir/src/projection.rs
@@ -297,8 +297,6 @@ mod tests {
     use super::*;
 
     // Simple test types - using u32 for all type parameters
-    #[allow(dead_code)]
-    type TestProjection = Projection<u32, u32, u32>;
     type TestPath = ProjectionPath<u32, u32, u32>;
 
     #[test]

--- a/crates/hir/src/test_db.rs
+++ b/crates/hir/src/test_db.rs
@@ -43,8 +43,6 @@ use common::{
     diagnostics::{LabelStyle, Severity, cmp_complete_diagnostics},
     file::File,
     indexmap::IndexMap,
-    paths::absolute_utf8,
-    stdlib::{HasBuiltinCore, HasBuiltinStd},
 };
 use derive_more::TryIntoError;
 use rustc_hash::FxHashMap;
@@ -175,17 +173,16 @@ define_input_db!(HirAnalysisTestDb);
 #[allow(dead_code)]
 impl HirAnalysisTestDb {
     pub fn new_stand_alone(&mut self, file_path: Utf8PathBuf, text: &str) -> File {
-        let file_path =
-            absolute_utf8(file_path.as_path()).expect("resolve absolute standalone path");
-        // Use the index from the database and reinitialize it with core files
+        let file_url = if file_path.is_absolute() {
+            <Url as UrlExt>::from_file_path_lossy(file_path.as_std_path())
+        } else {
+            Url::parse("file:///hir_test/")
+                .unwrap()
+                .join(file_path.as_str())
+                .expect("join synthetic standalone path")
+        };
         let index = self.workspace();
-        self.initialize_builtin_core();
-        self.initialize_builtin_std();
-        index.touch(
-            self,
-            <Url as UrlExt>::from_file_path_lossy(file_path.as_std_path()),
-            Some(text.to_string()),
-        )
+        index.touch(self, file_url, Some(text.to_string()))
     }
 
     pub fn top_mod(&self, input: File) -> (TopLevelMod<'_>, HirPropertyFormatter<'_>) {

--- a/crates/hir/test_files/ty_check/assoc_ty_bound_normalizes.fe
+++ b/crates/hir/test_files/ty_check/assoc_ty_bound_normalizes.fe
@@ -1,0 +1,8 @@
+trait HasItem {
+    type Item
+}
+
+fn use_bound<T: HasItem<Item = u256>>() -> u256 {
+    let x: T::Item = 1
+    x
+}

--- a/crates/hir/test_files/ty_check/assoc_ty_bound_normalizes.snap
+++ b/crates/hir/test_files/ty_check/assoc_ty_bound_normalizes.snap
@@ -1,0 +1,33 @@
+---
+source: crates/hir/tests/ty_check.rs
+assertion_line: 41
+expression: res
+input_file: test_files/ty_check/assoc_ty_bound_normalizes.fe
+---
+note: 
+  ┌─ assoc_ty_bound_normalizes.fe:5:49
+  │  
+5 │   fn use_bound<T: HasItem<Item = u256>>() -> u256 {
+  │ ╭─────────────────────────────────────────────────^
+6 │ │     let x: T::Item = 1
+7 │ │     x
+8 │ │ }
+  │ ╰─^ u256
+
+note: 
+  ┌─ assoc_ty_bound_normalizes.fe:6:9
+  │
+6 │     let x: T::Item = 1
+  │         ^ u256
+
+note: 
+  ┌─ assoc_ty_bound_normalizes.fe:6:22
+  │
+6 │     let x: T::Item = 1
+  │                      ^ u256
+
+note: 
+  ┌─ assoc_ty_bound_normalizes.fe:7:5
+  │
+7 │     x
+  │     ^ u256

--- a/crates/hir/test_files/ty_check/result_map_chain.fe
+++ b/crates/hir/test_files/ty_check/result_map_chain.fe
@@ -1,0 +1,25 @@
+use core::functional::Fn
+use core::result::Result::{self, Ok}
+
+struct Wrap {
+    val: u256,
+}
+
+struct ToWrap {}
+impl Fn<u256, Wrap> for ToWrap {
+    fn call(self, _ x: own u256) -> Wrap {
+        Wrap { val: x }
+    }
+}
+
+struct FromWrap {}
+impl Fn<Wrap, u256> for FromWrap {
+    fn call(self, _ w: own Wrap) -> u256 {
+        w.val
+    }
+}
+
+fn pipeline() -> u256 {
+    let r: Result<bool, u256> = Ok(42)
+    r.map(ToWrap{}).map(FromWrap{}).unwrap()
+}

--- a/crates/hir/test_files/ty_check/result_map_chain.snap
+++ b/crates/hir/test_files/ty_check/result_map_chain.snap
@@ -1,0 +1,116 @@
+---
+source: crates/hir/tests/ty_check.rs
+expression: res
+input_file: test_files/ty_check/result_map_chain.fe
+---
+note: 
+   ┌─ result_map_chain.fe:10:42
+   │  
+10 │       fn call(self, _ x: own u256) -> Wrap {
+   │ ╭──────────────────────────────────────────^
+11 │ │         Wrap { val: x }
+12 │ │     }
+   │ ╰─────^ Wrap
+
+note: 
+   ┌─ result_map_chain.fe:11:9
+   │
+11 │         Wrap { val: x }
+   │         ^^^^^^^^^^^^^^^ Wrap
+
+note: 
+   ┌─ result_map_chain.fe:11:21
+   │
+11 │         Wrap { val: x }
+   │                     ^ u256
+
+note: 
+   ┌─ result_map_chain.fe:17:42
+   │  
+17 │       fn call(self, _ w: own Wrap) -> u256 {
+   │ ╭──────────────────────────────────────────^
+18 │ │         w.val
+19 │ │     }
+   │ ╰─────^ u256
+
+note: 
+   ┌─ result_map_chain.fe:18:9
+   │
+18 │         w.val
+   │         ^ Wrap
+
+note: 
+   ┌─ result_map_chain.fe:18:9
+   │
+18 │         w.val
+   │         ^^^^^ u256
+
+note: 
+   ┌─ result_map_chain.fe:22:23
+   │  
+22 │   fn pipeline() -> u256 {
+   │ ╭───────────────────────^
+23 │ │     let r: Result<bool, u256> = Ok(42)
+24 │ │     r.map(ToWrap{}).map(FromWrap{}).unwrap()
+25 │ │ }
+   │ ╰─^ u256
+
+note: 
+   ┌─ result_map_chain.fe:23:9
+   │
+23 │     let r: Result<bool, u256> = Ok(42)
+   │         ^ Result<bool, u256>
+
+note: 
+   ┌─ result_map_chain.fe:23:33
+   │
+23 │     let r: Result<bool, u256> = Ok(42)
+   │                                 ^^ fn Ok<bool, u256>
+
+note: 
+   ┌─ result_map_chain.fe:23:33
+   │
+23 │     let r: Result<bool, u256> = Ok(42)
+   │                                 ^^^^^^ Result<bool, u256>
+
+note: 
+   ┌─ result_map_chain.fe:23:36
+   │
+23 │     let r: Result<bool, u256> = Ok(42)
+   │                                    ^^ u256
+
+note: 
+   ┌─ result_map_chain.fe:24:5
+   │
+24 │     r.map(ToWrap{}).map(FromWrap{}).unwrap()
+   │     ^ Result<bool, u256>
+
+note: 
+   ┌─ result_map_chain.fe:24:5
+   │
+24 │     r.map(ToWrap{}).map(FromWrap{}).unwrap()
+   │     ^^^^^^^^^^^^^^^ Result<bool, Wrap>
+
+note: 
+   ┌─ result_map_chain.fe:24:5
+   │
+24 │     r.map(ToWrap{}).map(FromWrap{}).unwrap()
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Result<bool, u256>
+
+note: 
+   ┌─ result_map_chain.fe:24:5
+   │
+24 │     r.map(ToWrap{}).map(FromWrap{}).unwrap()
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256
+
+note: 
+   ┌─ result_map_chain.fe:24:11
+   │
+24 │     r.map(ToWrap{}).map(FromWrap{}).unwrap()
+   │           ^^^^^^^^ ToWrap
+
+note: 
+   ┌─ result_map_chain.fe:24:25
+   │
+24 │     r.map(ToWrap{}).map(FromWrap{}).unwrap()
+   │                         ^^^^^^^^^^ FromWrap

--- a/crates/hir/test_files/ty_check/trait_assoc_const.fe
+++ b/crates/hir/test_files/ty_check/trait_assoc_const.fe
@@ -44,3 +44,15 @@ impl HasDefaultConst for UsesDefault {}
 fn use_default_const() -> u32 {
     UsesDefault::C
 }
+
+trait HasValue {
+    const X: usize
+}
+
+trait HasAssoc {
+    type Assoc: HasValue
+}
+
+fn use_assoc_bound_const<T: HasAssoc>() -> usize {
+    T::Assoc::X
+}

--- a/crates/hir/test_files/ty_check/trait_assoc_const.snap
+++ b/crates/hir/test_files/ty_check/trait_assoc_const.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/hir-analysis/tests/ty_check.rs
+source: crates/hir/tests/ty_check.rs
 expression: res
 input_file: test_files/ty_check/trait_assoc_const.fe
 ---
@@ -39,3 +39,18 @@ note:
    │
 45 │     UsesDefault::C
    │     ^^^^^^^^^^^^^^ u32
+
+note: 
+   ┌─ trait_assoc_const.fe:56:50
+   │  
+56 │   fn use_assoc_bound_const<T: HasAssoc>() -> usize {
+   │ ╭──────────────────────────────────────────────────^
+57 │ │     T::Assoc::X
+58 │ │ }
+   │ ╰─^ usize
+
+note: 
+   ┌─ trait_assoc_const.fe:57:5
+   │
+57 │     T::Assoc::X
+   │     ^^^^^^^^^^^ usize

--- a/crates/mir/src/lower/contracts/plan.rs
+++ b/crates/mir/src/lower/contracts/plan.rs
@@ -27,8 +27,6 @@ pub struct FieldPlan<'db> {
     pub index: usize,
     pub slot: BigUint,
     pub declared_ty: TyId<'db>,
-    #[allow(dead_code)]
-    pub target_ty: TyId<'db>,
     pub is_provider: bool,
 }
 
@@ -143,10 +141,6 @@ pub struct InitEntrypointPlan<'db> {
 
 #[derive(Clone)]
 pub struct RuntimeDispatchArmPlan<'db> {
-    #[allow(dead_code)]
-    pub recv_idx: u32,
-    #[allow(dead_code)]
-    pub arm_idx: u32,
     pub selector: u32,
     pub callee: SyntheticId<'db>,
 }
@@ -195,7 +189,6 @@ impl<'db> ContractPlan<'db> {
                 index: field.index as usize,
                 slot: BigUint::from(field.slot_offset),
                 declared_ty: field.declared_ty,
-                target_ty: field.target_ty,
                 is_provider: field.is_provider,
             })
             .collect::<Vec<_>>();
@@ -380,8 +373,6 @@ impl<'db> ContractPlan<'db> {
                     },
                 ));
                 arms.push(RuntimeDispatchArmPlan {
-                    recv_idx: recv.index(db),
-                    arm_idx: arm.index(db),
                     selector,
                     callee: helper_id,
                 });

--- a/crates/uitest/fixtures/ty_check/assoc_const_via_assoc_bound.fe
+++ b/crates/uitest/fixtures/ty_check/assoc_const_via_assoc_bound.fe
@@ -1,0 +1,11 @@
+trait HasValue {
+    const X: usize
+}
+
+trait HasAssoc {
+    type Assoc: HasValue
+}
+
+fn use_assoc_bound_const<T: HasAssoc>() -> usize {
+    T::Assoc::X
+}

--- a/crates/uitest/fixtures/ty_check/assoc_const_via_assoc_bound.snap
+++ b/crates/uitest/fixtures/ty_check/assoc_const_via_assoc_bound.snap
@@ -1,0 +1,5 @@
+---
+source: crates/uitest/tests/ty_check.rs
+expression: diags
+input_file: fixtures/ty_check/assoc_const_via_assoc_bound.fe
+---

--- a/crates/uitest/fixtures/ty_check/assoc_ty_bound_normalizes.fe
+++ b/crates/uitest/fixtures/ty_check/assoc_ty_bound_normalizes.fe
@@ -1,0 +1,8 @@
+trait HasItem {
+    type Item
+}
+
+fn use_bound<T: HasItem<Item = u256>>() -> u256 {
+    let x: T::Item = 1
+    x
+}

--- a/crates/uitest/fixtures/ty_check/assoc_ty_bound_normalizes.snap
+++ b/crates/uitest/fixtures/ty_check/assoc_ty_bound_normalizes.snap
@@ -1,0 +1,7 @@
+---
+source: crates/uitest/tests/ty_check.rs
+assertion_line: 27
+expression: diags
+input_file: fixtures/ty_check/assoc_ty_bound_normalizes.fe
+---
+

--- a/crates/uitest/fixtures/ty_check/method_bound/result_map_chain_second_mapper_bad.fe
+++ b/crates/uitest/fixtures/ty_check/method_bound/result_map_chain_second_mapper_bad.fe
@@ -1,0 +1,25 @@
+use core::functional::Fn
+use core::result::Result::{self, Ok}
+
+struct Wrap {
+    val: u256,
+}
+
+struct ToWrap {}
+impl Fn<u256, Wrap> for ToWrap {
+    fn call(self, _ x: own u256) -> Wrap {
+        Wrap { val: x }
+    }
+}
+
+struct StillNeedsU256 {}
+impl Fn<u256, u256> for StillNeedsU256 {
+    fn call(self, _ x: own u256) -> u256 {
+        x
+    }
+}
+
+fn pipeline() -> u256 {
+    let r: Result<bool, u256> = Ok(42)
+    r.map(ToWrap{}).map(StillNeedsU256{}).unwrap()
+}

--- a/crates/uitest/fixtures/ty_check/method_bound/result_map_chain_second_mapper_bad.snap
+++ b/crates/uitest/fixtures/ty_check/method_bound/result_map_chain_second_mapper_bad.snap
@@ -1,0 +1,21 @@
+---
+source: crates/uitest/tests/ty_check.rs
+expression: diags
+input_file: fixtures/ty_check/method_bound/result_map_chain_second_mapper_bad.fe
+---
+error[6-0003]: trait bound is not satisfied
+   ┌─ result_map_chain_second_mapper_bad.fe:24:21
+   │
+24 │     r.map(ToWrap{}).map(StillNeedsU256{}).unwrap()
+   │                     ^^^ `StillNeedsU256` doesn't implement `Fn<Wrap, u256>`
+   │
+   ┌─ src/result.fe:62:22
+   │
+62 │     pub fn map<U, F: Fn<T, U>>(own self, _ func: F) -> Result<E, U> {
+   │                      -------- required by this bound on `map`
+
+error[6-0003]: trait bound is not satisfied
+   ┌─ result_map_chain_second_mapper_bad.fe:24:21
+   │
+24 │     r.map(ToWrap{}).map(StillNeedsU256{}).unwrap()
+   │                     ^^^ `StillNeedsU256` doesn't implement `Fn<Wrap, u256>`

--- a/crates/uitest/fixtures/ty_check/result_map_chain.fe
+++ b/crates/uitest/fixtures/ty_check/result_map_chain.fe
@@ -1,0 +1,25 @@
+use core::functional::Fn
+use core::result::Result::{self, Ok}
+
+struct Wrap {
+    pub val: u256,
+}
+
+struct ToWrap {}
+impl Fn<u256, Wrap> for ToWrap {
+    fn call(self, _ x: own u256) -> Wrap {
+        Wrap { val: x }
+    }
+}
+
+struct FromWrap {}
+impl Fn<Wrap, u256> for FromWrap {
+    fn call(self, _ w: own Wrap) -> u256 {
+        w.val
+    }
+}
+
+fn pipeline() -> u256 {
+    let r: Result<bool, u256> = Ok(42)
+    r.map(ToWrap{}).map(FromWrap{}).unwrap()
+}

--- a/crates/uitest/fixtures/ty_check/result_map_chain.snap
+++ b/crates/uitest/fixtures/ty_check/result_map_chain.snap
@@ -1,0 +1,6 @@
+---
+source: crates/uitest/tests/ty_check.rs
+assertion_line: 27
+expression: diags
+input_file: fixtures/ty_check/result_map_chain.fe
+---


### PR DESCRIPTION
fixes #1389 

The minimal fix is in the first commit. Subsequent commits are hardening the API to avoid similar issues in the future.