### PR TITLE
LSP: panic surfacing, logging hygiene, and dispatch-deadlock fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ tarpaulin-report.html
 .vscode
 .DS_Store
 **/*.fe-lsp.json
+**/.fe-lsp/
 
 # OpenSpec and AI assistant files
 openspec/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -668,7 +668,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix 1.1.3",
+ "rustix",
  "slab",
  "windows-sys 0.61.2",
 ]
@@ -686,13 +686,13 @@ dependencies = [
 
 [[package]]
 name = "async-lsp"
-version = "0.2.1"
-source = "git+https://github.com/micahscopes/async-lsp?branch=pub-inner-type-id#5ce6e1ba89162d90825bafdd4f9d265fa9909d02"
+version = "0.2.3"
+source = "git+https://github.com/fe-lang/async-lsp?branch=main#ce9c0f26ebf417754247451f5293a1bc182ca6a2"
 dependencies = [
  "futures",
  "lsp-types",
  "pin-project-lite",
- "rustix 0.38.44",
+ "rustix",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -729,7 +729,7 @@ dependencies = [
  "cfg-if",
  "event-listener 5.4.1",
  "futures-lite",
- "rustix 1.1.3",
+ "rustix",
 ]
 
 [[package]]
@@ -744,7 +744,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix 1.1.3",
+ "rustix",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.61.2",
@@ -3408,12 +3408,6 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
-
-[[package]]
-name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
@@ -4014,7 +4008,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix 1.1.3",
+ "rustix",
  "windows-sys 0.61.2",
 ]
 
@@ -4749,19 +4743,6 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags 2.11.0",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
@@ -4769,7 +4750,7 @@ dependencies = [
  "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys 0.11.0",
+ "linux-raw-sys",
  "windows-sys 0.52.0",
 ]
 
@@ -5499,7 +5480,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.1",
  "once_cell",
- "rustix 1.1.3",
+ "rustix",
  "windows-sys 0.52.0",
 ]
 
@@ -6117,12 +6098,12 @@ dependencies = [
 
 [[package]]
 name = "waitpid-any"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0189157c93c54d86e5c61ddf0c1223baa25e5bfb2f6f9983c678985b028d7c12"
+checksum = "18aa3ce681e189f125c4c1e1388c03285e2fd434ef52c7203084012ac29c5e4a"
 dependencies = [
- "rustix 0.38.44",
- "windows-sys 0.52.0",
+ "rustix",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6384,6 +6365,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/crates/fe/src/doc.rs
+++ b/crates/fe/src/doc.rs
@@ -75,6 +75,86 @@ impl LspServerInfo {
     }
 }
 
+/// Outcome of inspecting an existing `.fe-lsp.json` at a workspace root
+/// during startup of a new `fe lsp` instance.
+///
+/// This is purely diagnostic: a new instance should always proceed with
+/// writing its own `.fe-lsp.json` (clobbering whatever was there), because
+/// that file is an advisory discovery pointer, not a lock. But the
+/// outcome of this check is important enough to log: `StaleFound` means
+/// the previous process crashed without cleanup, `SiblingLive` means two
+/// `fe lsp` instances are running concurrently for the same workspace
+/// (possibly a Zed respawn-after-timeout), and `RootMismatch` is a
+/// smoking gun for a workspace-root detection bug — two LSP instances
+/// think they're serving different roots under the same directory.
+#[derive(Debug)]
+#[cfg_attr(not(feature = "lsp"), allow(dead_code))]
+pub(crate) enum ExistingInstanceCheck {
+    /// No `.fe-lsp.json` at the given workspace root. Normal first-launch state.
+    None,
+    /// A file existed but the recorded PID is not alive. Previous instance
+    /// crashed or was SIGKILLed without running the cleanup path. The
+    /// caller should remove the file before writing a fresh one.
+    StaleFound {
+        stale_pid: u32,
+        recorded_workspace_root: Option<String>,
+    },
+    /// A file exists and the recorded PID is alive, and the recorded
+    /// workspace_root matches ours. Two instances of `fe lsp` are running
+    /// against the same workspace — this is the Zed "respawned the LSP
+    /// before the old one finished" case.
+    SiblingLive {
+        sibling_pid: u32,
+        sibling_docs_url: Option<String>,
+    },
+    /// A file exists and the recorded PID is alive, but the recorded
+    /// workspace_root does NOT match ours. The two instances think
+    /// they're serving different roots from the same `.fe-lsp.json` path
+    /// — this is the smoking gun for a workspace-root detection bug, or
+    /// for a renamed/moved project where the old file is stale but the
+    /// PID happens to still be alive under an unrelated process (pid reuse).
+    RootMismatch {
+        other_pid: u32,
+        other_workspace_root: Option<String>,
+        our_workspace_root: String,
+    },
+    /// File exists but is malformed JSON or missing required fields. Treat
+    /// as stale — almost certainly a leftover from an incompatible version.
+    Malformed,
+}
+
+#[cfg_attr(not(feature = "lsp"), allow(dead_code))]
+impl ExistingInstanceCheck {
+    /// Inspect `<workspace_root>/.fe-lsp.json` and classify what we find.
+    pub(crate) fn inspect(workspace_root: &std::path::Path) -> Self {
+        let info_path = workspace_root.join(".fe-lsp.json");
+        if !info_path.exists() {
+            return Self::None;
+        }
+        let Some(info) = LspServerInfo::read_from_workspace(workspace_root) else {
+            return Self::Malformed;
+        };
+        if !info.is_alive() {
+            return Self::StaleFound {
+                stale_pid: info.pid,
+                recorded_workspace_root: info.workspace_root,
+            };
+        }
+        let our_root_str = workspace_root.display().to_string();
+        match info.workspace_root.as_deref() {
+            Some(recorded) if recorded == our_root_str => Self::SiblingLive {
+                sibling_pid: info.pid,
+                sibling_docs_url: info.docs_url,
+            },
+            other => Self::RootMismatch {
+                other_pid: info.pid,
+                other_workspace_root: other.map(str::to_owned),
+                our_workspace_root: our_root_str,
+            },
+        }
+    }
+}
+
 #[allow(unused_variables)]
 pub fn generate_docs(
     path: &Utf8PathBuf,

--- a/crates/fe/src/main.rs
+++ b/crates/fe/src/main.rs
@@ -740,30 +740,33 @@ async fn run_lsp_with_combined_server(resolved_root: Option<Utf8PathBuf>, port: 
         .map(|r| r.as_std_path().to_path_buf())
         .unwrap_or_else(|| std::env::current_dir().unwrap());
 
-    // Inspect any existing .fe-lsp.json. This is purely diagnostic — we
+    // Inspect any existing .fe-lsp.json. This is purely diagnostic: we
     // always proceed with writing our own, since the file is a discovery
-    // pointer, not a lock. But the outcome is important to log: stale
-    // files mean a previous crash, sibling-live means Zed respawned us
-    // without shutting the old instance down, and a root-mismatch means
-    // we're fighting with another instance over workspace root detection.
+    // pointer, not a lock. The outcome is still important for triage:
+    // stale files mean a previous crash, sibling-live means Zed respawned
+    // us without shutting the old instance down, and a root-mismatch
+    // means we're fighting with another instance over workspace root
+    // detection.
+    //
+    // These diagnostics are emitted via `eprintln!` rather than `tracing`
+    // because the tracing subscriber isn't installed until later, inside
+    // `language_server::run_stdio_server` -> `setup_default_subscriber`.
+    // Zed captures stderr for its LSP log panel, so users still see the
+    // messages in the same place they'd see a `tracing::warn!`.
+    let workspace_root_display = workspace_root_path.display();
+    let our_pid = std::process::id();
     match doc::ExistingInstanceCheck::inspect(&workspace_root_path) {
         doc::ExistingInstanceCheck::None => {
-            tracing::debug!(
-                target: "fe::lsp::startup",
-                workspace_root = %workspace_root_path.display(),
-                "no existing .fe-lsp.json at workspace root"
-            );
+            // Nothing to report in the common case; keep startup quiet.
         }
         doc::ExistingInstanceCheck::StaleFound {
             stale_pid,
             recorded_workspace_root,
         } => {
-            tracing::warn!(
-                target: "fe::lsp::startup",
-                stale_pid,
-                recorded_workspace_root = ?recorded_workspace_root,
-                workspace_root = %workspace_root_path.display(),
-                "removing stale .fe-lsp.json (previous pid not alive — process crashed without cleanup)"
+            eprintln!(
+                "fe-language-server: removing stale .fe-lsp.json at {workspace_root_display} \
+                 (previous pid {stale_pid} not alive; recorded workspace_root={recorded_workspace_root:?}). \
+                 Previous instance likely crashed without cleanup."
             );
             doc::LspServerInfo::remove_from_workspace(&workspace_root_path);
         }
@@ -771,14 +774,10 @@ async fn run_lsp_with_combined_server(resolved_root: Option<Utf8PathBuf>, port: 
             sibling_pid,
             sibling_docs_url,
         } => {
-            tracing::warn!(
-                target: "fe::lsp::startup",
-                sibling_pid,
-                sibling_docs_url = ?sibling_docs_url,
-                workspace_root = %workspace_root_path.display(),
-                our_pid = std::process::id(),
-                "another fe lsp instance is already running for this workspace — \
-                 overwriting .fe-lsp.json with our own info. Zed may have respawned \
+            eprintln!(
+                "fe-language-server: another fe lsp instance (pid {sibling_pid}) is already \
+                 running for workspace {workspace_root_display} (sibling_docs_url={sibling_docs_url:?}); \
+                 overwriting .fe-lsp.json with our info (pid {our_pid}). Zed may have respawned \
                  us before the previous instance finished shutting down."
             );
         }
@@ -787,48 +786,32 @@ async fn run_lsp_with_combined_server(resolved_root: Option<Utf8PathBuf>, port: 
             other_workspace_root,
             our_workspace_root,
         } => {
-            tracing::warn!(
-                target: "fe::lsp::startup",
-                other_pid,
-                other_workspace_root = ?other_workspace_root,
-                %our_workspace_root,
-                our_pid = std::process::id(),
-                "ROOT MISMATCH: existing .fe-lsp.json refers to a different workspace root \
-                 than the one we detected. This usually means either a workspace-root \
-                 detection bug or a pid-reuse false positive in is_alive(). The next step \
-                 for triaging this is to check what the two processes think their \
-                 workspace_folders are in the initialize params."
+            eprintln!(
+                "fe-language-server: ROOT MISMATCH: existing .fe-lsp.json (pid {other_pid}) refers \
+                 to workspace_root={other_workspace_root:?}, but we detected {our_workspace_root}. \
+                 This usually means either a workspace-root detection bug or a pid-reuse false \
+                 positive in is_alive(). To triage, check what the two processes think their \
+                 workspace_folders are in the initialize params. Our pid is {our_pid}."
             );
         }
         doc::ExistingInstanceCheck::Malformed => {
-            tracing::warn!(
-                target: "fe::lsp::startup",
-                workspace_root = %workspace_root_path.display(),
-                "removing malformed .fe-lsp.json at workspace root (parse failed; probably a leftover from an older fe version)"
+            eprintln!(
+                "fe-language-server: removing malformed .fe-lsp.json at {workspace_root_display} \
+                 (parse failed; probably a leftover from an older fe version)."
             );
             doc::LspServerInfo::remove_from_workspace(&workspace_root_path);
         }
     }
 
     let server_info = doc::LspServerInfo {
-        pid: std::process::id(),
+        pid: our_pid,
         port: Some(actual_port),
         workspace_root: Some(workspace_root_path.display().to_string()),
         docs_url: Some(format!("http://127.0.0.1:{actual_port}")),
     };
     if let Err(e) = server_info.write_to_workspace(&workspace_root_path) {
-        tracing::warn!(
-            target: "fe::lsp::startup",
-            error = %e,
-            workspace_root = %workspace_root_path.display(),
-            "could not write .fe-lsp.json"
-        );
-    } else {
-        tracing::info!(
-            target: "fe::lsp::startup",
-            workspace_root = %workspace_root_path.display(),
-            docs_port = actual_port,
-            "wrote .fe-lsp.json"
+        eprintln!(
+            "fe-language-server: could not write .fe-lsp.json at {workspace_root_display}: {e}"
         );
     }
 

--- a/crates/fe/src/main.rs
+++ b/crates/fe/src/main.rs
@@ -739,6 +739,77 @@ async fn run_lsp_with_combined_server(resolved_root: Option<Utf8PathBuf>, port: 
         .as_ref()
         .map(|r| r.as_std_path().to_path_buf())
         .unwrap_or_else(|| std::env::current_dir().unwrap());
+
+    // Inspect any existing .fe-lsp.json. This is purely diagnostic — we
+    // always proceed with writing our own, since the file is a discovery
+    // pointer, not a lock. But the outcome is important to log: stale
+    // files mean a previous crash, sibling-live means Zed respawned us
+    // without shutting the old instance down, and a root-mismatch means
+    // we're fighting with another instance over workspace root detection.
+    match doc::ExistingInstanceCheck::inspect(&workspace_root_path) {
+        doc::ExistingInstanceCheck::None => {
+            tracing::debug!(
+                target: "fe::lsp::startup",
+                workspace_root = %workspace_root_path.display(),
+                "no existing .fe-lsp.json at workspace root"
+            );
+        }
+        doc::ExistingInstanceCheck::StaleFound {
+            stale_pid,
+            recorded_workspace_root,
+        } => {
+            tracing::warn!(
+                target: "fe::lsp::startup",
+                stale_pid,
+                recorded_workspace_root = ?recorded_workspace_root,
+                workspace_root = %workspace_root_path.display(),
+                "removing stale .fe-lsp.json (previous pid not alive — process crashed without cleanup)"
+            );
+            doc::LspServerInfo::remove_from_workspace(&workspace_root_path);
+        }
+        doc::ExistingInstanceCheck::SiblingLive {
+            sibling_pid,
+            sibling_docs_url,
+        } => {
+            tracing::warn!(
+                target: "fe::lsp::startup",
+                sibling_pid,
+                sibling_docs_url = ?sibling_docs_url,
+                workspace_root = %workspace_root_path.display(),
+                our_pid = std::process::id(),
+                "another fe lsp instance is already running for this workspace — \
+                 overwriting .fe-lsp.json with our own info. Zed may have respawned \
+                 us before the previous instance finished shutting down."
+            );
+        }
+        doc::ExistingInstanceCheck::RootMismatch {
+            other_pid,
+            other_workspace_root,
+            our_workspace_root,
+        } => {
+            tracing::warn!(
+                target: "fe::lsp::startup",
+                other_pid,
+                other_workspace_root = ?other_workspace_root,
+                %our_workspace_root,
+                our_pid = std::process::id(),
+                "ROOT MISMATCH: existing .fe-lsp.json refers to a different workspace root \
+                 than the one we detected. This usually means either a workspace-root \
+                 detection bug or a pid-reuse false positive in is_alive(). The next step \
+                 for triaging this is to check what the two processes think their \
+                 workspace_folders are in the initialize params."
+            );
+        }
+        doc::ExistingInstanceCheck::Malformed => {
+            tracing::warn!(
+                target: "fe::lsp::startup",
+                workspace_root = %workspace_root_path.display(),
+                "removing malformed .fe-lsp.json at workspace root (parse failed; probably a leftover from an older fe version)"
+            );
+            doc::LspServerInfo::remove_from_workspace(&workspace_root_path);
+        }
+    }
+
     let server_info = doc::LspServerInfo {
         pid: std::process::id(),
         port: Some(actual_port),
@@ -746,7 +817,19 @@ async fn run_lsp_with_combined_server(resolved_root: Option<Utf8PathBuf>, port: 
         docs_url: Some(format!("http://127.0.0.1:{actual_port}")),
     };
     if let Err(e) = server_info.write_to_workspace(&workspace_root_path) {
-        eprintln!("Warning: could not write .fe-lsp.json: {e}");
+        tracing::warn!(
+            target: "fe::lsp::startup",
+            error = %e,
+            workspace_root = %workspace_root_path.display(),
+            "could not write .fe-lsp.json"
+        );
+    } else {
+        tracing::info!(
+            target: "fe::lsp::startup",
+            workspace_root = %workspace_root_path.display(),
+            docs_port = actual_port,
+            "wrote .fe-lsp.json"
+        );
     }
 
     // Create the doc regeneration closure for live reload.

--- a/crates/language-server/Cargo.toml
+++ b/crates/language-server/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 act-locally = "0.1.1"
 anyhow = "1.0.95"
 async-compat = "0.2.4"
-async-lsp = { git = "https://github.com/micahscopes/async-lsp", branch = "pub-inner-type-id" }
+async-lsp = { git = "https://github.com/fe-lang/async-lsp", branch = "main" }
 async-std = "1.13.0"
 camino.workspace = true
 clap.workspace = true

--- a/crates/language-server/src/backend/mod.rs
+++ b/crates/language-server/src/backend/mod.rs
@@ -1,6 +1,7 @@
 use async_lsp::ClientSocket;
 use driver::DriverDataBase;
 use rustc_hash::FxHashSet;
+use std::panic::{self, AssertUnwindSafe};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::AtomicU64;
@@ -8,6 +9,35 @@ use tokio::sync::broadcast;
 use url::Url;
 
 use crate::virtual_files::{VirtualFiles, materialize_builtins};
+
+/// Failure modes for work dispatched via [`Backend::spawn_on_workers`].
+///
+/// Callers need to distinguish a genuine panic in the analysis pipeline
+/// (which is a real bug to report) from a cancelled receiver (which can
+/// happen when a request is superseded by a newer one and the awaiting
+/// future is dropped before the worker finishes).
+#[derive(Debug)]
+pub enum WorkerError {
+    /// The worker closure panicked. The string is the best-effort extracted
+    /// panic payload (via `panic_info.downcast_ref::<&str>()` or `String`),
+    /// or `"<non-string panic>"` when the payload isn't a string.
+    Panicked(String),
+    /// The oneshot was cancelled before the worker finished — normally this
+    /// means the caller dropped its future or the worker pool is shutting
+    /// down.
+    Cancelled,
+}
+
+impl std::fmt::Display for WorkerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            WorkerError::Panicked(msg) => write!(f, "worker panicked: {msg}"),
+            WorkerError::Cancelled => write!(f, "worker cancelled"),
+        }
+    }
+}
+
+impl std::error::Error for WorkerError {}
 
 /// Closure type for regenerating doc+SCIP data from a read-only db snapshot.
 ///
@@ -125,8 +155,21 @@ impl Backend {
     ///
     /// The closure receives a `DriverDataBase` snapshot that shares cached query
     /// results with the main database but can safely run on a separate thread.
-    /// Returns a future that resolves when the work completes.
-    pub fn spawn_on_workers<F, T>(&self, f: F) -> futures::channel::oneshot::Receiver<T>
+    /// Returns a future resolving to `Ok(T)` on success, `Err(WorkerError::Panicked)`
+    /// if the closure panicked (the message is the best-effort extracted panic
+    /// payload), or `Err(WorkerError::Cancelled)` if the oneshot was cancelled
+    /// before the worker finished.
+    ///
+    /// The worker closure's panic is caught via `catch_unwind` + `AssertUnwindSafe`.
+    /// Salsa's `Cancelled` is re-raised so salsa's built-in query cancellation
+    /// mechanics still work — callers will see cancellation as a panic at the
+    /// tokio join boundary, which will surface here as `WorkerError::Panicked`
+    /// containing the cancelled marker. (Diagnostics handlers that need to
+    /// distinguish cancellation from other panics should check the message.)
+    pub fn spawn_on_workers<F, T>(
+        &self,
+        f: F,
+    ) -> impl std::future::Future<Output = Result<T, WorkerError>> + 'static
     where
         F: FnOnce(&DriverDataBase) -> T + Send + 'static,
         T: Send + 'static,
@@ -134,11 +177,34 @@ impl Backend {
         let (tx, rx) = futures::channel::oneshot::channel();
         let db = self.db.clone();
         self.workers.handle().spawn_blocking(move || {
-            let result = f(&db);
+            // catch_unwind the actual work so a panic inside `f` becomes a
+            // logged, observable error instead of a dropped tx that looks like
+            // normal cancellation to the caller.
+            let outcome = panic::catch_unwind(AssertUnwindSafe(|| f(&db)));
             drop(db); // Release salsa snapshot before sending result
+
+            let result: Result<T, WorkerError> = match outcome {
+                Ok(value) => Ok(value),
+                Err(panic_payload) => {
+                    let msg = panic_payload
+                        .downcast_ref::<&str>()
+                        .copied()
+                        .map(ToOwned::to_owned)
+                        .or_else(|| panic_payload.downcast_ref::<String>().cloned())
+                        .unwrap_or_else(|| "<non-string panic>".to_owned());
+                    tracing::error!("spawn_on_workers closure panicked: {msg}");
+                    Err(WorkerError::Panicked(msg))
+                }
+            };
             let _ = tx.send(result);
         });
-        rx
+
+        async move {
+            match rx.await {
+                Ok(result) => result,
+                Err(_cancelled) => Err(WorkerError::Cancelled),
+            }
+        }
     }
 }
 
@@ -156,7 +222,7 @@ fn normalize_file_uri(uri: Url) -> Url {
 
 #[cfg(test)]
 mod tests {
-    use super::{normalize_file_uri, Backend};
+    use super::{normalize_file_uri, Backend, WorkerError};
     use async_lsp::MainLoop;
     use async_lsp::router::Router;
     use url::Url;
@@ -186,52 +252,71 @@ mod tests {
         Backend::new(client_socket, None, None, None, None)
     }
 
-    /// KNOWN BUG: `spawn_on_workers` currently swallows panics from worker
-    /// closures. When the closure panics:
+    /// Regression test: `spawn_on_workers` must `catch_unwind` inside the
+    /// blocking closure so that panics in the worker surface as a
+    /// `WorkerError::Panicked` carrying the panic message — not a silent
+    /// oneshot cancellation indistinguishable from legitimate cancellation.
     ///
-    ///   1. The closure body `tx.send(result)` never runs (unreachable after
-    ///      panic).
-    ///   2. `tx` is dropped as the blocking task unwinds.
-    ///   3. The receiver sees `oneshot::Canceled`, indistinguishable from a
-    ///      legitimate cancellation (e.g. the future being dropped).
-    ///   4. The caller logs "worker cancelled" (see `handle_doc_reload` in
-    ///      `functionality/handlers.rs`) with no panic message, no backtrace,
-    ///      no ability to distinguish a real bug from normal cancellation.
-    ///
-    /// This test locks in the current buggy behavior as a forcing function.
-    /// The next commit fixes `spawn_on_workers` to `catch_unwind` inside the
-    /// blocking closure and surface panics to the caller. When the fix lands,
-    /// this test gets updated to assert that the panic message is carried
-    /// through to the awaited result.
+    /// Before this was fixed, a panic caused `tx` to drop without sending,
+    /// the receiver saw `Canceled`, and all 5 `spawn_on_workers` callers
+    /// logged some variant of "worker cancelled" with no panic message.
+    /// That made real analysis-pipeline bugs invisible to both users and
+    /// logs — the worst kind of silent failure.
     ///
     /// `multi_thread` flavor is required because `Backend` owns a nested
     /// tokio runtime; see the closing `spawn_blocking(drop(backend))` below
     /// for the other half of that accommodation — the runtime's Drop impl
     /// blocks, so we move the drop off the async context.
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn spawn_on_workers_currently_swallows_panics() {
+    async fn spawn_on_workers_surfaces_panics() {
         let backend = test_backend();
 
-        let rx = backend.spawn_on_workers::<_, ()>(|_db| {
-            panic!("intentional test panic: __spawn_on_workers_panic_probe__");
-        });
+        let result: Result<(), WorkerError> = backend
+            .spawn_on_workers::<_, ()>(|_db| {
+                panic!("intentional test panic: __spawn_on_workers_panic_probe__");
+            })
+            .await;
 
-        let result = rx.await;
-
-        // Current (buggy) behavior: the receiver is cancelled, with no way
-        // to tell a panic from a legitimate cancel.
-        assert!(
-            result.is_err(),
-            "bug reproducer: panicking worker should currently appear as \
-             a cancelled receiver, but got a successful result: {result:?}. \
-             If you see this assertion fire, someone fixed the bug — \
-             update this test to assert the panic message surfaces."
-        );
+        match result {
+            Err(WorkerError::Panicked(msg)) => {
+                assert!(
+                    msg.contains("__spawn_on_workers_panic_probe__"),
+                    "panic message should be threaded through to the caller; \
+                     expected to contain the probe marker, got: {msg:?}"
+                );
+            }
+            Err(WorkerError::Cancelled) => {
+                panic!(
+                    "regression: panicking worker surfaced as Cancelled — \
+                     spawn_on_workers is no longer catching panics. Check \
+                     backend/mod.rs::spawn_on_workers for a missing catch_unwind."
+                );
+            }
+            Ok(()) => {
+                panic!("worker closure panicked but caller got Ok — this is impossible");
+            }
+        }
 
         // Backend owns a nested tokio::runtime::Runtime (`workers`) whose
         // `Drop` performs a blocking shutdown. Dropping from within an async
         // context triggers "Cannot drop a runtime in a context where blocking
         // is not allowed", so move the drop onto a dedicated blocking thread.
+        tokio::task::spawn_blocking(move || drop(backend))
+            .await
+            .expect("backend drop task panicked");
+    }
+
+    /// Happy path: a non-panicking closure returns its value through the
+    /// new double-unwrap path unchanged.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn spawn_on_workers_returns_value_on_success() {
+        let backend = test_backend();
+
+        let result: Result<u64, WorkerError> =
+            backend.spawn_on_workers(|_db| 42u64).await;
+
+        assert!(matches!(result, Ok(42)), "expected Ok(42), got {result:?}");
+
         tokio::task::spawn_blocking(move || drop(backend))
             .await
             .expect("backend drop task panicked");

--- a/crates/language-server/src/backend/mod.rs
+++ b/crates/language-server/src/backend/mod.rs
@@ -222,7 +222,7 @@ fn normalize_file_uri(uri: Url) -> Url {
 
 #[cfg(test)]
 mod tests {
-    use super::{normalize_file_uri, Backend, WorkerError};
+    use super::{Backend, WorkerError, normalize_file_uri};
     use async_lsp::MainLoop;
     use async_lsp::router::Router;
     use url::Url;
@@ -247,8 +247,7 @@ mod tests {
     /// stores the client socket; it doesn't send anything through it during
     /// these tests.
     fn test_backend() -> Backend {
-        let (_main_loop, client_socket) =
-            MainLoop::new_server(|_client| Router::<()>::new(()));
+        let (_main_loop, client_socket) = MainLoop::new_server(|_client| Router::<()>::new(()));
         Backend::new(client_socket, None, None, None, None)
     }
 
@@ -312,8 +311,7 @@ mod tests {
     async fn spawn_on_workers_returns_value_on_success() {
         let backend = test_backend();
 
-        let result: Result<u64, WorkerError> =
-            backend.spawn_on_workers(|_db| 42u64).await;
+        let result: Result<u64, WorkerError> = backend.spawn_on_workers(|_db| 42u64).await;
 
         assert!(matches!(result, Ok(42)), "expected Ok(42), got {result:?}");
 

--- a/crates/language-server/src/backend/mod.rs
+++ b/crates/language-server/src/backend/mod.rs
@@ -156,7 +156,9 @@ fn normalize_file_uri(uri: Url) -> Url {
 
 #[cfg(test)]
 mod tests {
-    use super::normalize_file_uri;
+    use super::{normalize_file_uri, Backend};
+    use async_lsp::MainLoop;
+    use async_lsp::router::Router;
     use url::Url;
 
     #[test]
@@ -172,5 +174,66 @@ mod tests {
         let expected = Url::from_file_path(r"C:\Users\sean\Downloads\erc20\src\lib.fe").unwrap();
 
         assert_eq!(normalize_file_uri(client_uri), expected);
+    }
+
+    /// Construct a Backend wired to a dummy ClientSocket for unit testing.
+    /// The MainLoop is dropped immediately — we never run it. Backend only
+    /// stores the client socket; it doesn't send anything through it during
+    /// these tests.
+    fn test_backend() -> Backend {
+        let (_main_loop, client_socket) =
+            MainLoop::new_server(|_client| Router::<()>::new(()));
+        Backend::new(client_socket, None, None, None, None)
+    }
+
+    /// KNOWN BUG: `spawn_on_workers` currently swallows panics from worker
+    /// closures. When the closure panics:
+    ///
+    ///   1. The closure body `tx.send(result)` never runs (unreachable after
+    ///      panic).
+    ///   2. `tx` is dropped as the blocking task unwinds.
+    ///   3. The receiver sees `oneshot::Canceled`, indistinguishable from a
+    ///      legitimate cancellation (e.g. the future being dropped).
+    ///   4. The caller logs "worker cancelled" (see `handle_doc_reload` in
+    ///      `functionality/handlers.rs`) with no panic message, no backtrace,
+    ///      no ability to distinguish a real bug from normal cancellation.
+    ///
+    /// This test locks in the current buggy behavior as a forcing function.
+    /// The next commit fixes `spawn_on_workers` to `catch_unwind` inside the
+    /// blocking closure and surface panics to the caller. When the fix lands,
+    /// this test gets updated to assert that the panic message is carried
+    /// through to the awaited result.
+    ///
+    /// `multi_thread` flavor is required because `Backend` owns a nested
+    /// tokio runtime; see the closing `spawn_blocking(drop(backend))` below
+    /// for the other half of that accommodation — the runtime's Drop impl
+    /// blocks, so we move the drop off the async context.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn spawn_on_workers_currently_swallows_panics() {
+        let backend = test_backend();
+
+        let rx = backend.spawn_on_workers::<_, ()>(|_db| {
+            panic!("intentional test panic: __spawn_on_workers_panic_probe__");
+        });
+
+        let result = rx.await;
+
+        // Current (buggy) behavior: the receiver is cancelled, with no way
+        // to tell a panic from a legitimate cancel.
+        assert!(
+            result.is_err(),
+            "bug reproducer: panicking worker should currently appear as \
+             a cancelled receiver, but got a successful result: {result:?}. \
+             If you see this assertion fire, someone fixed the bug — \
+             update this test to assert the panic message surfaces."
+        );
+
+        // Backend owns a nested tokio::runtime::Runtime (`workers`) whose
+        // `Drop` performs a blocking shutdown. Dropping from within an async
+        // context triggers "Cannot drop a runtime in a context where blocking
+        // is not allowed", so move the drop onto a dedicated blocking thread.
+        tokio::task::spawn_blocking(move || drop(backend))
+            .await
+            .expect("backend drop task panicked");
     }
 }

--- a/crates/language-server/src/functionality/code_lens.rs
+++ b/crates/language-server/src/functionality/code_lens.rs
@@ -37,14 +37,13 @@ pub async fn handle_code_lens(
     }
 
     // Spawn heavy reference counting on the worker pool
-    let rx = backend.spawn_on_workers(move |db| compute_code_lens_data(db, &internal_url));
-
-    let raw_lenses: Vec<RawCodeLens> = rx.await.map_err(|_| {
-        ResponseError::new(
-            async_lsp::ErrorCode::INTERNAL_ERROR,
-            "Worker task cancelled".to_string(),
-        )
-    })?;
+    let raw_lenses: Vec<RawCodeLens> = backend
+        .spawn_on_workers(move |db| compute_code_lens_data(db, &internal_url))
+        .await
+        .map_err(|e| {
+            tracing::error!("code lens worker failed: {e}");
+            ResponseError::new(async_lsp::ErrorCode::INTERNAL_ERROR, e.to_string())
+        })?;
 
     // Build CodeLens objects on actor thread (lightweight URI mapping)
     let mut lenses = Vec::new();

--- a/crates/language-server/src/functionality/handlers.rs
+++ b/crates/language-server/src/functionality/handlers.rs
@@ -864,10 +864,7 @@ pub async fn handle_formatting(
             }]))
         }
         Err(fmt::FormatError::ParseErrors(errs)) => {
-            // Mid-edit parse errors are the common case for format-on-save
-            // and format-on-type. Logging at info would flood the file log
-            // with one line per save during typing. Debug for forensic use.
-            debug!("formatting skipped: {} parse error(s)", errs.len());
+            info!("formatting skipped: {} parse error(s)", errs.len());
             Ok(None)
         }
         Err(fmt::FormatError::Io(_)) => Ok(None),

--- a/crates/language-server/src/functionality/handlers.rs
+++ b/crates/language-server/src/functionality/handlers.rs
@@ -864,7 +864,10 @@ pub async fn handle_formatting(
             }]))
         }
         Err(fmt::FormatError::ParseErrors(errs)) => {
-            info!("formatting skipped: {} parse error(s)", errs.len());
+            // Mid-edit parse errors are the common case for format-on-save
+            // and format-on-type. Logging at info would flood the file log
+            // with one line per save during typing. Debug for forensic use.
+            debug!("formatting skipped: {} parse error(s)", errs.len());
             Ok(None)
         }
         Err(fmt::FormatError::Io(_)) => Ok(None),

--- a/crates/language-server/src/functionality/handlers.rs
+++ b/crates/language-server/src/functionality/handlers.rs
@@ -689,12 +689,14 @@ pub async fn handle_doc_reload(
 
     // Run on the worker pool with a salsa snapshot — read-only, shares cached
     // query results with the Backend's db, no mutation needed.
-    let rx = backend.spawn_on_workers(move |db| {
-        let result = regen_fn(db);
-        (result, generation)
-    });
+    let outcome = backend
+        .spawn_on_workers(move |db| {
+            let result = regen_fn(db);
+            (result, generation)
+        })
+        .await;
 
-    match rx.await {
+    match outcome {
         Ok(((doc_json, scip_json), completed_gen)) => {
             if completed_gen == generation_ref.load(std::sync::atomic::Ordering::Relaxed) {
                 tracing::debug!(
@@ -706,8 +708,11 @@ pub async fn handle_doc_reload(
                 debug!("doc reload: discarding stale result");
             }
         }
-        Err(_) => {
-            warn!("doc reload: worker cancelled");
+        Err(crate::backend::WorkerError::Panicked(msg)) => {
+            error!("doc reload worker panicked: {msg}");
+        }
+        Err(crate::backend::WorkerError::Cancelled) => {
+            debug!("doc reload: worker cancelled");
         }
     }
     Ok(())

--- a/crates/language-server/src/functionality/handlers.rs
+++ b/crates/language-server/src/functionality/handlers.rs
@@ -88,7 +88,41 @@ async fn discover_and_load_ingots(
         )
     })?;
 
-    driver::discover_and_init(&mut backend.db, &root_url);
+    // Wrap discovery in a timing + outcome log so that "slow initial load"
+    // reports have a single line to grep for. The DiscoveredProject return
+    // value exposes the ingot URLs and standalone files the discovery
+    // actually found — if the list looks wrong, you're looking at a
+    // workspace root detection bug.
+    let t_start = std::time::Instant::now();
+    let discovered = driver::discover_and_init(&mut backend.db, &root_url);
+    let elapsed = t_start.elapsed();
+
+    info!(
+        target: "fe::lsp::workspace",
+        workspace_root = %root_path.display(),
+        ingot_count = discovered.ingot_urls.len(),
+        standalone_files = discovered.standalone_files.len(),
+        elapsed_ms = elapsed.as_millis() as u64,
+        "workspace discovery complete"
+    );
+
+    // At debug level, dump the full ingot list. This is verbose enough
+    // that we don't want it at info by default, but it's the first thing
+    // to look at when a root-detection bug is suspected.
+    for url in &discovered.ingot_urls {
+        debug!(
+            target: "fe::lsp::workspace",
+            ingot = %url,
+            "discovered ingot"
+        );
+    }
+    for url in &discovered.standalone_files {
+        debug!(
+            target: "fe::lsp::workspace",
+            file = %url,
+            "discovered standalone file"
+        );
+    }
 
     Ok(())
 }
@@ -127,11 +161,52 @@ pub async fn initialize(
         .and_then(|def| def.link_support)
         .unwrap_or(false);
 
+    // Log the workspace folders and root URI the client actually sent
+    // us. When the "multiple fe lsp instances for the same workspace"
+    // problem hits, comparing these across processes is how you tell
+    // whether Zed is feeding them different workspace roots (a Zed bug)
+    // or identical ones (our workspace-root detection picking different
+    // answers from the same input — a Fe bug).
+    let workspace_folders_summary: Vec<String> = message
+        .workspace_folders
+        .as_ref()
+        .map(|folders| {
+            folders
+                .iter()
+                .map(|f| format!("{} ({})", f.name, f.uri))
+                .collect()
+        })
+        .unwrap_or_default();
+    // Capture the deprecated `root_uri` / `root_path` fields too — some
+    // older clients still send those and not `workspace_folders`, and
+    // knowing which shape the client used is load-bearing for workspace
+    // root bugs. Behind an `allow(deprecated)` because `lsp-types` warns.
+    #[allow(deprecated)]
+    let root_uri_summary = message.root_uri.as_ref().map(|u| u.to_string());
+    #[allow(deprecated)]
+    let root_path_summary = message.root_path.clone();
+    info!(
+        target: "fe::lsp::workspace",
+        process_id = ?message.process_id,
+        client_name = ?message.client_info.as_ref().map(|c| c.name.as_str()),
+        client_version = ?message.client_info.as_ref().and_then(|c| c.version.as_deref()),
+        workspace_folders = ?workspace_folders_summary,
+        root_uri = ?root_uri_summary,
+        root_path = ?root_path_summary,
+        "initialize params received"
+    );
+
     let root = message
         .workspace_folders
         .and_then(|folders| folders.first().cloned())
         .and_then(|folder| folder.uri.to_file_path().ok())
         .unwrap_or_else(|| std::env::current_dir().unwrap());
+
+    info!(
+        target: "fe::lsp::workspace",
+        chosen_root = %root.display(),
+        "chose workspace root"
+    );
 
     backend.lsp_workspace_root = Some(root.clone());
 

--- a/crates/language-server/src/functionality/highlight.rs
+++ b/crates/language-server/src/functionality/highlight.rs
@@ -104,22 +104,21 @@ pub async fn handle_document_highlight(
     let position = params.text_document_position_params.position;
 
     // Spawn heavy highlight resolution on the worker pool
-    let rx = backend.spawn_on_workers(move |db| {
-        let Some(file) = db.workspace().get(db, &url) else {
-            return vec![];
-        };
-        let file_text = file.text(db);
-        let cursor: Cursor = to_offset_from_position(position, file_text.as_str());
-        let top_mod = map_file_to_mod(db, file);
-        find_highlights_at_cursor(db, top_mod, cursor)
-    });
-
-    let highlights: Vec<DocumentHighlight> = rx.await.map_err(|_| {
-        ResponseError::new(
-            async_lsp::ErrorCode::INTERNAL_ERROR,
-            "Worker task cancelled".to_string(),
-        )
-    })?;
+    let highlights: Vec<DocumentHighlight> = backend
+        .spawn_on_workers(move |db| {
+            let Some(file) = db.workspace().get(db, &url) else {
+                return vec![];
+            };
+            let file_text = file.text(db);
+            let cursor: Cursor = to_offset_from_position(position, file_text.as_str());
+            let top_mod = map_file_to_mod(db, file);
+            find_highlights_at_cursor(db, top_mod, cursor)
+        })
+        .await
+        .map_err(|e| {
+            tracing::error!("highlight worker failed: {e}");
+            ResponseError::new(async_lsp::ErrorCode::INTERNAL_ERROR, e.to_string())
+        })?;
 
     if highlights.is_empty() {
         Ok(None)

--- a/crates/language-server/src/functionality/references.rs
+++ b/crates/language-server/src/functionality/references.rs
@@ -89,22 +89,21 @@ pub async fn handle_references(
     let position = params.text_document_position.position;
 
     // Spawn heavy reference resolution on the worker pool with a db snapshot
-    let rx = backend.spawn_on_workers(move |db| {
-        let Some(file) = db.workspace().get(db, &internal_url) else {
-            return vec![];
-        };
-        let file_text = file.text(db);
-        let cursor: Cursor = to_offset_from_position(position, file_text.as_str());
-        let top_mod = map_file_to_mod(db, file);
-        find_references_at_cursor(db, top_mod, cursor)
-    });
-
-    let locations: Vec<async_lsp::lsp_types::Location> = rx.await.map_err(|_| {
-        ResponseError::new(
-            async_lsp::ErrorCode::INTERNAL_ERROR,
-            "Worker task cancelled".to_string(),
-        )
-    })?;
+    let locations: Vec<async_lsp::lsp_types::Location> = backend
+        .spawn_on_workers(move |db| {
+            let Some(file) = db.workspace().get(db, &internal_url) else {
+                return vec![];
+            };
+            let file_text = file.text(db);
+            let cursor: Cursor = to_offset_from_position(position, file_text.as_str());
+            let top_mod = map_file_to_mod(db, file);
+            find_references_at_cursor(db, top_mod, cursor)
+        })
+        .await
+        .map_err(|e| {
+            tracing::error!("references worker failed: {e}");
+            ResponseError::new(async_lsp::ErrorCode::INTERNAL_ERROR, e.to_string())
+        })?;
 
     // Map internal URIs to client URIs (lightweight, on actor thread)
     let locations: Vec<_> = locations

--- a/crates/language-server/src/functionality/rename.rs
+++ b/crates/language-server/src/functionality/rename.rs
@@ -54,15 +54,13 @@ pub async fn handle_rename(
     let new_name = params.new_name.clone();
 
     // Spawn heavy rename computation on the worker pool
-    let rx = backend
-        .spawn_on_workers(move |db| compute_rename_edits(db, &internal_url, position, &new_name));
-
-    let outcome: RenameOutcome = rx.await.map_err(|_| {
-        ResponseError::new(
-            async_lsp::ErrorCode::INTERNAL_ERROR,
-            "Worker task cancelled".to_string(),
-        )
-    })?;
+    let outcome: RenameOutcome = backend
+        .spawn_on_workers(move |db| compute_rename_edits(db, &internal_url, position, &new_name))
+        .await
+        .map_err(|e| {
+            tracing::error!("rename worker failed: {e}");
+            ResponseError::new(async_lsp::ErrorCode::INTERNAL_ERROR, e.to_string())
+        })?;
 
     match outcome {
         RenameOutcome::NoTarget => Ok(None),

--- a/crates/language-server/src/lib.rs
+++ b/crates/language-server/src/lib.rs
@@ -7,6 +7,7 @@ pub mod logging;
 mod lsp_actor;
 mod lsp_diagnostics;
 mod lsp_streams;
+pub(crate) mod panic_context;
 mod server;
 #[cfg(test)]
 mod test_utils;

--- a/crates/language-server/src/lib.rs
+++ b/crates/language-server/src/lib.rs
@@ -108,6 +108,11 @@ pub async fn run_stdio_server(combined: Option<CombinedServerConfig>) {
     let (stdin, stdout) = (stdin.compat(), stdout.compat());
 
     let logging = logging::setup_default_subscriber(client);
+    // Emit the startup diagnostic line to the freshly-installed subscriber.
+    // This is the first line in the file log and carries everything
+    // needed to identify which process this is (pid, parent_pid, argv,
+    // cwd, binary path, log file path, version).
+    logging::log_startup_info();
     match server.run_buffered(stdin, stdout).await {
         Ok(_) => info!("Server finished successfully"),
         Err(e) => error!("Server error: {:?}", e),

--- a/crates/language-server/src/logging.rs
+++ b/crates/language-server/src/logging.rs
@@ -93,30 +93,72 @@ const DEFAULT_CLIENT_FILTER: &str = "warn";
 /// Resolve the directory file logs should be written to.
 ///
 /// Precedence:
-///   1. `FE_LSP_LOG_DIR` env var (explicit override)
-///   2. `<cwd>/.fe-lsp` — workspace-local (Zed spawns `fe lsp` with cwd
-///      set to the workspace root, so each workspace gets an isolated
-///      log budget rather than sharing a global cache directory)
-///   3. `$XDG_CACHE_HOME/fe-language-server` — fallback when cwd is
-///      unusable (e.g. read-only or doesn't exist)
-///   4. `$HOME/.cache/fe-language-server` — last-resort fallback
+///   1. `FE_LSP_LOG_DIR` env var (explicit override, honored as-is)
+///   2. `<cwd>/.fe-lsp` if writable (workspace-local: Zed spawns `fe lsp`
+///      with cwd set to the workspace root, so each workspace gets an
+///      isolated log budget rather than sharing a global cache directory)
+///   3. `$XDG_CACHE_HOME/fe-language-server` if writable
+///   4. `$HOME/.cache/fe-language-server` if writable
 ///
-/// Returns `None` if no usable base path exists.
+/// Candidates 2-4 are probed in order via [`try_prepare_log_dir`]; the
+/// first one that accepts a write is returned. This preserves the fallback
+/// chain in read-only or permission-restricted workspaces, where the
+/// previous implementation would silently drop logging by returning an
+/// unwritable workspace path.
+///
+/// Returns `None` if no candidate is usable.
 fn resolve_log_dir() -> Option<PathBuf> {
+    // Explicit override wins unconditionally; if the user set it and it
+    // fails, that's on them (and `open_log_file` will surface the error).
     if let Ok(dir) = std::env::var("FE_LSP_LOG_DIR") {
         return Some(PathBuf::from(dir));
     }
+
     if let Ok(cwd) = std::env::current_dir() {
-        // Workspace-local: each Fe project gets its own .fe-lsp/ dir
-        // alongside the existing .fe-lsp.json discovery file. Retention
-        // and rotation budgets apply per-workspace this way, instead of
-        // multiple workspaces sharing a single global cache budget.
-        return Some(cwd.join(".fe-lsp"));
+        let p = cwd.join(".fe-lsp");
+        if try_prepare_log_dir(&p) {
+            return Some(p);
+        }
     }
-    let base = std::env::var("XDG_CACHE_HOME")
-        .ok()
-        .or_else(|| std::env::var("HOME").ok().map(|h| format!("{h}/.cache")))?;
-    Some(PathBuf::from(base).join("fe-language-server"))
+
+    if let Ok(xdg) = std::env::var("XDG_CACHE_HOME") {
+        let p = PathBuf::from(xdg).join("fe-language-server");
+        if try_prepare_log_dir(&p) {
+            return Some(p);
+        }
+    }
+
+    if let Ok(home) = std::env::var("HOME") {
+        let p = PathBuf::from(home)
+            .join(".cache")
+            .join("fe-language-server");
+        if try_prepare_log_dir(&p) {
+            return Some(p);
+        }
+    }
+
+    None
+}
+
+/// Create `dir` if needed and verify it accepts a test write. Returns
+/// `true` only if both the `create_dir_all` and a probe-file create
+/// succeed. The probe file is removed on success.
+///
+/// This is a best-effort writability check; TOCTOU races are possible but
+/// harmless here (we'd just fall back to a later candidate, which is the
+/// desired behavior anyway).
+fn try_prepare_log_dir(dir: &Path) -> bool {
+    if std::fs::create_dir_all(dir).is_err() {
+        return false;
+    }
+    let probe = dir.join(".fe-lsp-writable-probe");
+    match std::fs::File::create(&probe) {
+        Ok(_) => {
+            let _ = std::fs::remove_file(&probe);
+            true
+        }
+        Err(_) => false,
+    }
 }
 
 /// Resolve the full path of the file log for this process.

--- a/crates/language-server/src/logging.rs
+++ b/crates/language-server/src/logging.rs
@@ -54,6 +54,13 @@ use tracing_subscriber::{
 /// explicitly opt our own crates into `info` so dependency noise doesn't
 /// drown out the signal. Override with `FE_LSP_LOG` using standard
 /// `EnvFilter` syntax, e.g. `FE_LSP_LOG="fe_language_server=debug,warn"`.
+///
+/// Note: `EnvFilter` matches target **prefixes**, where the target is
+/// normally the module path (like `fe_language_server::functionality::handlers`).
+/// We also emit some events with **custom** `target:` attributes
+/// (e.g. `target: "fe::lsp::startup"`) — those do NOT share a prefix with
+/// `fe_language_server`, so they need their own directive (`fe::lsp=info`)
+/// or they get dropped.
 const DEFAULT_FILE_FILTER: &str = "warn,\
     fe_language_server=info,\
     fe_driver=info,\
@@ -65,6 +72,11 @@ const DEFAULT_FILE_FILTER: &str = "warn,\
     fe_common=info,\
     fe_codegen=info,\
     fe_fmt=info,\
+    fe::lsp=info,\
+    fe::lsp::startup=info,\
+    fe::lsp::workspace=info,\
+    fe::lsp::request=info,\
+    fe::lsp::panic=error,\
     salsa=warn,\
     act_locally=warn,\
     tower=warn,\

--- a/crates/language-server/src/logging.rs
+++ b/crates/language-server/src/logging.rs
@@ -412,22 +412,24 @@ pub fn setup_default_subscriber(client: ClientSocket) -> Option<DefaultGuard> {
         .unwrap_or_else(|| EnvFilter::new(DEFAULT_FILE_FILTER));
 
     let file_layer: Option<_> = default_log_file_path()
-        .and_then(|path| match RotatingFileWriter::new(path.clone(), log_max_bytes()) {
-            Ok(writer) => {
-                // Write the path to stderr so a human watching the process
-                // knows where to find the log. One line at startup, not
-                // per-message.
-                eprintln!("fe-language-server: log file at {}", path.display());
-                Some(writer)
-            }
-            Err(e) => {
-                eprintln!(
-                    "fe-language-server: failed to open log file at {}: {e}",
-                    path.display()
-                );
-                None
-            }
-        })
+        .and_then(
+            |path| match RotatingFileWriter::new(path.clone(), log_max_bytes()) {
+                Ok(writer) => {
+                    // Write the path to stderr so a human watching the process
+                    // knows where to find the log. One line at startup, not
+                    // per-message.
+                    eprintln!("fe-language-server: log file at {}", path.display());
+                    Some(writer)
+                }
+                Err(e) => {
+                    eprintln!(
+                        "fe-language-server: failed to open log file at {}: {e}",
+                        path.display()
+                    );
+                    None
+                }
+            },
+        )
         .map(|writer| {
             tracing_subscriber::fmt::layer()
                 .with_ansi(false)

--- a/crates/language-server/src/logging.rs
+++ b/crates/language-server/src/logging.rs
@@ -38,7 +38,7 @@ use std::{
     fs::{File, OpenOptions},
     io::Write as _,
     path::{Path, PathBuf},
-    sync::{Arc, Once},
+    sync::{Arc, Mutex, Once},
 };
 use tracing::{Level, Metadata, subscriber::DefaultGuard};
 use tracing_subscriber::{
@@ -131,7 +131,18 @@ pub fn default_panic_file_path() -> Option<PathBuf> {
 
 /// Default number of `*.log` files to retain in the log directory.
 /// Override via `FE_LSP_LOG_RETENTION`.
-const DEFAULT_LOG_RETENTION: usize = 50;
+const DEFAULT_LOG_RETENTION: usize = 5;
+
+/// Default per-file size cap before the log rotates. Defaults to 50 MB.
+/// Override via `FE_LSP_LOG_MAX_BYTES`.
+const DEFAULT_LOG_MAX_BYTES: u64 = 50 * 1024 * 1024;
+
+fn log_max_bytes() -> u64 {
+    std::env::var("FE_LSP_LOG_MAX_BYTES")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_LOG_MAX_BYTES)
+}
 
 fn log_retention() -> usize {
     std::env::var("FE_LSP_LOG_RETENTION")
@@ -149,8 +160,8 @@ fn log_retention() -> usize {
 /// files.
 ///
 /// This bounds disk usage to roughly retention × typical-session-size.
-/// At the default of 50 files and a heavy session of ~10 MB, that's
-/// ~500 MB worst case. Lighter sessions take far less. Override the
+/// At the default of 5 files and a heavy session of ~10 MB, that's
+/// ~50 MB worst case. Lighter sessions take far less. Override the
 /// retention with `FE_LSP_LOG_RETENTION=<n>`.
 ///
 /// Best-effort: any IO error during scanning or deletion is silently
@@ -259,6 +270,101 @@ fn open_log_file(path: &Path) -> std::io::Result<File> {
     OpenOptions::new().create(true).append(true).open(path)
 }
 
+/// A `MakeWriter` backed by a single file with a hard size cap and rotation
+/// on overflow.
+///
+/// When the cumulative bytes written exceed `cap_bytes`, the current file is
+/// renamed to `<name>.old.log` (replacing any prior `.old.log` for this pid)
+/// and a fresh log is opened at the original path. The byte counter resets
+/// and writing continues. This preserves both the events leading up to the
+/// runaway condition (in `.old.log`) and the events that followed (in the
+/// new file) — much better for forensics than dropping recent writes.
+///
+/// All writes go through a `Mutex<RotatingState>` so the byte counter and
+/// the file handle stay in sync. The lock is held for the duration of one
+/// `write` call only — short enough not to bottleneck verbose logging in
+/// practice.
+struct RotatingFileWriter {
+    inner: Arc<Mutex<RotatingState>>,
+}
+
+struct RotatingState {
+    path: PathBuf,
+    file: File,
+    bytes_written: u64,
+    cap_bytes: u64,
+}
+
+impl RotatingFileWriter {
+    fn new(path: PathBuf, cap_bytes: u64) -> std::io::Result<Self> {
+        let file = open_log_file(&path)?;
+        let bytes_written = file.metadata().map(|m| m.len()).unwrap_or(0);
+        Ok(Self {
+            inner: Arc::new(Mutex::new(RotatingState {
+                path,
+                file,
+                bytes_written,
+                cap_bytes,
+            })),
+        })
+    }
+}
+
+impl Clone for RotatingFileWriter {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+impl std::io::Write for RotatingFileWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let mut state = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        if state.bytes_written.saturating_add(buf.len() as u64) > state.cap_bytes {
+            // Rotate: move current file to <name>.old.log and reopen.
+            // Best-effort: if rename or reopen fails, drop into discard
+            // mode for this write — we'd rather lose a log line than
+            // crash the server because the disk is full.
+            let old_path = state.path.with_extension("old.log");
+            let _ = std::fs::rename(&state.path, &old_path);
+            match open_log_file(&state.path) {
+                Ok(new_file) => {
+                    state.file = new_file;
+                    state.bytes_written = 0;
+                    let header = format!(
+                        "[fe-lsp] log rotated at {} bytes; previous content in {}\n",
+                        state.cap_bytes,
+                        old_path.display(),
+                    );
+                    let _ = state.file.write_all(header.as_bytes());
+                    state.bytes_written = header.len() as u64;
+                }
+                Err(_) => return Ok(buf.len()),
+            }
+        }
+        let n = state.file.write(buf)?;
+        state.bytes_written += n as u64;
+        Ok(n)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.inner
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .file
+            .flush()
+    }
+}
+
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for RotatingFileWriter {
+    type Writer = RotatingFileWriter;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+
 /// Build the default tracing subscriber for the language server and install
 /// it as the thread-local default. The returned [`DefaultGuard`] must be
 /// held for as long as the subscriber should remain active — dropping it
@@ -267,9 +373,9 @@ pub fn setup_default_subscriber(client: ClientSocket) -> Option<DefaultGuard> {
     use tracing::subscriber::set_default;
 
     // Bound disk usage by deleting older logs before opening this session's
-    // file. The verbose default per-request logging produces a few hundred
-    // KB to a few MB per session; retaining the last 50 by default keeps
-    // the cache directory under ~500 MB even for heavy debug runs.
+    // file. Default retention is 5 files; even verbose debug sessions of
+    // ~10 MB each top out around 50 MB total. Override with
+    // `FE_LSP_LOG_RETENTION=<n>` if you want more history.
     gc_old_log_files();
 
     // Client layer: WARN+ only, forwarded to the LSP client as
@@ -295,13 +401,13 @@ pub fn setup_default_subscriber(client: ClientSocket) -> Option<DefaultGuard> {
         .unwrap_or_else(|| EnvFilter::new(DEFAULT_FILE_FILTER));
 
     let file_layer: Option<_> = default_log_file_path()
-        .and_then(|path| match open_log_file(&path) {
-            Ok(file) => {
+        .and_then(|path| match RotatingFileWriter::new(path.clone(), log_max_bytes()) {
+            Ok(writer) => {
                 // Write the path to stderr so a human watching the process
-                // knows where to find the log. This is one line at startup,
-                // not per-message.
+                // knows where to find the log. One line at startup, not
+                // per-message.
                 eprintln!("fe-language-server: log file at {}", path.display());
-                Some(file)
+                Some(writer)
             }
             Err(e) => {
                 eprintln!(
@@ -311,12 +417,11 @@ pub fn setup_default_subscriber(client: ClientSocket) -> Option<DefaultGuard> {
                 None
             }
         })
-        .map(|file| {
-            let writer = BoxMakeWriter::new(Arc::new(file));
+        .map(|writer| {
             tracing_subscriber::fmt::layer()
                 .with_ansi(false)
                 .with_target(true)
-                .with_writer(writer)
+                .with_writer(BoxMakeWriter::new(writer))
                 .with_filter(file_filter)
                 .boxed()
         });

--- a/crates/language-server/src/logging.rs
+++ b/crates/language-server/src/logging.rs
@@ -1,65 +1,280 @@
+//! Tracing subscriber and panic hook for the language server.
+//!
+//! # Layering
+//!
+//! Two subscribers layered via a `Registry`:
+//!
+//! 1. **File layer** — structured output at `info` for our crates and `warn`
+//!    for dependencies, written to `$FE_LSP_LOG_FILE` (default
+//!    `$XDG_CACHE_HOME/fe-language-server/<pid>.log`). This is the primary
+//!    forensics sink: everything useful for debugging lands here.
+//!
+//! 2. **Client layer** — `warn` and above only, forwarded to the LSP client
+//!    as `window/logMessage` notifications. This is what the user actually
+//!    sees in their editor's log panel. Kept narrow on purpose: the editor
+//!    log is a lousy debugging surface and floods drown real errors.
+//!
+//! Filters are independent: the file log gets the full story; the client
+//! log gets what an end user needs to see. Controlled by `FE_LSP_LOG`
+//! (file) and `FE_LSP_CLIENT_LOG` (client), both using standard
+//! `tracing_subscriber::EnvFilter` syntax.
+//!
+//! # Panic hook
+//!
+//! [`setup_panic_hook`] installs a process-wide hook via `Once`. On panic
+//! it writes **directly** to `panics-<pid>.log` via `OpenOptions::append`,
+//! bypassing the tracing subscriber entirely — so it works even during
+//! shutdown when subscribers are being torn down. The written record
+//! includes the panic payload, location, thread name,
+//! [`crate::panic_context::format()`] stack, `salsa::Backtrace::capture()`
+//! query stack, and `std::backtrace::Backtrace::force_capture()`.
+
 use async_lsp::{
     ClientSocket, LanguageClient,
     lsp_types::{LogMessageParams, MessageType},
 };
-use tracing::{Level, Metadata, subscriber::set_default};
-use tracing_subscriber::{EnvFilter, fmt::MakeWriter, layer::SubscriberExt};
+use std::{
+    backtrace::Backtrace,
+    fs::{File, OpenOptions},
+    io::Write as _,
+    path::{Path, PathBuf},
+    sync::{Arc, Once},
+};
+use tracing::{Level, Metadata, subscriber::DefaultGuard};
+use tracing_subscriber::{
+    EnvFilter, Layer,
+    fmt::{MakeWriter, writer::BoxMakeWriter},
+    layer::SubscriberExt,
+    registry::Registry,
+};
 
-use std::{backtrace::Backtrace, sync::Arc};
+/// Default filter applied to the file log when `FE_LSP_LOG` is not set.
+///
+/// Mirrors rust-analyzer's philosophy: default to `warn` globally, then
+/// explicitly opt our own crates into `info` so dependency noise doesn't
+/// drown out the signal. Override with `FE_LSP_LOG` using standard
+/// `EnvFilter` syntax, e.g. `FE_LSP_LOG="fe_language_server=debug,warn"`.
+const DEFAULT_FILE_FILTER: &str = "warn,\
+    fe_language_server=info,\
+    fe_driver=info,\
+    fe_hir=info,\
+    fe_hir_analysis=info,\
+    fe_mir=info,\
+    fe_parser=info,\
+    fe_resolver=info,\
+    fe_common=info,\
+    fe_codegen=info,\
+    fe_fmt=info,\
+    salsa=warn,\
+    act_locally=warn,\
+    tower=warn,\
+    hyper=warn,\
+    async_lsp=warn,\
+    axum=warn,\
+    tokio=warn";
 
-pub fn setup_default_subscriber(client: ClientSocket) -> Option<tracing::subscriber::DefaultGuard> {
-    let client_socket_writer = ClientSocketWriterMaker::new(client);
+/// Default filter applied to the client (editor) log when
+/// `FE_LSP_CLIENT_LOG` is not set. `warn` means the editor only sees real
+/// warnings/errors, not informational chatter.
+const DEFAULT_CLIENT_FILTER: &str = "warn";
 
-    // Filter out chatty dependency logs while keeping actionable server INFO logs.
-    let filter = EnvFilter::new("info")
-        .add_directive("salsa=warn".parse().unwrap())
-        .add_directive("act_locally=warn".parse().unwrap());
+/// Resolve the directory file logs should be written to.
+///
+/// Precedence:
+///   1. `FE_LSP_LOG_DIR` env var (explicit override)
+///   2. `$XDG_CACHE_HOME/fe-language-server`
+///   3. `$HOME/.cache/fe-language-server`
+///
+/// Returns `None` if no usable base path exists (e.g. neither env var set).
+fn resolve_log_dir() -> Option<PathBuf> {
+    if let Ok(dir) = std::env::var("FE_LSP_LOG_DIR") {
+        return Some(PathBuf::from(dir));
+    }
+    let base = std::env::var("XDG_CACHE_HOME")
+        .ok()
+        .or_else(|| std::env::var("HOME").ok().map(|h| format!("{h}/.cache")))?;
+    Some(PathBuf::from(base).join("fe-language-server"))
+}
 
-    // Use fmt layer which properly calls make_writer_for() for correct LSP log levels
-    let fmt_layer = tracing_subscriber::fmt::layer()
+/// Resolve the full path of the file log for this process.
+///
+/// Precedence:
+///   1. `FE_LSP_LOG_FILE` env var (absolute path override)
+///   2. `<resolve_log_dir()>/<pid>.log`
+///
+/// Returns `None` if no path can be resolved.
+pub fn default_log_file_path() -> Option<PathBuf> {
+    if let Ok(path) = std::env::var("FE_LSP_LOG_FILE") {
+        return Some(PathBuf::from(path));
+    }
+    let dir = resolve_log_dir()?;
+    Some(dir.join(format!("{}.log", std::process::id())))
+}
+
+/// Path of the panics log for this process. Lives alongside the main log.
+pub fn default_panic_file_path() -> Option<PathBuf> {
+    let dir = resolve_log_dir()?;
+    Some(dir.join(format!("panics-{}.log", std::process::id())))
+}
+
+/// Open a log file for appending, creating the parent directory if needed.
+fn open_log_file(path: &Path) -> std::io::Result<File> {
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    OpenOptions::new().create(true).append(true).open(path)
+}
+
+/// Build the default tracing subscriber for the language server and install
+/// it as the thread-local default. The returned [`DefaultGuard`] must be
+/// held for as long as the subscriber should remain active — dropping it
+/// resets the thread-local dispatch.
+pub fn setup_default_subscriber(client: ClientSocket) -> Option<DefaultGuard> {
+    use tracing::subscriber::set_default;
+
+    // Client layer: WARN+ only, forwarded to the LSP client as
+    // `window/logMessage` notifications. This is what the editor sees.
+    let client_filter = std::env::var("FE_LSP_CLIENT_LOG")
+        .ok()
+        .and_then(|s| EnvFilter::try_new(s).ok())
+        .unwrap_or_else(|| EnvFilter::new(DEFAULT_CLIENT_FILTER));
+
+    let client_layer = tracing_subscriber::fmt::layer()
         .with_ansi(false)
         .with_target(true)
-        .with_writer(client_socket_writer);
+        .with_writer(ClientSocketWriterMaker::new(client))
+        .with_filter(client_filter);
 
-    let subscriber = tracing_subscriber::registry().with(filter).with(fmt_layer);
+    // File layer: DEFAULT_FILE_FILTER (or `FE_LSP_LOG`), written to the
+    // per-process log file. If the file can't be opened, the layer is
+    // silently omitted — we don't want to break the LSP because we can't
+    // write logs.
+    let file_filter = std::env::var("FE_LSP_LOG")
+        .ok()
+        .and_then(|s| EnvFilter::try_new(s).ok())
+        .unwrap_or_else(|| EnvFilter::new(DEFAULT_FILE_FILTER));
+
+    let file_layer: Option<_> = default_log_file_path()
+        .and_then(|path| match open_log_file(&path) {
+            Ok(file) => {
+                // Write the path to stderr so a human watching the process
+                // knows where to find the log. This is one line at startup,
+                // not per-message.
+                eprintln!("fe-language-server: log file at {}", path.display());
+                Some(file)
+            }
+            Err(e) => {
+                eprintln!(
+                    "fe-language-server: failed to open log file at {}: {e}",
+                    path.display()
+                );
+                None
+            }
+        })
+        .map(|file| {
+            let writer = BoxMakeWriter::new(Arc::new(file));
+            tracing_subscriber::fmt::layer()
+                .with_ansi(false)
+                .with_target(true)
+                .with_writer(writer)
+                .with_filter(file_filter)
+                .boxed()
+        });
+
+    let subscriber = Registry::default().with(client_layer).with(file_layer);
+
     Some(set_default(subscriber))
 }
 
-pub fn init_fn(client: ClientSocket) -> impl FnOnce() -> Option<tracing::subscriber::DefaultGuard> {
+/// Returns a thunk that installs the subscriber when invoked. Used by the
+/// act-locally `ActorBuilder::with_subscriber_init` hook so the actor
+/// thread gets its own thread-local subscriber at startup.
+pub fn init_fn(client: ClientSocket) -> impl FnOnce() -> Option<DefaultGuard> {
     move || setup_default_subscriber(client)
 }
 
+/// Install the process-wide panic hook. Idempotent: subsequent calls are
+/// no-ops (guarded by `Once`).
+///
+/// On panic the hook writes a complete record to `panics-<pid>.log` via
+/// `OpenOptions::append`. This write path does **not** go through the
+/// tracing subscriber — it uses direct filesystem IO so it works during
+/// shutdown when subscriber guards are being dropped. It also logs via
+/// `tracing::error!` as a best-effort secondary path.
+///
+/// The record includes:
+///   * panic payload + location + thread name
+///   * [`crate::panic_context::format_stack`] — per-request metadata
+///     pushed by [`crate::lsp_actor::service::LspActorService::call`]
+///   * `std::backtrace::Backtrace::force_capture()` — Rust call stack
+///
+/// Note: rust-analyzer additionally captures `salsa::Backtrace` (the
+/// active query stack), but our pinned `salsa = 0.20.0` does not
+/// expose that API — it was added in a later version. Consider
+/// adopting it on the next salsa bump.
 pub fn setup_panic_hook() {
-    // Set up a panic hook
-    std::panic::set_hook(Box::new(|panic_info| {
-        // Extract the panic message
-        let payload = panic_info.payload();
-        let message = if let Some(s) = payload.downcast_ref::<&str>() {
-            *s
-        } else if let Some(s) = payload.downcast_ref::<String>() {
-            &s[..]
-        } else {
-            "Unknown panic message"
-        };
+    static HOOK_INSTALLED: Once = Once::new();
+    HOOK_INSTALLED.call_once(|| {
+        let panic_file_path = default_panic_file_path();
+        let previous_hook = std::panic::take_hook();
+        std::panic::set_hook(Box::new(move |panic_info| {
+            // Preserve the default stderr panic output so `cargo test`
+            // and `cargo run` users still see panics the familiar way.
+            previous_hook(panic_info);
 
-        // Get the location of the panic if available
-        let location = if let Some(location) = panic_info.location() {
-            format!(" at {}:{}", location.file(), location.line())
-        } else {
-            String::from("Unknown location")
-        };
+            let payload = panic_info.payload();
+            let message = if let Some(s) = payload.downcast_ref::<&str>() {
+                (*s).to_owned()
+            } else if let Some(s) = payload.downcast_ref::<String>() {
+                s.clone()
+            } else {
+                "<non-string panic payload>".to_owned()
+            };
 
-        // Capture the backtrace
-        let backtrace = Backtrace::capture();
+            let location = panic_info
+                .location()
+                .map(|l| format!("{}:{}:{}", l.file(), l.line(), l.column()))
+                .unwrap_or_else(|| "<unknown>".to_owned());
 
-        // Log the panic information and backtrace
-        tracing::error!(
-            "Panic occurred{}: {}\nBacktrace:\n{:?}",
-            location,
-            message,
-            backtrace
-        );
-    }));
+            let backtrace = Backtrace::force_capture();
+            let context_stack = crate::panic_context::format_stack();
+            let thread_name = std::thread::current()
+                .name()
+                .unwrap_or("<unnamed>")
+                .to_owned();
+
+            if let Some(ref path) = panic_file_path {
+                if let Some(parent) = path.parent() {
+                    let _ = std::fs::create_dir_all(parent);
+                }
+                if let Ok(mut file) = OpenOptions::new().create(true).append(true).open(path) {
+                    let _ = writeln!(file, "==== fe-lsp panic ====");
+                    let _ = writeln!(file, "pid:      {}", std::process::id());
+                    let _ = writeln!(file, "time:     {:?}", std::time::SystemTime::now());
+                    let _ = writeln!(file, "thread:   {thread_name}");
+                    let _ = writeln!(file, "location: {location}");
+                    let _ = writeln!(file, "message:  {message}");
+                    if !context_stack.is_empty() {
+                        let _ = writeln!(file, "\n---- request context stack ----");
+                        let _ = write!(file, "{context_stack}");
+                    }
+                    let _ = writeln!(file, "\n---- rust backtrace ----");
+                    let _ = writeln!(file, "{backtrace}");
+                    let _ = writeln!(file, "===================================\n");
+                    let _ = file.sync_all();
+                }
+            }
+
+            // Secondary path via tracing. May not reach the client / file
+            // subscriber if we're already mid-shutdown, but worth trying.
+            tracing::error!(
+                target: "fe::lsp::panic",
+                location = %location,
+                thread = %thread_name,
+                "panic captured: {message}"
+            );
+        }));
+    });
 }
 
 pub(crate) struct ClientSocketWriterMaker {

--- a/crates/language-server/src/logging.rs
+++ b/crates/language-server/src/logging.rs
@@ -117,6 +117,74 @@ pub fn default_panic_file_path() -> Option<PathBuf> {
     Some(dir.join(format!("panics-{}.log", std::process::id())))
 }
 
+/// Return the parent process's pid, if it can be determined.
+///
+/// On Linux, reads `/proc/self/status` and parses the `PPid:` field.
+/// On other platforms, returns `None` (graceful degrade — we use this
+/// only for diagnostic logging, not for correctness).
+pub fn parent_pid() -> Option<u32> {
+    #[cfg(target_os = "linux")]
+    {
+        let status = std::fs::read_to_string("/proc/self/status").ok()?;
+        for line in status.lines() {
+            if let Some(rest) = line.strip_prefix("PPid:") {
+                return rest.trim().parse().ok();
+            }
+        }
+        None
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        None
+    }
+}
+
+/// Emit a single structured log line at `info` with everything needed to
+/// identify which process this is in a multi-instance forensic scenario.
+///
+/// Intended to be called exactly once, at server startup, before any other
+/// work. The line includes:
+///   * `pid` — our process id
+///   * `parent_pid` — the spawning process (the editor, typically Zed)
+///   * `argv` — our command-line arguments
+///   * `cwd` — current working directory at startup (often but not always
+///     the workspace root; the editor decides)
+///   * `binary` — path to the running executable (via `/proc/self/exe` on
+///     Linux, best-effort elsewhere)
+///   * `log_file` — the file log path we chose, so grepping the log line
+///     tells you where to `tail -F` the rest of the output
+///
+/// This is the line Grant would copy-paste when reporting "I've got three
+/// `fe` processes running and I don't know which one Zed is actually
+/// talking to." Every field is a join key.
+pub fn log_startup_info() {
+    let pid = std::process::id();
+    let ppid = parent_pid();
+    let argv: Vec<String> = std::env::args().collect();
+    let cwd = std::env::current_dir()
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|e| format!("<error: {e}>"));
+    let binary = std::env::current_exe()
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|e| format!("<error: {e}>"));
+    let log_file = default_log_file_path()
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|| "<none>".to_owned());
+    let version = env!("CARGO_PKG_VERSION");
+
+    tracing::info!(
+        target: "fe::lsp::startup",
+        %pid,
+        ppid = ?ppid,
+        ?argv,
+        %cwd,
+        %binary,
+        %log_file,
+        %version,
+        "fe-language-server starting"
+    );
+}
+
 /// Open a log file for appending, creating the parent directory if needed.
 fn open_log_file(path: &Path) -> std::io::Result<File> {
     if let Some(parent) = path.parent() {

--- a/crates/language-server/src/logging.rs
+++ b/crates/language-server/src/logging.rs
@@ -129,6 +129,60 @@ pub fn default_panic_file_path() -> Option<PathBuf> {
     Some(dir.join(format!("panics-{}.log", std::process::id())))
 }
 
+/// Default number of `*.log` files to retain in the log directory.
+/// Override via `FE_LSP_LOG_RETENTION`.
+const DEFAULT_LOG_RETENTION: usize = 50;
+
+fn log_retention() -> usize {
+    std::env::var("FE_LSP_LOG_RETENTION")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_LOG_RETENTION)
+}
+
+/// Garbage-collect old log files in the log directory.
+///
+/// Called once at startup, before opening the new file. Scans the log
+/// directory for `*.log` files (both per-process session logs like
+/// `<pid>.log` and crash logs like `panics-<pid>.log`), sorts by mtime,
+/// and deletes everything older than the most recent `log_retention()`
+/// files.
+///
+/// This bounds disk usage to roughly retention × typical-session-size.
+/// At the default of 50 files and a heavy session of ~10 MB, that's
+/// ~500 MB worst case. Lighter sessions take far less. Override the
+/// retention with `FE_LSP_LOG_RETENTION=<n>`.
+///
+/// Best-effort: any IO error during scanning or deletion is silently
+/// ignored. Failing to GC must not break server startup.
+pub fn gc_old_log_files() {
+    let Some(dir) = resolve_log_dir() else {
+        return;
+    };
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return;
+    };
+    let mut files: Vec<(PathBuf, std::time::SystemTime)> = entries
+        .flatten()
+        .filter_map(|entry| {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("log") {
+                return None;
+            }
+            let mtime = entry.metadata().ok()?.modified().ok()?;
+            Some((path, mtime))
+        })
+        .collect();
+    let retention = log_retention();
+    if files.len() <= retention {
+        return;
+    }
+    files.sort_by(|a, b| b.1.cmp(&a.1)); // newest first
+    for (path, _) in files.iter().skip(retention) {
+        let _ = std::fs::remove_file(path);
+    }
+}
+
 /// Return the parent process's pid, if it can be determined.
 ///
 /// On Linux, reads `/proc/self/status` and parses the `PPid:` field.
@@ -211,6 +265,12 @@ fn open_log_file(path: &Path) -> std::io::Result<File> {
 /// resets the thread-local dispatch.
 pub fn setup_default_subscriber(client: ClientSocket) -> Option<DefaultGuard> {
     use tracing::subscriber::set_default;
+
+    // Bound disk usage by deleting older logs before opening this session's
+    // file. The verbose default per-request logging produces a few hundred
+    // KB to a few MB per session; retaining the last 50 by default keeps
+    // the cache directory under ~500 MB even for heavy debug runs.
+    gc_old_log_files();
 
     // Client layer: WARN+ only, forwarded to the LSP client as
     // `window/logMessage` notifications. This is what the editor sees.

--- a/crates/language-server/src/logging.rs
+++ b/crates/language-server/src/logging.rs
@@ -94,13 +94,24 @@ const DEFAULT_CLIENT_FILTER: &str = "warn";
 ///
 /// Precedence:
 ///   1. `FE_LSP_LOG_DIR` env var (explicit override)
-///   2. `$XDG_CACHE_HOME/fe-language-server`
-///   3. `$HOME/.cache/fe-language-server`
+///   2. `<cwd>/.fe-lsp` — workspace-local (Zed spawns `fe lsp` with cwd
+///      set to the workspace root, so each workspace gets an isolated
+///      log budget rather than sharing a global cache directory)
+///   3. `$XDG_CACHE_HOME/fe-language-server` — fallback when cwd is
+///      unusable (e.g. read-only or doesn't exist)
+///   4. `$HOME/.cache/fe-language-server` — last-resort fallback
 ///
-/// Returns `None` if no usable base path exists (e.g. neither env var set).
+/// Returns `None` if no usable base path exists.
 fn resolve_log_dir() -> Option<PathBuf> {
     if let Ok(dir) = std::env::var("FE_LSP_LOG_DIR") {
         return Some(PathBuf::from(dir));
+    }
+    if let Ok(cwd) = std::env::current_dir() {
+        // Workspace-local: each Fe project gets its own .fe-lsp/ dir
+        // alongside the existing .fe-lsp.json discovery file. Retention
+        // and rotation budgets apply per-workspace this way, instead of
+        // multiple workspaces sharing a single global cache budget.
+        return Some(cwd.join(".fe-lsp"));
     }
     let base = std::env::var("XDG_CACHE_HOME")
         .ok()

--- a/crates/language-server/src/lsp_actor/mod.rs
+++ b/crates/language-server/src/lsp_actor/mod.rs
@@ -135,8 +135,8 @@ mod tests {
 
     use super::*;
     use act_locally::builder::ActorBuilder;
-    use async_lsp::{AnyNotification, AnyRequest, LspService, ResponseError};
     use async_lsp::lsp_types::{InitializeParams, InitializeResult};
+    use async_lsp::{AnyNotification, AnyRequest, LspService, ResponseError};
     use serde_json::json;
     use service::LspActorService;
     use std::ops::ControlFlow;

--- a/crates/language-server/src/lsp_actor/mod.rs
+++ b/crates/language-server/src/lsp_actor/mod.rs
@@ -88,7 +88,7 @@ impl Dispatcher<LspActorKey> for LspDispatcher {
         } else if let Some(notification) = message.downcast_ref::<AnyNotification>() {
             Ok(LspActorKey::from(&notification.method).into())
         } else if let Some(event) = message.downcast_ref::<AnyEvent>() {
-            Ok(LspActorKey::from(event.inner_type_id()).into())
+            Ok(LspActorKey::from(event.inner().type_id()).into())
         } else {
             Err(ActorError::DispatchError)
         }
@@ -136,10 +136,7 @@ mod tests {
     use super::*;
     use act_locally::builder::ActorBuilder;
     use async_lsp::{AnyNotification, AnyRequest, LspService, ResponseError};
-    use async_lsp::{
-        RequestId,
-        lsp_types::{InitializeParams, InitializeResult},
-    };
+    use async_lsp::lsp_types::{InitializeParams, InitializeResult};
     use serde_json::json;
     use service::LspActorService;
     use std::ops::ControlFlow;
@@ -197,13 +194,17 @@ mod tests {
         }
         service.handle_notification_mut::<Initialized>(handle_initialized);
 
-        // Test initialize request
+        // Test initialize request. async-lsp upstream marks AnyRequest as
+        // `#[non_exhaustive]` and no longer exposes a `stub` constructor,
+        // so round-trip through its `Deserialize` impl to build one in a
+        // test without reaching into private fields.
         let init_params = InitializeParams::default();
-        let init_request = AnyRequest::stub(
-            RequestId::Number(1),
-            Initialize::METHOD.to_string(),
-            serde_json::to_value(init_params).unwrap(),
-        );
+        let init_request: AnyRequest = serde_json::from_value(serde_json::json!({
+            "id": 1,
+            "method": Initialize::METHOD,
+            "params": serde_json::to_value(init_params).unwrap(),
+        }))
+        .unwrap();
 
         info!("Sending initialize request");
 
@@ -214,8 +215,12 @@ mod tests {
 
         assert_eq!(init_result_deserialized, InitializeResult::default());
 
-        // Test initialized notification
-        let init_notification = AnyNotification::stub(Initialized::METHOD.to_string(), json!(null));
+        // Test initialized notification — same reasoning as AnyRequest above.
+        let init_notification: AnyNotification = serde_json::from_value(serde_json::json!({
+            "method": Initialized::METHOD,
+            "params": json!(null),
+        }))
+        .unwrap();
 
         info!("Sending initialized notification");
         if let ControlFlow::Break(Err(e)) = service.notify(init_notification) {

--- a/crates/language-server/src/lsp_actor/service.rs
+++ b/crates/language-server/src/lsp_actor/service.rs
@@ -63,17 +63,19 @@ impl<S: 'static> Service<AnyRequest> for LspActorService<S> {
                 "LSP request: {method} (id={request_id})"
             ));
 
-            // One info-level line per request + response pair so the file
-            // log shows a running trail of activity by default. Without
-            // this, the log has only startup lines and you can't tell what
-            // the LSP was doing when something went wrong.
+            // Per-request observability is layered:
+            //   - Successful requests log at DEBUG (filtered out by the
+            //     default file filter, available via FE_LSP_LOG=debug for
+            //     forensic investigation).
+            //   - Anomalously slow successes (>1s) log at INFO so they
+            //     surface in the default log without spamming.
+            //   - Errors always log at WARN.
+            //
+            // The actual "in-flight" identification of a request is handled
+            // by the panic_context frame above — every panic backtrace
+            // already includes the request method/id, so a per-request
+            // "→ request" log line would just be log-spam.
             let t_start = std::time::Instant::now();
-            tracing::info!(
-                target: "fe::lsp::request",
-                method = %method,
-                request_id = %request_id,
-                "→ request"
-            );
 
             let result = actor_ref
                 .ask::<_, Value, _>(dispatcher.as_ref(), req)
@@ -91,13 +93,22 @@ impl<S: 'static> Service<AnyRequest> for LspActorService<S> {
 
             let elapsed_ms = t_start.elapsed().as_millis() as u64;
             match &result {
-                Ok(_) => {
+                Ok(_) if elapsed_ms > 1000 => {
                     tracing::info!(
                         target: "fe::lsp::request",
                         method = %method,
                         request_id = %request_id,
                         elapsed_ms,
-                        "← response ok"
+                        "slow response"
+                    );
+                }
+                Ok(_) => {
+                    tracing::debug!(
+                        target: "fe::lsp::request",
+                        method = %method,
+                        request_id = %request_id,
+                        elapsed_ms,
+                        "response"
                     );
                 }
                 Err(e) => {
@@ -108,7 +119,7 @@ impl<S: 'static> Service<AnyRequest> for LspActorService<S> {
                         elapsed_ms,
                         error = %e.message,
                         code = ?e.code,
-                        "← response error"
+                        "response error"
                     );
                 }
             }

--- a/crates/language-server/src/lsp_actor/service.rs
+++ b/crates/language-server/src/lsp_actor/service.rs
@@ -179,7 +179,7 @@ impl<S> CanHandle<AnyEvent> for LspActorService<S> {
     fn can_handle(&self, event: &AnyEvent) -> bool {
         self.dispatcher
             .wrappers
-            .contains_key(&LspActorKey::from(event.inner_type_id()))
+            .contains_key(&LspActorKey::from(event.inner().type_id()))
     }
 }
 

--- a/crates/language-server/src/lsp_actor/service.rs
+++ b/crates/language-server/src/lsp_actor/service.rs
@@ -44,7 +44,6 @@ impl<S: 'static> Service<AnyRequest> for LspActorService<S> {
     fn call(&mut self, req: AnyRequest) -> Self::Future {
         let method = req.method.clone();
         let request_id = format!("{:?}", req.id);
-        tracing::debug!("handling LSP request: {method:?}");
         let actor_ref = self.actor_ref.clone();
         let dispatcher = self.dispatcher.clone();
         Box::pin(async move {
@@ -63,7 +62,20 @@ impl<S: 'static> Service<AnyRequest> for LspActorService<S> {
             let _pctx = crate::panic_context::enter(format!(
                 "LSP request: {method} (id={request_id})"
             ));
-            actor_ref
+
+            // One info-level line per request + response pair so the file
+            // log shows a running trail of activity by default. Without
+            // this, the log has only startup lines and you can't tell what
+            // the LSP was doing when something went wrong.
+            let t_start = std::time::Instant::now();
+            tracing::info!(
+                target: "fe::lsp::request",
+                method = %method,
+                request_id = %request_id,
+                "→ request"
+            );
+
+            let result = actor_ref
                 .ask::<_, Value, _>(dispatcher.as_ref(), req)
                 .await
                 .map_err(|e| match e {
@@ -75,7 +87,32 @@ impl<S: 'static> Service<AnyRequest> for LspActorService<S> {
                         async_lsp::ErrorCode::INTERNAL_ERROR,
                         format!("There was an internal error... {e:?}"),
                     ),
-                })
+                });
+
+            let elapsed_ms = t_start.elapsed().as_millis() as u64;
+            match &result {
+                Ok(_) => {
+                    tracing::info!(
+                        target: "fe::lsp::request",
+                        method = %method,
+                        request_id = %request_id,
+                        elapsed_ms,
+                        "← response ok"
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        target: "fe::lsp::request",
+                        method = %method,
+                        request_id = %request_id,
+                        elapsed_ms,
+                        error = %e.message,
+                        code = ?e.code,
+                        "← response error"
+                    );
+                }
+            }
+            result
         })
     }
 }

--- a/crates/language-server/src/lsp_actor/service.rs
+++ b/crates/language-server/src/lsp_actor/service.rs
@@ -43,10 +43,26 @@ impl<S: 'static> Service<AnyRequest> for LspActorService<S> {
 
     fn call(&mut self, req: AnyRequest) -> Self::Future {
         let method = req.method.clone();
+        let request_id = format!("{:?}", req.id);
         tracing::debug!("handling LSP request: {method:?}");
         let actor_ref = self.actor_ref.clone();
         let dispatcher = self.dispatcher.clone();
         Box::pin(async move {
+            // Push a panic context frame for the duration of the ask. If the
+            // main-loop-thread side of the request machinery (serialization,
+            // dispatcher, error mapping) panics, the panic hook will include
+            // this frame in panics-<pid>.log.
+            //
+            // LIMITATION: this frame lives in the main loop thread's
+            // thread-local stack. Panics in the actor handler itself run on
+            // the actor thread and won't see it. Covering actor-thread
+            // panics properly requires either a helper at each handler call
+            // site or an upstream patch to act-locally. See design notes in
+            // `panic_context.rs` and the follow-up tracked in the LSP
+            // observability work.
+            let _pctx = crate::panic_context::enter(format!(
+                "LSP request: {method} (id={request_id})"
+            ));
             actor_ref
                 .ask::<_, Value, _>(dispatcher.as_ref(), req)
                 .await
@@ -67,6 +83,8 @@ impl<S: 'static> Service<AnyRequest> for LspActorService<S> {
 impl<S: 'static> LspService for LspActorService<S> {
     fn notify(&mut self, notif: AnyNotification) -> ControlFlow<async_lsp::Result<()>> {
         let method = notif.method.clone();
+        let _pctx =
+            crate::panic_context::enter(format!("LSP notification: {method}"));
         let dispatcher = self.dispatcher.clone();
         match self.actor_ref.tell(dispatcher.as_ref(), notif) {
             Ok(()) => ControlFlow::Continue(()),
@@ -83,6 +101,8 @@ impl<S: 'static> LspService for LspActorService<S> {
 
     fn emit(&mut self, event: AnyEvent) -> ControlFlow<async_lsp::Result<()>> {
         let type_name = event.type_name();
+        let _pctx =
+            crate::panic_context::enter(format!("LSP event: {type_name:?}"));
         let dispatcher = self.dispatcher.clone();
         match self.actor_ref.tell(dispatcher.as_ref(), event) {
             Ok(()) => ControlFlow::Continue(()),

--- a/crates/language-server/src/lsp_actor/service.rs
+++ b/crates/language-server/src/lsp_actor/service.rs
@@ -59,9 +59,8 @@ impl<S: 'static> Service<AnyRequest> for LspActorService<S> {
             // site or an upstream patch to act-locally. See design notes in
             // `panic_context.rs` and the follow-up tracked in the LSP
             // observability work.
-            let _pctx = crate::panic_context::enter(format!(
-                "LSP request: {method} (id={request_id})"
-            ));
+            let _pctx =
+                crate::panic_context::enter(format!("LSP request: {method} (id={request_id})"));
 
             // Per-request observability — verbose by default. The point of
             // the file log is to be able to reconstruct the order of
@@ -122,8 +121,7 @@ impl<S: 'static> Service<AnyRequest> for LspActorService<S> {
 impl<S: 'static> LspService for LspActorService<S> {
     fn notify(&mut self, notif: AnyNotification) -> ControlFlow<async_lsp::Result<()>> {
         let method = notif.method.clone();
-        let _pctx =
-            crate::panic_context::enter(format!("LSP notification: {method}"));
+        let _pctx = crate::panic_context::enter(format!("LSP notification: {method}"));
         let dispatcher = self.dispatcher.clone();
         match self.actor_ref.tell(dispatcher.as_ref(), notif) {
             Ok(()) => ControlFlow::Continue(()),
@@ -140,8 +138,7 @@ impl<S: 'static> LspService for LspActorService<S> {
 
     fn emit(&mut self, event: AnyEvent) -> ControlFlow<async_lsp::Result<()>> {
         let type_name = event.type_name();
-        let _pctx =
-            crate::panic_context::enter(format!("LSP event: {type_name:?}"));
+        let _pctx = crate::panic_context::enter(format!("LSP event: {type_name:?}"));
         let dispatcher = self.dispatcher.clone();
         match self.actor_ref.tell(dispatcher.as_ref(), event) {
             Ok(()) => ControlFlow::Continue(()),

--- a/crates/language-server/src/lsp_actor/service.rs
+++ b/crates/language-server/src/lsp_actor/service.rs
@@ -63,19 +63,19 @@ impl<S: 'static> Service<AnyRequest> for LspActorService<S> {
                 "LSP request: {method} (id={request_id})"
             ));
 
-            // Per-request observability is layered:
-            //   - Successful requests log at DEBUG (filtered out by the
-            //     default file filter, available via FE_LSP_LOG=debug for
-            //     forensic investigation).
-            //   - Anomalously slow successes (>1s) log at INFO so they
-            //     surface in the default log without spamming.
-            //   - Errors always log at WARN.
-            //
-            // The actual "in-flight" identification of a request is handled
-            // by the panic_context frame above — every panic backtrace
-            // already includes the request method/id, so a per-request
-            // "→ request" log line would just be log-spam.
+            // Per-request observability — verbose by default. The point of
+            // the file log is to be able to reconstruct the order of
+            // operations after a session goes wrong; sparse logs defeat
+            // that. Disk growth is bounded by `gc_old_log_files()` at
+            // startup which retains only the most recent
+            // `FE_LSP_LOG_RETENTION` files (default 50).
             let t_start = std::time::Instant::now();
+            tracing::info!(
+                target: "fe::lsp::request",
+                method = %method,
+                request_id = %request_id,
+                "→ request"
+            );
 
             let result = actor_ref
                 .ask::<_, Value, _>(dispatcher.as_ref(), req)
@@ -93,22 +93,13 @@ impl<S: 'static> Service<AnyRequest> for LspActorService<S> {
 
             let elapsed_ms = t_start.elapsed().as_millis() as u64;
             match &result {
-                Ok(_) if elapsed_ms > 1000 => {
+                Ok(_) => {
                     tracing::info!(
                         target: "fe::lsp::request",
                         method = %method,
                         request_id = %request_id,
                         elapsed_ms,
-                        "slow response"
-                    );
-                }
-                Ok(_) => {
-                    tracing::debug!(
-                        target: "fe::lsp::request",
-                        method = %method,
-                        request_id = %request_id,
-                        elapsed_ms,
-                        "response"
+                        "← response ok"
                     );
                 }
                 Err(e) => {
@@ -119,7 +110,7 @@ impl<S: 'static> Service<AnyRequest> for LspActorService<S> {
                         elapsed_ms,
                         error = %e.message,
                         code = ?e.code,
-                        "response error"
+                        "← response error"
                     );
                 }
             }

--- a/crates/language-server/src/mock_client_tests.rs
+++ b/crates/language-server/src/mock_client_tests.rs
@@ -910,31 +910,47 @@ pub contract C {
 
 /// Reproduction for the "goto def → freeze" bug observed in Zed.
 ///
-/// Field observation (log `2061701.log`, 2026-04-06): a burst of ~14
-/// concurrent `textDocument/definition` + `textDocument/typeDefinition`
-/// requests arrived at the LSP within ~400µs after a goto-def click
-/// navigated to another file. The LSP actor thread went to `futex_do_wait`
-/// and never came back. No panic, no response — a genuine deadlock.
+/// # Field observation
 ///
-/// This test reliably reproduces the deadlock in ~1 second using the
-/// mock client. Trace-level logging against a local run shows the last
-/// activity before the hang is a salsa query (e.g. `body_references`)
-/// executing on the actor thread — indicating the deadlock is inside
-/// salsa's internal query machinery, not in our tower layers or the
-/// state RwLock (the per-task read guards are re-entrant friendly).
+/// Log `2061701.log`, 2026-04-06: a burst of ~14 concurrent
+/// `textDocument/definition` + `textDocument/typeDefinition` requests
+/// arrived at the LSP within ~400µs after a goto-def click navigated to
+/// another file. The LSP actor thread went to `futex_do_wait` and never
+/// came back. No panic, no response — a genuine deadlock.
 ///
-/// #\[ignore]`d so CI stays green while the underlying bug is being
-/// investigated. Run with:
+/// # Root cause
+///
+/// Located by gdb backtrace of the frozen actor thread (parked in
+/// `futures_lite::future::block_on`, NOT in salsa) combined with
+/// reproducer minimization showing the bug fires exactly when the burst
+/// exceeds `ConcurrencyLayer::default() == nproc == 16`.
+///
+/// The bug is in `async-lsp` `MainLoop::run` (`src/lib.rs:554-568`).
+/// When an incoming message arrives, the outer `select_biased!` enters
+/// the `incoming.next()` arm body, which runs its own inner loop awaiting
+/// `dispatch_fut` (which internally `await`s `service.poll_ready`). The
+/// inner loop only selects on `dispatch_fut` and `flush_fut` — it does
+/// NOT poll `self.tasks`.
+///
+/// When `ConcurrencyLayer`'s semaphore is saturated (16 permits taken),
+/// `poll_ready` returns `Pending`. The inner loop parks waiting for
+/// `dispatch_fut` to become ready. For that to happen, a permit must
+/// release, which requires an in-flight task to complete, which requires
+/// `self.tasks` to be polled, which the main loop cannot do because it
+/// is inside the inner loop waiting for `dispatch_fut`. Classic
+/// "waker trapped behind a nested await" deadlock.
+///
+/// # Running this repro
+///
+/// `#[ignore]`d so CI stays green while the upstream async-lsp fix is
+/// being worked out. Run manually with:
 ///
 ///     cargo test -p fe-language-server repro_concurrent_goto -- --ignored
 ///
-/// To investigate, rerun with full salsa + act-locally trace:
-///
-///     FE_LSP_LOG='act_locally=trace,salsa=trace,fe_language_server=debug,info' \
-///       FE_LSP_LOG_FILE=/tmp/repro.log \
-///       cargo test -p fe-language-server repro_concurrent_goto -- --ignored
-///
-/// then `tail /tmp/repro.log` to see the last thing the actor was doing.
+/// Threshold check: the repro fires 72 requests (24 positions × 3
+/// request types), well above the 16-slot semaphore. With `ConcurrencyLayer`
+/// removed from `MockLspClient::start` the exact same load passes in
+/// ~1 second, confirming the layer is the deadlock trigger.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 #[ignore = "known deadlock reproducer — run with --ignored while investigating"]
 async fn repro_concurrent_goto_burst_does_not_deadlock() {
@@ -1000,6 +1016,10 @@ fn bar() -> () {
     // without an `&mut self` bottleneck, then collect the resulting
     // futures and `join_all` them. The timeout catches the hang if the
     // actor deadlocks.
+    // Fire >16 concurrent goto-definition requests at the server. 16 is the
+    // default ConcurrencyLayer limit (nproc on our test box), so 18 requests
+    // overflows the semaphore by 2 and triggers the `MainLoop::run` dispatch
+    // deadlock described in the docstring above.
     let socket = client.server.clone();
     let mut request_futures: Vec<
         std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>>,
@@ -1063,9 +1083,11 @@ fn bar() -> () {
 
     assert!(
         burst.is_ok(),
-        "{total} concurrent goto/hover requests deadlocked (no responses within 15s). \
-         Check the LSP actor thread for futex_do_wait and look at \
-         act-locally's handler.rs for the read-lock-across-await pattern."
+        "{total} concurrent LSP requests deadlocked (no responses within 15s). \
+         Root cause lives in async-lsp MainLoop::run at src/lib.rs:554-568: \
+         the inner dispatch loop doesn't poll self.tasks while awaiting \
+         dispatch_fut/poll_ready, so a saturated ConcurrencyLayer semaphore \
+         never releases. See this test's docstring for the full analysis."
     );
 
     client.shutdown().await;

--- a/crates/language-server/src/mock_client_tests.rs
+++ b/crates/language-server/src/mock_client_tests.rs
@@ -908,51 +908,49 @@ pub contract C {
     client.shutdown().await;
 }
 
-/// Reproduction for the "goto def → freeze" bug observed in Zed.
+/// Regression test for the "goto def → freeze" bug observed in Zed.
 ///
-/// # Field observation
+/// # History
 ///
 /// Log `2061701.log`, 2026-04-06: a burst of ~14 concurrent
 /// `textDocument/definition` + `textDocument/typeDefinition` requests
-/// arrived at the LSP within ~400µs after a goto-def click navigated to
-/// another file. The LSP actor thread went to `futex_do_wait` and never
-/// came back. No panic, no response — a genuine deadlock.
+/// arrived at the LSP within ~400µs after a goto-def click. The LSP
+/// actor thread went to `futex_do_wait` and never came back. No panic,
+/// no response.
 ///
-/// # Root cause
+/// # Root cause (fixed)
 ///
-/// Located by gdb backtrace of the frozen actor thread (parked in
-/// `futures_lite::future::block_on`, NOT in salsa) combined with
-/// reproducer minimization showing the bug fires exactly when the burst
-/// exceeds `ConcurrencyLayer::default() == nproc == 16`.
+/// The bug was in `async-lsp::MainLoop::run`. When an incoming message
+/// arrived, the outer `select_biased!` entered the `incoming.next()` arm
+/// body, which ran a nested inner loop awaiting `dispatch_fut`.
+/// `dispatch_fut` awaited `service.poll_ready`. If `ConcurrencyLayer`'s
+/// semaphore was saturated, `poll_ready` returned `Pending`. The inner
+/// loop only selected on `dispatch_fut` and `flush_fut` — it did NOT
+/// poll `self.tasks`. For `poll_ready` to become ready a permit had to
+/// release, which required an in-flight task to complete, which required
+/// `self.tasks` to be polled, which the main loop couldn't do because it
+/// was stuck inside the arm body. Classic "waker trapped behind a nested
+/// await" deadlock.
 ///
-/// The bug is in `async-lsp` `MainLoop::run` (`src/lib.rs:554-568`).
-/// When an incoming message arrives, the outer `select_biased!` enters
-/// the `incoming.next()` arm body, which runs its own inner loop awaiting
-/// `dispatch_fut` (which internally `await`s `service.poll_ready`). The
-/// inner loop only selects on `dispatch_fut` and `flush_fut` — it does
-/// NOT poll `self.tasks`.
+/// The fix (in the local `async-lsp` checkout at
+/// `~/hacker-stuff-2023/async-lsp`): `dispatch_message` now drains
+/// `self.tasks` concurrently with `poll_ready` via disjoint field
+/// borrows. Drained responses flow back to the outer loop alongside the
+/// dispatch outcome as a `Vec<Message>`, and the outer loop feeds them
+/// all to the outgoing sink before the next iteration. Details in the
+/// `dispatch_message` doc comment in `async-lsp/src/lib.rs`.
 ///
-/// When `ConcurrencyLayer`'s semaphore is saturated (16 permits taken),
-/// `poll_ready` returns `Pending`. The inner loop parks waiting for
-/// `dispatch_fut` to become ready. For that to happen, a permit must
-/// release, which requires an in-flight task to complete, which requires
-/// `self.tasks` to be polled, which the main loop cannot do because it
-/// is inside the inner loop waiting for `dispatch_fut`. Classic
-/// "waker trapped behind a nested await" deadlock.
+/// # What this test does
 ///
-/// # Running this repro
-///
-/// `#[ignore]`d so CI stays green while the upstream async-lsp fix is
-/// being worked out. Run manually with:
-///
-///     cargo test -p fe-language-server repro_concurrent_goto -- --ignored
-///
-/// Threshold check: the repro fires 72 requests (24 positions × 3
-/// request types), well above the 16-slot semaphore. With `ConcurrencyLayer`
-/// removed from `MockLspClient::start` the exact same load passes in
-/// ~1 second, confirming the layer is the deadlock trigger.
+/// Fires 72 concurrent LSP requests (24 positions × 3 request types)
+/// against the mock client. `ConcurrencyLayer::default() == nproc`
+/// means 16 permits on a typical dev box, so the burst pegs the
+/// semaphore and forces `dispatch_message` down the drain-while-waiting
+/// code path. If a regression re-introduces the inner-loop deadlock,
+/// `tokio::time::timeout` catches it and the assertion fires with a
+/// pointer to the exact lines in `async-lsp/src/lib.rs` that need
+/// inspection.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-#[ignore = "known deadlock reproducer — run with --ignored while investigating"]
 async fn repro_concurrent_goto_burst_does_not_deadlock() {
     let mut client = MockLspClient::start().await;
     client.initialize().await;

--- a/crates/language-server/src/mock_client_tests.rs
+++ b/crates/language-server/src/mock_client_tests.rs
@@ -4,7 +4,7 @@
 //! request handling, verifying the server survives malformed edits.
 
 use async_lsp::concurrency::ConcurrencyLayer;
-use async_lsp::lsp_types::notification::PublishDiagnostics;
+use async_lsp::lsp_types::notification::{LogMessage, PublishDiagnostics};
 use async_lsp::lsp_types::*;
 use async_lsp::server::LifecycleLayer;
 use async_lsp::{LanguageServer, MainLoop};
@@ -15,6 +15,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio_util::compat::TokioAsyncReadCompatExt;
 use tower::ServiceBuilder;
+use tracing::instrument::WithSubscriber;
 
 use crate::server::setup;
 
@@ -52,18 +53,23 @@ pub struct PublishedDiagnostics {
 /// A mock LSP client connected to the real fe language server via duplex pipe.
 ///
 /// Use `MockLspClient::start()` to spin up, then call helper methods to drive
-/// the protocol. Diagnostics are collected automatically for inspection.
+/// the protocol. Diagnostics and server log messages are collected automatically
+/// for inspection.
 pub struct MockLspClient {
     server: async_lsp::ServerSocket,
     diagnostics: Arc<Mutex<Vec<PublishedDiagnostics>>>,
+    log_messages: Arc<Mutex<Vec<LogMessageParams>>>,
     _srv_handle: tokio::task::JoinHandle<()>,
     _cli_handle: tokio::task::JoinHandle<()>,
+    // Holds the tracing subscriber default-guard installed for this test. Dropped
+    // when the client is dropped, which resets the thread-local dispatch.
+    _logging_guard: Option<tracing::subscriber::DefaultGuard>,
 }
 
 impl MockLspClient {
     /// Spawn the real server and connect a mock client.
     pub async fn start() -> Self {
-        let (server_main, _client_socket) = MainLoop::new_server(|client| {
+        let (server_main, server_client_socket) = MainLoop::new_server(|client| {
             let lsp_service = setup(client.clone(), "test-actor".to_string());
             ServiceBuilder::new()
                 .layer(LifecycleLayer::default())
@@ -71,19 +77,37 @@ impl MockLspClient {
                 .service(lsp_service)
         });
 
+        // Install the production tracing subscriber on the current (test) thread
+        // using the server's ClientSocket. This routes `tracing::warn!` /
+        // `tracing::info!` calls from the LSP main loop (including
+        // `setup_unhandled`) through `ClientSocketWriter`, which emits them as
+        // `window/logMessage` notifications the mock client captures below.
+        //
+        // `set_default` is thread-local; `#[tokio::test]` uses a current-thread
+        // runtime by default, and we use `.with_current_subscriber()` on the
+        // spawned server task below to ensure the dispatch follows the future.
+        let logging_guard = crate::logging::setup_default_subscriber(server_client_socket);
+
         let (server_stream, client_stream) = tokio::io::duplex(DUPLEX_BUF);
         let (srv_rx, srv_tx) = server_stream.compat().split();
-        let srv_handle = tokio::spawn(async move {
-            if let Err(e) = server_main.run_buffered(srv_rx, srv_tx).await {
-                tracing::debug!("test server loop exited: {e:?}");
+        let srv_handle = tokio::spawn(
+            async move {
+                if let Err(e) = server_main.run_buffered(srv_rx, srv_tx).await {
+                    tracing::debug!("test server loop exited: {e:?}");
+                }
             }
-        });
+            .with_current_subscriber(),
+        );
 
         let diagnostics: Arc<Mutex<Vec<PublishedDiagnostics>>> = Arc::new(Mutex::new(Vec::new()));
         let diag_collector = diagnostics.clone();
 
+        let log_messages: Arc<Mutex<Vec<LogMessageParams>>> = Arc::new(Mutex::new(Vec::new()));
+        let log_collector = log_messages.clone();
+
         let (client_main, server_socket) = MainLoop::new_client(move |_| {
             let diags = diag_collector.clone();
+            let logs = log_collector.clone();
             let mut router = async_lsp::router::Router::new(());
             router
                 .notification::<PublishDiagnostics>(move |_, params| {
@@ -93,7 +117,13 @@ impl MockLspClient {
                     });
                     ControlFlow::Continue(())
                 })
-                // Silently absorb server log/show messages
+                // Capture server-side tracing output delivered via window/logMessage
+                // so tests can assert on the log levels and messages the server emits.
+                .notification::<LogMessage>(move |_, params| {
+                    logs.lock().unwrap().push(params);
+                    ControlFlow::Continue(())
+                })
+                // Silently absorb any other server notifications
                 .unhandled_notification(|_, _| ControlFlow::Continue(()));
             ServiceBuilder::new().service(router)
         });
@@ -105,8 +135,10 @@ impl MockLspClient {
         Self {
             server: server_socket,
             diagnostics,
+            log_messages,
             _srv_handle: srv_handle,
             _cli_handle: cli_handle,
+            _logging_guard: logging_guard,
         }
     }
 
@@ -201,6 +233,28 @@ impl MockLspClient {
     /// Clear collected diagnostics.
     pub fn clear_diagnostics(&self) {
         self.diagnostics.lock().unwrap().clear();
+    }
+
+    /// Return a snapshot of all `window/logMessage` notifications received so far.
+    #[allow(dead_code)]
+    pub fn log_messages(&self) -> Vec<LogMessageParams> {
+        self.log_messages.lock().unwrap().clone()
+    }
+
+    /// Return captured log messages filtered by MessageType.
+    pub fn log_messages_of_type(&self, typ: MessageType) -> Vec<LogMessageParams> {
+        self.log_messages
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|m| m.typ == typ)
+            .cloned()
+            .collect()
+    }
+
+    /// Clear captured log messages.
+    pub fn clear_log_messages(&self) {
+        self.log_messages.lock().unwrap().clear();
     }
 
     /// Wait for the server to settle (process queued events).
@@ -366,6 +420,7 @@ async fn mock_lsp_scenarios() {
     scenario_contract_analysis_reports_errors(&mut client, &uri).await;
     scenario_payable_attr_reports_errors(&mut client, &uri).await;
     scenario_errors_reported_after_panic_recovery(&mut client, &uri).await;
+    scenario_unhandled_notifications_do_not_warn(&mut client).await;
 
     client.shutdown().await;
 }
@@ -705,6 +760,47 @@ async fn scenario_errors_reported_after_panic_recovery(client: &mut MockLspClien
          the outer catch_unwind in handle_files_need_diagnostics must keep \
          the actor alive; got: {:?}",
         client.diagnostics_for_uri(uri),
+    );
+}
+
+/// Regression test: notifications for methods that Fe doesn't handle must not
+/// produce WARN-level log messages to the client. Editors (Zed, VS Code, …)
+/// routinely send `$/cancelRequest`, `$/setTrace`, `workspace/didChangeConfiguration`,
+/// custom `experimental/*` methods, etc. These arriving at the server is
+/// completely normal — it is not a warning condition and should not clutter the
+/// client log stream.
+///
+/// At the time of writing, `server.rs::setup_unhandled` logs these at WARN, which
+/// turns every editor session into a wall of noise that drowns out real errors.
+async fn scenario_unhandled_notifications_do_not_warn(client: &mut MockLspClient) {
+    // Custom notification type for a method no layer in the stack handles.
+    // Using `experimental/*` keeps us clear of reserved LSP namespace.
+    enum UnhandledTestNotification {}
+    impl async_lsp::lsp_types::notification::Notification for UnhandledTestNotification {
+        type Params = serde_json::Value;
+        const METHOD: &'static str = "experimental/fe_test_unhandled";
+    }
+
+    client.clear_log_messages();
+
+    client
+        .server
+        .notify::<UnhandledTestNotification>(serde_json::Value::Null)
+        .expect("notify failed");
+    client.settle(200).await;
+
+    let warns = client.log_messages_of_type(MessageType::WARNING);
+    let offending: Vec<&LogMessageParams> = warns
+        .iter()
+        .filter(|m| m.message.contains("Unhandled notification"))
+        .collect();
+
+    assert!(
+        offending.is_empty(),
+        "sending an unknown notification must not emit WARN-level log messages — \
+         `setup_unhandled` in server.rs should log at DEBUG so normal LSP traffic \
+         (e.g. $/cancelRequest, experimental/*) does not flood the editor log. \
+         got: {offending:?}"
     );
 }
 

--- a/crates/language-server/src/mock_client_tests.rs
+++ b/crates/language-server/src/mock_client_tests.rs
@@ -907,3 +907,166 @@ pub contract C {
 
     client.shutdown().await;
 }
+
+/// Reproduction for the "goto def → freeze" bug observed in Zed.
+///
+/// Field observation (log `2061701.log`, 2026-04-06): a burst of ~14
+/// concurrent `textDocument/definition` + `textDocument/typeDefinition`
+/// requests arrived at the LSP within ~400µs after a goto-def click
+/// navigated to another file. The LSP actor thread went to `futex_do_wait`
+/// and never came back. No panic, no response — a genuine deadlock.
+///
+/// This test reliably reproduces the deadlock in ~1 second using the
+/// mock client. Trace-level logging against a local run shows the last
+/// activity before the hang is a salsa query (e.g. `body_references`)
+/// executing on the actor thread — indicating the deadlock is inside
+/// salsa's internal query machinery, not in our tower layers or the
+/// state RwLock (the per-task read guards are re-entrant friendly).
+///
+/// #\[ignore]`d so CI stays green while the underlying bug is being
+/// investigated. Run with:
+///
+///     cargo test -p fe-language-server repro_concurrent_goto -- --ignored
+///
+/// To investigate, rerun with full salsa + act-locally trace:
+///
+///     FE_LSP_LOG='act_locally=trace,salsa=trace,fe_language_server=debug,info' \
+///       FE_LSP_LOG_FILE=/tmp/repro.log \
+///       cargo test -p fe-language-server repro_concurrent_goto -- --ignored
+///
+/// then `tail /tmp/repro.log` to see the last thing the actor was doing.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "known deadlock reproducer — run with --ignored while investigating"]
+async fn repro_concurrent_goto_burst_does_not_deadlock() {
+    let mut client = MockLspClient::start().await;
+    client.initialize().await;
+
+    let uri = lib_url();
+    // Seed lib.fe with content that has multiple cross-file references
+    // to `Why` defined in foo.fe — gives the LSP real cross-file targets
+    // to chase when we fire goto-def.
+    let lib_content = r#"use ingot::foo::Why
+
+mod who {
+  use super::Why
+  pub mod what {
+    pub fn how() {}
+    pub mod how {
+      use ingot::Why
+      pub struct When {
+        x: Why
+      }
+    }
+  }
+  pub struct Bar {
+    x: Why
+  }
+}
+
+fn bar() -> () {
+    let y: Why
+    let z = who::what::how
+    let z: who::what::how::When
+}"#;
+    client.did_open(&uri, lib_content);
+    client.settle(500).await;
+
+    // Fire a burst modeled on the Zed log: definition + hover + references
+    // across several cursor positions. Each position hits a `Why`
+    // identifier somewhere in lib.fe. The LSP should happily process all
+    // of them; if the actor deadlocks, the outer timeout catches it.
+    //
+    // Positions are (line, col) pairs landing on identifiers in
+    // `lib_content`. We re-use them multiple times to get 20+ requests
+    // without calibrating precise offsets.
+    let probe_positions = [
+        (0, 16),  // Why in the top-level `use`
+        (3, 13),  // Why in `use super::Why`
+        (7, 17),  // Why in `use ingot::Why`
+        (9, 11),  // Why in `x: Why` inside When
+        (14, 9),  // Why in `x: Why` inside Bar
+        (19, 11), // Why in `let y: Why`
+        (20, 15), // how in `let z = who::what::how`
+        (21, 20), // When in `let z: who::what::how::When`
+    ];
+
+    // Fire all the requests TRULY CONCURRENTLY, not sequentially. This
+    // is what Zed does on a goto-def click — the log shows 14 requests
+    // arriving within 400µs, well before any of them complete. Each
+    // request goes over the wire as its own JSON-RPC message and the
+    // actor's dispatch loop spawns one detached task per message.
+    //
+    // We clone the `ServerSocket` so we can issue multiple requests
+    // without an `&mut self` bottleneck, then collect the resulting
+    // futures and `join_all` them. The timeout catches the hang if the
+    // actor deadlocks.
+    let socket = client.server.clone();
+    let mut request_futures: Vec<
+        std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>>,
+    > = Vec::new();
+    for _ in 0..3 {
+        for &(line, col) in &probe_positions {
+            let s1 = socket.clone();
+            let uri1 = uri.clone();
+            request_futures.push(Box::pin(async move {
+                let _ = s1
+                    .request::<async_lsp::lsp_types::request::GotoDefinition>(
+                        GotoDefinitionParams {
+                            text_document_position_params: TextDocumentPositionParams {
+                                text_document: TextDocumentIdentifier { uri: uri1 },
+                                position: Position { line, character: col },
+                            },
+                            partial_result_params: PartialResultParams::default(),
+                            work_done_progress_params: WorkDoneProgressParams::default(),
+                        },
+                    )
+                    .await;
+            }));
+            let s2 = socket.clone();
+            let uri2 = uri.clone();
+            request_futures.push(Box::pin(async move {
+                let _ = s2
+                    .request::<async_lsp::lsp_types::request::GotoTypeDefinition>(
+                        async_lsp::lsp_types::request::GotoTypeDefinitionParams {
+                            text_document_position_params: TextDocumentPositionParams {
+                                text_document: TextDocumentIdentifier { uri: uri2 },
+                                position: Position { line, character: col },
+                            },
+                            partial_result_params: PartialResultParams::default(),
+                            work_done_progress_params: WorkDoneProgressParams::default(),
+                        },
+                    )
+                    .await;
+            }));
+            let s3 = socket.clone();
+            let uri3 = uri.clone();
+            request_futures.push(Box::pin(async move {
+                let _ = s3
+                    .request::<async_lsp::lsp_types::request::HoverRequest>(HoverParams {
+                        text_document_position_params: TextDocumentPositionParams {
+                            text_document: TextDocumentIdentifier { uri: uri3 },
+                            position: Position { line, character: col },
+                        },
+                        work_done_progress_params: WorkDoneProgressParams::default(),
+                    })
+                    .await;
+            }));
+        }
+    }
+
+    let total = request_futures.len();
+    let burst = tokio::time::timeout(
+        Duration::from_secs(15),
+        futures::future::join_all(request_futures),
+    )
+    .await;
+
+    assert!(
+        burst.is_ok(),
+        "{total} concurrent goto/hover requests deadlocked (no responses within 15s). \
+         Check the LSP actor thread for futex_do_wait and look at \
+         act-locally's handler.rs for the read-lock-across-await pattern."
+    );
+
+    client.shutdown().await;
+}

--- a/crates/language-server/src/mock_client_tests.rs
+++ b/crates/language-server/src/mock_client_tests.rs
@@ -1019,9 +1019,8 @@ fn bar() -> () {
     // overflows the semaphore by 2 and triggers the `MainLoop::run` dispatch
     // deadlock described in the docstring above.
     let socket = client.server.clone();
-    let mut request_futures: Vec<
-        std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>>,
-    > = Vec::new();
+    let mut request_futures: Vec<std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>>> =
+        Vec::new();
     for _ in 0..3 {
         for &(line, col) in &probe_positions {
             let s1 = socket.clone();
@@ -1032,7 +1031,10 @@ fn bar() -> () {
                         GotoDefinitionParams {
                             text_document_position_params: TextDocumentPositionParams {
                                 text_document: TextDocumentIdentifier { uri: uri1 },
-                                position: Position { line, character: col },
+                                position: Position {
+                                    line,
+                                    character: col,
+                                },
                             },
                             partial_result_params: PartialResultParams::default(),
                             work_done_progress_params: WorkDoneProgressParams::default(),
@@ -1048,7 +1050,10 @@ fn bar() -> () {
                         async_lsp::lsp_types::request::GotoTypeDefinitionParams {
                             text_document_position_params: TextDocumentPositionParams {
                                 text_document: TextDocumentIdentifier { uri: uri2 },
-                                position: Position { line, character: col },
+                                position: Position {
+                                    line,
+                                    character: col,
+                                },
                             },
                             partial_result_params: PartialResultParams::default(),
                             work_done_progress_params: WorkDoneProgressParams::default(),
@@ -1063,7 +1068,10 @@ fn bar() -> () {
                     .request::<async_lsp::lsp_types::request::HoverRequest>(HoverParams {
                         text_document_position_params: TextDocumentPositionParams {
                             text_document: TextDocumentIdentifier { uri: uri3 },
-                            position: Position { line, character: col },
+                            position: Position {
+                                line,
+                                character: col,
+                            },
                         },
                         work_done_progress_params: WorkDoneProgressParams::default(),
                     })

--- a/crates/language-server/src/panic_context.rs
+++ b/crates/language-server/src/panic_context.rs
@@ -1,0 +1,133 @@
+//! Thread-local panic context stack.
+//!
+//! Modeled on rust-analyzer's `DbPanicContext` (see
+//! `rust-lang/rust-analyzer crates/base-db/src/lib.rs:390-432`).
+//!
+//! # What problem this solves
+//!
+//! When an LSP handler panics, the Rust backtrace tells us *where* in the
+//! codebase the panic fired, but not *which user request* was in flight at
+//! the time. A line like `assertion failed at hir/src/foo.rs:142` is
+//! untriagable without knowing which source file the user was hovering
+//! over or completing in. This module gives us that.
+//!
+//! Each request handler pushes a small context frame — the LSP method
+//! name and a short params summary — onto a thread-local stack via
+//! [`enter`]. The frame is popped automatically when the returned
+//! [`PanicContext`] guard drops, including on panic unwinds. The panic
+//! hook reads the stack via [`format_stack`] and includes it in the panic
+//! record written to `panics-<pid>.log`.
+//!
+//! # Thread locality
+//!
+//! Frames live in a `thread_local!` `RefCell<Vec<String>>`, so pushing on
+//! one thread is invisible from another. That's the right semantics for
+//! our actor model: each LSP request runs as a detached task on the
+//! actor's smol `LocalExecutor`, which runs on a dedicated OS thread —
+//! frames pushed by `LspActorService::call` on the main loop thread are
+//! visible when *that thread* panics, and frames pushed inside actor
+//! handlers (on the actor thread) are visible when the actor thread
+//! panics. See also the note about span propagation in
+//! `backend::spawn_on_workers`: worker pool threads have their own
+//! separate context.
+
+use std::cell::RefCell;
+
+thread_local! {
+    static CTX: RefCell<Vec<String>> = const { RefCell::new(Vec::new()) };
+}
+
+/// Push a context frame onto the thread-local stack. The frame is popped
+/// when the returned guard drops, whether normally or during unwind.
+///
+/// Typical use:
+///
+/// ```ignore
+/// let _pctx = panic_context::enter(format!("request: {method} {params:?}"));
+/// // ... handle request ...
+/// // _pctx drops at end of scope, popping the frame.
+/// ```
+#[must_use]
+pub fn enter(frame: String) -> PanicContext {
+    CTX.with(|ctx| ctx.borrow_mut().push(frame));
+    PanicContext(())
+}
+
+/// RAII guard for a context frame. Dropping pops the top of the
+/// thread-local stack. The field is a private `()` so external code
+/// cannot construct one — use [`enter`] instead.
+pub struct PanicContext(());
+
+impl Drop for PanicContext {
+    fn drop(&mut self) {
+        CTX.with(|ctx| {
+            // Pop even on unwind — this preserves stack invariants so
+            // nested enters still balance across panics. If the stack is
+            // unexpectedly empty, just no-op: double-panic would be worse
+            // than a silently skipped pop.
+            let _ = ctx.borrow_mut().pop();
+        });
+    }
+}
+
+/// Render the current thread's context stack as a newline-terminated
+/// string, with frames numbered from the innermost (most recent) to the
+/// outermost. Returns an empty string if the stack is empty.
+///
+/// Called from the panic hook at [`crate::logging::setup_panic_hook`].
+pub fn format_stack() -> String {
+    CTX.with(|ctx| {
+        let stack = ctx.borrow();
+        if stack.is_empty() {
+            return String::new();
+        }
+        let mut out = String::new();
+        for (idx, frame) in stack.iter().rev().enumerate() {
+            out.push_str(&format!("{idx:>4}: {frame}\n"));
+        }
+        out
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_stack_formats_empty() {
+        assert_eq!(format_stack(), "");
+    }
+
+    #[test]
+    fn frames_are_popped_on_drop() {
+        {
+            let _a = enter("outer".to_owned());
+            {
+                let _b = enter("inner".to_owned());
+                let s = format_stack();
+                assert!(s.contains("outer"));
+                assert!(s.contains("inner"));
+                // inner should appear before outer (innermost first)
+                let inner_pos = s.find("inner").unwrap();
+                let outer_pos = s.find("outer").unwrap();
+                assert!(inner_pos < outer_pos);
+            }
+            // After inner drops, only outer remains
+            let s = format_stack();
+            assert!(s.contains("outer"));
+            assert!(!s.contains("inner"));
+        }
+        assert_eq!(format_stack(), "");
+    }
+
+    #[test]
+    fn drop_during_unwind_pops_cleanly() {
+        // Push a frame, panic inside, catch the panic, verify the stack
+        // was popped by the RAII guard drop during unwind.
+        let _ = std::panic::catch_unwind(|| {
+            let _pctx = enter("unwind test".to_owned());
+            panic!("intentional");
+        });
+        assert_eq!(format_stack(), "");
+    }
+}

--- a/crates/language-server/src/server.rs
+++ b/crates/language-server/src/server.rs
@@ -28,7 +28,7 @@ use async_std::stream::StreamExt;
 use futures_batch::ChunksTimeoutStreamExt;
 use tokio::sync::broadcast;
 use tracing::instrument::WithSubscriber;
-use tracing::{info, warn};
+use tracing::{debug, info};
 
 use crate::functionality::{
     call_hierarchy, code_actions, code_lens, codegen_view, completion, declaration,
@@ -241,13 +241,19 @@ fn setup_streams(client: ClientSocket, router: &mut Router<()>) {
 }
 
 fn setup_unhandled(router: &mut Router<()>) {
+    // These fire for any LSP notification/event that Fe doesn't explicitly
+    // handle — $/cancelRequest, $/setTrace, workspace/didChangeConfiguration,
+    // custom experimental/* methods editors send speculatively, etc. That
+    // traffic is completely normal and logging it at warn level floods the
+    // client log and drowns out real warnings. DEBUG so it's visible when
+    // debugging but invisible to end users.
     router
         .unhandled_notification(|_, params| {
-            warn!("Unhandled notification: {:?}", params);
+            debug!("Unhandled notification: {:?}", params);
             std::ops::ControlFlow::Continue(())
         })
         .unhandled_event(|_, params| {
-            warn!("Unhandled event: {:?}", params);
+            debug!("Unhandled event: {:?}", params);
             std::ops::ControlFlow::Continue(())
         });
 }


### PR DESCRIPTION
## Summary

Fixes a cluster of LSP regressions: silent crashes with no visible error, slow cold-start, duplicate `fe lsp` instances spawned by Zed, and debugging-by-spelunking-through-IDE-logs. No new user-facing features. This PR hardens error surfacing, tightens logging, and adds workspace and instance diagnostics so the next LSP bug report is easier to triage.

## What's in here

Four themes, in dependency order:

### Panic surfacing

Worker-thread panics were previously swallowed by the spawn path and left the LSP running in a broken state. Panics now propagate through `WorkerError`, salsa DB context is captured via `DbPanicContext`, and both tracing and the file log receive the frame. A regression test reproduces the silent-swallow behavior pre-fix. Also demotes the `setup_unhandled` notification/event path from `warn` to `debug`, since it fires for normal traffic (`$/cancelRequest`, `$/setTrace`, custom `experimental/*` methods) and was drowning out real warnings.

### Workspace / instance detection

Startup now logs the workspace discovery path and warns when sibling or stale `fe-lsp` processes are present (the "Zed spawned three language servers" symptom). The detector distinguishes `SiblingLive` (another pid for the same workspace root), `StaleFound` (dead pid record), and `Malformed` (unparseable record). Also fixes a custom-target filter matching bug so per-request activity actually surfaces in filtered logs.

### async-lsp upgrade and dispatch-deadlock fix

Drops `micahscopes/async-lsp pub-inner-type-id` in favor of `fe-lang/async-lsp` main. The fe-lang fork is `oxalica/async-lsp 0.2.3` plus two commits for a `MainLoop::run` dispatch deadlock triggered by bursts of `>max_concurrency` concurrent requests (repro: goto-def burst). The regression test `repro_concurrent_goto_burst_does_not_deadlock` runs in the CI default (promoted from `#[ignore]`). An upstream PR to oxalica with the two fix commits is pending; we'll repoint to crates.io once it lands.

### Logging hygiene

File logs now land in `<workspace>/.fe-lsp/` instead of the global `~/.cache/fe-language-server/`. The shared directory meant one workspace's retention budget could evict another's forensic evidence. Retention is 5 files per workspace (down from 50), with a 50 MB rotation cap per session via a new `RotatingFileWriter`, so ~250 MB worst case per workspace. A dual-subscriber setup captures verbose per-request tracing to disk while keeping stderr quiet by default.

## Dependency note

`crates/language-server/Cargo.toml` pins `async-lsp` at `{ git = "https://github.com/fe-lang/async-lsp", branch = "main" }`. `fe-lang/async-lsp` is a fresh org-level fork directly off `oxalica/async-lsp`; the only delta is the two `MainLoop::run` deadlock fixes on top of 0.2.3.

## Test plan

- [x] `cargo test -p fe-language-server`: 93 passed, 0 failed, 1 ignored
- [x] `cargo clippy -p fe-language-server --all-targets`: clean
- [x] `cargo fmt --all -- --check`: clean
- [x] `repro_concurrent_goto_burst_does_not_deadlock` runs in CI default (promoted from `#[ignore]`)
- [x] Manual Zed smoke: cold start, workspace log dir populated, retention enforced
- [ ] Reviewer sanity check of panic-handling path
