### PR TITLE
Release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+[//]: # (towncrier release notes start)

--- a/newsfragments/1383.feature.md
+++ b/newsfragments/1383.feature.md
@@ -1,0 +1,1 @@
+Replace the git resolver backend from git2 (libgit2) to gitoxide (pure Rust). This removes the OpenSSL/libgit2 C dependency and adds sparse checkout support, allowing the resolver to fetch only the required subdirectory of a remote repository instead of the entire tree.

--- a/newsfragments/1386.bugfix.md
+++ b/newsfragments/1386.bugfix.md
@@ -1,0 +1,1 @@
+Suppress downstream type mismatch diagnostics when the underlying type is already invalid. This reduces cascading error noise and makes compiler output easier to read.

--- a/newsfragments/1388.feature.md
+++ b/newsfragments/1388.feature.md
@@ -1,0 +1,1 @@
+Expose missing `Ctx` trait APIs: `origin`, `coinbase`, `prevrandao`, `gaslimit`, `chainid`, `basefee`, `selfbalance`, and `blockhash`.

--- a/newsfragments/1389.bugfix.md
+++ b/newsfragments/1389.bugfix.md
@@ -1,0 +1,1 @@
+Fix chained method call type inference (e.g. `result.map(fn1).map(fn2)`). The compiler now correctly unifies types through canonicalized receivers, resolving incorrect type mismatch errors on valid method chains.

--- a/newsfragments/1392.bugfix.md
+++ b/newsfragments/1392.bugfix.md
@@ -1,0 +1,1 @@
+Overhaul LSP stability and observability: worker-thread panics now surface as visible errors instead of being silently swallowed, a dual-layer logging system writes detailed diagnostics to workspace-local `.fe-lsp/` log files with automatic rotation and retention, and a dispatch-deadlock in concurrent request handling has been fixed via an upgraded async-lsp dependency.

--- a/newsfragments/1393.internal.md
+++ b/newsfragments/1393.internal.md
@@ -1,0 +1,1 @@
+Bump sonatina to eb50941.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.towncrier]
 # Read https://github.com/argotorg/fe/newsfragments/README.md for instructions
 # package = "fe"
-filename = "docs/src/release_notes.md"
+filename = "CHANGELOG.md"
 directory = "newsfragments"
 underlines = ["", ""]
 issue_format = "[#{issue}](https://github.com/argotorg/fe/issues/{issue})"
@@ -10,35 +10,35 @@ title_format = "## {version} ({project_date})"
 
 [[tool.towncrier.type]]
 directory = "feature"
-name = "### Features"
+name = "Features"
 showcontent = true
 
 [[tool.towncrier.type]]
 directory = "bugfix"
-name = "### Bugfixes"
+name = "Bugfixes"
 showcontent = true
 
 [[tool.towncrier.type]]
 directory = "performance"
-name = "### Performance improvements"
+name = "Performance improvements"
 showcontent = true
 
 [[tool.towncrier.type]]
 directory = "doc"
-name = "### Improved Documentation"
+name = "Improved Documentation"
 showcontent = true
 
 [[tool.towncrier.type]]
 directory = "removal"
-name = "### Deprecations and Removals"
+name = "Deprecations and Removals"
 showcontent = true
 
 [[tool.towncrier.type]]
 directory = "internal"
-name = "### Internal Changes - for Fe Contributors"
+name = "Internal Changes - for Fe Contributors"
 showcontent = true
 
 [[tool.towncrier.type]]
 directory = "misc"
-name = "### Miscellaneous changes"
+name = "Miscellaneous changes"
 showcontent = false


### PR DESCRIPTION
- Adds the newsfragments for the changes that happened between 26.0.0 and current master
- creates a `CHANGLOG.md` in root
- some needed settings tuning