### PR TITLE
hir: materialize event encode receiver before reserving encoder head

### DIFF
--- a/crates/fe/tests/fixtures/fe_test/abi_dynamic_payload.fe
+++ b/crates/fe/tests/fixtures/fe_test/abi_dynamic_payload.fe
@@ -1,0 +1,13 @@
+use std::abi::Bytes
+use std::evm::encode_abi_payload
+
+#[test]
+fn test_abi_dynamic_payload_tuple_encoding() uses (evm: Evm) {
+    let payload: (u256, Bytes) = (0xdeadbeef, Bytes::empty())
+    let (ptr, len) = encode_abi_payload(payload)
+
+    assert(len == 96)
+    assert(evm.mload(ptr) == 0xdeadbeef)
+    assert(evm.mload(ptr + 32) == 64)
+    assert(evm.mload(ptr + 64) == 0)
+}


### PR DESCRIPTION
When the emitted tuple of data fields is built inline after reserve_head(), its heap allocation lands inside the encoder's output range and corrupts log data. Bind the tuple (or single field) to `values` before constructing the encoder so its memory is allocated first.