### PR TITLE
Fix panic on invalid depency path, add diagnostic

### DIFF
--- a/crates/common/src/config/dependency.rs
+++ b/crates/common/src/config/dependency.rs
@@ -1,6 +1,7 @@
 use camino::Utf8PathBuf;
 use smol_str::SmolStr;
 use toml::Value;
+use typed_path::{Utf8UnixPath, Utf8WindowsPath};
 use url::Url;
 
 use crate::dependencies::RemoteFiles;
@@ -70,10 +71,10 @@ pub fn parse_dependencies_table(
                         DependencyEntryLocation::WorkspaceCurrent,
                         arguments,
                     ));
-                } else {
+                } else if let Some(path) = parse_dependency_path(&alias, path, diagnostics) {
                     dependencies.push(DependencyEntry::new(
                         alias.clone(),
-                        DependencyEntryLocation::RelativePath(Utf8PathBuf::from(path)),
+                        DependencyEntryLocation::RelativePath(path),
                         crate::dependencies::DependencyArguments::default(),
                     ));
                 }
@@ -127,11 +128,13 @@ pub fn parse_dependencies_table(
                         Err(diag) => diagnostics.push(diag),
                     }
                 } else if let Some(path) = table.get("path").and_then(|value| value.as_str()) {
-                    dependencies.push(DependencyEntry::new(
-                        alias.clone(),
-                        DependencyEntryLocation::RelativePath(Utf8PathBuf::from(path)),
-                        arguments,
-                    ));
+                    if let Some(path) = parse_dependency_path(&alias, path, diagnostics) {
+                        dependencies.push(DependencyEntry::new(
+                            alias.clone(),
+                            DependencyEntryLocation::RelativePath(path),
+                            arguments,
+                        ));
+                    }
                 } else if has_name || (!has_name_field && arguments.version.is_some()) {
                     if arguments.name.is_none() {
                         arguments.name = Some(alias.clone());
@@ -163,6 +166,39 @@ pub fn parse_dependencies_table(
         }
     }
     dependencies
+}
+
+fn parse_dependency_path(
+    alias: &SmolStr,
+    value: &str,
+    diagnostics: &mut Vec<ConfigDiagnostic>,
+) -> Option<Utf8PathBuf> {
+    if value.is_empty() || has_root(value) || has_url_scheme(value) {
+        diagnostics.push(ConfigDiagnostic::InvalidDependencyPath {
+            alias: alias.clone(),
+            value: value.into(),
+        });
+        return None;
+    }
+    Some(Utf8PathBuf::from(value))
+}
+
+fn has_root(value: &str) -> bool {
+    Utf8UnixPath::new(value).has_root() || Utf8WindowsPath::new(value).has_root()
+}
+
+fn has_url_scheme(value: &str) -> bool {
+    let Some((scheme, _)) = value.split_once(':') else {
+        return false;
+    };
+    let Some(first) = scheme.chars().next() else {
+        return false;
+    };
+    first.is_ascii_alphabetic()
+        && scheme
+            .chars()
+            .skip(1)
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '+' | '-' | '.'))
 }
 
 fn parse_git_dependency(

--- a/crates/common/src/config/mod.rs
+++ b/crates/common/src/config/mod.rs
@@ -115,33 +115,40 @@ pub fn is_workspace_content(content: &str) -> bool {
 }
 
 impl IngotConfig {
-    pub fn dependencies(&self, base_url: &Url) -> Vec<Dependency> {
-        self.dependency_entries
-            .iter()
-            .map(|dependency| match &dependency.location {
+    pub fn dependencies(&self, base_url: &Url) -> (Vec<Dependency>, Vec<ConfigDiagnostic>) {
+        let mut dependencies = Vec::new();
+        let mut diagnostics = Vec::new();
+        for dependency in &self.dependency_entries {
+            match &dependency.location {
                 DependencyEntryLocation::RelativePath(path) => {
-                    let url = base_url.join_directory(path).unwrap();
-                    Dependency {
-                        alias: dependency.alias.clone(),
-                        arguments: dependency.arguments.clone(),
-                        location: DependencyLocation::Local(LocalFiles {
-                            path: path.clone(),
-                            url,
+                    match base_url.join_directory(path) {
+                        Ok(url) => dependencies.push(Dependency {
+                            alias: dependency.alias.clone(),
+                            arguments: dependency.arguments.clone(),
+                            location: DependencyLocation::Local(LocalFiles {
+                                path: path.clone(),
+                                url,
+                            }),
+                        }),
+                        Err(_) => diagnostics.push(ConfigDiagnostic::InvalidDependencyPath {
+                            alias: dependency.alias.clone(),
+                            value: path.as_str().into(),
                         }),
                     }
                 }
-                DependencyEntryLocation::Remote(remote) => Dependency {
+                DependencyEntryLocation::Remote(remote) => dependencies.push(Dependency {
                     alias: dependency.alias.clone(),
                     arguments: dependency.arguments.clone(),
                     location: DependencyLocation::Remote(remote.clone()),
-                },
-                DependencyEntryLocation::WorkspaceCurrent => Dependency {
+                }),
+                DependencyEntryLocation::WorkspaceCurrent => dependencies.push(Dependency {
                     alias: dependency.alias.clone(),
                     arguments: dependency.arguments.clone(),
                     location: DependencyLocation::WorkspaceCurrent,
-                },
-            })
-            .collect()
+                }),
+            }
+        }
+        (dependencies, diagnostics)
     }
 
     pub fn formatted_diagnostics(&self) -> Option<String> {
@@ -180,6 +187,10 @@ pub enum ConfigDiagnostic {
     InvalidDependencyAlias(SmolStr),
     InvalidDependencyName(SmolStr),
     InvalidDependencyVersion(SmolStr),
+    InvalidDependencyPath {
+        alias: SmolStr,
+        value: SmolStr,
+    },
     MissingDependencyPath {
         alias: SmolStr,
         description: String,
@@ -254,6 +265,12 @@ impl Display for ConfigDiagnostic {
             }
             Self::InvalidDependencyVersion(version) => {
                 write!(f, "Invalid dependency version \"{version}\"")
+            }
+            Self::InvalidDependencyPath { alias, value } => {
+                write!(
+                    f,
+                    "The dependency \"{alias}\" has an invalid path \"{value}\""
+                )
             }
             Self::MissingDependencyPath { alias, description } => write!(
                 f,
@@ -498,6 +515,17 @@ fn format_field_path(parent: &str, key: &str) -> String {
 mod tests {
     use super::*;
 
+    use crate::dependencies::DependencyArguments;
+
+    fn dependencies(config: &IngotConfig, base: &Url) -> Vec<Dependency> {
+        let (dependencies, diagnostics) = config.dependencies(base);
+        assert!(
+            diagnostics.is_empty(),
+            "unexpected dependency diagnostics: {diagnostics:?}"
+        );
+        dependencies
+    }
+
     #[test]
     fn parses_git_dependency_entry() {
         let toml = r#"
@@ -518,7 +546,7 @@ remote = { source = "https://example.com/fe.git", rev = "abcd1234", path = "cont
             config.diagnostics
         );
         let base = Url::parse("file:///workspace/root/").unwrap();
-        let dependencies = config.dependencies(&base);
+        let dependencies = dependencies(&config, &base);
         assert_eq!(dependencies.len(), 1);
         match &dependencies[0].location {
             DependencyLocation::Remote(remote) => {
@@ -563,6 +591,72 @@ invalid_source = { source = "not a url", rev = "1234" }
     }
 
     #[test]
+    fn reports_diagnostics_for_invalid_dependency_paths() {
+        let toml = r#"
+[ingot]
+name = "root"
+version = "1.0.0"
+
+[dependencies]
+invalid_url = "http://[::1"
+invalid_file = { path = "file:///tmp/dep" }
+invalid_absolute = { path = "/tmp/dep" }
+invalid_windows_root = { path = '\tmp\dep' }
+invalid_windows_unc = { path = '\\server\share\dep' }
+invalid_empty = { path = "" }
+"#;
+        let config_file = Config::parse(toml).expect("config parses");
+        let Config::Ingot(config) = config_file else {
+            panic!("expected ingot config");
+        };
+        assert!(config.dependency_entries.is_empty());
+
+        for (expected_alias, expected_value) in [
+            ("invalid_url", "http://[::1"),
+            ("invalid_file", "file:///tmp/dep"),
+            ("invalid_absolute", "/tmp/dep"),
+            ("invalid_windows_root", r"\tmp\dep"),
+            ("invalid_windows_unc", r"\\server\share\dep"),
+            ("invalid_empty", ""),
+        ] {
+            assert!(config.diagnostics.iter().any(|diag| {
+                matches!(
+                    diag,
+                    ConfigDiagnostic::InvalidDependencyPath { alias, value }
+                        if alias.as_str() == expected_alias && value.as_str() == expected_value
+                )
+            }));
+        }
+    }
+
+    #[test]
+    fn reports_diagnostics_for_dependency_url_join_errors() {
+        let config = IngotConfig {
+            metadata: IngotMetadata::default(),
+            arithmetic: None,
+            dependency_arithmetic: None,
+            profiles: BTreeMap::new(),
+            dependency_entries: vec![DependencyEntry::new(
+                SmolStr::new("dep"),
+                DependencyEntryLocation::RelativePath("http://[::1".into()),
+                DependencyArguments::default(),
+            )],
+            diagnostics: Vec::new(),
+        };
+
+        let (dependencies, diagnostics) =
+            config.dependencies(&Url::parse("file:///workspace/root/").unwrap());
+
+        assert!(dependencies.is_empty());
+        assert_eq!(diagnostics.len(), 1);
+        assert!(matches!(
+            &diagnostics[0],
+            ConfigDiagnostic::InvalidDependencyPath { alias, value }
+                if alias.as_str() == "dep" && value.as_str() == "http://[::1"
+        ));
+    }
+
+    #[test]
     fn parses_name_only_dependency() {
         let toml = r#"
 [ingot]
@@ -577,12 +671,11 @@ util = { name = "utils" }
             panic!("expected ingot config");
         };
         assert_eq!(
-            config
-                .dependencies(&Url::parse("file:///workspace/root/").unwrap())
-                .len(),
+            dependencies(&config, &Url::parse("file:///workspace/root/").unwrap()).len(),
             1
         );
-        let dependency = &config.dependencies(&Url::parse("file:///workspace/root/").unwrap())[0];
+        let dependencies = dependencies(&config, &Url::parse("file:///workspace/root/").unwrap());
+        let dependency = &dependencies[0];
         assert_eq!(dependency.arguments.name.as_deref(), Some("utils"));
         assert!(matches!(
             dependency.location,
@@ -604,7 +697,8 @@ util = true
         let Config::Ingot(config) = config_file else {
             panic!("expected ingot config");
         };
-        let dependency = &config.dependencies(&Url::parse("file:///workspace/root/").unwrap())[0];
+        let dependencies = dependencies(&config, &Url::parse("file:///workspace/root/").unwrap());
+        let dependency = &dependencies[0];
         assert_eq!(dependency.arguments.name.as_deref(), Some("util"));
         assert!(matches!(
             dependency.location,
@@ -626,7 +720,8 @@ util = "0.1.0"
         let Config::Ingot(config) = config_file else {
             panic!("expected ingot config");
         };
-        let dependency = &config.dependencies(&Url::parse("file:///workspace/root/").unwrap())[0];
+        let dependencies = dependencies(&config, &Url::parse("file:///workspace/root/").unwrap());
+        let dependency = &dependencies[0];
         assert_eq!(dependency.arguments.name.as_deref(), Some("util"));
         assert_eq!(
             dependency

--- a/crates/common/src/ingot.rs
+++ b/crates/common/src/ingot.rs
@@ -215,41 +215,43 @@ impl<'db> Ingot<'db> {
                 graph_deps
             } else {
                 match self.config(db) {
-                    Some(config) => config
-                        .dependencies(&base_url)
-                        .into_iter()
-                        .filter_map(|dependency| {
-                            let url = match &dependency.location {
-                                DependencyLocation::Remote(remote) => db
-                                    .dependency_graph()
-                                    .local_for_remote_git(db, remote)
-                                    .unwrap_or_else(|| remote.source.clone()),
-                                DependencyLocation::Local(local) => local.url.clone(),
-                                DependencyLocation::WorkspaceCurrent => {
-                                    let name = dependency.arguments.name.clone()?;
-                                    let workspace_root = db
+                    Some(config) => {
+                        let (dependencies, _) = config.dependencies(&base_url);
+                        dependencies
+                            .into_iter()
+                            .filter_map(|dependency| {
+                                let url = match &dependency.location {
+                                    DependencyLocation::Remote(remote) => db
                                         .dependency_graph()
-                                        .workspace_root_for_member(db, &base_url)?;
-                                    let candidates = db
-                                        .dependency_graph()
-                                        .workspace_members_by_name(db, &workspace_root, &name);
-                                    let selected =
-                                        if let Some(version) = &dependency.arguments.version {
-                                            candidates.iter().find(|member| {
-                                                member.version.as_ref() == Some(version)
-                                            })
-                                        } else if candidates.len() == 1 {
-                                            candidates.first()
-                                        } else {
-                                            None
-                                        };
-                                    let member = selected?;
-                                    member.url.clone()
-                                }
-                            };
-                            Some((dependency.alias.clone(), url))
-                        })
-                        .collect(),
+                                        .local_for_remote_git(db, remote)
+                                        .unwrap_or_else(|| remote.source.clone()),
+                                    DependencyLocation::Local(local) => local.url.clone(),
+                                    DependencyLocation::WorkspaceCurrent => {
+                                        let name = dependency.arguments.name.clone()?;
+                                        let workspace_root = db
+                                            .dependency_graph()
+                                            .workspace_root_for_member(db, &base_url)?;
+                                        let candidates = db
+                                            .dependency_graph()
+                                            .workspace_members_by_name(db, &workspace_root, &name);
+                                        let selected =
+                                            if let Some(version) = &dependency.arguments.version {
+                                                candidates.iter().find(|member| {
+                                                    member.version.as_ref() == Some(version)
+                                                })
+                                            } else if candidates.len() == 1 {
+                                                candidates.first()
+                                            } else {
+                                                None
+                                            };
+                                        let member = selected?;
+                                        member.url.clone()
+                                    }
+                                };
+                                Some((dependency.alias.clone(), url))
+                            })
+                            .collect()
+                    }
                     None => vec![],
                 }
             }

--- a/crates/driver/src/ingot_handler.rs
+++ b/crates/driver/src/ingot_handler.rs
@@ -1173,6 +1173,9 @@ impl<'a> ResolutionHandler<IngotResolverImpl> for IngotHandler<'a> {
             diagnostics.retain(|diag| !matches!(diag, ConfigDiagnostic::MissingVersion));
         }
 
+        let (config_dependencies, dependency_diagnostics) = config.dependencies(&ingot_url);
+        diagnostics.extend(dependency_diagnostics);
+
         if !diagnostics.is_empty() {
             match &origin {
                 IngotOrigin::Local => self.report_warn(IngotInitDiagnostics::ConfigDiagnostics {
@@ -1276,7 +1279,7 @@ impl<'a> ResolutionHandler<IngotResolverImpl> for IngotHandler<'a> {
             &config,
         );
         let mut dependencies = Vec::new();
-        for dependency in config.dependencies(&ingot_url) {
+        for dependency in config_dependencies {
             let is_external = self.is_external_dependency(workspace_root.as_ref(), &dependency);
             if let Some(converted) =
                 self.convert_dependency(&ingot_url, &origin, workspace_root.as_ref(), dependency)

--- a/crates/fe/tests/fixtures/cli_output/ingots/invalid_dependency_path/fe.toml
+++ b/crates/fe/tests/fixtures/cli_output/ingots/invalid_dependency_path/fe.toml
@@ -1,0 +1,6 @@
+[ingot]
+name = "invalid_dependency_path"
+version = "0.1.0"
+
+[dependencies]
+dep = "http://[::1"

--- a/crates/fe/tests/fixtures/cli_output/ingots/invalid_dependency_path/invalid_dependency_path.snap
+++ b/crates/fe/tests/fixtures/cli_output/ingots/invalid_dependency_path/invalid_dependency_path.snap
@@ -1,0 +1,8 @@
+---
+source: crates/fe/tests/cli_output.rs
+expression: output
+---
+=== STDERR ===
+Error: Invalid fe.toml in ingot file://<project>/crates/fe/tests/fixtures/cli_output/ingots/invalid_dependency_path/: The dependency "dep" has an invalid path "http://[::1"
+
+=== EXIT CODE: 1 ===

--- a/crates/fe/tests/fixtures/cli_output/ingots/invalid_dependency_path/invalid_dependency_path_tree.snap
+++ b/crates/fe/tests/fixtures/cli_output/ingots/invalid_dependency_path/invalid_dependency_path_tree.snap
@@ -1,0 +1,12 @@
+---
+source: crates/fe/tests/cli_output.rs
+assertion_line: 528
+expression: output
+---
+=== STDOUT ===
+invalid_dependency_path v0.1.0
+
+=== STDERR ===
+Error: Invalid fe.toml in ingot file://<project>/crates/fe/tests/fixtures/cli_output/ingots/invalid_dependency_path/: The dependency "dep" has an invalid path "http://[::1"
+
+=== EXIT CODE: 1 ===

--- a/crates/fe/tests/fixtures/cli_output/ingots/invalid_dependency_path/src/lib.fe
+++ b/crates/fe/tests/fixtures/cli_output/ingots/invalid_dependency_path/src/lib.fe
@@ -1,0 +1,1 @@
+pub fn main() {}


### PR DESCRIPTION
Fix for @g-r-a-n-t's F-002:

| `F-002` | crash | open | minimal | `repros/F-002-dependency-url-panic` | Invalid dependency URL panics instead of producing a diagnostic. |
