### PR TITLE
Fix StorageBytes ABI return allocation

### DIFF
--- a/crates/fe/tests/fixtures/fe_test/storage_bytes_encode_return.fe
+++ b/crates/fe/tests/fixtures/fe_test/storage_bytes_encode_return.fe
@@ -1,0 +1,83 @@
+use core::abi::Bytes
+use std::evm::{Address, Call, Create, Evm, RawMem, StorageBytes, assert, decode_returndata, last_returndata, mem}
+
+type Blobs = StorageBytes<u256, 0, 1>
+
+msg BlobMsg {
+    #[selector = 0x01]
+    Set { data: Bytes },
+    #[selector = 0x02]
+    Get,
+}
+
+pub contract Blob {
+    recv BlobMsg {
+        Set { data } {
+            let blobs: Blobs = Blobs::new()
+            blobs.store_view(key: 0, view: data.view())
+        }
+
+        Get {} {
+            let blobs: Blobs = Blobs::new()
+            blobs.encode_return(key: 0)
+        }
+    }
+}
+
+fn multi_word_payload() -> Bytes
+uses (evm: mut Evm)
+{
+    let payload_len: u256 = 65
+    let payload_size: u256 = 128
+    let data_ptr = mem::alloc(payload_size)
+
+    evm.mstore(addr: data_ptr, value: payload_len)
+    evm.mstore(
+        addr: data_ptr + 32,
+        value: 0x1111111111111111111111111111111111111111111111111111111111111111,
+    )
+    evm.mstore(
+        addr: data_ptr + 64,
+        value: 0x2222222222222222222222222222222222222222222222222222222222222222,
+    )
+    evm.mstore(
+        addr: data_ptr + 96,
+        value: 0x3300000000000000000000000000000000000000000000000000000000000000,
+    )
+
+    Bytes { data: data_ptr, len: payload_len, size: payload_size }
+}
+
+fn raw_get(addr: Address) -> Bytes
+uses (evm: mut Evm)
+{
+    let ptr = mem::alloc(4)
+    evm.mstore(addr: ptr, value: (0x02 as u256) << 224)
+    assert(evm.raw_call(addr: addr, gas: 1000000, value: 0, args_offset: ptr, args_len: 4))
+
+    let returned: Bytes = decode_returndata(last_returndata())
+    returned
+}
+
+#[test]
+fn test_storage_bytes_encode_return_multi_word()
+uses (evm: mut Evm)
+{
+    let blob = evm.create2<Blob>(value: 0, args: (), salt: 0)
+    assert(blob.inner != 0)
+
+    evm.call(
+        addr: blob,
+        gas: 1000000,
+        value: 0,
+        message: BlobMsg::Set { data: multi_word_payload() },
+    )
+
+    let returned = raw_get(addr: blob)
+    assert(returned.len() == 65)
+    assert(returned.byte_at(0) == 0x11)
+    assert(returned.byte_at(31) == 0x11)
+    assert(returned.byte_at(32) == 0x22)
+    assert(returned.byte_at(63) == 0x22)
+    assert(returned.byte_at(64) == 0x33)
+}

--- a/ingots/std/src/evm/storage_bytes.fe
+++ b/ingots/std/src/evm/storage_bytes.fe
@@ -56,21 +56,26 @@ fn copy_view_words_to_memory<I>(_ view: BytesView<I>, _ dest: u256)
 ///
 /// `data_ptr` is a raw calldata byte offset.
 pub fn encode_bytes_return_from_calldata(data_ptr: u256, len: u256) -> ! {
-    ops::mstore(addr: 0, value: 32)
-    ops::mstore(addr: 32, value: len)
-    ops::calldatacopy(dest: 64, offset: data_ptr, len: len)
-    zero_pad_memory_bytes(ptr: 64, len: len)
-    ops::return_data(offset: 0, len: 64 + ceil_words(len) * 32)
+    let total_len = 64 + ceil_words(len) * 32
+    let ptr = mem::alloc(total_len)
+    ops::mstore(addr: ptr, value: 32)
+    ops::mstore(addr: ptr + 32, value: len)
+    ops::calldatacopy(dest: ptr + 64, offset: data_ptr, len: len)
+    zero_pad_memory_bytes(ptr: ptr + 64, len: len)
+    ops::return_data(offset: ptr, len: total_len)
 }
 
 /// Return ABI-encoded `bytes` copied from an arbitrary byte view.
 pub fn encode_bytes_return_view<I>(view: BytesView<I>) -> !
     where I: ByteInput
 {
-    ops::mstore(addr: 0, value: 32)
-    ops::mstore(addr: 32, value: view.len())
-    copy_view_words_to_memory(view, 64)
-    ops::return_data(offset: 0, len: 64 + ceil_words(view.len()) * 32)
+    let len = view.len()
+    let total_len = 64 + ceil_words(len) * 32
+    let ptr = mem::alloc(total_len)
+    ops::mstore(addr: ptr, value: 32)
+    ops::mstore(addr: ptr + 32, value: len)
+    copy_view_words_to_memory(view, ptr + 64)
+    ops::return_data(offset: ptr, len: total_len)
 }
 
 /// Emit a Solidity-compatible event with a single dynamic `bytes` payload.
@@ -187,16 +192,18 @@ impl<K: StorageKey + Copy, const LEN_SALT: u256, const WORD_SALT: u256>
         let words: StorageMap<(K, u256), u256, WORD_SALT> = StorageMap::new()
 
         let len = lengths.get(key)
-        ops::mstore(addr: 0, value: 32)
-        ops::mstore(addr: 32, value: len)
-
         let word_count = ceil_words(len)
+        let total_len = 64 + word_count * 32
+        let ptr = mem::alloc(total_len)
+        ops::mstore(addr: ptr, value: 32)
+        ops::mstore(addr: ptr + 32, value: len)
+
         let mut i: u256 = 0
         while i < word_count {
-            ops::mstore(addr: 64 + i * 32, value: words.get((key, i)))
+            ops::mstore(addr: ptr + 64 + i * 32, value: words.get((key, i)))
             i += 1
         }
 
-        ops::return_data(offset: 0, len: 64 + word_count * 32)
+        ops::return_data(offset: ptr, len: total_len)
     }
 }


### PR DESCRIPTION
Fix for @g-r-a-n-t's F-005:

| `F-005` | std/runtime bug | open | minimal | `repros/F-005-storage-bytes-encode-return` | StorageBytes.encode_return` fails for multi-word bytes. |