### PR TITLE
Add static_assert

### DIFF
--- a/crates/fe/src/extract.rs
+++ b/crates/fe/src/extract.rs
@@ -233,7 +233,7 @@ impl<'db> DocExtractor<'db> {
     pub fn extract_item(&self, item: ItemKind<'db>) -> Option<DocItem> {
         // Skip items that shouldn't be documented
         match item {
-            ItemKind::Use(_) | ItemKind::Body(_) => return None,
+            ItemKind::StaticAssert(_) | ItemKind::Use(_) | ItemKind::Body(_) => return None,
             _ => {}
         }
 
@@ -309,7 +309,7 @@ impl<'db> DocExtractor<'db> {
             ItemKind::Const(_) => Some(DocItemKind::Const),
             ItemKind::Impl(_) => Some(DocItemKind::Impl),
             ItemKind::ImplTrait(_) => Some(DocItemKind::ImplTrait),
-            ItemKind::Use(_) | ItemKind::Body(_) => None,
+            ItemKind::StaticAssert(_) | ItemKind::Use(_) | ItemKind::Body(_) => None,
         }
     }
 
@@ -796,7 +796,10 @@ impl<'db> DocExtractor<'db> {
                     // Use ingot-aware builder for inline modules too
                     children.push(self.build_module_node_for_ingot_inline(ingot, child));
                 }
-                ItemKind::Use(_) | ItemKind::Body(_) | ItemKind::TopMod(_) => {}
+                ItemKind::StaticAssert(_)
+                | ItemKind::Use(_)
+                | ItemKind::Body(_)
+                | ItemKind::TopMod(_) => {}
                 _ => {
                     if let (Some(name), Some(kind)) =
                         (child.name(self.db), self.item_kind_to_doc_kind(child))
@@ -867,7 +870,7 @@ impl<'db> DocExtractor<'db> {
                 ItemKind::Mod(_) | ItemKind::TopMod(_) => {
                     children.push(self.build_module_node_for_ingot_inline(ingot, child));
                 }
-                ItemKind::Use(_) | ItemKind::Body(_) => {}
+                ItemKind::StaticAssert(_) | ItemKind::Use(_) | ItemKind::Body(_) => {}
                 _ => {
                     if let (Some(name), Some(kind)) =
                         (child.name(self.db), self.item_kind_to_doc_kind(child))
@@ -926,7 +929,7 @@ impl<'db> DocExtractor<'db> {
                 ItemKind::Mod(_) | ItemKind::TopMod(_) => {
                     children.push(self.build_module_node(child));
                 }
-                ItemKind::Use(_) | ItemKind::Body(_) => {}
+                ItemKind::StaticAssert(_) | ItemKind::Use(_) | ItemKind::Body(_) => {}
                 _ => {
                     if let (Some(name), Some(kind)) =
                         (child.name(self.db), self.item_kind_to_doc_kind(child))

--- a/crates/fmt/src/ast/items.rs
+++ b/crates/fmt/src/ast/items.rs
@@ -29,7 +29,9 @@ fn token_piece_basic<'a>(
     Some(match token.kind() {
         FnKw => TokenPiece::new(alloc.nil()),
         PubKw | UnsafeKw | MutKw | StructKw | ContractKw | EnumKw | TraitKw | MsgKw | ModKw
-        | UseKw | ConstKw | TypeKw | ExternKw => TokenPiece::new(text).space_after(),
+        | UseKw | ConstKw | StaticAssertKw | TypeKw | ExternKw => {
+            TokenPiece::new(text).space_after()
+        }
         ImplKw => TokenPiece::new(text),
         ForKw => TokenPiece::new(text).space_before(),
         Eq | Arrow => TokenPiece::new(text).spaces(),
@@ -351,6 +353,7 @@ impl ToDoc for ast::Item {
             Some(ItemKind::Trait(trait_)) => trait_.to_doc(ctx),
             Some(ItemKind::ImplTrait(impl_trait)) => impl_trait.to_doc(ctx),
             Some(ItemKind::Const(const_)) => const_.to_doc(ctx),
+            Some(ItemKind::StaticAssert(assert_)) => assert_.to_doc(ctx),
             Some(ItemKind::Use(use_)) => use_.to_doc(ctx),
             Some(ItemKind::Extern(extern_)) => extern_.to_doc(ctx),
             Some(ItemKind::Msg(msg)) => msg.to_doc(ctx),
@@ -1360,6 +1363,25 @@ impl ToDoc for ast::Const {
             .append(name)
             .append(ty_doc)
             .append(value_doc)
+    }
+}
+
+impl ToDoc for ast::StaticAssert {
+    fn to_doc<'a>(&self, ctx: &'a RewriteContext<'a>) -> Doc<'a> {
+        let alloc = &ctx.alloc;
+
+        token_doc_item_like_if_comments!(self, ctx);
+
+        let attrs = attrs_doc(self, ctx);
+        let condition = self
+            .condition()
+            .map(|condition| condition.to_doc(ctx))
+            .unwrap_or_else(|| alloc.nil());
+
+        attrs
+            .append(alloc.text("static_assert("))
+            .append(condition)
+            .append(alloc.text(")"))
     }
 }
 

--- a/crates/hir/src/analysis/diagnostics.rs
+++ b/crates/hir/src/analysis/diagnostics.rs
@@ -3021,6 +3021,30 @@ impl DiagnosticVoucher for BodyDiag<'_> {
                 error_code,
             ),
 
+            Self::StaticAssertFailed {
+                primary,
+                comparison,
+            } => {
+                let mut notes = Vec::new();
+                if let Some(comparison) = comparison {
+                    notes.push(format!("left: `{}`", comparison.lhs));
+                    notes.push(format!("right: `{}`", comparison.rhs));
+                    notes.push(format!("operator: `{}`", comparison.op.symbol()));
+                }
+
+                CompleteDiagnostic {
+                    severity,
+                    message: "static assertion failed".to_string(),
+                    sub_diagnostics: vec![SubDiagnostic {
+                        style: LabelStyle::Primary,
+                        message: "`static_assert` evaluated to `false`".to_string(),
+                        span: primary.resolve(db),
+                    }],
+                    notes,
+                    error_code,
+                }
+            }
+
             Self::InvalidCast {
                 primary,
                 from,

--- a/crates/hir/src/analysis/name_resolution/path_resolver.rs
+++ b/crates/hir/src/analysis/name_resolution/path_resolver.rs
@@ -1529,7 +1529,7 @@ pub fn resolve_name_res<'db>(
                     }
                 }
 
-                ItemKind::Use(_) | ItemKind::Body(_) => unreachable!(),
+                ItemKind::StaticAssert(_) | ItemKind::Use(_) | ItemKind::Body(_) => unreachable!(),
             },
             ScopeId::GenericParam(parent, idx) => {
                 let owner = GenericParamOwner::from_item_opt(parent).unwrap();

--- a/crates/hir/src/analysis/semantic/borrowck/check.rs
+++ b/crates/hir/src/analysis/semantic/borrowck/check.rs
@@ -222,6 +222,7 @@ fn collect_top_mod_semantic_borrow_diagnostic_vouchers<'db>(
             | ItemKind::Impl(_)
             | ItemKind::ImplTrait(_)
             | ItemKind::TypeAlias(_)
+            | ItemKind::StaticAssert(_)
             | ItemKind::Use(_)
             | ItemKind::TopMod(_)
             | ItemKind::Body(_) => {}

--- a/crates/hir/src/analysis/semantic/consts.rs
+++ b/crates/hir/src/analysis/semantic/consts.rs
@@ -20,6 +20,75 @@ pub struct SemConstId<'db> {
     pub value: SemConstValue<'db>,
 }
 
+impl<'db> SemConstId<'db> {
+    pub fn pretty_print(self, db: &'db dyn HirAnalysisDb) -> String {
+        match self.value(db) {
+            SemConstValue::Unit => "()".to_string(),
+            SemConstValue::Scalar { value, .. } => match value {
+                SemConstScalar::Bool(value) => value.to_string(),
+                SemConstScalar::Int { value } => value.to_string(),
+                SemConstScalar::Bytes(bytes) => {
+                    let hex = bytes
+                        .iter()
+                        .map(|byte| format!("{byte:02x}"))
+                        .collect::<String>();
+                    format!("0x{hex}")
+                }
+            },
+            SemConstValue::TypeLevel { const_ty, .. } => const_ty.pretty_print(db).to_string(),
+            SemConstValue::Tuple { elems, .. } => {
+                let elems = elems
+                    .iter()
+                    .map(|elem| elem.pretty_print(db))
+                    .collect::<Vec<_>>();
+                if elems.len() == 1 {
+                    format!("({},)", elems[0])
+                } else {
+                    format!("({})", elems.join(", "))
+                }
+            }
+            SemConstValue::Struct { ty, fields } => {
+                let fields = fields
+                    .iter()
+                    .map(|field| field.pretty_print(db))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                format!("{}({fields})", ty.pretty_print(db))
+            }
+            SemConstValue::Array { elems, .. } => {
+                let elems = elems
+                    .iter()
+                    .map(|elem| elem.pretty_print(db))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                format!("[{elems}]")
+            }
+            SemConstValue::Enum {
+                ty,
+                variant,
+                fields,
+            } => {
+                let variant_name = ty
+                    .as_enum(db)
+                    .and_then(|enum_| enum_.variants(db).nth(variant.0 as usize))
+                    .and_then(|variant| variant.name(db))
+                    .map(|name| name.data(db).to_string())
+                    .unwrap_or_else(|| "<unknown>".to_string());
+                let fields = fields
+                    .iter()
+                    .map(|field| field.pretty_print(db))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                if fields.is_empty() {
+                    format!("{}::{variant_name}", ty.pretty_print(db))
+                } else {
+                    format!("{}::{variant_name}({fields})", ty.pretty_print(db))
+                }
+            }
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Update)]
 pub enum SemConstValue<'db> {
     Unit,

--- a/crates/hir/src/analysis/ty/diagnostics.rs
+++ b/crates/hir/src/analysis/ty/diagnostics.rs
@@ -12,7 +12,8 @@ use crate::{analysis::name_resolution::diagnostics::PathResDiag, hir_def::ItemKi
 use crate::{analysis::ty::ty_check::EffectParamOwner, span::DynLazySpan};
 use crate::{
     core::hir_def::{
-        CallableDef, Enum, FieldIndex, FieldParent, Func, GenericParamOwner, IdentId, ImplTrait,
+        CallableDef, CompBinOp, Enum, FieldIndex, FieldParent, Func, GenericParamOwner, IdentId,
+        ImplTrait,
     },
     hir_def::TypeAlias,
 };
@@ -224,6 +225,13 @@ pub struct CallConstraintDiagInfo<'db> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Update)]
+pub struct StaticAssertComparisonValues {
+    pub op: CompBinOp,
+    pub lhs: String,
+    pub rhs: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Update)]
 pub enum BodyDiag<'db> {
     TypeMismatch {
         span: DynLazySpan<'db>,
@@ -391,6 +399,10 @@ pub enum BodyDiag<'db> {
 
     TypeMustBeKnown(DynLazySpan<'db>),
     ConstValueMustBeKnown(DynLazySpan<'db>),
+    StaticAssertFailed {
+        primary: DynLazySpan<'db>,
+        comparison: Option<StaticAssertComparisonValues>,
+    },
 
     InvalidCast {
         primary: DynLazySpan<'db>,
@@ -769,6 +781,7 @@ impl<'db> BodyDiag<'db> {
             Self::TypeMustBeKnown(..) => 14,
             Self::InvalidCast { .. } => 55,
             Self::ConstValueMustBeKnown(..) => 64,
+            Self::StaticAssertFailed { .. } => 81,
             Self::AccessedFieldNotFound { .. } => 15,
             Self::OpsTraitNotImplemented { .. } => 16,
             Self::UnsupportedUnaryPlus(..) => 52,

--- a/crates/hir/src/analysis/ty/mod.rs
+++ b/crates/hir/src/analysis/ty/mod.rs
@@ -346,6 +346,7 @@ fn walk<'db>(
                 | ItemKind::Trait(_) => Domain::Type,
 
                 ItemKind::TopMod(_)
+                | ItemKind::StaticAssert(_)
                 | ItemKind::Use(_)
                 | ItemKind::Impl(_)
                 | ItemKind::ImplTrait(_)
@@ -392,6 +393,14 @@ impl ModuleAnalysisPass for BodyAnalysisPass {
                     _ => None,
                 })
                 .flat_map(|const_| &ty_check::check_const_body(db, const_).0)
+                .map(|diag| diag.to_voucher()),
+        );
+
+        diags.extend(
+            top_mod
+                .all_static_asserts(db)
+                .iter()
+                .flat_map(|assert_| ty_check::check_static_assert(db, *assert_).iter())
                 .map(|diag| diag.to_voucher()),
         );
 

--- a/crates/hir/src/analysis/ty/ty_check/mod.rs
+++ b/crates/hir/src/analysis/ty/ty_check/mod.rs
@@ -24,9 +24,10 @@ use crate::analysis::ty::visitor::TyVisitable;
 use crate::hir_def::CallableDef;
 use crate::{
     hir_def::{
-        Body, Const, Contract, ContractRecvArm, Expr, ExprId, Func, GenericParam,
+        BinOp, Body, Const, Contract, ContractRecvArm, Expr, ExprId, Func, GenericParam,
         GenericParamOwner, ItemKind, LitKind, ManualContractRootAttr, Partial, Pat, PatId, PathId,
-        Stmt, StmtId, StringId, TypeBound, TypeId as HirTyId, WhereClauseOwner,
+        StaticAssert, StaticAssertComparison, Stmt, StmtId, StringId, TypeBound, TypeId as HirTyId,
+        WhereClauseOwner,
     },
     span::{
         DynLazySpan, expr::LazyExprSpan, pat::LazyPatSpan, path::LazyPathSpan, types::LazyTySpan,
@@ -56,8 +57,8 @@ use super::{
     assoc_const::AssocConstUse,
     canonical::Canonical,
     diagnostics::{
-        BodyDiag, CallConstraintDiagInfo, FuncBodyDiag, TraitConstraintDiag, TyDiagCollection,
-        TyLowerDiag,
+        BodyDiag, CallConstraintDiagInfo, FuncBodyDiag, StaticAssertComparisonValues,
+        TraitConstraintDiag, TyDiagCollection, TyLowerDiag,
     },
     effects::{EffectKeyKind, ResolvedEffectKey, resolve_effect_key},
     trait_def::TraitInstId,
@@ -74,7 +75,7 @@ use super::{
     unify::{InferenceKey, Snapshot, UnificationError, UnificationTable},
 };
 use crate::analysis::semantic::SemanticCodeRegionRef;
-use crate::analysis::semantic::{SemConstValue, eval_body_owner_const};
+use crate::analysis::semantic::{SemConstId, SemConstScalar, SemConstValue, eval_body_owner_const};
 use crate::analysis::ty::ty_def::{TyBase, TyData};
 use crate::analysis::ty::{
     const_ty::{ConstTyData, invalid_cause_from_ctfe_error},
@@ -121,6 +122,135 @@ pub fn check_anon_const_body<'db>(
     expected: TyId<'db>,
 ) -> (Vec<FuncBodyDiag<'db>>, TypedBody<'db>) {
     check_body(db, BodyOwner::AnonConstBody { body, expected })
+}
+
+#[salsa::tracked(return_ref)]
+pub fn check_static_assert<'db>(
+    db: &'db dyn HirAnalysisDb,
+    assert_: StaticAssert<'db>,
+) -> Vec<FuncBodyDiag<'db>> {
+    let condition = assert_.condition(db);
+    let expected = TyId::bool(db);
+    let owner = BodyOwner::AnonConstBody {
+        body: condition,
+        expected,
+    };
+    let (body_diags, typed_body) = check_anon_const_body(db, condition, expected);
+    let ignorable_body_diags = static_assert_ignorable_type_diags(db, body_diags);
+    if !body_diags.is_empty() && !ignorable_body_diags {
+        return body_diags.clone();
+    }
+
+    match eval_body_owner_const(db, owner, Vec::new()) {
+        Ok(value) => match static_assert_bool_value(db, value) {
+            Some(true) => {}
+            Some(false) => {
+                let mut diags = Vec::new();
+                let comparison = assert_.comparison(db).and_then(|comparison| {
+                    static_assert_comparison_values(db, condition, typed_body, comparison)
+                });
+                diags.push(
+                    BodyDiag::StaticAssertFailed {
+                        primary: condition.span().into(),
+                        comparison,
+                    }
+                    .into(),
+                );
+                return diags;
+            }
+            None => {
+                return vec![BodyDiag::ConstValueMustBeKnown(condition.span().into()).into()];
+            }
+        },
+        Err(crate::analysis::semantic::CtfeError::NotConstEvaluable { .. }) => {
+            return vec![BodyDiag::ConstValueMustBeKnown(condition.span().into()).into()];
+        }
+        Err(err) => {
+            let ty = TyId::invalid(db, invalid_cause_from_ctfe_error(db, owner, err));
+            if let Some(diag) = ty.emit_diag(db, condition.span().into()) {
+                return vec![diag.into()];
+            }
+        }
+    }
+
+    Vec::new()
+}
+
+fn static_assert_bool_value<'db>(
+    db: &'db dyn HirAnalysisDb,
+    value: SemConstId<'db>,
+) -> Option<bool> {
+    let SemConstValue::Scalar {
+        value: SemConstScalar::Bool(value),
+        ..
+    } = value.value(db)
+    else {
+        return None;
+    };
+    Some(value)
+}
+
+fn static_assert_ignorable_type_diags<'db>(
+    db: &'db dyn HirAnalysisDb,
+    diags: &[FuncBodyDiag<'db>],
+) -> bool {
+    !diags.is_empty()
+        && diags.iter().all(|diag| {
+            matches!(
+                diag,
+                FuncBodyDiag::Body(BodyDiag::TypeAnnotationNeeded { ty, .. })
+                    if ty.is_integral_var(db)
+            )
+        })
+}
+
+fn static_assert_comparison_values<'db>(
+    db: &'db dyn HirAnalysisDb,
+    condition: Body<'db>,
+    typed_body: &TypedBody<'db>,
+    comparison: StaticAssertComparison<'db>,
+) -> Option<StaticAssertComparisonValues> {
+    let Partial::Present(Expr::Bin(lhs_expr, rhs_expr, BinOp::Comp(op))) =
+        condition.expr(db).data(db, condition)
+    else {
+        return None;
+    };
+    if *op != comparison.op {
+        return None;
+    }
+
+    let lhs = eval_static_assert_comparison_operand(
+        db,
+        comparison.lhs,
+        typed_body.expr_ty(db, *lhs_expr),
+    )?;
+    let rhs = eval_static_assert_comparison_operand(
+        db,
+        comparison.rhs,
+        typed_body.expr_ty(db, *rhs_expr),
+    )?;
+
+    Some(StaticAssertComparisonValues {
+        op: comparison.op,
+        lhs: lhs.pretty_print(db),
+        rhs: rhs.pretty_print(db),
+    })
+}
+
+fn eval_static_assert_comparison_operand<'db>(
+    db: &'db dyn HirAnalysisDb,
+    body: Body<'db>,
+    expected: TyId<'db>,
+) -> Option<SemConstId<'db>> {
+    if expected.has_invalid(db) {
+        return None;
+    }
+    let owner = BodyOwner::AnonConstBody { body, expected };
+    let body_diags = &check_anon_const_body(db, body, expected).0;
+    if !body_diags.is_empty() && !static_assert_ignorable_type_diags(db, body_diags) {
+        return None;
+    }
+    eval_body_owner_const(db, owner, Vec::new()).ok()
 }
 
 pub(super) fn check_body<'db>(

--- a/crates/hir/src/core/hir_def/expr.rs
+++ b/crates/hir/src/core/hir_def/expr.rs
@@ -140,7 +140,7 @@ pub enum ArithBinOp {
     Range,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, salsa::Update)]
 pub enum CompBinOp {
     /// `==`
     Eq,
@@ -154,6 +154,19 @@ pub enum CompBinOp {
     Gt,
     /// `>=`
     GtEq,
+}
+
+impl CompBinOp {
+    pub fn symbol(self) -> &'static str {
+        match self {
+            Self::Eq => "==",
+            Self::NotEq => "!=",
+            Self::Lt => "<",
+            Self::LtEq => "<=",
+            Self::Gt => ">",
+            Self::GtEq => ">=",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/crates/hir/src/core/hir_def/item.rs
+++ b/crates/hir/src/core/hir_def/item.rs
@@ -9,9 +9,10 @@ use common::{file::File, ingot::Ingot};
 use parser::ast;
 
 use super::{
-    AttrListId, Body, EffectParamListId, FuncParamListId, FuncParamName, GenericParamListId,
-    HirIngot, IdentId, InlineAttr, InlineAttrErrorKind, InlineHint, ManualContractRootAttr,
-    Partial, Pat, PatId, TupleTypeId, TypeBound, TypeId, UseAlias, WhereClauseId,
+    AttrListId, Body, CompBinOp, EffectParamListId, FuncParamListId, FuncParamName,
+    GenericParamListId, HirIngot, IdentId, InlineAttr, InlineAttrErrorKind, InlineHint,
+    ManualContractRootAttr, Partial, Pat, PatId, TupleTypeId, TypeBound, TypeId, UseAlias,
+    WhereClauseId,
     scope_graph::{ScopeGraph, ScopeId},
 };
 use crate::{
@@ -22,8 +23,9 @@ use crate::{
         DynLazySpan, HirOrigin,
         item::{
             LazyConstSpan, LazyContractSpan, LazyEnumSpan, LazyFuncSpan, LazyImplSpan,
-            LazyImplTraitSpan, LazyItemSpan, LazyModSpan, LazyStructSpan, LazyTopModSpan,
-            LazyTraitSpan, LazyTraitTypeSpan, LazyTypeAliasSpan, LazyUseSpan, LazyVariantDefSpan,
+            LazyImplTraitSpan, LazyItemSpan, LazyModSpan, LazyStaticAssertSpan, LazyStructSpan,
+            LazyTopModSpan, LazyTraitSpan, LazyTraitTypeSpan, LazyTypeAliasSpan, LazyUseSpan,
+            LazyVariantDefSpan,
         },
         params::LazyGenericParamListSpan,
     },
@@ -54,6 +56,7 @@ pub enum ItemKind<'db> {
     Trait(Trait<'db>),
     ImplTrait(ImplTrait<'db>),
     Const(Const<'db>),
+    StaticAssert(StaticAssert<'db>),
     Use(Use<'db>),
     /// Body is not an `Item`, but this makes it easier for analyzers to handle
     /// it.
@@ -81,7 +84,7 @@ impl<'db> ItemKind<'db> {
             TypeAlias(alias) => alias.name(db).to_opt(),
             Trait(trait_) => trait_.name(db).to_opt(),
             Const(const_) => const_.name(db).to_opt(),
-            Use(_) | Body(_) | Impl(_) | ImplTrait(_) => None,
+            Use(_) | StaticAssert(_) | Body(_) | Impl(_) | ImplTrait(_) => None,
         }
     }
 
@@ -99,6 +102,7 @@ impl<'db> ItemKind<'db> {
             Self::Trait(trait_) => trait_.attributes(db),
             Self::ImplTrait(impl_trait) => impl_trait.attributes(db),
             Self::Const(const_) => const_.attributes(db),
+            Self::StaticAssert(assert_) => assert_.attributes(db),
             Self::Use(use_) => use_.attributes(db),
             _ => return None,
         }
@@ -119,6 +123,7 @@ impl<'db> ItemKind<'db> {
             Impl(_) => "impl",
             ImplTrait(_) => "impl trait",
             Const(_) => "const",
+            StaticAssert(_) => "static_assert",
             Use(_) => "use",
             Body(_) => "body",
         }
@@ -135,7 +140,7 @@ impl<'db> ItemKind<'db> {
             TypeAlias(alias) => Some(alias.span().alias().into()),
             Trait(trait_) => Some(trait_.span().name().into()),
             Const(const_) => Some(const_.span().name().into()),
-            TopMod(_) | Use(_) | Body(_) | Impl(_) | ImplTrait(_) => None,
+            TopMod(_) | StaticAssert(_) | Use(_) | Body(_) | Impl(_) | ImplTrait(_) => None,
         }
     }
 
@@ -152,7 +157,7 @@ impl<'db> ItemKind<'db> {
             Trait(trait_) => trait_.vis(db),
             Const(const_) => const_.vis(db),
             Use(use_) => use_.vis(db),
-            Impl(_) | ImplTrait(_) | Body(_) => Visibility::Private,
+            StaticAssert(_) | Impl(_) | ImplTrait(_) | Body(_) => Visibility::Private,
         }
     }
 
@@ -169,6 +174,7 @@ impl<'db> ItemKind<'db> {
             ItemKind::Impl(impl_) => impl_.top_mod(db),
             ItemKind::ImplTrait(impl_trait) => impl_trait.top_mod(db),
             ItemKind::Const(const_) => const_.top_mod(db),
+            ItemKind::StaticAssert(assert_) => assert_.top_mod(db),
             ItemKind::Use(use_) => use_.top_mod(db),
             ItemKind::Body(body) => body.top_mod(db),
         }
@@ -582,6 +588,17 @@ impl<'db> TopLevelMod<'db> {
             .iter()
             .filter_map(|item| match item {
                 ItemKind::Mod(mod_) => Some(*mod_),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[salsa::tracked(return_ref)]
+    pub fn all_static_asserts(self, db: &'db dyn HirDb) -> Vec<StaticAssert<'db>> {
+        self.all_items(db)
+            .iter()
+            .filter_map(|item| match item {
+                ItemKind::StaticAssert(assert_) => Some(*assert_),
                 _ => None,
             })
             .collect()
@@ -1294,6 +1311,38 @@ impl<'db> Const<'db> {
     // raw type_ref access kept; shim exposes public ___tmp method.
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, salsa::Update)]
+pub struct StaticAssertComparison<'db> {
+    pub op: CompBinOp,
+    pub lhs: Body<'db>,
+    pub rhs: Body<'db>,
+}
+
+#[salsa::tracked]
+#[derive(Debug)]
+pub struct StaticAssert<'db> {
+    #[id]
+    id: TrackedItemId<'db>,
+
+    pub(in crate::core) attributes: AttrListId<'db>,
+    pub condition: Body<'db>,
+    pub comparison: Option<StaticAssertComparison<'db>>,
+    pub top_mod: TopLevelMod<'db>,
+
+    #[return_ref]
+    pub(crate) origin: HirOrigin<ast::StaticAssert>,
+}
+
+impl<'db> StaticAssert<'db> {
+    pub fn span(self) -> LazyStaticAssertSpan<'db> {
+        LazyStaticAssertSpan::new(self)
+    }
+
+    pub fn scope(self) -> ScopeId<'db> {
+        ScopeId::from_item(self.into())
+    }
+}
+
 #[salsa::tracked]
 #[derive(Debug)]
 pub struct Use<'db> {
@@ -1612,11 +1661,15 @@ pub enum TrackedItemVariant<'db> {
     Trait(Partial<IdentId<'db>>),
     ImplTrait(u32),
     Const(Partial<IdentId<'db>>),
+    StaticAssert(u32),
     ContractInit,
     ContractRecvArm { recv_idx: u32, arm_idx: u32 },
     Use(Partial<super::UsePathId<'db>>),
     FuncBody,
     NamelessBody,
+    StaticAssertCondition,
+    StaticAssertComparisonLhs,
+    StaticAssertComparisonRhs,
     Joined(Box<Self>, Box<Self>),
 }
 impl TrackedItemVariant<'_> {

--- a/crates/hir/src/core/lower/item.rs
+++ b/crates/hir/src/core/lower/item.rs
@@ -4,9 +4,10 @@ use salsa::Accumulator as _;
 use super::{FileLowerCtxt, attr::named_attr_specs};
 use crate::{
     hir_def::{
-        AttrListId, Body, EffectParamListId, FuncParamListId, GenericParamListId, IdentId,
-        InlineAttrErrorKind, KeywordAttrArgSpec, KeywordAttrSpec, PathId, TraitRefId, TupleTypeId,
-        TypeBound, TypeId, WhereClauseId, item::*, parse_inline_attr_specs,
+        AttrListId, Body, BodyKind, CompBinOp, EffectParamListId, FuncParamListId,
+        GenericParamListId, IdentId, InlineAttrErrorKind, KeywordAttrArgSpec, KeywordAttrSpec,
+        PathId, TraitRefId, TupleTypeId, TypeBound, TypeId, WhereClauseId, item::*,
+        parse_inline_attr_specs,
     },
     lower::msg::lower_msg_as_mod,
     span::HirOrigin,
@@ -258,6 +259,29 @@ impl<'db> ItemKind<'db> {
                     "const",
                 );
                 Const::lower_ast(ctxt, const_);
+            }
+            ast::ItemKind::StaticAssert(assert_) => {
+                super::arithmetic::report_arithmetic_attr_on_unsupported_item(
+                    ctxt,
+                    assert_.attr_list(),
+                    "static assertion",
+                );
+                super::event::report_event_attr_on_non_struct_item(
+                    ctxt,
+                    assert_.attr_list(),
+                    "static assertion",
+                );
+                super::error::report_error_attr_on_non_struct_item(
+                    ctxt,
+                    assert_.attr_list(),
+                    "static assertion",
+                );
+                super::payable::report_payable_attr_on_unsupported_item(
+                    ctxt,
+                    assert_.attr_list(),
+                    "static assertion",
+                );
+                StaticAssert::lower_ast(ctxt, assert_);
             }
             ast::ItemKind::Use(use_) => {
                 super::arithmetic::report_arithmetic_attr_on_unsupported_item(
@@ -863,6 +887,77 @@ impl<'db> Const<'db> {
             origin,
         );
         ctxt.leave_item_scope(const_)
+    }
+}
+
+impl<'db> StaticAssert<'db> {
+    pub(super) fn lower_ast(ctxt: &mut FileLowerCtxt<'db>, ast: ast::StaticAssert) -> Self {
+        let idx = ctxt.next_static_assert_idx();
+        let id = ctxt.joined_id(TrackedItemVariant::StaticAssert(idx));
+        ctxt.enter_item_scope(id, false);
+
+        let attributes = AttrListId::lower_ast_opt(ctxt, ast.attr_list());
+        let condition_ast = ast.condition();
+        let condition = Body::lower_ast_with_variant(
+            ctxt,
+            condition_ast.clone(),
+            TrackedItemVariant::StaticAssertCondition,
+            BodyKind::Anonymous,
+        );
+        let comparison =
+            condition_ast.and_then(|expr| StaticAssertComparison::lower_ast(ctxt, expr));
+        let origin = HirOrigin::raw(&ast);
+
+        let assert_ = Self::new(
+            ctxt.db(),
+            id,
+            attributes,
+            condition,
+            comparison,
+            ctxt.top_mod(),
+            origin,
+        );
+        ctxt.leave_item_scope(assert_)
+    }
+}
+
+impl<'db> StaticAssertComparison<'db> {
+    fn lower_ast(ctxt: &mut FileLowerCtxt<'db>, expr: ast::Expr) -> Option<Self> {
+        let expr = peel_parens(expr);
+        let ast::ExprKind::Bin(bin) = expr.kind() else {
+            return None;
+        };
+        let ast::BinOp::Comp(op) = bin.op()? else {
+            return None;
+        };
+
+        Some(Self {
+            op: CompBinOp::lower_ast(op),
+            lhs: Body::lower_ast_with_variant(
+                ctxt,
+                bin.lhs(),
+                TrackedItemVariant::StaticAssertComparisonLhs,
+                BodyKind::Anonymous,
+            ),
+            rhs: Body::lower_ast_with_variant(
+                ctxt,
+                bin.rhs(),
+                TrackedItemVariant::StaticAssertComparisonRhs,
+                BodyKind::Anonymous,
+            ),
+        })
+    }
+}
+
+fn peel_parens(mut expr: ast::Expr) -> ast::Expr {
+    loop {
+        match expr.kind() {
+            ast::ExprKind::Paren(paren) => match paren.expr() {
+                Some(inner) => expr = inner,
+                None => return expr,
+            },
+            _ => return expr,
+        }
     }
 }
 

--- a/crates/hir/src/core/lower/mod.rs
+++ b/crates/hir/src/core/lower/mod.rs
@@ -174,6 +174,7 @@ pub(super) struct FileLowerCtxt<'db> {
     builder: ScopeGraphBuilder<'db>,
     next_impl_idx: u32,
     next_impl_trait_idx: u32,
+    next_static_assert_idx: u32,
 }
 
 impl<'db> FileLowerCtxt<'db> {
@@ -182,6 +183,7 @@ impl<'db> FileLowerCtxt<'db> {
             builder: ScopeGraphBuilder::enter_top_mod(db, top_mod),
             next_impl_idx: 0,
             next_impl_trait_idx: 0,
+            next_static_assert_idx: 0,
         }
     }
 
@@ -305,6 +307,12 @@ impl<'db> FileLowerCtxt<'db> {
     pub(super) fn next_impl_trait_idx(&mut self) -> u32 {
         let idx = self.next_impl_trait_idx;
         self.next_impl_trait_idx += 1;
+        idx
+    }
+
+    pub(super) fn next_static_assert_idx(&mut self) -> u32 {
+        let idx = self.next_static_assert_idx;
+        self.next_static_assert_idx += 1;
         idx
     }
 

--- a/crates/hir/src/core/lower/scope_builder.rs
+++ b/crates/hir/src/core/lower/scope_builder.rs
@@ -279,6 +279,11 @@ impl<'db> ScopeGraphBuilder<'db> {
                     .unwrap_or_else(EdgeKind::anon)
             }
 
+            StaticAssert(_) => {
+                self.graph.add_lex_edge(item_node, parent_node);
+                EdgeKind::anon()
+            }
+
             Use(use_) => {
                 self.graph.unresolved_uses.insert(use_);
 

--- a/crates/hir/src/core/print.rs
+++ b/crates/hir/src/core/print.rs
@@ -1083,6 +1083,7 @@ impl<'db> ItemKind<'db> {
             ItemKind::Trait(t) => t.pretty_print(db),
             ItemKind::ImplTrait(i) => i.pretty_print(db),
             ItemKind::Const(c) => c.pretty_print(db),
+            ItemKind::StaticAssert(a) => a.pretty_print(db),
             ItemKind::Use(u) => u.pretty_print(db),
             ItemKind::Body(_) => panic!("Body should not be printed as an item"),
         }
@@ -1577,6 +1578,18 @@ impl<'db> Const<'db> {
         let body = unwrap_partial(self.body(db), "Const::body");
         result.push_str(&body.pretty_print(db));
 
+        result
+    }
+}
+
+impl<'db> StaticAssert<'db> {
+    /// Pretty-prints a static assertion.
+    pub fn pretty_print(self, db: &dyn HirDb) -> String {
+        let mut result = String::new();
+        result.push_str(&self.attributes(db).pretty_print_with_newline(db));
+        result.push_str("static_assert(");
+        result.push_str(&self.condition(db).pretty_print(db));
+        result.push(')');
         result
     }
 }

--- a/crates/hir/src/core/semantic/reference/has_references.rs
+++ b/crates/hir/src/core/semantic/reference/has_references.rs
@@ -94,6 +94,7 @@ impl<'db> HasReferences<'db> for ItemKind<'db> {
             ItemKind::ImplTrait(impl_trait) => impl_trait_references(db, *impl_trait),
             ItemKind::Use(use_item) => use_references(db, *use_item),
             ItemKind::Const(c) => c.body(db).to_opt().map_or(EMPTY_REFS, |b| b.references(db)),
+            ItemKind::StaticAssert(assert_) => assert_.condition(db).references(db),
             // Modules don't contain references themselves
             ItemKind::TopMod(_) | ItemKind::Mod(_) => EMPTY_REFS,
             ItemKind::Contract(contract) => contract_references(db, *contract),

--- a/crates/hir/src/core/semantic/reference/resolver.rs
+++ b/crates/hir/src/core/semantic/reference/resolver.rs
@@ -266,6 +266,7 @@ pub fn resolved_item_scope_targets<'db>(
                 EMPTY_RESOLVED
             }
         }
+        ItemKind::StaticAssert(assert_) => resolved_body_scope_targets(db, assert_.condition(db)),
         ItemKind::TopMod(_) | ItemKind::Mod(_) => EMPTY_RESOLVED,
     }
 }

--- a/crates/hir/src/core/semantic/symbol.rs
+++ b/crates/hir/src/core/semantic/symbol.rs
@@ -94,6 +94,7 @@ impl<'db> From<ItemKind<'db>> for SymbolKind {
             ItemKind::ImplTrait(_) => SymbolKind::ImplTrait,
             ItemKind::Const(_) => SymbolKind::Const,
             ItemKind::Use(_) => SymbolKind::Use,
+            ItemKind::StaticAssert(_) => SymbolKind::Const,
             ItemKind::Body(_) => SymbolKind::Func, // Bodies are function-like
         }
     }
@@ -540,7 +541,7 @@ pub fn item_kind_to_url_suffix(item: ItemKind) -> Option<&'static str> {
         ItemKind::Const(_) => Some("const"),
         ItemKind::Impl(_) => Some("impl"),
         ItemKind::ImplTrait(_) => Some("impl"),
-        ItemKind::Use(_) | ItemKind::Body(_) => None,
+        ItemKind::StaticAssert(_) | ItemKind::Use(_) | ItemKind::Body(_) => None,
     }
 }
 

--- a/crates/hir/src/core/span/item.rs
+++ b/crates/hir/src/core/span/item.rs
@@ -4,6 +4,7 @@ use super::{
     LazySpanAtom,
     attr::LazyAttrListSpan,
     define_lazy_span_node,
+    expr::LazyExprSpan,
     params::{
         LazyFuncParamListSpan, LazyGenericParamListSpan, LazyUsesClauseSpan, LazyWhereClauseSpan,
     },
@@ -15,8 +16,8 @@ use super::{
 };
 use crate::{
     hir_def::{
-        Body, Const, Contract, Enum, Func, Impl, ImplTrait, ItemKind, Mod, Struct, TopLevelMod,
-        Trait, TypeAlias, Use,
+        Body, Const, Contract, Enum, Func, Impl, ImplTrait, ItemKind, Mod, StaticAssert, Struct,
+        TopLevelMod, Trait, TypeAlias, Use,
     },
     span::{
         DesugaredOrigin, DesugaredUseFocus, MsgDesugaredFocus,
@@ -428,6 +429,20 @@ define_lazy_span_node!(
 impl<'db> LazyConstSpan<'db> {
     pub fn new(c: Const<'db>) -> Self {
         Self(crate::span::transition::SpanTransitionChain::new(c))
+    }
+}
+
+define_lazy_span_node!(
+    LazyStaticAssertSpan,
+    ast::StaticAssert,
+    @node {
+        (attributes, attr_list, LazyAttrListSpan),
+        (condition, condition, LazyExprSpan),
+    }
+);
+impl<'db> LazyStaticAssertSpan<'db> {
+    pub fn new(a: StaticAssert<'db>) -> Self {
+        Self(crate::span::transition::SpanTransitionChain::new(a))
     }
 }
 

--- a/crates/hir/src/core/span/mod.rs
+++ b/crates/hir/src/core/span/mod.rs
@@ -5,8 +5,8 @@ use salsa::Update;
 use crate::{
     HirDb, SpannedHirDb,
     core::hir_def::{
-        Body, Const, Contract, Enum, Func, Impl, ImplTrait, Mod, Struct, TopLevelMod, Trait,
-        TypeAlias, Use,
+        Body, Const, Contract, Enum, Func, Impl, ImplTrait, Mod, StaticAssert, Struct, TopLevelMod,
+        Trait, TypeAlias, Use,
     },
     core::lower::top_mod_ast,
 };
@@ -41,8 +41,8 @@ pub mod lazy_spans {
             LazyBodySpan, LazyConstSpan, LazyContractRecvSpan, LazyContractSpan, LazyEnumSpan,
             LazyFieldDefListSpan, LazyFieldDefSpan, LazyFuncSignatureSpan, LazyFuncSpan,
             LazyImplSpan, LazyImplTraitSpan, LazyItemSpan, LazyModSpan, LazyRecvArmListSpan,
-            LazyRecvArmSpan, LazyStructSpan, LazyTopModSpan, LazyTraitSpan, LazyTypeAliasSpan,
-            LazyUseSpan, LazyVariantDefListSpan, LazyVariantDefSpan,
+            LazyRecvArmSpan, LazyStaticAssertSpan, LazyStructSpan, LazyTopModSpan, LazyTraitSpan,
+            LazyTypeAliasSpan, LazyUseSpan, LazyVariantDefListSpan, LazyVariantDefSpan,
         },
         params::{
             LazyConstGenericParamSpan, LazyFuncParamListSpan, LazyFuncParamSpan,
@@ -156,6 +156,13 @@ pub fn impl_trait_ast<'db>(
 }
 
 pub fn const_ast<'db>(db: &'db dyn SpannedHirDb, item: Const<'db>) -> &'db HirOrigin<ast::Const> {
+    item.origin(db)
+}
+
+pub fn static_assert_ast<'db>(
+    db: &'db dyn SpannedHirDb,
+    item: StaticAssert<'db>,
+) -> &'db HirOrigin<ast::StaticAssert> {
     item.origin(db)
 }
 

--- a/crates/hir/src/core/span/transition.rs
+++ b/crates/hir/src/core/span/transition.rs
@@ -11,13 +11,14 @@ use thin_vec::ThinVec;
 use super::{
     DesugaredOrigin, DesugaredUseFocus, HirOrigin, LazySpan, UseDesugared, body_ast, const_ast,
     contract_ast, enum_ast, expr::ExprRoot, func_ast, impl_ast, impl_trait_ast, mod_ast,
-    pat::PatRoot, stmt::StmtRoot, struct_ast, trait_ast, type_alias_ast, use_ast,
+    pat::PatRoot, static_assert_ast, stmt::StmtRoot, struct_ast, trait_ast, type_alias_ast,
+    use_ast,
 };
 use crate::{
     HirDb, SpannedHirDb,
     hir_def::{
-        Body, Const, Contract, Enum, Func, Impl, ImplTrait, ItemKind, Mod, Struct, TopLevelMod,
-        Trait, TypeAlias, Use,
+        Body, Const, Contract, Enum, Func, Impl, ImplTrait, ItemKind, Mod, StaticAssert, Struct,
+        TopLevelMod, Trait, TypeAlias, Use,
     },
     lower::top_mod_ast,
 };
@@ -78,6 +79,7 @@ impl<'db> SpanTransitionChain<'db> {
             ChainRoot::Trait(t) => t.top_mod(db),
             ChainRoot::ImplTrait(i) => i.top_mod(db),
             ChainRoot::Const(c) => c.top_mod(db),
+            ChainRoot::StaticAssert(a) => a.top_mod(db),
             ChainRoot::Use(u) => u.top_mod(db),
             ChainRoot::Body(b) => b.top_mod(db),
             ChainRoot::Stmt(s) => s.body.top_mod(db),
@@ -105,6 +107,7 @@ pub(crate) enum ChainRoot<'db> {
     Trait(Trait<'db>),
     ImplTrait(ImplTrait<'db>),
     Const(Const<'db>),
+    StaticAssert(StaticAssert<'db>),
     Use(Use<'db>),
     Body(Body<'db>),
     Stmt(StmtRoot<'db>),
@@ -209,6 +212,7 @@ impl ChainInitiator for ChainRoot<'_> {
                 ItemKind::Trait(trait_) => trait_.init(db),
                 ItemKind::ImplTrait(impl_trait) => impl_trait.init(db),
                 ItemKind::Const(const_) => const_.init(db),
+                ItemKind::StaticAssert(assert_) => assert_.init(db),
                 ItemKind::Use(use_) => use_.init(db),
                 ItemKind::Body(body) => body.init(db),
             },
@@ -223,6 +227,7 @@ impl ChainInitiator for ChainRoot<'_> {
             Self::Trait(trait_) => trait_.init(db),
             Self::ImplTrait(impl_trait) => impl_trait.init(db),
             Self::Const(const_) => const_.init(db),
+            Self::StaticAssert(assert_) => assert_.init(db),
             Self::Use(use_) => use_.init(db),
             Self::Body(body) => body.init(db),
             Self::Stmt(stmt) => stmt.init(db),
@@ -296,6 +301,7 @@ impl_chain_root! {
     (Trait<'db>, trait_ast),
     (ImplTrait<'db>, impl_trait_ast),
     (Const<'db>, const_ast),
+    (StaticAssert<'db>, static_assert_ast),
     (Use<'db>, use_ast),
     (Body<'db>, body_ast),
 }

--- a/crates/hir/src/core/visitor.rs
+++ b/crates/hir/src/core/visitor.rs
@@ -12,9 +12,10 @@ use crate::{
         Expr, ExprId, Field, FieldDef, FieldDefListId, FieldIndex, FieldParent, Func, FuncParam,
         FuncParamListId, FuncParamName, GenericArg, GenericArgListId, GenericParam,
         GenericParamListId, IdentId, Impl, ImplTrait, ItemKind, KindBound, LitKind, MatchArm, Mod,
-        Partial, Pat, PatId, PathId, PathKind, Stmt, StmtId, Struct, TopLevelMod, Trait,
-        TraitRefId, TupleTypeId, TypeAlias, TypeBound, TypeId, TypeKind, Use, UseAlias, UsePathId,
-        UsePathSegment, VariantDef, VariantDefListId, VariantKind, WhereClauseId, WherePredicate,
+        Partial, Pat, PatId, PathId, PathKind, StaticAssert, Stmt, StmtId, Struct, TopLevelMod,
+        Trait, TraitRefId, TupleTypeId, TypeAlias, TypeBound, TypeId, TypeKind, Use, UseAlias,
+        UsePathId, UsePathSegment, VariantDef, VariantDefListId, VariantKind, WhereClauseId,
+        WherePredicate,
         attr::{self, AttrArgValue},
         scope_graph::ScopeId,
     },
@@ -29,9 +30,10 @@ pub mod prelude {
         walk_field_def_list, walk_field_list, walk_func, walk_func_param, walk_func_param_list,
         walk_generic_arg, walk_generic_arg_list, walk_generic_param, walk_generic_param_list,
         walk_impl, walk_impl_trait, walk_item, walk_kind_bound, walk_mod, walk_pat, walk_path,
-        walk_stmt, walk_struct, walk_super_trait_list, walk_top_mod, walk_trait, walk_trait_ref,
-        walk_type, walk_type_alias, walk_type_bound, walk_type_bound_list, walk_use, walk_use_path,
-        walk_variant_def, walk_variant_def_list, walk_where_clause, walk_where_predicate,
+        walk_static_assert, walk_stmt, walk_struct, walk_super_trait_list, walk_top_mod,
+        walk_trait, walk_trait_ref, walk_type, walk_type_alias, walk_type_bound,
+        walk_type_bound_list, walk_use, walk_use_path, walk_variant_def, walk_variant_def_list,
+        walk_where_clause, walk_where_predicate,
     };
     pub use crate::core::span::lazy_spans::*;
 }
@@ -148,6 +150,14 @@ pub trait Visitor<'db> {
         constant: Const<'db>,
     ) {
         walk_const(self, ctxt, constant)
+    }
+
+    fn visit_static_assert(
+        &mut self,
+        ctxt: &mut VisitorCtxt<'db, LazyStaticAssertSpan<'db>>,
+        assert_: StaticAssert<'db>,
+    ) {
+        walk_static_assert(self, ctxt, assert_)
     }
 
     fn visit_use(&mut self, ctxt: &mut VisitorCtxt<'db, LazyUseSpan<'db>>, use_: Use<'db>) {
@@ -452,6 +462,10 @@ pub fn walk_item<'db, V>(
         ItemKind::Const(const_) => {
             let mut new_ctxt = VisitorCtxt::with_const(ctxt.db, const_);
             visitor.visit_const(&mut new_ctxt, const_)
+        }
+        ItemKind::StaticAssert(assert_) => {
+            let mut new_ctxt = VisitorCtxt::with_static_assert(ctxt.db, assert_);
+            visitor.visit_static_assert(&mut new_ctxt, assert_)
         }
         ItemKind::Use(use_) => {
             let mut new_ctxt = VisitorCtxt::with_use(ctxt.db, use_);
@@ -1085,6 +1099,25 @@ pub fn walk_const<'db, V>(
     if let Some(body) = const_.body(ctxt.db).to_opt() {
         visitor.visit_body(&mut VisitorCtxt::with_body(ctxt.db, body), body);
     }
+}
+
+pub fn walk_static_assert<'db, V>(
+    visitor: &mut V,
+    ctxt: &mut VisitorCtxt<'db, LazyStaticAssertSpan<'db>>,
+    assert_: StaticAssert<'db>,
+) where
+    V: Visitor<'db> + ?Sized,
+{
+    ctxt.with_new_ctxt(
+        |span| span.attributes(),
+        |ctxt| {
+            let id = assert_.attributes(ctxt.db);
+            visitor.visit_attribute_list(ctxt, id);
+        },
+    );
+
+    let body = assert_.condition(ctxt.db);
+    visitor.visit_body(&mut VisitorCtxt::with_body(ctxt.db, body), body);
 }
 
 pub fn walk_use<'db, V>(
@@ -2344,6 +2377,7 @@ where
             ChainRoot::Trait(trait_) => trait_.top_mod(self.db),
             ChainRoot::ImplTrait(impl_trait) => impl_trait.top_mod(self.db),
             ChainRoot::Const(const_) => const_.top_mod(self.db),
+            ChainRoot::StaticAssert(assert_) => assert_.top_mod(self.db),
             ChainRoot::Use(use_) => use_.top_mod(self.db),
             ChainRoot::Body(body) => body.top_mod(self.db),
             ChainRoot::Stmt(_) | ChainRoot::Expr(_) | ChainRoot::Pat(_) => {
@@ -2519,6 +2553,7 @@ define_item_ctxt_ctor! {
     (LazyTraitSpan<'db>, with_trait(trait_: Trait<'db>)),
     (LazyImplTraitSpan<'db>, with_impl_trait(impl_trait: ImplTrait<'db>)),
     (LazyConstSpan<'db>, with_const(const_: Const<'db>)),
+    (LazyStaticAssertSpan<'db>, with_static_assert(assert_: StaticAssert<'db>)),
     (LazyUseSpan<'db>, with_use(use_: Use<'db>)),
     (LazyBodySpan<'db>, with_body(body: Body<'db>)),
 }

--- a/crates/hir/tests/semantic_borrowck.rs
+++ b/crates/hir/tests/semantic_borrowck.rs
@@ -145,6 +145,7 @@ fn for_each_fixture_instance(
             | ItemKind::Impl(_)
             | ItemKind::ImplTrait(_)
             | ItemKind::TypeAlias(_)
+            | ItemKind::StaticAssert(_)
             | ItemKind::Use(_)
             | ItemKind::TopMod(_)
             | ItemKind::Body(_) => {}

--- a/crates/hir/tests/semantic_ctfe.rs
+++ b/crates/hir/tests/semantic_ctfe.rs
@@ -322,6 +322,7 @@ fn contract_init_fixed_array_arg_fixture_has_no_type_level_semantic_consts() {
             | ItemKind::Impl(_)
             | ItemKind::ImplTrait(_)
             | ItemKind::TypeAlias(_)
+            | ItemKind::StaticAssert(_)
             | ItemKind::Use(_)
             | ItemKind::TopMod(_)
             | ItemKind::Body(_) => {}

--- a/crates/parser/src/ast/item.rs
+++ b/crates/parser/src/ast/item.rs
@@ -46,6 +46,7 @@ impl Item {
             .or_else(|| support::child(self.syntax()).map(ItemKind::Trait))
             .or_else(|| support::child(self.syntax()).map(ItemKind::ImplTrait))
             .or_else(|| support::child(self.syntax()).map(ItemKind::Const))
+            .or_else(|| support::child(self.syntax()).map(ItemKind::StaticAssert))
             .or_else(|| support::child(self.syntax()).map(ItemKind::Use))
             .or_else(|| support::child(self.syntax()).map(ItemKind::Extern))
     }
@@ -497,6 +498,19 @@ impl Const {
 }
 
 ast_node! {
+    /// `static_assert(expr)`
+    pub struct StaticAssert,
+    SK::StaticAssert,
+}
+impl super::AttrListOwner for StaticAssert {}
+impl StaticAssert {
+    /// Returns the asserted condition.
+    pub fn condition(&self) -> Option<super::Expr> {
+        support::child(self.syntax())
+    }
+}
+
+ast_node! {
     /// `use foo::{bar, Baz::*}`
     pub struct Use,
     SK::Use,
@@ -732,6 +746,7 @@ pub enum ItemKind {
     Trait(Trait),
     ImplTrait(ImplTrait),
     Const(Const),
+    StaticAssert(StaticAssert),
     Use(Use),
     Extern(Extern),
 }
@@ -1088,6 +1103,19 @@ mod tests {
         assert_eq!(c.name().unwrap().text(), "FOO");
         assert!(matches!(c.ty().unwrap().kind(), TypeKind::Path(_)));
         assert!(matches!(c.value().unwrap().kind(), ExprKind::Bin(_)));
+    }
+
+    #[test]
+    #[wasm_bindgen_test]
+    fn static_assert() {
+        let source = r#"
+            static_assert(1 + 1 == 2)
+        "#;
+        let assert_: StaticAssert = parse_item(source);
+        assert!(matches!(
+            assert_.condition().unwrap().kind(),
+            ExprKind::Bin(_)
+        ));
     }
 
     #[test]

--- a/crates/parser/src/parser/item.rs
+++ b/crates/parser/src/parser/item.rs
@@ -38,6 +38,7 @@ define_scope! {
         ImplKw,
         UseKw,
         ConstKw,
+        StaticAssertKw,
         ExternKw,
         TypeKw,
         PubKw,
@@ -115,7 +116,12 @@ impl super::Parse for ItemScope {
 
         if modifiers.is_unsafe && !is_fn_item_head(parser) {
             parser.error("expected `fn` after `unsafe` keyword");
-        } else if modifiers.is_pub && matches!(parser.current_kind(), Some(ImplKw | ExternKw)) {
+        } else if modifiers.is_pub
+            && matches!(
+                parser.current_kind(),
+                Some(ImplKw | ExternKw | StaticAssertKw)
+            )
+        {
             let error_msg = format!(
                 "`pub` can't be used for `{}`",
                 parser.current_token().unwrap().text()
@@ -125,8 +131,19 @@ impl super::Parse for ItemScope {
 
         parser.expect(
             &[
-                ModKw, FnKw, StructKw, ContractKw, MsgKw, EnumKw, TraitKw, ImplKw, UseKw, ConstKw,
-                ExternKw, TypeKw,
+                ModKw,
+                FnKw,
+                StructKw,
+                ContractKw,
+                MsgKw,
+                EnumKw,
+                TraitKw,
+                ImplKw,
+                UseKw,
+                ConstKw,
+                StaticAssertKw,
+                ExternKw,
+                TypeKw,
             ],
             Some(ExpectedKind::Syntax(SyntaxKind::Item)),
         )?;
@@ -148,6 +165,7 @@ impl super::Parse for ItemScope {
                     parser.parse_cp(ConstScope::default(), checkpoint)
                 }
             }
+            Some(StaticAssertKw) => parser.parse_cp(StaticAssertScope::default(), checkpoint),
             Some(ExternKw) => parser.parse_cp(ExternScope::default(), checkpoint),
             Some(TypeKw) => parser.parse_cp(TypeAliasScope::default(), checkpoint),
             _ => unreachable!(),
@@ -879,6 +897,38 @@ impl super::Parse for ConstScope {
         if parser.find_and_pop(SyntaxKind::Eq, ExpectedKind::Unspecified)? {
             parser.bump();
             parse_expr(parser)?;
+        }
+        Ok(())
+    }
+}
+
+define_scope! { StaticAssertScope, StaticAssert }
+impl super::Parse for StaticAssertScope {
+    type Error = Recovery<ErrProof>;
+
+    fn parse<S: TokenStream>(&mut self, parser: &mut Parser<S>) -> Result<(), Self::Error> {
+        parser.bump_expected(SyntaxKind::StaticAssertKw);
+        parser.set_newline_as_trivia(true);
+        parser.set_scope_recovery_stack(&[SyntaxKind::LParen, SyntaxKind::RParen]);
+
+        if parser.find_and_pop(
+            SyntaxKind::LParen,
+            ExpectedKind::Syntax(SyntaxKind::StaticAssert),
+        )? {
+            parser.bump();
+            if parser.current_kind() != Some(SyntaxKind::RParen) {
+                parse_expr(parser)?;
+            }
+        }
+
+        if parser.find_and_pop(
+            SyntaxKind::RParen,
+            ExpectedKind::ClosingBracket {
+                bracket: SyntaxKind::RParen,
+                parent: SyntaxKind::StaticAssert,
+            },
+        )? {
+            parser.bump();
         }
         Ok(())
     }

--- a/crates/parser/src/syntax_kind.rs
+++ b/crates/parser/src/syntax_kind.rs
@@ -165,6 +165,9 @@ pub enum SyntaxKind {
     /// `const`
     #[token("const")]
     ConstKw,
+    /// `static_assert`
+    #[token("static_assert")]
+    StaticAssertKw,
     /// `if`
     #[token("if")]
     IfKw,
@@ -404,6 +407,8 @@ pub enum SyntaxKind {
     ImplTrait,
     /// `const FOO: i32 = 1`
     Const,
+    /// `static_assert(expr)`
+    StaticAssert,
     /// `use foo::{Foo as Foo1, bar::Baz}`
     Use,
     /// `msg Erc20Msg { ... }`
@@ -575,6 +580,7 @@ impl SyntaxKind {
                     | SyntaxKind::ImplKw
                     | SyntaxKind::TraitKw
                     | SyntaxKind::ConstKw
+                    | SyntaxKind::StaticAssertKw
                     | SyntaxKind::UseKw
                     | SyntaxKind::ExternKw
             )
@@ -631,6 +637,7 @@ impl SyntaxKind {
             SyntaxKind::FnKw => "`fn`",
             SyntaxKind::ModKw => "`mod`",
             SyntaxKind::ConstKw => "`const`",
+            SyntaxKind::StaticAssertKw => "`static_assert`",
             SyntaxKind::IfKw => "`if`",
             SyntaxKind::ElseKw => "`else`",
             SyntaxKind::MatchKw => "`match`",
@@ -749,6 +756,7 @@ impl SyntaxKind {
             SyntaxKind::TraitConstItem => "`trait` const item",
             SyntaxKind::ImplTrait => "`impl` trait block",
             SyntaxKind::Const => "const definition",
+            SyntaxKind::StaticAssert => "static assertion",
             SyntaxKind::Use => "`use` statement",
             SyntaxKind::UseTree => "`use` tree",
             SyntaxKind::UseTreeList => "`use` tree list",
@@ -848,6 +856,7 @@ impl SyntaxKind {
                 | SyntaxKind::FnKw
                 | SyntaxKind::ModKw
                 | SyntaxKind::ConstKw
+                | SyntaxKind::StaticAssertKw
                 | SyntaxKind::IfKw
                 | SyntaxKind::ElseKw
                 | SyntaxKind::MatchKw

--- a/crates/uitest/fixtures/ty_check/static_assert.fe
+++ b/crates/uitest/fixtures/ty_check/static_assert.fe
@@ -1,0 +1,30 @@
+const A: u8 = 1
+const B: u8 = 2
+const TRUTH: bool = true
+const LIE: bool = false
+
+static_assert(false)
+static_assert(2 == 3)
+static_assert(A + 2 == B)
+static_assert((TRUTH == LIE))
+static_assert(A < 1)
+static_assert(A > B)
+static_assert(B <= A)
+static_assert(A >= B)
+static_assert(A != 1)
+static_assert(1 / 0 == 0)
+static_assert(1)
+
+mod nested {
+    const C: u8 = 5
+
+    static_assert(C == 6)
+}
+
+static_assert(true)
+
+fn runtime() -> bool {
+    true
+}
+
+static_assert(runtime())

--- a/crates/uitest/fixtures/ty_check/static_assert.snap
+++ b/crates/uitest/fixtures/ty_check/static_assert.snap
@@ -1,0 +1,118 @@
+---
+source: crates/uitest/tests/ty_check.rs
+expression: diags
+input_file: fixtures/ty_check/static_assert.fe
+---
+error[3-0024]: non-const function call in const context
+   ┌─ static_assert.fe:30:15
+   │
+30 │ static_assert(runtime())
+   │               ^^^^^^^^^ calls in const context must be `const fn`
+
+error[3-0025]: division by zero in const context
+   ┌─ static_assert.fe:15:15
+   │
+15 │ static_assert(1 / 0 == 0)
+   │               ^^^^^ cannot divide by zero
+
+error[8-0000]: type mismatch
+   ┌─ static_assert.fe:16:15
+   │
+16 │ static_assert(1)
+   │               ^ expected `bool`, but `{integer}` is given
+
+error[8-0081]: static assertion failed
+  ┌─ static_assert.fe:6:15
+  │
+6 │ static_assert(false)
+  │               ^^^^^ `static_assert` evaluated to `false`
+
+error[8-0081]: static assertion failed
+  ┌─ static_assert.fe:7:15
+  │
+7 │ static_assert(2 == 3)
+  │               ^^^^^^ `static_assert` evaluated to `false`
+  │
+  = left: `2`
+  = right: `3`
+  = operator: `==`
+
+error[8-0081]: static assertion failed
+  ┌─ static_assert.fe:8:15
+  │
+8 │ static_assert(A + 2 == B)
+  │               ^^^^^^^^^^ `static_assert` evaluated to `false`
+  │
+  = left: `3`
+  = right: `2`
+  = operator: `==`
+
+error[8-0081]: static assertion failed
+  ┌─ static_assert.fe:9:15
+  │
+9 │ static_assert((TRUTH == LIE))
+  │               ^^^^^^^^^^^^^^ `static_assert` evaluated to `false`
+  │
+  = left: `true`
+  = right: `false`
+  = operator: `==`
+
+error[8-0081]: static assertion failed
+   ┌─ static_assert.fe:10:15
+   │
+10 │ static_assert(A < 1)
+   │               ^^^^^ `static_assert` evaluated to `false`
+   │
+   = left: `1`
+   = right: `1`
+   = operator: `<`
+
+error[8-0081]: static assertion failed
+   ┌─ static_assert.fe:11:15
+   │
+11 │ static_assert(A > B)
+   │               ^^^^^ `static_assert` evaluated to `false`
+   │
+   = left: `1`
+   = right: `2`
+   = operator: `>`
+
+error[8-0081]: static assertion failed
+   ┌─ static_assert.fe:12:15
+   │
+12 │ static_assert(B <= A)
+   │               ^^^^^^ `static_assert` evaluated to `false`
+   │
+   = left: `2`
+   = right: `1`
+   = operator: `<=`
+
+error[8-0081]: static assertion failed
+   ┌─ static_assert.fe:13:15
+   │
+13 │ static_assert(A >= B)
+   │               ^^^^^^ `static_assert` evaluated to `false`
+   │
+   = left: `1`
+   = right: `2`
+   = operator: `>=`
+
+error[8-0081]: static assertion failed
+   ┌─ static_assert.fe:14:15
+   │
+14 │ static_assert(A != 1)
+   │               ^^^^^^ `static_assert` evaluated to `false`
+   │
+   = left: `1`
+   = right: `1`
+   = operator: `!=`
+
+error[8-0081]: static assertion failed
+   ┌─ static_assert.fe:21:19
+   │
+21 │     static_assert(C == 6)
+   │                   ^^^^^^ `static_assert` evaluated to `false`
+   │
+   = left: `5`
+   = right: `6`
+   = operator: `==`


### PR DESCRIPTION
Adds support for `static_assert(bool_expr)`. This is a special compiler built-in, so we can print comparisons nicely.

```
error[8-0081]: static assertion failed
  ┌─ static_assert.fe:8:15
  │
8 │ static_assert(A + 2 == B)
  │               ^^^^^^^^^^ `static_assert` evaluated to `false`
  │
  = left: `3`
  = right: `2`
  = operator: `==`
  ```