### PR TITLE
ci: pin Foundry version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,7 @@ env:
   CARGO_PROFILE_TEST_DEBUG: 0
   RUST_BACKTRACE: full
   SOLC_VERSION: v0.8.30
+  FOUNDRY_VERSION: v1.5.1
 
 jobs:
   lint:
@@ -78,7 +79,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: stable
+          version: ${{ env.FOUNDRY_VERSION }}
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest
       - name: Cache Dependencies


### PR DESCRIPTION
CI was failing during the Foundry install step before tests ran.

Using `stable` requires foundryup to resolve the latest release through the GitHub releases API at job runtime. Pinning a concrete release avoids that lookup and makes the CI toolchain deterministic.