### PR TITLE
Fix LSP CPU/memory blowup from SCIP regen on every edit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2049,6 +2049,7 @@ dependencies = [
  "fe-language-server",
  "fe-mir",
  "fe-resolver",
+ "fe-semantic-indexing",
  "fe-solc-runner",
  "fe-test-utils",
  "fe-web",
@@ -2081,7 +2082,10 @@ dependencies = [
  "criterion",
  "fe-common",
  "fe-driver",
+ "fe-hir",
  "fe-parser",
+ "fe-semantic-indexing",
+ "tempfile",
  "tracing",
  "url",
  "walkdir",
@@ -2231,6 +2235,7 @@ dependencies = [
  "camino",
  "clap",
  "codespan-reporting",
+ "criterion",
  "dir-test",
  "fe-codegen",
  "fe-common",
@@ -2240,6 +2245,7 @@ dependencies = [
  "fe-mir",
  "fe-parser",
  "fe-resolver",
+ "fe-semantic-indexing",
  "fe-test-utils",
  "fe-web",
  "futures",
@@ -2316,6 +2322,26 @@ dependencies = [
  "tracing",
  "url",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "fe-semantic-indexing"
+version = "26.1.0"
+dependencies = [
+ "camino",
+ "dir-test",
+ "fe-common",
+ "fe-driver",
+ "fe-hir",
+ "fe-test-utils",
+ "fe-web",
+ "rustc-hash 2.1.1",
+ "salsa",
+ "scip",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ test-utils = { path = "crates/test-utils", package = "fe-test-utils" }
 resolver = { path = "crates/resolver", package = "fe-resolver" }
 codegen = { path = "crates/codegen", package = "fe-codegen" }
 fe-web = { path = "crates/fe-web" }
+semantic-indexing = { path = "crates/semantic-indexing", package = "fe-semantic-indexing" }
 language-server = { path = "crates/language-server", package = "fe-language-server" }
 mir = { path = "crates/mir", package = "fe-mir" }
 cranelift-entity = "0.130"

--- a/crates/bench/Cargo.toml
+++ b/crates/bench/Cargo.toml
@@ -6,15 +6,23 @@ edition.workspace = true
 [dev-dependencies]
 criterion = "0.5"
 walkdir = "2.4"
+tempfile = "3.23"
 
 [dependencies]
 driver.workspace = true
 parser.workspace = true
 common.workspace = true
+hir.workspace = true
+semantic-indexing.workspace = true
 camino.workspace = true
 url.workspace = true
 tracing.workspace = true
+tempfile = "3.23"
 
 [[bench]]
 name = "analysis"
+harness = false
+
+[[bench]]
+name = "scip_regen"
 harness = false

--- a/crates/bench/benches/scip_regen.rs
+++ b/crates/bench/benches/scip_regen.rs
@@ -1,0 +1,112 @@
+use common::InputDb;
+use criterion::{Criterion, SamplingMode, criterion_group, criterion_main};
+use driver::DriverDataBase;
+use url::Url;
+
+const SAMPLE_CODE: &str = r#"
+struct Point {
+    pub x: i32
+    pub y: i32
+}
+
+impl Point {
+    pub fn new(x: i32, y: i32) -> Point {
+        Point { x, y }
+    }
+
+    pub fn distance(self, other: Point) -> i32 {
+        let dx = self.x - other.x
+        let dy = self.y - other.y
+        dx * dx + dy * dy
+    }
+
+    pub fn translate(self, dx: i32, dy: i32) -> Point {
+        Point::new(self.x + dx, self.y + dy)
+    }
+}
+
+pub fn origin() -> Point {
+    Point::new(0, 0)
+}
+
+pub fn midpoint(a: Point, b: Point) -> Point {
+    Point::new((a.x + b.x) / 2, (a.y + b.y) / 2)
+}
+"#;
+
+const EDITED_CODE: &str = r#"
+struct Point {
+    pub x: i32
+    pub y: i32
+}
+
+impl Point {
+    pub fn new(x: i32, y: i32) -> Point {
+        Point { x, y }
+    }
+
+    pub fn distance(self, other: Point) -> i32 {
+        let dx = self.x - other.x
+        let dy = self.y - other.y
+        dx * dx + dy * dy
+    }
+
+    pub fn translate(self, dx: i32, dy: i32) -> Point {
+        Point::new(self.x + dx, self.y + dy)
+    }
+
+    pub fn scale(self, factor: i32) -> Point {
+        Point::new(self.x * factor, self.y * factor)
+    }
+}
+
+pub fn zero() -> Point {
+    Point::new(0, 0)
+}
+
+pub fn midpoint(a: Point, b: Point) -> Point {
+    Point::new((a.x + b.x) / 2, (a.y + b.y) / 2)
+}
+"#;
+
+fn scip_regen(c: &mut Criterion) {
+    let mut g = c.benchmark_group("scip_regen");
+    g.sampling_mode(SamplingMode::Flat);
+    g.sample_size(10);
+
+    let temp = tempfile::tempdir().expect("create temp dir");
+    let file_path = temp.path().join("main.fe");
+    let file_url = Url::from_file_path(&file_path).unwrap();
+    let ingot_url = Url::from_directory_path(temp.path()).unwrap();
+
+    let mut db = DriverDataBase::default();
+    db.workspace()
+        .touch(&mut db, file_url.clone(), Some(SAMPLE_CODE.to_string()));
+
+    // Warm the salsa cache with initial analysis
+    let ingot = db
+        .workspace()
+        .containing_ingot(&db, file_url.clone())
+        .expect("ingot");
+    db.run_on_ingot(ingot);
+
+    // Warm the SCIP generation cache (first call is cold)
+    let _ = semantic_indexing::scip_batch::generate_scip(&db, &ingot_url);
+
+    // Benchmark: warm SCIP regen after edit (salsa-cached path)
+    g.bench_function("warm_edit_scip", |b| {
+        b.iter(|| {
+            db.workspace()
+                .update(&mut db, file_url.clone(), EDITED_CODE.to_string());
+            let result = semantic_indexing::scip_batch::generate_scip(&db, &ingot_url);
+            db.workspace()
+                .update(&mut db, file_url.clone(), SAMPLE_CODE.to_string());
+            result
+        });
+    });
+
+    g.finish();
+}
+
+criterion_group!(benches, scip_regen);
+criterion_main!(benches);

--- a/crates/common/src/file/workspace.rs
+++ b/crates/common/src/file/workspace.rs
@@ -3,7 +3,7 @@ use radix_immutable::{StringPrefixView, StringTrie, Trie};
 use salsa::Setter;
 use url::Url;
 
-use crate::{InputDb, file::File, indexmap::IndexMap};
+use crate::{InputDb, file::File, indexmap::ArcIndexMap};
 
 #[derive(Debug)]
 pub enum InputIndexError {
@@ -14,13 +14,13 @@ pub enum InputIndexError {
 #[derive(Debug)]
 pub struct Workspace {
     files: StringTrie<Url, File>,
-    paths: IndexMap<File, Url>,
+    paths: ArcIndexMap<File, Url>,
 }
 
 #[salsa::tracked]
 impl Workspace {
     pub fn default(db: &dyn InputDb) -> Self {
-        Workspace::new(db, Trie::new(), IndexMap::default())
+        Workspace::new(db, Trie::new(), ArcIndexMap::default())
     }
     pub(crate) fn set(
         &self,
@@ -28,7 +28,6 @@ impl Workspace {
         url: Url,
         file: File,
     ) -> Result<File, InputIndexError> {
-        // Check if the file is already associated with another URL
         let paths = self.paths(db);
         if let Some(existing_url) = paths.get(&file)
             && existing_url != &url
@@ -55,6 +54,7 @@ impl Workspace {
                 self.set_files(db).to(files);
                 let mut paths = self.paths(db);
                 paths.remove(&file);
+                self.set_paths(db).to(paths);
                 Some(file)
             } else {
                 None
@@ -75,13 +75,10 @@ impl Workspace {
 
     #[salsa::tracked]
     pub fn get_relative_path(self, db: &dyn InputDb, base: Url, file: File) -> Option<Utf8PathBuf> {
-        // Get the file path
         let file_url = match self.paths(db).get(&file) {
             Some(url) => url.clone(),
             None => return None,
         };
-
-        // Get the relative path between the base URL and file URL
         base.make_relative(&file_url).map(Utf8PathBuf::from)
     }
 

--- a/crates/common/src/indexmap.rs
+++ b/crates/common/src/indexmap.rs
@@ -74,6 +74,96 @@ impl<K, V> DerefMut for IndexMap<K, V> {
     }
 }
 
+/// Arc-wrapped IndexMap for use as a salsa input field.
+/// Clone is O(1) (Arc refcount bump). Mutations use Arc::make_mut.
+#[derive(Debug, Clone)]
+pub struct ArcIndexMap<K, V>(pub std::sync::Arc<IndexMap<K, V>>);
+
+impl<K, V> ArcIndexMap<K, V> {
+    pub fn new() -> Self {
+        Self(std::sync::Arc::new(IndexMap::new()))
+    }
+
+    pub fn get<Q>(&self, key: &Q) -> Option<&V>
+    where
+        K: std::borrow::Borrow<Q> + Eq + Hash,
+        Q: Eq + Hash + ?Sized,
+    {
+        self.0.get(key)
+    }
+
+    pub fn insert(&mut self, key: K, value: V)
+    where
+        K: Eq + Hash + Clone,
+        V: Clone,
+    {
+        std::sync::Arc::make_mut(&mut self.0).insert(key, value);
+    }
+
+    pub fn remove<Q>(&mut self, key: &Q)
+    where
+        K: std::borrow::Borrow<Q> + Eq + Hash + Clone,
+        V: Clone,
+        Q: Eq + Hash + ?Sized,
+    {
+        std::sync::Arc::make_mut(&mut self.0).remove(key);
+    }
+}
+
+impl<K, V> Default for ArcIndexMap<K, V> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<K, V> PartialEq for ArcIndexMap<K, V>
+where
+    K: Eq + Hash,
+    V: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        std::sync::Arc::ptr_eq(&self.0, &other.0) || *self.0 == *other.0
+    }
+}
+
+impl<K, V> Eq for ArcIndexMap<K, V>
+where
+    K: Eq + Hash,
+    V: Eq,
+{
+}
+
+impl<K, V> Hash for ArcIndexMap<K, V>
+where
+    K: Hash + Eq,
+    V: Hash,
+{
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        for (k, v) in self.0.as_ref() {
+            k.hash(state);
+            v.hash(state);
+        }
+    }
+}
+
+unsafe impl<K, V> Update for ArcIndexMap<K, V>
+where
+    K: Eq + Hash + Clone,
+    V: Clone + PartialEq,
+{
+    unsafe fn maybe_update(old_pointer: *mut Self, new_value: Self) -> bool {
+        let old = unsafe { &mut *old_pointer };
+        if std::sync::Arc::ptr_eq(&old.0, &new_value.0) {
+            return false;
+        }
+        if *old.0 == *new_value.0 {
+            return false;
+        }
+        *old = new_value;
+        true
+    }
+}
+
 unsafe impl<K, V> Update for IndexMap<K, V>
 where
     K: Update + Eq + Hash,

--- a/crates/fe-web/src/model.rs
+++ b/crates/fe-web/src/model.rs
@@ -20,7 +20,7 @@ pub const SCHEMA_VERSION: u32 = 2;
 // ============================================================================
 
 /// A part of a signature - either plain text or a linkable reference
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(test, derive(schemars::JsonSchema))]
 pub struct SignaturePart {
     /// The display text
@@ -60,7 +60,7 @@ pub fn plain_signature(s: impl Into<String>) -> RichSignature {
 ///
 /// Byte offsets are exact: `file_text[byte_start..byte_end] == signature_text`.
 /// Skipped during serialization — only used in-memory during doc generation.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SignatureSpanData {
     /// Absolute file URL (file:// scheme), used to compute relative path for
     /// matching against SCIP document `relative_path` fields.
@@ -76,7 +76,7 @@ pub struct SignatureSpanData {
 // ============================================================================
 
 /// A documented item in the Fe codebase
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(test, derive(schemars::JsonSchema))]
 pub struct DocItem {
     /// Unique path identifier (e.g., "std::option::Option")
@@ -120,7 +120,7 @@ pub struct DocItem {
 }
 
 /// A type that implements a trait
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(test, derive(schemars::JsonSchema))]
 pub struct DocImplementor {
     /// The implementing type name
@@ -271,7 +271,7 @@ pub enum DocVisibility {
 }
 
 /// Parsed documentation content with sections
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(test, derive(schemars::JsonSchema))]
 pub struct DocContent {
     /// The main summary (first paragraph)
@@ -338,7 +338,7 @@ impl DocContent {
 }
 
 /// A named section within documentation (e.g., "Examples", "Panics")
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(test, derive(schemars::JsonSchema))]
 pub struct DocSection {
     pub name: String,
@@ -346,7 +346,7 @@ pub struct DocSection {
 }
 
 /// A generic parameter with its bounds
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(test, derive(schemars::JsonSchema))]
 pub struct DocGenericParam {
     pub name: String,
@@ -355,7 +355,7 @@ pub struct DocGenericParam {
 }
 
 /// A child of a documented item
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(test, derive(schemars::JsonSchema))]
 pub struct DocChild {
     pub kind: DocChildKind,
@@ -432,7 +432,7 @@ impl DocChildKind {
 }
 
 /// Source location for linking to source code
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(test, derive(schemars::JsonSchema))]
 pub struct DocSourceLoc {
     /// Absolute file path — used only in-memory by LSP for "goto source".
@@ -446,7 +446,7 @@ pub struct DocSourceLoc {
 }
 
 /// A trait implementation reference (shown on type pages)
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(test, derive(schemars::JsonSchema))]
 pub struct DocTraitImpl {
     /// The name of the trait being implemented (e.g., "Clone"). Empty for inherent impls.
@@ -470,7 +470,7 @@ pub struct DocTraitImpl {
 }
 
 /// A method in an impl block (for inline display on type pages)
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(test, derive(schemars::JsonSchema))]
 pub struct DocImplMethod {
     /// Method name
@@ -760,7 +760,7 @@ fn extract_simple_type_name(type_str: &str) -> String {
 }
 
 /// Module tree for navigation sidebar
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(test, derive(schemars::JsonSchema))]
 pub struct DocModuleTree {
     pub name: String,
@@ -778,7 +778,7 @@ impl DocModuleTree {
 }
 
 /// A reference to an item within a module
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(test, derive(schemars::JsonSchema))]
 pub struct DocModuleItem {
     pub name: String,

--- a/crates/fe/Cargo.toml
+++ b/crates/fe/Cargo.toml
@@ -25,6 +25,7 @@ rayon = "1"
 mir.workspace = true
 cranelift-entity.workspace = true
 rustc-hash.workspace = true
+semantic-indexing.workspace = true
 codegen = { path = "../codegen", package = "fe-codegen" }
 contract-harness = { path = "../contract-harness", package = "fe-contract-harness" }
 solc-runner = { path = "../solc-runner", package = "fe-solc-runner" }
@@ -51,3 +52,4 @@ axum = { version = "0.8", optional = true }
 dir-test.workspace = true
 test-utils.workspace = true
 tempfile = "3.23"
+semantic-indexing.workspace = true

--- a/crates/fe/src/doc.rs
+++ b/crates/fe/src/doc.rs
@@ -3,10 +3,13 @@ use common::InputDb;
 use driver::DriverDataBase;
 use fe_web::model::DocIndex;
 use hir::hir_def::HirIngot;
+use semantic_indexing::extract::DocExtractor;
+use semantic_indexing::scip_batch;
+use semantic_indexing::tracked::{
+    docs_for_ingot, module_tree_for_ingot, trait_impl_links_for_ingot,
+};
 use serde::{Deserialize, Serialize};
 use url::Url;
-
-use crate::extract::DocExtractor;
 
 /// Server info written by LSP for discovery
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -213,7 +216,7 @@ pub fn generate_docs(
     let git_root = detect_git_root(path.as_std_path());
 
     let index = if path.is_file() && path.extension() == Some("fe") {
-        extract_single_file(&mut db, path, git_root.as_deref())
+        extract_single_file(&mut db, path)
     } else if path.is_dir() {
         // Check if this is a workspace (fe.toml with [workspace] section)
         let fe_toml = path.join("fe.toml");
@@ -222,15 +225,15 @@ pub fn generate_docs(
                 if let Ok(common::config::Config::Workspace(ws_config)) =
                     common::config::Config::parse(&content)
                 {
-                    extract_workspace(&mut db, path, &ws_config, git_root.as_deref())
+                    extract_workspace(&mut db, path, &ws_config)
                 } else {
-                    extract_ingot(&mut db, path, git_root.as_deref())
+                    extract_ingot(&mut db, path)
                 }
             } else {
-                extract_ingot(&mut db, path, git_root.as_deref())
+                extract_ingot(&mut db, path)
             }
         } else {
-            extract_ingot(&mut db, path, git_root.as_deref())
+            extract_ingot(&mut db, path)
         }
     } else {
         eprintln!("Error: Path must be either a .fe file or a directory containing fe.toml");
@@ -240,6 +243,17 @@ pub fn generate_docs(
     let Some(mut index) = index else {
         std::process::exit(1);
     };
+
+    // Rewrite display_file paths relative to git root (for source links in static docs)
+    if let Some(ref root) = git_root {
+        for item in &mut index.items {
+            if let Some(ref mut source) = item.source
+                && let Ok(rel) = std::path::Path::new(&source.file).strip_prefix(root)
+            {
+                source.display_file = rel.to_string_lossy().to_string();
+            }
+        }
+    }
 
     // Append builtin ingot docs when --builtins is set
     if builtins {
@@ -254,21 +268,13 @@ pub fn generate_docs(
                 continue;
             }
 
-            let extractor = make_extractor(&db, git_root.as_deref());
-            for top_mod in builtin_ingot.all_modules(&db) {
-                for item in top_mod.children_nested(&db) {
-                    if let Some(doc_item) = extractor.extract_item_for_ingot(item, builtin_ingot) {
-                        index.items.push(doc_item);
-                    }
-                }
-            }
-            let root_mod = builtin_ingot.root_mod(&db);
+            index
+                .items
+                .extend(docs_for_ingot(&db, builtin_ingot).clone());
             index
                 .modules
-                .extend(extractor.build_module_tree_for_ingot(builtin_ingot, root_mod));
-
-            let trait_impl_links = extractor.extract_trait_impl_links(builtin_ingot);
-            index.link_trait_impls(trait_impl_links);
+                .extend(module_tree_for_ingot(&db, builtin_ingot).clone());
+            index.link_trait_impls(trait_impl_links_for_ingot(&db, builtin_ingot).clone());
 
             let mod_count = builtin_ingot.all_modules(&db).len();
             println!("  Included builtin '{label}' ({mod_count} modules)");
@@ -410,24 +416,7 @@ pub fn generate_docs(
     }
 }
 
-/// Create a DocExtractor with optional git-root-relative source paths.
-fn make_extractor<'db>(
-    db: &'db dyn hir::SpannedHirDb,
-    git_root: Option<&std::path::Path>,
-) -> DocExtractor<'db> {
-    let extractor = DocExtractor::new(db);
-    if let Some(root) = git_root {
-        extractor.with_root_path(root.to_path_buf())
-    } else {
-        extractor
-    }
-}
-
-fn extract_single_file(
-    db: &mut DriverDataBase,
-    file_path: &Utf8PathBuf,
-    git_root: Option<&std::path::Path>,
-) -> Option<DocIndex> {
+fn extract_single_file(db: &mut DriverDataBase, file_path: &Utf8PathBuf) -> Option<DocIndex> {
     let canonical = file_path.canonicalize_utf8().ok()?;
     let file_url = Url::from_file_path(&canonical).ok()?;
 
@@ -437,14 +426,13 @@ fn extract_single_file(
     let file = db.workspace().get(db, &file_url)?;
     let top_mod = db.top_mod(file);
 
-    // Check for errors first
     let diags = db.run_on_top_mod(top_mod);
     if !diags.is_empty() {
         eprintln!("Warning: File has errors, documentation may be incomplete");
         diags.emit(db);
     }
 
-    let extractor = make_extractor(db, git_root);
+    let extractor = DocExtractor::new(db);
     Some(extractor.extract_module(top_mod))
 }
 
@@ -452,7 +440,6 @@ fn extract_workspace(
     db: &mut DriverDataBase,
     workspace_root: &Utf8PathBuf,
     ws_config: &common::config::WorkspaceConfig,
-    git_root: Option<&std::path::Path>,
 ) -> Option<DocIndex> {
     use common::config::WorkspaceMemberSelection;
 
@@ -525,22 +512,11 @@ fn extract_workspace(
             diags.emit(db);
         }
 
-        let extractor = make_extractor(db, git_root);
-        for top_mod in ingot.all_modules(db) {
-            for item in top_mod.children_nested(db) {
-                if let Some(doc_item) = extractor.extract_item_for_ingot(item, ingot) {
-                    combined.items.push(doc_item);
-                }
-            }
-        }
-
-        let root_mod = ingot.root_mod(db);
+        combined.items.extend(docs_for_ingot(db, ingot).clone());
         combined
             .modules
-            .extend(extractor.build_module_tree_for_ingot(ingot, root_mod));
-
-        let trait_impl_links = extractor.extract_trait_impl_links(ingot);
-        combined.link_trait_impls(trait_impl_links);
+            .extend(module_tree_for_ingot(db, ingot).clone());
+        combined.link_trait_impls(trait_impl_links_for_ingot(db, ingot).clone());
     }
 
     if combined.items.is_empty() && combined.modules.is_empty() {
@@ -551,11 +527,7 @@ fn extract_workspace(
     Some(combined)
 }
 
-fn extract_ingot(
-    db: &mut DriverDataBase,
-    dir_path: &Utf8PathBuf,
-    git_root: Option<&std::path::Path>,
-) -> Option<DocIndex> {
+fn extract_ingot(db: &mut DriverDataBase, dir_path: &Utf8PathBuf) -> Option<DocIndex> {
     let canonical_path = dir_path.canonicalize_utf8().ok()?;
     let ingot_url = Url::from_directory_path(canonical_path.as_str()).ok()?;
 
@@ -573,25 +545,12 @@ fn extract_ingot(
         diags.emit(db);
     }
 
-    let extractor = make_extractor(db, git_root);
     let mut index = DocIndex::new();
-
-    // Extract items from all modules with ingot-qualified paths (like LSP does)
-    for top_mod in ingot.all_modules(db) {
-        for item in top_mod.children_nested(db) {
-            if let Some(doc_item) = extractor.extract_item_for_ingot(item, ingot) {
-                index.items.push(doc_item);
-            }
-        }
-    }
-
-    // Build module tree with ingot-qualified paths
-    let root_mod = ingot.root_mod(db);
-    index.modules = extractor.build_module_tree_for_ingot(ingot, root_mod);
-
-    // Extract and link trait implementations
-    let trait_impl_links = extractor.extract_trait_impl_links(ingot);
-    index.link_trait_impls(trait_impl_links);
+    index.items.extend(docs_for_ingot(db, ingot).clone());
+    index
+        .modules
+        .extend(module_tree_for_ingot(db, ingot).clone());
+    index.link_trait_impls(trait_impl_links_for_ingot(db, ingot).clone());
 
     Some(index)
 }
@@ -650,32 +609,26 @@ fn generate_scip_json_for_doc(
         canonical
     };
 
+    // Generate SCIP per-ingot via salsa-cached path, then enrich signatures
     for ingot_url in &ingot_urls {
-        match crate::scip_index::generate_scip_with_root(db, ingot_url, &workspace_root) {
-            Ok(mut result) => {
-                // For file:// ingots, base_url is None (paths resolve via
-                // workspace_root). For builtin ingots, pass the URL base
-                // so file lookup works for non-file:// schemes.
-                let base_url = if ingot_url.to_file_path().is_ok() {
-                    None
-                } else {
-                    Some(ingot_url)
-                };
-                crate::scip_index::enrich_signatures_with_base(
-                    db,
-                    &workspace_root,
-                    base_url,
-                    doc_index,
-                    &mut result.index,
-                );
+        if let Ok(mut result) = scip_batch::generate_scip_with_root(db, ingot_url, &workspace_root)
+        {
+            let base_url = if ingot_url.to_file_path().is_ok() {
+                None
+            } else {
+                Some(ingot_url)
+            };
+            scip_batch::enrich_signatures_with_base(
+                db,
+                &workspace_root,
+                base_url,
+                doc_index,
+                &mut result.index,
+            );
 
-                combined_index.documents.extend(result.index.documents);
-                combined_doc_urls.extend(result.doc_urls);
-                any_succeeded = true;
-            }
-            Err(e) => {
-                eprintln!("Warning: SCIP generation failed for {}: {e}", ingot_url);
-            }
+            combined_index.documents.extend(result.index.documents);
+            combined_doc_urls.extend(result.doc_urls);
+            any_succeeded = true;
         }
     }
 
@@ -683,7 +636,7 @@ fn generate_scip_json_for_doc(
         return None;
     }
 
-    Some(crate::scip_index::scip_to_json_data(
+    Some(scip_batch::scip_to_json_data(
         &combined_index,
         &combined_doc_urls,
     ))

--- a/crates/fe/src/main.rs
+++ b/crates/fe/src/main.rs
@@ -7,11 +7,7 @@ mod dependency_diagnostics;
 mod doc;
 #[cfg(feature = "doc-server")]
 mod doc_serve;
-pub(crate) mod extract;
-mod index_util;
-mod lsif;
 mod report;
-mod scip_index;
 mod test;
 #[cfg(not(target_arch = "wasm32"))]
 mod tree;
@@ -738,7 +734,6 @@ pub fn run(opts: &Options) {
 
 #[cfg(feature = "lsp")]
 async fn run_lsp_with_combined_server(resolved_root: Option<Utf8PathBuf>, port: Option<u16>) {
-    use std::sync::Arc;
     use tokio::net::TcpListener;
 
     // Bind the combined server listener
@@ -839,17 +834,10 @@ async fn run_lsp_with_combined_server(resolved_root: Option<Utf8PathBuf>, port: 
         );
     }
 
-    // Create the doc regeneration closure for live reload.
-    // Uses a read-only salsa snapshot — the Backend's db is already initialized
-    // with all ingots/files, so we enumerate from the snapshot's dependency graph
-    // and workspace rather than re-discovering from disk.
-    let doc_regenerate_fn: language_server::DocRegenerateFn = Arc::new(regenerate_doc_data_from_db);
-
     let config = language_server::CombinedServerConfig {
         listener,
         doc_html,
         docs_url: Some(format!("http://127.0.0.1:{actual_port}")),
-        doc_regenerate_fn: Some(doc_regenerate_fn),
     };
 
     language_server::run_stdio_server(Some(config)).await;
@@ -861,7 +849,8 @@ async fn run_lsp_with_combined_server(resolved_root: Option<Utf8PathBuf>, port: 
 /// Initial doc data generation from a workspace root.
 ///
 /// Discovers ingots via `discover_and_init` (requires `&mut`), then delegates
-/// to `build_doc_index` for the actual extraction. Used at LSP startup.
+/// Generate doc + SCIP data for a workspace. Used at LSP startup.
+/// Regenerate doc + SCIP data via salsa-tracked functions.
 #[cfg(feature = "lsp")]
 fn regenerate_doc_data(
     db: &mut driver::DriverDataBase,
@@ -872,185 +861,12 @@ fn regenerate_doc_data(
         .unwrap_or_else(|_| workspace_root.to_owned());
 
     if let Ok(root_url) = url::Url::from_directory_path(&root_path) {
-        let discovered = driver::discover_and_init(db, &root_url);
-        build_doc_index(db, &discovered.ingot_urls, &discovered.standalone_files)
+        let _discovered = driver::discover_and_init(db, &root_url);
+        semantic_indexing::doc::regenerate(db)
     } else {
         let json = serde_json::to_string(&fe_web::model::DocIndex::new()).unwrap();
         (json, None)
     }
-}
-
-/// Regenerate doc data from an already-initialized database snapshot.
-///
-/// Enumerates ingots from the dependency graph and standalone files from the
-/// workspace — no mutation needed. Used for live reload on save.
-#[cfg(feature = "lsp")]
-pub fn regenerate_doc_data_from_db(db: &driver::DriverDataBase) -> (String, Option<String>) {
-    use common::InputDb;
-
-    let builtin_core_url = url::Url::parse(common::stdlib::BUILTIN_CORE_BASE_URL).unwrap();
-    let builtin_std_url = url::Url::parse(common::stdlib::BUILTIN_STD_BASE_URL).unwrap();
-
-    // Get non-builtin ingot URLs from the dependency graph
-    let ingot_urls: Vec<url::Url> = db
-        .dependency_graph()
-        .petgraph(db)
-        .node_weights()
-        .filter(|u| *u != &builtin_core_url && *u != &builtin_std_url)
-        .cloned()
-        .collect();
-
-    // Find standalone files (in workspace but not under any ingot)
-    let standalone_files: Vec<url::Url> = db
-        .workspace()
-        .all_files(db)
-        .iter()
-        .filter_map(|(url, _file)| {
-            if db.workspace().containing_ingot(db, url.clone()).is_none() {
-                Some(url)
-            } else {
-                None
-            }
-        })
-        .collect();
-
-    build_doc_index(db, &ingot_urls, &standalone_files)
-}
-
-/// Core doc extraction logic shared by initial generation and live reload.
-///
-/// Takes a read-only db reference and pre-computed URL lists.
-#[cfg(feature = "lsp")]
-fn build_doc_index(
-    db: &driver::DriverDataBase,
-    ingot_urls: &[url::Url],
-    standalone_file_urls: &[url::Url],
-) -> (String, Option<String>) {
-    use crate::extract::DocExtractor;
-    use common::InputDb;
-    use common::stdlib::{HasBuiltinCore, HasBuiltinStd};
-    use hir::hir_def::HirIngot;
-
-    let mut index = fe_web::model::DocIndex::new();
-    let mut scip_json: Option<String> = None;
-
-    let extractor = DocExtractor::new(db);
-
-    // Extract docs from each ingot
-    for ingot_url in ingot_urls {
-        let Some(ingot) = db.workspace().containing_ingot(db, ingot_url.clone()) else {
-            continue;
-        };
-        for top_mod in ingot.all_modules(db) {
-            for item in top_mod.children_nested(db) {
-                if let Some(doc_item) = extractor.extract_item_for_ingot(item, ingot) {
-                    index.items.push(doc_item);
-                }
-            }
-        }
-        let root_mod = ingot.root_mod(db);
-        index
-            .modules
-            .extend(extractor.build_module_tree_for_ingot(ingot, root_mod));
-        let trait_impl_links = extractor.extract_trait_impl_links(ingot);
-        index.link_trait_impls(trait_impl_links);
-    }
-
-    // Extract docs from standalone .fe files
-    for file_url in standalone_file_urls {
-        if let Some(file) = db.workspace().get(db, file_url) {
-            let top_mod = db.top_mod(file);
-            for item in top_mod.children_nested(db) {
-                if let Some(doc_item) = extractor.extract_item(item) {
-                    index.items.push(doc_item);
-                }
-            }
-            index
-                .modules
-                .push(extractor.build_standalone_module_tree(top_mod));
-        }
-    }
-
-    // Include builtin libraries (core, std)
-    let existing: std::collections::HashSet<_> =
-        index.modules.iter().map(|m| m.name.clone()).collect();
-    for (label, builtin) in [("core", db.builtin_core()), ("std", db.builtin_std())] {
-        if existing.contains(label) {
-            continue;
-        }
-        for top_mod in builtin.all_modules(db) {
-            for item in top_mod.children_nested(db) {
-                if let Some(doc_item) = extractor.extract_item_for_ingot(item, builtin) {
-                    index.items.push(doc_item);
-                }
-            }
-        }
-        let root_mod = builtin.root_mod(db);
-        index
-            .builtin_modules
-            .extend(extractor.build_module_tree_for_ingot(builtin, root_mod));
-        let trait_impl_links = extractor.extract_trait_impl_links(builtin);
-        index.link_trait_impls(trait_impl_links);
-    }
-
-    // Generate SCIP data
-    let mut combined_scip = scip::types::Index::default();
-    let mut combined_doc_urls = std::collections::HashMap::new();
-    let mut any_scip = false;
-
-    let builtin_urls = [
-        url::Url::parse(common::stdlib::BUILTIN_CORE_BASE_URL).unwrap(),
-        url::Url::parse(common::stdlib::BUILTIN_STD_BASE_URL).unwrap(),
-    ];
-    let all_scip_urls: Vec<_> = ingot_urls.iter().chain(builtin_urls.iter()).collect();
-
-    for ingot_url in &all_scip_urls {
-        match crate::scip_index::generate_scip(db, ingot_url) {
-            Ok(mut result) => {
-                if ingot_url.scheme() == "file" {
-                    if let Some(project_root) = ingot_url
-                        .to_file_path()
-                        .ok()
-                        .and_then(|p| camino::Utf8PathBuf::from_path_buf(p).ok())
-                    {
-                        crate::scip_index::enrich_signatures(
-                            db,
-                            &project_root,
-                            &mut index,
-                            &mut result.index,
-                        );
-                    }
-                } else {
-                    crate::scip_index::enrich_signatures_with_base(
-                        db,
-                        camino::Utf8Path::new("/"),
-                        Some(ingot_url),
-                        &mut index,
-                        &mut result.index,
-                    );
-                }
-                combined_scip.documents.extend(result.index.documents);
-                combined_doc_urls.extend(result.doc_urls);
-                any_scip = true;
-            }
-            Err(e) => {
-                eprintln!("Warning: SCIP generation failed for {ingot_url}: {e}");
-            }
-        }
-    }
-    if any_scip {
-        scip_json = Some(crate::scip_index::scip_to_json_data(
-            &combined_scip,
-            &combined_doc_urls,
-        ));
-    }
-
-    // Serialize DocIndex with HTML bodies injected
-    let mut value = serde_json::to_value(&index).expect("serialize DocIndex");
-    fe_web::static_site::inject_html_bodies(&mut value);
-    let json = serde_json::to_string(&value).expect("serialize JSON");
-
-    (json, scip_json)
 }
 
 /// Generate the doc HTML for the combined server.
@@ -1142,11 +958,11 @@ fn run_lsif(path: &Utf8PathBuf, output: Option<&Utf8PathBuf>) {
             }
         };
         let writer = std::io::BufWriter::new(file);
-        lsif::generate_lsif(&mut db, &ingot_url, writer)
+        semantic_indexing::lsif::generate_lsif(&db, &ingot_url, writer)
     } else {
         let stdout = std::io::stdout().lock();
         let writer = std::io::BufWriter::new(stdout);
-        lsif::generate_lsif(&mut db, &ingot_url, writer)
+        semantic_indexing::lsif::generate_lsif(&db, &ingot_url, writer)
     };
 
     if let Err(e) = result {
@@ -1181,15 +997,13 @@ fn run_scip(path: &Utf8PathBuf, output: &Utf8PathBuf) {
         eprintln!("Warning: ingot had initialization diagnostics");
     }
 
-    let index = match scip_index::generate_scip(&db, &ingot_url) {
-        Ok(index) => index,
-        Err(e) => {
+    let result =
+        semantic_indexing::scip_batch::generate_scip(&db, &ingot_url).unwrap_or_else(|e| {
             eprintln!("Error generating SCIP: {e}");
             std::process::exit(1);
-        }
-    };
+        });
 
-    if let Err(e) = scip::write_message_to_file(output.as_std_path(), index.index) {
+    if let Err(e) = scip::write_message_to_file(output.as_std_path(), result.index) {
         eprintln!("Error writing SCIP file: {e}");
         std::process::exit(1);
     }

--- a/crates/hir/src/core/semantic/index.rs
+++ b/crates/hir/src/core/semantic/index.rs
@@ -1,0 +1,99 @@
+//! Per-module semantic index queries, cached by salsa.
+//!
+//! Layer 1: per-module reference data that downstream consumers compose into
+//! per-ingot outputs. Salsa caches each module independently.
+
+use common::ingot::Ingot;
+
+use crate::analysis::HirAnalysisDb;
+use crate::core::semantic::reference::resolver::resolved_item_scope_targets;
+use crate::core::semantic::symbol::{IndexedReference, ReferenceIndex};
+use crate::hir_def::{HirIngot, TopLevelMod, scope_graph::ScopeId};
+use crate::span::DynLazySpan;
+
+use rustc_hash::FxHashMap;
+
+/// A single resolved reference: target scope + source span + metadata.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, salsa::Update)]
+pub struct ResolvedRef<'db> {
+    pub target: ScopeId<'db>,
+    pub span: DynLazySpan<'db>,
+    pub is_self_ty: bool,
+}
+
+/// Per-module: all references originating from this module's items.
+/// Cached by salsa — only recomputes when this module's resolved targets change.
+#[salsa::tracked(return_ref)]
+pub fn module_references<'db>(
+    db: &'db dyn HirAnalysisDb,
+    top_mod: TopLevelMod<'db>,
+) -> Vec<ResolvedRef<'db>> {
+    let scope_graph = top_mod.scope_graph(db);
+    let mut refs = Vec::new();
+
+    for item in scope_graph.items_dfs(db) {
+        for resolved in resolved_item_scope_targets(db, item) {
+            refs.push(ResolvedRef {
+                target: resolved.scope,
+                span: resolved.span.clone(),
+                is_self_ty: resolved.is_self_ty,
+            });
+        }
+    }
+
+    refs
+}
+
+/// Pre-warm the per-module reference cache in parallel.
+///
+/// Must be called OUTSIDE any salsa tracked query -- `salsa::par_map` forks the
+/// database internally and worker threads attach their own forks. Calling from
+/// inside a tracked query would conflict with the existing attachment.
+///
+/// After this returns, every module's `module_references` result is cached in
+/// salsa's memo table, so subsequent reads (e.g., from `build_reference_index_from_cached`)
+/// are cheap hash lookups.
+pub fn pre_warm_module_references<'db>(db: &'db dyn HirAnalysisDb, ingot: Ingot<'db>) {
+    let modules = ingot.all_modules(db);
+    if modules.is_empty() {
+        return;
+    }
+
+    // Ensure the HirAnalysisDb view is registered before par_map forks the db.
+    // Views are normally registered lazily by the first tracked function call,
+    // but par_map needs them registered up front for as_view on forked dbs.
+    HirAnalysisDb::zalsa_register_downcaster(db);
+
+    let _: Vec<()> = salsa::par_map(db, modules.to_vec(), |db, top_mod| {
+        let _ = module_references(db, top_mod);
+    });
+}
+
+/// Build a ReferenceIndex for an ingot from cached per-module data.
+///
+/// Each module's references are salsa-cached -- only changed modules recompute.
+/// This function assembles the full inverted index from those cached slices.
+///
+/// For best cold-start performance, call `pre_warm_module_references` before
+/// the tracked query that invokes this function.
+pub fn build_reference_index_from_cached<'db>(
+    db: &'db dyn HirAnalysisDb,
+    ingot: Ingot<'db>,
+) -> ReferenceIndex<'db> {
+    let mut index: FxHashMap<ScopeId<'db>, Vec<IndexedReference<'db>>> = FxHashMap::default();
+
+    for top_mod in ingot.all_modules(db) {
+        for resolved_ref in module_references(db, *top_mod) {
+            index
+                .entry(resolved_ref.target)
+                .or_default()
+                .push(IndexedReference {
+                    span: resolved_ref.span.clone(),
+                    is_self_ty: resolved_ref.is_self_ty,
+                    module: *top_mod,
+                });
+        }
+    }
+
+    ReferenceIndex::from_map(index)
+}

--- a/crates/hir/src/core/semantic/mod.rs
+++ b/crates/hir/src/core/semantic/mod.rs
@@ -20,6 +20,7 @@
 //!   `item.rs` and replace call sites by adding only the minimal semantic
 //!   method(s) here.
 
+pub mod index;
 pub mod reference;
 pub mod symbol;
 pub use reference::{

--- a/crates/hir/src/core/semantic/symbol.rs
+++ b/crates/hir/src/core/semantic/symbol.rs
@@ -7,9 +7,8 @@
 
 use crate::HirDb;
 use crate::SpannedHirDb;
-use crate::analysis::HirAnalysisDb;
 use crate::hir_def::scope_graph::ScopeId;
-use crate::hir_def::{Attr, EnumVariant, FieldParent, HirIngot, ItemKind, TopLevelMod, Visibility};
+use crate::hir_def::{Attr, EnumVariant, FieldParent, ItemKind, TopLevelMod, Visibility};
 use crate::span::{DesugaredOrigin, DynLazySpan, HirOrigin, LazySpan};
 use common::diagnostics::Span;
 use common::file::File;
@@ -575,7 +574,7 @@ pub fn qualify_path_with_ingot_name(db: &dyn SpannedHirDb, path: &str, ingot: In
 // ---------------------------------------------------------------------------
 
 /// A single reference to a symbol, with its span and metadata.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, salsa::Update)]
 pub struct IndexedReference<'db> {
     /// The span of the reference occurrence.
     pub span: DynLazySpan<'db>,
@@ -590,40 +589,26 @@ pub struct IndexedReference<'db> {
 ///
 /// Built once per ingot, eliminates the O(items × modules) scan that SCIP
 /// and LSIF currently perform.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ReferenceIndex<'db> {
     /// Target scope → list of references pointing at it.
     index: FxHashMap<ScopeId<'db>, Vec<IndexedReference<'db>>>,
 }
 
-impl<'db> ReferenceIndex<'db> {
-    /// Build the inverted reference index for an entire ingot.
-    ///
-    /// Walks every item in every module once, resolving all scope-level
-    /// references and inverting them into a target → refs map.
-    pub fn build<DB>(db: &'db DB, ingot: impl HirIngot<'db>) -> Self
-    where
-        DB: HirAnalysisDb + SpannedHirDb,
-    {
-        use super::reference::resolver::resolved_item_scope_targets;
-
-        let mut index: FxHashMap<ScopeId<'db>, Vec<IndexedReference<'db>>> = FxHashMap::default();
-
-        for top_mod in ingot.all_modules(db) {
-            let scope_graph = top_mod.scope_graph(db);
-            for item in scope_graph.items_dfs(db) {
-                for resolved in resolved_item_scope_targets(db, item) {
-                    index
-                        .entry(resolved.scope)
-                        .or_default()
-                        .push(IndexedReference {
-                            span: resolved.span.clone(),
-                            is_self_ty: resolved.is_self_ty,
-                            module: *top_mod,
-                        });
-                }
-            }
+unsafe impl<'db> salsa::Update for ReferenceIndex<'db> {
+    unsafe fn maybe_update(old_pointer: *mut Self, new_value: Self) -> bool {
+        let old = unsafe { &mut *old_pointer };
+        if old == &new_value {
+            return false;
         }
+        *old = new_value;
+        true
+    }
+}
 
+impl<'db> ReferenceIndex<'db> {
+    /// Construct from a pre-built map.
+    pub fn from_map(index: FxHashMap<ScopeId<'db>, Vec<IndexedReference<'db>>>) -> Self {
         Self { index }
     }
 

--- a/crates/language-server/Cargo.toml
+++ b/crates/language-server/Cargo.toml
@@ -48,6 +48,7 @@ fmt.workspace = true
 hir.workspace = true
 parser.workspace = true
 resolver.workspace = true
+semantic-indexing.workspace = true
 tempfile = "3.20.0"
 
 [features]
@@ -57,3 +58,9 @@ default = []
 test-utils.workspace = true
 dir-test.workspace = true
 tokio-util = { version = "0.7", features = ["compat"] }
+criterion = "0.5"
+tempfile = "3.23"
+
+[[bench]]
+name = "doc_reload"
+harness = false

--- a/crates/language-server/benches/doc_reload.rs
+++ b/crates/language-server/benches/doc_reload.rs
@@ -1,0 +1,154 @@
+//! Benchmark for the LSP doc reload hot path (issue #1424).
+//!
+//! Measures the cost of SCIP generation after file edits.
+//! With salsa caching (Layers 1-3), builtins never recompute and only
+//! the user ingot's changed modules trigger work.
+//!
+//! Run: cargo bench -p fe-language-server --bench doc_reload
+
+use common::InputDb;
+use criterion::{Criterion, SamplingMode, criterion_group, criterion_main};
+use driver::DriverDataBase;
+use url::Url;
+
+fn rss_mb() -> f64 {
+    std::fs::read_to_string("/proc/self/status")
+        .ok()
+        .and_then(|s| {
+            s.lines()
+                .find(|l| l.starts_with("VmRSS:"))
+                .and_then(|l| l.split_whitespace().nth(1))
+                .and_then(|v| v.parse::<f64>().ok())
+        })
+        .map(|kb| kb / 1024.0)
+        .unwrap_or(0.0)
+}
+
+const SAMPLE_CODE: &str = r#"
+struct Point {
+    pub x: i32
+    pub y: i32
+}
+
+impl Point {
+    pub fn new(x: i32, y: i32) -> Point {
+        Point { x, y }
+    }
+
+    pub fn distance(self, other: Point) -> i32 {
+        let dx = self.x - other.x
+        let dy = self.y - other.y
+        dx * dx + dy * dy
+    }
+
+    pub fn translate(self, dx: i32, dy: i32) -> Point {
+        Point::new(self.x + dx, self.y + dy)
+    }
+}
+
+pub fn origin() -> Point {
+    Point::new(0, 0)
+}
+
+pub fn midpoint(a: Point, b: Point) -> Point {
+    Point::new((a.x + b.x) / 2, (a.y + b.y) / 2)
+}
+"#;
+
+const EDITED_CODE: &str = r#"
+struct Point {
+    pub x: i32
+    pub y: i32
+}
+
+impl Point {
+    pub fn new(x: i32, y: i32) -> Point {
+        Point { x, y }
+    }
+
+    pub fn distance(self, other: Point) -> i32 {
+        let dx = self.x - other.x
+        let dy = self.y - other.y
+        dx * dx + dy * dy
+    }
+
+    pub fn translate(self, dx: i32, dy: i32) -> Point {
+        Point::new(self.x + dx, self.y + dy)
+    }
+
+    pub fn scale(self, factor: i32) -> Point {
+        Point::new(self.x * factor, self.y * factor)
+    }
+}
+
+pub fn zero() -> Point {
+    Point::new(0, 0)
+}
+
+pub fn midpoint(a: Point, b: Point) -> Point {
+    Point::new((a.x + b.x) / 2, (a.y + b.y) / 2)
+}
+"#;
+
+fn doc_reload(c: &mut Criterion) {
+    let mut g = c.benchmark_group("doc_reload");
+    g.sampling_mode(SamplingMode::Flat);
+    g.sample_size(10);
+
+    let temp = tempfile::tempdir().expect("create temp dir");
+    let file_path = temp.path().join("main.fe");
+    let file_url = Url::from_file_path(&file_path).unwrap();
+    let ingot_url = Url::from_directory_path(temp.path()).unwrap();
+
+    let mut db = DriverDataBase::default();
+    db.workspace()
+        .touch(&mut db, file_url.clone(), Some(SAMPLE_CODE.to_string()));
+
+    // Warm salsa cache (initial analysis + first SCIP gen)
+    let ingot = db
+        .workspace()
+        .containing_ingot(&db, file_url.clone())
+        .expect("ingot");
+    db.run_on_ingot(ingot);
+    let _ = semantic_indexing::scip_batch::generate_scip(&db, &ingot_url);
+
+    // Measure: SCIP regen after single edit (salsa-cached, builtins skip)
+    g.bench_function("scip_after_single_edit", |b| {
+        b.iter(|| {
+            db.workspace()
+                .update(&mut db, file_url.clone(), EDITED_CODE.to_string());
+            let result = semantic_indexing::scip_batch::generate_scip(&db, &ingot_url);
+            db.workspace()
+                .update(&mut db, file_url.clone(), SAMPLE_CODE.to_string());
+            result
+        });
+    });
+
+    // Measure: 20 rapid edits (the scenario from issue #1424)
+    let rss_before = rss_mb();
+    g.bench_function("20_rapid_edits", |b| {
+        let edits: Vec<String> = (0..20)
+            .map(|i| SAMPLE_CODE.replace("origin", &format!("origin_{i}")))
+            .collect();
+
+        b.iter(|| {
+            for edit in &edits {
+                db.workspace()
+                    .update(&mut db, file_url.clone(), edit.clone());
+                let _ = semantic_indexing::scip_batch::generate_scip(&db, &ingot_url);
+            }
+            db.workspace()
+                .update(&mut db, file_url.clone(), SAMPLE_CODE.to_string());
+        });
+    });
+    let rss_after = rss_mb();
+    eprintln!(
+        "[doc_reload] RSS: before={rss_before:.1}MB after={rss_after:.1}MB delta={:.1}MB",
+        rss_after - rss_before
+    );
+
+    g.finish();
+}
+
+criterion_group!(benches, doc_reload);
+criterion_main!(benches);

--- a/crates/language-server/src/backend/mod.rs
+++ b/crates/language-server/src/backend/mod.rs
@@ -39,14 +39,6 @@ impl std::fmt::Display for WorkerError {
 
 impl std::error::Error for WorkerError {}
 
-/// Closure type for regenerating doc+SCIP data from a read-only db snapshot.
-///
-/// Receives a salsa snapshot of the Backend's `DriverDataBase`. The snapshot
-/// shares cached query results so incremental queries are fast, and read-only
-/// access avoids the deadlock that would occur if we tried to mutate a snapshot
-/// while the original db is still alive.
-pub type DocRegenerateFn = Arc<dyn Fn(&DriverDataBase) -> (String, Option<String>) + Send + Sync>;
-
 pub struct Backend {
     pub(super) client: ClientSocket,
     pub(super) db: DriverDataBase,
@@ -55,7 +47,6 @@ pub struct Backend {
     pub(super) readonly_warnings: FxHashSet<Url>,
     pub(super) definition_link_support: bool,
     pub(super) doc_nav_tx: Option<broadcast::Sender<String>>,
-    pub(super) doc_regenerate_fn: Option<DocRegenerateFn>,
     pub(super) doc_reload_tx: Option<broadcast::Sender<String>>,
     pub(super) doc_reload_generation: Arc<AtomicU64>,
     pub(super) docs_url: Option<String>,
@@ -66,7 +57,6 @@ impl Backend {
     pub fn new(
         client: ClientSocket,
         doc_nav_tx: Option<broadcast::Sender<String>>,
-        doc_regenerate_fn: Option<DocRegenerateFn>,
         doc_reload_tx: Option<broadcast::Sender<String>>,
         docs_url: Option<String>,
     ) -> Self {
@@ -92,7 +82,6 @@ impl Backend {
             readonly_warnings: FxHashSet::default(),
             definition_link_support: false,
             doc_nav_tx,
-            doc_regenerate_fn,
             doc_reload_tx,
             doc_reload_generation: Arc::new(AtomicU64::new(0)),
             docs_url,
@@ -248,7 +237,7 @@ mod tests {
     /// these tests.
     fn test_backend() -> Backend {
         let (_main_loop, client_socket) = MainLoop::new_server(|_client| Router::<()>::new(()));
-        Backend::new(client_socket, None, None, None, None)
+        Backend::new(client_socket, None, None, None)
     }
 
     /// Regression test: `spawn_on_workers` must `catch_unwind` inside the

--- a/crates/language-server/src/functionality/handlers.rs
+++ b/crates/language-server/src/functionality/handlers.rs
@@ -405,8 +405,7 @@ pub async fn handle_did_save_text_document(
     message: async_lsp::lsp_types::DidSaveTextDocumentParams,
 ) -> Result<(), ResponseError> {
     debug!("file saved: {:?}", message.text_document.uri);
-    // Request doc reload on save (debounced by the stream in setup_streams)
-    if backend.doc_regenerate_fn.is_some() {
+    if backend.doc_reload_tx.is_some() {
         let _ = backend.client.clone().emit(DocReloadRequest);
     }
     Ok(())
@@ -557,10 +556,7 @@ pub async fn handle_file_change(
 
     let _ = backend.client.emit(NeedsDiagnostics(message.uri));
 
-    // Request doc reload (debounced by the stream in setup_streams).
-    // Now that regen uses a read-only salsa snapshot of the backend's db,
-    // the snapshot reflects the in-memory changes from didChange above.
-    if backend.doc_regenerate_fn.is_some() {
+    if backend.doc_reload_tx.is_some() {
         let _ = backend.client.emit(DocReloadRequest);
     }
 
@@ -748,9 +744,9 @@ pub async fn handle_doc_reload(
     backend: &Backend,
     _message: DocReloadExecute,
 ) -> Result<(), ResponseError> {
-    let Some(regen_fn) = backend.doc_regenerate_fn.as_ref().cloned() else {
+    if backend.doc_reload_tx.is_none() {
         return Ok(());
-    };
+    }
 
     debug!("regenerating doc data for live reload");
     let t_start = std::time::Instant::now();
@@ -766,7 +762,7 @@ pub async fn handle_doc_reload(
     // query results with the Backend's db, no mutation needed.
     let outcome = backend
         .spawn_on_workers(move |db| {
-            let result = regen_fn(db);
+            let result = semantic_indexing::doc::regenerate(db);
             (result, generation)
         })
         .await;

--- a/crates/language-server/src/lib.rs
+++ b/crates/language-server/src/lib.rs
@@ -37,7 +37,6 @@ use tower::ServiceBuilder;
 use tracing::instrument::WithSubscriber;
 use tracing::{error, info};
 
-pub use backend::DocRegenerateFn;
 pub use logging::setup_panic_hook;
 
 /// Configuration for the combined HTTP+WS doc/LSP server.
@@ -47,8 +46,6 @@ pub struct CombinedServerConfig {
     /// Base URL for the documentation server (e.g. "http://127.0.0.1:9000").
     /// Passed to Backend so `fe.openDocs` can construct full URLs.
     pub docs_url: Option<String>,
-    /// Closure for regenerating doc+SCIP data from a db snapshot.
-    pub doc_regenerate_fn: Option<DocRegenerateFn>,
 }
 
 pub async fn run_stdio_server(combined: Option<CombinedServerConfig>) {
@@ -59,9 +56,8 @@ pub async fn run_stdio_server(combined: Option<CombinedServerConfig>) {
     // Doc reload channel: Backend sends reload payloads, combined server forwards to WS clients
     let (doc_reload_tx, _doc_reload_rx) = broadcast::channel::<String>(16);
 
-    // Extract docs_url and doc_regenerate_fn before moving combined config
     let docs_url = combined.as_ref().and_then(|c| c.docs_url.clone());
-    let doc_regenerate_fn = combined.as_ref().and_then(|c| c.doc_regenerate_fn.clone());
+    let has_combined = combined.is_some();
 
     // Start the combined server if configured
     if let Some(config) = combined {
@@ -81,15 +77,18 @@ pub async fn run_stdio_server(combined: Option<CombinedServerConfig>) {
     }
 
     let doc_nav_tx_for_backend = doc_nav_tx.clone();
-    let doc_reload_tx_for_backend = doc_reload_tx.clone();
+    let doc_reload_tx_for_backend = if has_combined {
+        Some(doc_reload_tx.clone())
+    } else {
+        None
+    };
 
     let (server, client) = async_lsp::MainLoop::new_server(|client| {
         let actor_ref = spawn_backend(
             client.clone(),
             "LSP actor".to_string(),
             Some(doc_nav_tx_for_backend.clone()),
-            doc_regenerate_fn.clone(),
-            Some(doc_reload_tx_for_backend.clone()),
+            doc_reload_tx_for_backend.clone(),
             docs_url.clone(),
         );
         // Publish the actor ref so the combined server can use it

--- a/crates/language-server/src/server.rs
+++ b/crates/language-server/src/server.rs
@@ -1,4 +1,4 @@
-use crate::backend::{Backend, DocRegenerateFn};
+use crate::backend::Backend;
 use crate::fallback::WithFallbackService;
 use crate::functionality::handlers::{
     DocReloadExecute, DocReloadRequest, FileChange, FilesNeedDiagnostics, NeedsDiagnostics,
@@ -44,7 +44,6 @@ pub(crate) fn spawn_backend(
     client: ClientSocket,
     name: String,
     doc_nav_tx: Option<broadcast::Sender<String>>,
-    doc_regenerate_fn: Option<DocRegenerateFn>,
     doc_reload_tx: Option<broadcast::Sender<String>>,
     docs_url: Option<String>,
 ) -> ActorRef<Backend, LspActorKey> {
@@ -57,7 +56,6 @@ pub(crate) fn spawn_backend(
             Ok(Backend::new(
                 client_for_actor,
                 doc_nav_tx,
-                doc_regenerate_fn,
                 doc_reload_tx,
                 docs_url,
             ))
@@ -200,7 +198,7 @@ pub(crate) fn setup(
     client: ClientSocket,
     name: String,
 ) -> WithFallbackService<LspActorService<Backend>, Router<()>> {
-    let actor_ref = spawn_backend(client.clone(), name, None, None, None, None);
+    let actor_ref = spawn_backend(client.clone(), name, None, None, None);
     setup_service(actor_ref, client)
 }
 

--- a/crates/semantic-indexing/Cargo.toml
+++ b/crates/semantic-indexing/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "fe-semantic-indexing"
+version = "26.1.0"
+edition.workspace = true
+license = "Apache-2.0"
+repository = "https://github.com/argotorg/fe"
+description = "Semantic indexing engine for Fe: salsa-cached SCIP, LSIF, and doc generation"
+
+[dependencies]
+common.workspace = true
+hir.workspace = true
+driver.workspace = true
+salsa.workspace = true
+url.workspace = true
+camino.workspace = true
+scip = "0.6.1"
+fe-web.workspace = true
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1"
+rustc-hash = "2"
+
+[dev-dependencies]
+tempfile = "3.23"
+test-utils.workspace = true
+dir-test.workspace = true

--- a/crates/semantic-indexing/src/doc.rs
+++ b/crates/semantic-indexing/src/doc.rs
@@ -1,0 +1,167 @@
+use common::InputDb;
+use common::stdlib::{HasBuiltinCore, HasBuiltinStd};
+
+use crate::extract::DocExtractor;
+use crate::scip_batch;
+use crate::tracked;
+
+/// Regenerate doc + SCIP JSON from a database snapshot.
+///
+/// Uses salsa-tracked per-ingot functions for doc extraction and SCIP generation.
+/// Builtins never recompute (their inputs never change).
+///
+/// Returns `(doc_json, scip_json)`.
+pub fn regenerate(db: &driver::DriverDataBase) -> (String, Option<String>) {
+    let builtin_core_url = url::Url::parse(common::stdlib::BUILTIN_CORE_BASE_URL).unwrap();
+    let builtin_std_url = url::Url::parse(common::stdlib::BUILTIN_STD_BASE_URL).unwrap();
+
+    let ingot_urls: Vec<url::Url> = db
+        .dependency_graph()
+        .petgraph(db)
+        .node_weights()
+        .filter(|u| *u != &builtin_core_url && *u != &builtin_std_url)
+        .cloned()
+        .collect();
+
+    let mut index = fe_web::model::DocIndex::new();
+
+    // User ingots — salsa-cached per-ingot
+    for ingot_url in &ingot_urls {
+        let Some(ingot) = db.workspace().containing_ingot(db, ingot_url.clone()) else {
+            continue;
+        };
+        index
+            .items
+            .extend(tracked::docs_for_ingot(db, ingot).clone());
+        index
+            .modules
+            .extend(tracked::module_tree_for_ingot(db, ingot).clone());
+        index.link_trait_impls(tracked::trait_impl_links_for_ingot(db, ingot).clone());
+    }
+
+    // Standalone files (not in any ingot)
+    let standalone_files: Vec<url::Url> = db
+        .workspace()
+        .all_files(db)
+        .iter()
+        .filter_map(|(url, _file)| {
+            if db.workspace().containing_ingot(db, url.clone()).is_none() {
+                Some(url)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    for file_url in &standalone_files {
+        if let Some(file) = db.workspace().get(db, file_url) {
+            let extractor = DocExtractor::new(db);
+            let top_mod = db.top_mod(file);
+            for item in top_mod.children_nested(db) {
+                if let Some(doc_item) = extractor.extract_item(item) {
+                    index.items.push(doc_item);
+                }
+            }
+            index
+                .modules
+                .push(extractor.build_standalone_module_tree(top_mod));
+        }
+    }
+
+    // Builtins — salsa-cached, never recompute after first call
+    let existing: std::collections::HashSet<_> =
+        index.modules.iter().map(|m| m.name.clone()).collect();
+    for (label, builtin) in [("core", db.builtin_core()), ("std", db.builtin_std())] {
+        if existing.contains(label) {
+            continue;
+        }
+        index
+            .items
+            .extend(tracked::docs_for_ingot(db, builtin).clone());
+        index
+            .builtin_modules
+            .extend(tracked::module_tree_for_ingot(db, builtin).clone());
+        index.link_trait_impls(tracked::trait_impl_links_for_ingot(db, builtin).clone());
+    }
+
+    // Generate SCIP via salsa-cached scip_batch path
+    let builtin_urls = [builtin_core_url, builtin_std_url];
+    let all_scip_urls: Vec<_> = ingot_urls.iter().chain(builtin_urls.iter()).collect();
+    let mut combined_scip = scip::types::Index::default();
+    let mut combined_doc_urls = std::collections::HashMap::new();
+    let mut any_scip = false;
+
+    for ingot_url in &all_scip_urls {
+        if let Ok(mut result) = scip_batch::generate_scip(db, ingot_url)
+            && !result.index.documents.is_empty()
+        {
+            let base_url = if ingot_url.to_file_path().is_ok() {
+                None
+            } else {
+                Some(*ingot_url)
+            };
+            scip_batch::enrich_signatures_with_base(
+                db,
+                camino::Utf8Path::new("/"),
+                base_url,
+                &mut index,
+                &mut result.index,
+            );
+            combined_scip.documents.extend(result.index.documents);
+            combined_doc_urls.extend(result.doc_urls);
+            any_scip = true;
+        }
+    }
+    let scip_json = if any_scip {
+        Some(scip_batch::scip_to_json_data(
+            &combined_scip,
+            &combined_doc_urls,
+        ))
+    } else {
+        None
+    };
+
+    let mut value = serde_json::to_value(&index).expect("serialize DocIndex");
+    fe_web::static_site::inject_html_bodies(&mut value);
+    let json = serde_json::to_string(&value).expect("serialize JSON");
+
+    (json, scip_json)
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn regenerate_produces_scip_with_enriched_signatures() {
+        let temp = tempfile::tempdir().expect("create temp dir");
+        std::fs::write(
+            temp.path().join("fe.toml"),
+            "[ingot]\nname = \"test_ingot\"\nversion = \"0.1.0\"\n",
+        )
+        .unwrap();
+        let src_dir = temp.path().join("src");
+        std::fs::create_dir_all(&src_dir).unwrap();
+        std::fs::write(
+            src_dir.join("lib.fe"),
+            "pub struct Foo {\n    pub x: i32\n}\n\npub fn make_foo() -> Foo {\n    Foo { x: 1 }\n}\n",
+        )
+        .unwrap();
+
+        let mut db = driver::DriverDataBase::default();
+        let ingot_url = url::Url::from_directory_path(temp.path()).expect("dir url");
+        driver::init_ingot(&mut db, &ingot_url);
+
+        let (doc_json, scip_json) = super::regenerate(&db);
+
+        assert!(!doc_json.is_empty(), "doc JSON should not be empty");
+        assert!(
+            scip_json.is_some(),
+            "SCIP JSON should be generated for an ingot with code"
+        );
+
+        let scip = scip_json.unwrap();
+        assert!(
+            scip.contains("symbols") || scip.contains("occurrences"),
+            "SCIP JSON should contain symbol data"
+        );
+    }
+}

--- a/crates/semantic-indexing/src/extract.rs
+++ b/crates/semantic-indexing/src/extract.rs
@@ -1112,4 +1112,44 @@ mod tests {
             "module tree mismatch"
         );
     }
+
+    #[test]
+    fn display_file_is_relative_for_ingot() {
+        let temp = tempfile::tempdir().expect("create temp dir");
+        std::fs::write(
+            temp.path().join("fe.toml"),
+            "[ingot]\nname = \"test_ingot\"\nversion = \"0.1.0\"\n",
+        )
+        .unwrap();
+        let src_dir = temp.path().join("src");
+        std::fs::create_dir_all(&src_dir).unwrap();
+        std::fs::write(
+            src_dir.join("lib.fe"),
+            "pub struct Foo {\n    pub x: i32\n}\n",
+        )
+        .unwrap();
+
+        let mut db = DriverDataBase::default();
+        let ingot_url = url::Url::from_directory_path(temp.path()).expect("dir url");
+        driver::init_ingot(&mut db, &ingot_url);
+
+        let ingot = db
+            .workspace()
+            .containing_ingot(&db, ingot_url)
+            .expect("ingot should exist");
+
+        let items = crate::tracked::docs_for_ingot(&db, ingot);
+        assert!(!items.is_empty(), "should extract at least one item");
+
+        for item in items.iter() {
+            if let Some(ref source) = item.source {
+                assert!(
+                    source.display_file.contains("src") || source.display_file.contains("lib.fe"),
+                    "display_file should contain path info, got: {}",
+                    source.display_file
+                );
+                assert_ne!(source.display_file, "", "display_file should not be empty");
+            }
+        }
+    }
 }

--- a/crates/semantic-indexing/src/index_util.rs
+++ b/crates/semantic-indexing/src/index_util.rs
@@ -82,7 +82,7 @@ impl LineIndex {
 }
 
 /// Shared ingot resolution context used by both SCIP and LSIF generators.
-pub(crate) struct IngotContext<'db> {
+pub struct IngotContext<'db> {
     pub ingot: Ingot<'db>,
     pub name: String,
     pub version: String,
@@ -104,7 +104,11 @@ impl<'db> IngotContext<'db> {
             .map(|v| v.to_string())
             .unwrap_or_else(|| "0.0.0".to_string());
 
-        let ref_index = ReferenceIndex::build(db, ingot);
+        // Pre-warm per-module reference resolution in parallel.
+        // This populates salsa's cache before the tracked query reads it.
+        hir::core::semantic::index::pre_warm_module_references(db, ingot);
+
+        let ref_index = crate::tracked::ingot_references(db, ingot).clone();
 
         Ok(Self {
             ingot,

--- a/crates/semantic-indexing/src/lib.rs
+++ b/crates/semantic-indexing/src/lib.rs
@@ -1,0 +1,6 @@
+pub mod doc;
+pub mod extract;
+pub mod index_util;
+pub mod lsif;
+pub mod scip_batch;
+pub mod tracked;

--- a/crates/semantic-indexing/src/lsif.rs
+++ b/crates/semantic-indexing/src/lsif.rs
@@ -287,7 +287,7 @@ fn emit_scope_lsif<W: Write>(
 
 /// Run LSIF generation on a project.
 pub fn generate_lsif(
-    db: &mut driver::DriverDataBase,
+    db: &driver::DriverDataBase,
     ingot_url: &url::Url,
     writer: impl Write,
 ) -> io::Result<()> {
@@ -597,7 +597,7 @@ mod tests {
 
         let ingot_url = url::Url::parse("file:///").unwrap();
         let mut output = Vec::new();
-        let _ = generate_lsif(&mut db, &ingot_url, &mut output);
+        let _ = generate_lsif(&db, &ingot_url, &mut output);
         String::from_utf8(output).unwrap()
     }
 

--- a/crates/semantic-indexing/src/scip_batch.rs
+++ b/crates/semantic-indexing/src/scip_batch.rs
@@ -1,8 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use std::io;
 
-use rayon::prelude::*;
-
 use camino::{Utf8Path, Utf8PathBuf};
 use common::InputDb;
 use common::diagnostics::Span;
@@ -60,9 +58,14 @@ impl ScipDocumentBuilder {
     }
 }
 
-fn span_to_scip_range(span: &Span, db: &dyn InputDb) -> Option<Vec<i32>> {
-    let text = span.file.text(db);
-    let line_index = LineIndex::new(text);
+fn span_to_scip_range(
+    span: &Span,
+    db: &dyn InputDb,
+    line_index_cache: &mut HashMap<common::file::File, LineIndex>,
+) -> Option<Vec<i32>> {
+    let line_index = line_index_cache
+        .entry(span.file)
+        .or_insert_with(|| LineIndex::new(span.file.text(db)));
 
     let start = line_index.position(span.range.start().into());
     let end = line_index.position(span.range.end().into());
@@ -236,6 +239,8 @@ pub fn generate_scip(db: &driver::DriverDataBase, ingot_url: &url::Url) -> io::R
     generate_scip_with_root(db, ingot_url, &project_root_path)
 }
 
+/// Parallel SCIP generation using Rayon with db clones.
+/// Use this for cold starts (CLI, first LSP gen) where the salsa cache is empty.
 /// Like `generate_scip`, but uses `project_root` for computing relative paths
 /// instead of deriving it from the ingot URL. This ensures SCIP document paths
 /// are relative to the workspace root when generating docs for workspace members.
@@ -246,48 +251,22 @@ pub fn generate_scip_with_root(
 ) -> io::Result<ScipResult> {
     let ctx = index_util::IngotContext::resolve(db, ingot_url)?;
 
-    let project_root_path = project_root.to_path_buf();
-
-    // Pre-compute relative paths for all module files
     let file_relative_paths: HashMap<String, String> = ctx
         .ingot
         .all_modules(db)
         .iter()
         .filter_map(|top_mod| {
             let doc_url = top_mod_url(db, top_mod)?;
-            let relative = relative_path(&project_root_path, &doc_url)?;
+            let relative = relative_path(project_root, &doc_url)?;
             Some((doc_url.to_string(), relative))
-        })
-        .collect();
-
-    // Process modules in parallel using rayon with Salsa DB forks.
-    // Each clone shares cached query results via Arc, making
-    // IngotContext::resolve (incl. ReferenceIndex::build) cheap.
-    // We create one fork per rayon thread (not per module) so each
-    // fork builds the IngotContext once for its chunk of modules.
-    let module_count = ctx.ingot.all_modules(db).len();
-    let fork_count = rayon::current_num_threads().max(1).min(module_count);
-    let db_forks: Vec<driver::DriverDataBase> = (0..fork_count).map(|_| db.clone()).collect();
-
-    let parallel_results: Vec<Vec<ModuleResult>> = db_forks
-        .into_par_iter()
-        .enumerate()
-        .map(|(thread_idx, fork)| {
-            let ctx = index_util::IngotContext::resolve(&fork, ingot_url)
-                .expect("IngotContext::resolve should succeed in forked db");
-            let modules = ctx.ingot.all_modules(&fork);
-            let start = thread_idx * module_count / fork_count;
-            let end = ((thread_idx + 1) * module_count / fork_count).min(module_count);
-            (start..end)
-                .filter_map(|idx| process_module(&fork, modules[idx], &ctx, &file_relative_paths))
-                .collect()
         })
         .collect();
 
     let mut documents: HashMap<String, ScipDocumentBuilder> = HashMap::new();
     let mut all_doc_urls: HashMap<String, String> = HashMap::new();
-    for chunk in parallel_results {
-        for result in chunk {
+
+    for top_mod in ctx.ingot.all_modules(db) {
+        if let Some(result) = process_module(db, *top_mod, &ctx, &file_relative_paths) {
             all_doc_urls.extend(result.doc_urls);
             for (url, builder) in result.documents {
                 match documents.entry(url) {
@@ -302,14 +281,6 @@ pub fn generate_scip_with_root(
         }
     }
 
-    // Emit cross-ingot references.
-    //
-    // The ReferenceIndex tracks all scope references originating from this
-    // ingot's code, including references to items in other ingots (e.g.
-    // `Option` from `core`).  process_module() above only queries for
-    // targets that appear in this ingot's scope graphs.  Here we iterate
-    // remaining targets in foreign ingots and emit reference occurrences
-    // so that cross-ingot type usages are visible in the SCIP data.
     emit_cross_ingot_references(db, &ctx, &file_relative_paths, &mut documents);
 
     let mut index = types::Index::new();
@@ -364,6 +335,7 @@ fn process_module<'db>(
 
     let mut documents: HashMap<String, ScipDocumentBuilder> = HashMap::new();
     let mut doc_urls: HashMap<String, String> = HashMap::new();
+    let mut line_index_cache: HashMap<common::file::File, LineIndex> = HashMap::new();
 
     // Ensure this module's file has a builder
     if let Some(relative) = file_relative_paths.get(&doc_url) {
@@ -397,6 +369,7 @@ fn process_module<'db>(
                 &doc_url,
                 file_relative_paths,
                 &mut documents,
+                &mut line_index_cache,
             );
             continue;
         };
@@ -423,7 +396,7 @@ fn process_module<'db>(
             }
 
             if let Some(name_span) = item.name_span().and_then(|span| span.resolve(db))
-                && let Some(range) = span_to_scip_range(&name_span, db)
+                && let Some(range) = span_to_scip_range(&name_span, db, &mut line_index_cache)
             {
                 push_occurrence(
                     doc,
@@ -449,7 +422,7 @@ fn process_module<'db>(
                         .unwrap_or_default();
                     ScipDocumentBuilder::new(relative)
                 });
-                if let Some(range) = span_to_scip_range(&resolved, db) {
+                if let Some(range) = span_to_scip_range(&resolved, db, &mut line_index_cache) {
                     push_occurrence(ref_doc, range, symbol.clone(), 0);
                 }
             }
@@ -498,7 +471,8 @@ fn process_module<'db>(
                     }
 
                     if let Some(name_span) = child.name_span(db)
-                        && let Some(range) = span_to_scip_range(&name_span, db)
+                        && let Some(range) =
+                            span_to_scip_range(&name_span, db, &mut line_index_cache)
                     {
                         push_occurrence(
                             doc,
@@ -523,7 +497,9 @@ fn process_module<'db>(
                                 .unwrap_or_default();
                             ScipDocumentBuilder::new(relative)
                         });
-                        if let Some(range) = span_to_scip_range(&resolved, db) {
+                        if let Some(range) =
+                            span_to_scip_range(&resolved, db, &mut line_index_cache)
+                        {
                             push_occurrence(ref_doc, range, child_symbol.clone(), 0);
                         }
                     }
@@ -539,6 +515,7 @@ fn process_module<'db>(
                     &doc_url,
                     file_relative_paths,
                     &mut documents,
+                    &mut line_index_cache,
                 );
             }
         } // end if !Mod/TopMod
@@ -553,6 +530,7 @@ fn process_module<'db>(
             &doc_url,
             file_relative_paths,
             &mut documents,
+            &mut line_index_cache,
         );
     }
 
@@ -571,6 +549,7 @@ fn process_module<'db>(
 /// Also indexes generic params of child items (methods) inside unnamed containers,
 /// since the child-indexing path in `process_module` is unreachable when the parent
 /// has no symbol.
+#[allow(clippy::too_many_arguments)]
 fn index_unnamed_item_generic_params<'db>(
     db: &'db driver::DriverDataBase,
     item: ItemKind<'db>,
@@ -579,6 +558,7 @@ fn index_unnamed_item_generic_params<'db>(
     doc_url: &str,
     file_relative_paths: &HashMap<String, String>,
     documents: &mut HashMap<String, ScipDocumentBuilder>,
+    line_index_cache: &mut HashMap<common::file::File, LineIndex>,
 ) {
     // Construct a synthetic parent symbol from the impl's byte offset.
     // The exact string doesn't matter — it just needs to be unique so type param
@@ -599,6 +579,7 @@ fn index_unnamed_item_generic_params<'db>(
         doc_url,
         file_relative_paths,
         documents,
+        line_index_cache,
     );
 
     // Also index generic params of children (methods inside impl blocks).
@@ -619,12 +600,14 @@ fn index_unnamed_item_generic_params<'db>(
             doc_url,
             file_relative_paths,
             documents,
+            line_index_cache,
         );
     }
 }
 
 /// Index generic parameters for a symbol using SymbolView::generic_params().
 /// Shared by both top-level items and child items (trait methods, etc.).
+#[allow(clippy::too_many_arguments)]
 fn index_generic_params_for<'db>(
     db: &'db driver::DriverDataBase,
     sym_view: &SymbolView<'db>,
@@ -633,6 +616,7 @@ fn index_generic_params_for<'db>(
     doc_url: &str,
     file_relative_paths: &HashMap<String, String>,
     documents: &mut HashMap<String, ScipDocumentBuilder>,
+    line_index_cache: &mut HashMap<common::file::File, LineIndex>,
 ) {
     for gp_scope in sym_view.generic_params(db) {
         let Some(gp_name) = gp_scope.name(db) else {
@@ -657,7 +641,7 @@ fn index_generic_params_for<'db>(
 
             if let Some(name_span) = gp_scope.name_span(db)
                 && let Some(resolved) = name_span.resolve(db)
-                && let Some(range) = span_to_scip_range(&resolved, db)
+                && let Some(range) = span_to_scip_range(&resolved, db, line_index_cache)
             {
                 push_occurrence(
                     doc,
@@ -681,7 +665,7 @@ fn index_generic_params_for<'db>(
                         .unwrap_or_default();
                     ScipDocumentBuilder::new(relative)
                 });
-                if let Some(range) = span_to_scip_range(&resolved, db) {
+                if let Some(range) = span_to_scip_range(&resolved, db, line_index_cache) {
                     push_occurrence(ref_doc, range, gp_symbol.clone(), 0);
                 }
             }
@@ -734,6 +718,7 @@ fn emit_cross_ingot_references<'db>(
 ) {
     // Cache target ingot metadata to avoid repeated lookups
     let mut ingot_meta: HashMap<common::ingot::Ingot<'db>, (String, String)> = HashMap::new();
+    let mut line_index_cache: HashMap<common::file::File, LineIndex> = HashMap::new();
 
     for (target_scope, refs) in ctx.ref_index.iter() {
         // Skip targets within the current ingot (already handled by process_module)
@@ -780,7 +765,7 @@ fn emit_cross_ingot_references<'db>(
                         .unwrap_or_default();
                     ScipDocumentBuilder::new(relative)
                 });
-                if let Some(range) = span_to_scip_range(&resolved, db) {
+                if let Some(range) = span_to_scip_range(&resolved, db, &mut line_index_cache) {
                     push_occurrence(ref_doc, range, symbol.clone(), 0);
                 }
 
@@ -1618,7 +1603,6 @@ fn simple_hash(s: &str) -> u32 {
     }
     h
 }
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/semantic-indexing/src/tracked.rs
+++ b/crates/semantic-indexing/src/tracked.rs
@@ -1,0 +1,57 @@
+use common::ingot::Ingot;
+use hir::core::semantic::symbol::ReferenceIndex;
+use hir::hir_def::HirIngot;
+
+use crate::extract::DocExtractor;
+
+/// Layer 2: per-ingot reference index, assembled from Layer 1 per-module data.
+/// Salsa caches this — builtins compute once and never again.
+#[salsa::tracked(return_ref)]
+pub fn ingot_references<'db>(
+    db: &'db dyn hir::analysis::HirAnalysisDb,
+    ingot: Ingot<'db>,
+) -> ReferenceIndex<'db> {
+    hir::core::semantic::index::build_reference_index_from_cached(db, ingot)
+}
+
+/// Per-ingot doc extraction, cached by salsa.
+/// Builtins never recompute (their inputs never change).
+#[salsa::tracked(return_ref)]
+pub fn docs_for_ingot<'db>(
+    db: &'db dyn hir::SpannedHirDb,
+    ingot: Ingot<'db>,
+) -> Vec<fe_web::model::DocItem> {
+    let extractor = DocExtractor::new(db);
+    let mut items = Vec::new();
+
+    for top_mod in ingot.all_modules(db) {
+        for item in top_mod.children_nested(db) {
+            if let Some(doc_item) = extractor.extract_item_for_ingot(item, ingot) {
+                items.push(doc_item);
+            }
+        }
+    }
+
+    items
+}
+
+/// Per-ingot module tree extraction, cached by salsa.
+#[salsa::tracked(return_ref)]
+pub fn module_tree_for_ingot<'db>(
+    db: &'db dyn hir::SpannedHirDb,
+    ingot: Ingot<'db>,
+) -> Vec<fe_web::model::DocModuleTree> {
+    let extractor = DocExtractor::new(db);
+    let root_mod = ingot.root_mod(db);
+    extractor.build_module_tree_for_ingot(ingot, root_mod)
+}
+
+/// Per-ingot trait impl links, cached by salsa.
+#[salsa::tracked(return_ref)]
+pub fn trait_impl_links_for_ingot<'db>(
+    db: &'db dyn hir::SpannedHirDb,
+    ingot: Ingot<'db>,
+) -> Vec<(String, fe_web::model::DocTraitImpl)> {
+    let extractor = DocExtractor::new(db);
+    extractor.extract_trait_impl_links(ingot)
+}

--- a/crates/semantic-indexing/tests/doc_fixtures/enum_with_variants.fe
+++ b/crates/semantic-indexing/tests/doc_fixtures/enum_with_variants.fe
@@ -1,0 +1,11 @@
+/// Represents a color.
+pub enum Color {
+    /// Red color
+    Red
+    /// Green color
+    Green
+    /// Blue color
+    Blue
+    /// Custom RGB value
+    Custom(u256)
+}

--- a/crates/semantic-indexing/tests/doc_fixtures/enum_with_variants.snap
+++ b/crates/semantic-indexing/tests/doc_fixtures/enum_with_variants.snap
@@ -1,0 +1,109 @@
+---
+source: crates/fe/src/extract.rs
+expression: output
+input_file: tests/doc_fixtures/enum_with_variants.fe
+---
+{
+  "items": [
+    {
+      "path": "enum_with_variants",
+      "name": "enum_with_variants",
+      "kind": "module",
+      "visibility": "public",
+      "docs": null,
+      "signature": "/// Represents a color.\npub enum Color {\n    /// Red color\n    Red\n    /// Green color\n    Green\n    /// Blue color\n    Blue\n    /// Custom RGB value\n    Custom(u256)\n}",
+      "generics": [],
+      "where_bounds": [],
+      "children": [],
+      "source": {
+        "display_file": "enum_with_variants.fe",
+        "line": 1,
+        "column": 0
+      },
+      "source_text": "/// Represents a color.\npub enum Color {\n    /// Red color\n    Red\n    /// Green color\n    Green\n    /// Blue color\n    Blue\n    /// Custom RGB value\n    Custom(u256)\n}\n",
+      "trait_impls": []
+    },
+    {
+      "path": "enum_with_variants::Color",
+      "name": "Color",
+      "kind": "enum",
+      "visibility": "public",
+      "docs": {
+        "summary": "Represents a color.",
+        "body": "Represents a color.",
+        "sections": []
+      },
+      "signature": "pub enum Color",
+      "generics": [],
+      "where_bounds": [],
+      "children": [
+        {
+          "kind": "variant",
+          "name": "Red",
+          "docs": {
+            "summary": "Red color",
+            "body": "Red color",
+            "sections": []
+          },
+          "signature": "Red",
+          "visibility": "public"
+        },
+        {
+          "kind": "variant",
+          "name": "Green",
+          "docs": {
+            "summary": "Green color",
+            "body": "Green color",
+            "sections": []
+          },
+          "signature": "Green",
+          "visibility": "public"
+        },
+        {
+          "kind": "variant",
+          "name": "Blue",
+          "docs": {
+            "summary": "Blue color",
+            "body": "Blue color",
+            "sections": []
+          },
+          "signature": "Blue",
+          "visibility": "public"
+        },
+        {
+          "kind": "variant",
+          "name": "Custom",
+          "docs": {
+            "summary": "Custom RGB value",
+            "body": "Custom RGB value",
+            "sections": []
+          },
+          "signature": "Custom(u256)",
+          "visibility": "public"
+        }
+      ],
+      "source": {
+        "display_file": "enum_with_variants.fe",
+        "line": 1,
+        "column": 0
+      },
+      "source_text": "/// Represents a color.\npub enum Color {\n    /// Red color\n    Red\n    /// Green color\n    Green\n    /// Blue color\n    Blue\n    /// Custom RGB value\n    Custom(u256)\n}",
+      "trait_impls": []
+    }
+  ],
+  "modules": [
+    {
+      "name": "enum_with_variants",
+      "path": "enum_with_variants",
+      "children": [],
+      "items": [
+        {
+          "name": "Color",
+          "path": "enum_with_variants::Color",
+          "kind": "enum",
+          "summary": "Represents a color."
+        }
+      ]
+    }
+  ]
+}

--- a/crates/semantic-indexing/tests/doc_fixtures/function_docs.fe
+++ b/crates/semantic-indexing/tests/doc_fixtures/function_docs.fe
@@ -1,0 +1,14 @@
+/// Compute the sum of two values.
+///
+/// # Examples
+/// ```
+/// let result: u256 = add(1, 2)
+/// ```
+pub fn add(a: u256, b: u256) -> u256 {
+    return a + b
+}
+
+/// Check if a value is zero.
+pub fn is_zero(val: u256) -> bool {
+    return val == 0
+}

--- a/crates/semantic-indexing/tests/doc_fixtures/function_docs.snap
+++ b/crates/semantic-indexing/tests/doc_fixtures/function_docs.snap
@@ -1,0 +1,92 @@
+---
+source: crates/fe/src/extract.rs
+expression: output
+input_file: tests/doc_fixtures/function_docs.fe
+---
+{
+  "items": [
+    {
+      "path": "function_docs",
+      "name": "function_docs",
+      "kind": "module",
+      "visibility": "public",
+      "docs": null,
+      "signature": "/// Compute the sum of two values.\n///\n/// # Examples\n/// ```\n/// let result: u256 = add(1, 2)\n/// ```\npub fn add(a: u256, b: u256) -> u256 {\n    return a + b\n}\n\n/// Check if a value is zero.\npub fn is_zero(val: u256) -> bool {\n    return val == 0\n}",
+      "generics": [],
+      "where_bounds": [],
+      "children": [],
+      "source": {
+        "display_file": "function_docs.fe",
+        "line": 1,
+        "column": 0
+      },
+      "source_text": "/// Compute the sum of two values.\n///\n/// # Examples\n/// ```\n/// let result: u256 = add(1, 2)\n/// ```\npub fn add(a: u256, b: u256) -> u256 {\n    return a + b\n}\n\n/// Check if a value is zero.\npub fn is_zero(val: u256) -> bool {\n    return val == 0\n}\n",
+      "trait_impls": []
+    },
+    {
+      "path": "function_docs::add",
+      "name": "add",
+      "kind": "function",
+      "visibility": "public",
+      "docs": {
+        "summary": "Compute the sum of two values.",
+        "body": "Compute the sum of two values.\n\n # Examples\n ```\n let result: u256 = add(1, 2)\n ```",
+        "sections": []
+      },
+      "signature": "pub fn add(a: u256, b: u256) -> u256",
+      "generics": [],
+      "where_bounds": [],
+      "children": [],
+      "source": {
+        "display_file": "function_docs.fe",
+        "line": 1,
+        "column": 0
+      },
+      "source_text": "/// Compute the sum of two values.\n///\n/// # Examples\n/// ```\n/// let result: u256 = add(1, 2)\n/// ```\npub fn add(a: u256, b: u256) -> u256 {\n    return a + b\n}",
+      "trait_impls": []
+    },
+    {
+      "path": "function_docs::is_zero",
+      "name": "is_zero",
+      "kind": "function",
+      "visibility": "public",
+      "docs": {
+        "summary": "Check if a value is zero.",
+        "body": "Check if a value is zero.",
+        "sections": []
+      },
+      "signature": "pub fn is_zero(val: u256) -> bool",
+      "generics": [],
+      "where_bounds": [],
+      "children": [],
+      "source": {
+        "display_file": "function_docs.fe",
+        "line": 11,
+        "column": 0
+      },
+      "source_text": "/// Check if a value is zero.\npub fn is_zero(val: u256) -> bool {\n    return val == 0\n}",
+      "trait_impls": []
+    }
+  ],
+  "modules": [
+    {
+      "name": "function_docs",
+      "path": "function_docs",
+      "children": [],
+      "items": [
+        {
+          "name": "add",
+          "path": "function_docs::add",
+          "kind": "function",
+          "summary": "Compute the sum of two values."
+        },
+        {
+          "name": "is_zero",
+          "path": "function_docs::is_zero",
+          "kind": "function",
+          "summary": "Check if a value is zero."
+        }
+      ]
+    }
+  ]
+}

--- a/crates/semantic-indexing/tests/doc_fixtures/module_tree.fe
+++ b/crates/semantic-indexing/tests/doc_fixtures/module_tree.fe
@@ -1,0 +1,17 @@
+/// The root module.
+
+/// An inner module for math operations.
+pub mod math {
+    /// Add two numbers.
+    pub fn add(a: u256, b: u256) -> u256 {
+        return a + b
+    }
+
+    /// Multiply two numbers.
+    pub fn mul(a: u256, b: u256) -> u256 {
+        return a * b
+    }
+}
+
+/// A top-level constant.
+pub const MAX_VALUE: u256 = 1000

--- a/crates/semantic-indexing/tests/doc_fixtures/module_tree.snap
+++ b/crates/semantic-indexing/tests/doc_fixtures/module_tree.snap
@@ -1,0 +1,150 @@
+---
+source: crates/fe/src/extract.rs
+expression: output
+input_file: tests/doc_fixtures/module_tree.fe
+---
+{
+  "items": [
+    {
+      "path": "module_tree",
+      "name": "module_tree",
+      "kind": "module",
+      "visibility": "public",
+      "docs": null,
+      "signature": "/// The root module.\n\n/// An inner module for math operations.\npub mod math {\n    /// Add two numbers.\n    pub fn add(a: u256, b: u256) -> u256 {\n        return a + b\n    }\n\n    /// Multiply two numbers.\n    pub fn mul(a: u256, b: u256) -> u256 {\n        return a * b\n    }\n}\n\n/// A top-level constant.\npub const MAX_VALUE: u256 = 1000",
+      "generics": [],
+      "where_bounds": [],
+      "children": [],
+      "source": {
+        "display_file": "module_tree.fe",
+        "line": 1,
+        "column": 0
+      },
+      "source_text": "/// The root module.\n\n/// An inner module for math operations.\npub mod math {\n    /// Add two numbers.\n    pub fn add(a: u256, b: u256) -> u256 {\n        return a + b\n    }\n\n    /// Multiply two numbers.\n    pub fn mul(a: u256, b: u256) -> u256 {\n        return a * b\n    }\n}\n\n/// A top-level constant.\npub const MAX_VALUE: u256 = 1000\n",
+      "trait_impls": []
+    },
+    {
+      "path": "module_tree::math",
+      "name": "math",
+      "kind": "module",
+      "visibility": "public",
+      "docs": {
+        "summary": "The root module.\n An inner module for math operations.",
+        "body": "The root module.\n An inner module for math operations.",
+        "sections": []
+      },
+      "signature": "pub mod math",
+      "generics": [],
+      "where_bounds": [],
+      "children": [],
+      "source": {
+        "display_file": "module_tree.fe",
+        "line": 1,
+        "column": 0
+      },
+      "source_text": "/// The root module.\n\n/// An inner module for math operations.\npub mod math {\n    /// Add two numbers.\n    pub fn add(a: u256, b: u256) -> u256 {\n        return a + b\n    }\n\n    /// Multiply two numbers.\n    pub fn mul(a: u256, b: u256) -> u256 {\n        return a * b\n    }\n}",
+      "trait_impls": []
+    },
+    {
+      "path": "module_tree::math::add",
+      "name": "add",
+      "kind": "function",
+      "visibility": "public",
+      "docs": {
+        "summary": "Add two numbers.",
+        "body": "Add two numbers.",
+        "sections": []
+      },
+      "signature": "pub fn add(a: u256, b: u256) -> u256",
+      "generics": [],
+      "where_bounds": [],
+      "children": [],
+      "source": {
+        "display_file": "module_tree.fe",
+        "line": 5,
+        "column": 4
+      },
+      "source_text": "/// Add two numbers.\n    pub fn add(a: u256, b: u256) -> u256 {\n        return a + b\n    }",
+      "trait_impls": []
+    },
+    {
+      "path": "module_tree::math::mul",
+      "name": "mul",
+      "kind": "function",
+      "visibility": "public",
+      "docs": {
+        "summary": "Multiply two numbers.",
+        "body": "Multiply two numbers.",
+        "sections": []
+      },
+      "signature": "pub fn mul(a: u256, b: u256) -> u256",
+      "generics": [],
+      "where_bounds": [],
+      "children": [],
+      "source": {
+        "display_file": "module_tree.fe",
+        "line": 10,
+        "column": 4
+      },
+      "source_text": "/// Multiply two numbers.\n    pub fn mul(a: u256, b: u256) -> u256 {\n        return a * b\n    }",
+      "trait_impls": []
+    },
+    {
+      "path": "module_tree::MAX_VALUE",
+      "name": "MAX_VALUE",
+      "kind": "const",
+      "visibility": "public",
+      "docs": {
+        "summary": "A top-level constant.",
+        "body": "A top-level constant.",
+        "sections": []
+      },
+      "signature": "pub const MAX_VALUE: u256 = 1000",
+      "generics": [],
+      "where_bounds": [],
+      "children": [],
+      "source": {
+        "display_file": "module_tree.fe",
+        "line": 16,
+        "column": 0
+      },
+      "source_text": "/// A top-level constant.\npub const MAX_VALUE: u256 = 1000",
+      "trait_impls": []
+    }
+  ],
+  "modules": [
+    {
+      "name": "module_tree",
+      "path": "module_tree",
+      "children": [
+        {
+          "name": "math",
+          "path": "module_tree::math",
+          "children": [],
+          "items": [
+            {
+              "name": "add",
+              "path": "module_tree::math::add",
+              "kind": "function",
+              "summary": "Add two numbers."
+            },
+            {
+              "name": "mul",
+              "path": "module_tree::math::mul",
+              "kind": "function",
+              "summary": "Multiply two numbers."
+            }
+          ]
+        }
+      ],
+      "items": [
+        {
+          "name": "MAX_VALUE",
+          "path": "module_tree::MAX_VALUE",
+          "kind": "const",
+          "summary": "A top-level constant."
+        }
+      ]
+    }
+  ]
+}

--- a/crates/semantic-indexing/tests/doc_fixtures/simple_struct.fe
+++ b/crates/semantic-indexing/tests/doc_fixtures/simple_struct.fe
@@ -1,0 +1,9 @@
+/// A point in 2D space.
+///
+/// Used to represent coordinates in the plane.
+pub struct Point {
+    /// The x coordinate
+    pub x: u256
+    /// The y coordinate
+    pub y: u256
+}

--- a/crates/semantic-indexing/tests/doc_fixtures/simple_struct.snap
+++ b/crates/semantic-indexing/tests/doc_fixtures/simple_struct.snap
@@ -1,0 +1,87 @@
+---
+source: crates/fe/src/extract.rs
+expression: output
+input_file: tests/doc_fixtures/simple_struct.fe
+---
+{
+  "items": [
+    {
+      "path": "simple_struct",
+      "name": "simple_struct",
+      "kind": "module",
+      "visibility": "public",
+      "docs": null,
+      "signature": "/// A point in 2D space.\n///\n/// Used to represent coordinates in the plane.\npub struct Point {\n    /// The x coordinate\n    pub x: u256\n    /// The y coordinate\n    pub y: u256\n}",
+      "generics": [],
+      "where_bounds": [],
+      "children": [],
+      "source": {
+        "display_file": "simple_struct.fe",
+        "line": 1,
+        "column": 0
+      },
+      "source_text": "/// A point in 2D space.\n///\n/// Used to represent coordinates in the plane.\npub struct Point {\n    /// The x coordinate\n    pub x: u256\n    /// The y coordinate\n    pub y: u256\n}\n",
+      "trait_impls": []
+    },
+    {
+      "path": "simple_struct::Point",
+      "name": "Point",
+      "kind": "struct",
+      "visibility": "public",
+      "docs": {
+        "summary": "A point in 2D space.",
+        "body": "A point in 2D space.\n\n Used to represent coordinates in the plane.",
+        "sections": []
+      },
+      "signature": "pub struct Point",
+      "generics": [],
+      "where_bounds": [],
+      "children": [
+        {
+          "kind": "field",
+          "name": "x",
+          "docs": {
+            "summary": "The x coordinate",
+            "body": "The x coordinate",
+            "sections": []
+          },
+          "signature": "x: u256",
+          "visibility": "public"
+        },
+        {
+          "kind": "field",
+          "name": "y",
+          "docs": {
+            "summary": "The y coordinate",
+            "body": "The y coordinate",
+            "sections": []
+          },
+          "signature": "y: u256",
+          "visibility": "public"
+        }
+      ],
+      "source": {
+        "display_file": "simple_struct.fe",
+        "line": 1,
+        "column": 0
+      },
+      "source_text": "/// A point in 2D space.\n///\n/// Used to represent coordinates in the plane.\npub struct Point {\n    /// The x coordinate\n    pub x: u256\n    /// The y coordinate\n    pub y: u256\n}",
+      "trait_impls": []
+    }
+  ],
+  "modules": [
+    {
+      "name": "simple_struct",
+      "path": "simple_struct",
+      "children": [],
+      "items": [
+        {
+          "name": "Point",
+          "path": "simple_struct::Point",
+          "kind": "struct",
+          "summary": "A point in 2D space."
+        }
+      ]
+    }
+  ]
+}

--- a/crates/semantic-indexing/tests/doc_fixtures/trait_and_impl.fe
+++ b/crates/semantic-indexing/tests/doc_fixtures/trait_and_impl.fe
@@ -1,0 +1,16 @@
+/// A trait for things that can be displayed.
+pub trait Displayable {
+    /// Returns a string representation.
+    fn display(self) -> u256
+}
+
+/// A simple counter.
+pub struct Counter {
+    pub value: u256
+}
+
+impl Displayable for Counter {
+    fn display(self) -> u256 {
+        return self.value
+    }
+}

--- a/crates/semantic-indexing/tests/doc_fixtures/trait_and_impl.snap
+++ b/crates/semantic-indexing/tests/doc_fixtures/trait_and_impl.snap
@@ -1,0 +1,113 @@
+---
+source: crates/fe/src/extract.rs
+assertion_line: 998
+expression: output
+input_file: tests/doc_fixtures/trait_and_impl.fe
+---
+{
+  "items": [
+    {
+      "path": "trait_and_impl",
+      "name": "trait_and_impl",
+      "kind": "module",
+      "visibility": "public",
+      "docs": null,
+      "signature": "/// A trait for things that can be displayed.\npub trait Displayable {\n    /// Returns a string representation.\n    fn display(self) -> u256\n}\n\n/// A simple counter.\npub struct Counter {\n    pub value: u256\n}\n\nimpl Displayable for Counter {\n    fn display(self) -> u256 {\n        return self.value\n    }\n}",
+      "generics": [],
+      "where_bounds": [],
+      "children": [],
+      "source": {
+        "display_file": "trait_and_impl.fe",
+        "line": 1,
+        "column": 0
+      },
+      "source_text": "/// A trait for things that can be displayed.\npub trait Displayable {\n    /// Returns a string representation.\n    fn display(self) -> u256\n}\n\n/// A simple counter.\npub struct Counter {\n    pub value: u256\n}\n\nimpl Displayable for Counter {\n    fn display(self) -> u256 {\n        return self.value\n    }\n}\n",
+      "trait_impls": []
+    },
+    {
+      "path": "trait_and_impl::Displayable",
+      "name": "Displayable",
+      "kind": "trait",
+      "visibility": "public",
+      "docs": {
+        "summary": "A trait for things that can be displayed.",
+        "body": "A trait for things that can be displayed.",
+        "sections": []
+      },
+      "signature": "pub trait Displayable",
+      "generics": [],
+      "where_bounds": [],
+      "children": [
+        {
+          "kind": "method",
+          "name": "display",
+          "docs": {
+            "summary": "Returns a string representation.",
+            "body": "Returns a string representation.",
+            "sections": []
+          },
+          "signature": "fn display(self) -> u256",
+          "visibility": "public"
+        }
+      ],
+      "source": {
+        "display_file": "trait_and_impl.fe",
+        "line": 1,
+        "column": 0
+      },
+      "source_text": "/// A trait for things that can be displayed.\npub trait Displayable {\n    /// Returns a string representation.\n    fn display(self) -> u256\n}",
+      "trait_impls": []
+    },
+    {
+      "path": "trait_and_impl::Counter",
+      "name": "Counter",
+      "kind": "struct",
+      "visibility": "public",
+      "docs": {
+        "summary": "A simple counter.",
+        "body": "A simple counter.",
+        "sections": []
+      },
+      "signature": "pub struct Counter",
+      "generics": [],
+      "where_bounds": [],
+      "children": [
+        {
+          "kind": "field",
+          "name": "value",
+          "docs": null,
+          "signature": "value: u256",
+          "visibility": "public"
+        }
+      ],
+      "source": {
+        "display_file": "trait_and_impl.fe",
+        "line": 7,
+        "column": 0
+      },
+      "source_text": "/// A simple counter.\npub struct Counter {\n    pub value: u256\n}",
+      "trait_impls": []
+    }
+  ],
+  "modules": [
+    {
+      "name": "trait_and_impl",
+      "path": "trait_and_impl",
+      "children": [],
+      "items": [
+        {
+          "name": "Counter",
+          "path": "trait_and_impl::Counter",
+          "kind": "struct",
+          "summary": "A simple counter."
+        },
+        {
+          "name": "Displayable",
+          "path": "trait_and_impl::Displayable",
+          "kind": "trait",
+          "summary": "A trait for things that can be displayed."
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

SCIP generation rebuilds the full reference index for all ingots (including core and std) on every edit. That's ~3s of work that produces the same output for builtins every single time.

Profiling shows 97% of that time is in `resolved_item_scope_targets` (building the reference index), not the SCIP formatting loop (30ms). Rayon parallelism over modules was speeding up the cheap part. This removes Rayon from SCIP gen and fixes the actual bottleneck with salsa caching.

## How it works

Three layers of salsa-tracked functions, each cached independently:

1. `module_references(db, module)` in hir. Per-module, only recomputes when that module's resolved targets change.
2. `ingot_references(db, ingot)` in semantic-indexing. Assembles per-module data into an ingot-level reference index. Builtins compute once and stay cached permanently.
3. `docs_for_ingot` / `generate_scip` read from cached layer 2 data. The formatting loop over modules takes 30ms.

`IngotContext::resolve` now calls `ingot_references` instead of `ReferenceIndex::build`, so every SCIP/LSIF generation path gets caching for free.

Cold start uses `salsa::par_map` to resolve all modules in parallel (1.8s vs 3.2s sequential for core). After that, edits only recompute the changed module.

## Other changes

- Moves SCIP/LSIF/doc extraction from the `fe` CLI binary into a new `fe-semantic-indexing` library crate so the CLI and language-server share one code path
- `ArcIndexMap` wraps `Workspace.paths` in an Arc so `File::url()` is O(1) instead of cloning the full IndexMap (showed up in Sean's flamegraph, 14/21 samples)
- `DocRegenerateFn` closure pattern replaced with direct function calls
- Criterion benchmarks for regression testing

Net +65 lines of library code. Rest of the diff is test fixtures, benchmarks, and file moves.

Closes #1424