### PR TITLE
Fix generic assoc const lowering, generic code region targets

### DIFF
--- a/crates/fe/tests/cli_output.rs
+++ b/crates/fe/tests/cli_output.rs
@@ -1749,6 +1749,16 @@ fn test_cli_test_workspace_root_is_workspace_aware() {
 }
 
 #[test]
+fn test_cli_test_fe_repo_root() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|path| path.parent())
+        .expect("fe repo root");
+    let (output, exit_code) = run_fe_main_in_dir(&["test"], root);
+    assert_eq!(exit_code, 0, "fe test failed:\n{output}");
+}
+
+#[test]
 fn test_cli_test_workspace_ingot_selects_single_ingot() {
     let root = workspace_fixture("test_workspace_fe_test_core_std_no_tests");
     let (output, exit_code) = run_fe_main_in_dir(&["test", "--ingot", "app"], &root);

--- a/crates/hir/src/analysis/semantic/borrowck/ir.rs
+++ b/crates/hir/src/analysis/semantic/borrowck/ir.rs
@@ -6,7 +6,8 @@ use crate::{
         HirAnalysisDb,
         semantic::{
             FieldIndex, Mutability, SConst, SLocalId, SemOrigin, SemanticBody, SemanticCalleeRef,
-            SemanticCodeRegionRef, SemanticLocalKind, SemanticProjectionPath, VariantIndex,
+            SemanticCodeRegionRef, SemanticCodeRegionTarget, SemanticLocalKind,
+            SemanticProjectionPath, VariantIndex,
         },
         ty::{
             provider::ProviderAddressSpace,
@@ -319,10 +320,10 @@ pub enum NExpr<'db> {
         field: FieldIndex,
     },
     CodeRegionOffset {
-        region: SemanticCodeRegionRef<'db>,
+        target: SemanticCodeRegionTarget<'db>,
     },
     CodeRegionLen {
-        region: SemanticCodeRegionRef<'db>,
+        target: SemanticCodeRegionTarget<'db>,
     },
     Call {
         call_site: crate::analysis::semantic::CallSiteId,

--- a/crates/hir/src/analysis/semantic/borrowck/normalize.rs
+++ b/crates/hir/src/analysis/semantic/borrowck/normalize.rs
@@ -751,11 +751,11 @@ impl<'db> NormalizeCtxt<'db> {
                 variant: *variant,
                 field: *field,
             },
-            SExpr::CodeRegionOffset { region } => NExpr::CodeRegionOffset {
-                region: region.clone(),
+            SExpr::CodeRegionOffset { target } => NExpr::CodeRegionOffset {
+                target: target.clone(),
             },
-            SExpr::CodeRegionLen { region } => NExpr::CodeRegionLen {
-                region: region.clone(),
+            SExpr::CodeRegionLen { target } => NExpr::CodeRegionLen {
+                target: target.clone(),
             },
             SExpr::Call {
                 call_site,

--- a/crates/hir/src/analysis/semantic/ir.rs
+++ b/crates/hir/src/analysis/semantic/ir.rs
@@ -228,6 +228,12 @@ pub enum SemanticCodeRegionRef<'db> {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Update)]
+pub enum SemanticCodeRegionTarget<'db> {
+    Resolved(SemanticCodeRegionRef<'db>),
+    Deferred { arg: ExprId, ty: TyId<'db> },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Update)]
 pub struct SPlace<'db> {
     pub local: SLocalId,
     pub path: SemanticProjectionPath<'db>,
@@ -406,10 +412,10 @@ pub enum SExpr<'db> {
         field: FieldIndex,
     },
     CodeRegionOffset {
-        region: SemanticCodeRegionRef<'db>,
+        target: SemanticCodeRegionTarget<'db>,
     },
     CodeRegionLen {
-        region: SemanticCodeRegionRef<'db>,
+        target: SemanticCodeRegionTarget<'db>,
     },
     Call {
         call_site: CallSiteId,

--- a/crates/hir/src/analysis/semantic/lower/body.rs
+++ b/crates/hir/src/analysis/semantic/lower/body.rs
@@ -11,9 +11,9 @@ use crate::{
         semantic::{
             CallSiteId, FieldIndex, Mutability, SBlock, SBlockId, SConst, SExpr, SLocal, SLocalId,
             SOperand, SPlace, SStmt, SStmtKind, STerminator, STerminatorKind, SValueId,
-            SemConstValue, SemOrigin, SemanticBody, SemanticLocalRole, VariantIndex, bool_const,
-            bytes_const, int_const, reify_runtime_const_for_ty, runtime_size_bytes,
-            sem_const_from_ty, unit_const,
+            SemConstValue, SemOrigin, SemanticBody, SemanticCodeRegionTarget, SemanticLocalRole,
+            VariantIndex, bool_const, bytes_const, int_const, reify_runtime_const_for_ty,
+            runtime_size_bytes, sem_const_from_ty, unit_const,
         },
         ty::{
             const_ty::const_ty_or_abstract_from_assoc_const_use,
@@ -861,16 +861,10 @@ impl<'a, 'db> SmirLowerCtxt<'a, 'db> {
             SemanticExprLowering::CodeRegionIntrinsic {
                 region_arg, kind, ..
             } => {
-                let region = self.typed_body.expr_code_region_ref(self.db, *region_arg).unwrap_or_else(
-                    || {
-                        panic!(
-                            "typed code-region intrinsic is missing instantiated code-region ref: call={expr:?} arg={region_arg:?}"
-                        )
-                    },
-                );
+                let target = self.lower_code_region_target(expr, *region_arg);
                 let lowered = match kind {
-                    CodeRegionIntrinsicKind::Offset => SExpr::CodeRegionOffset { region },
-                    CodeRegionIntrinsicKind::Len => SExpr::CodeRegionLen { region },
+                    CodeRegionIntrinsicKind::Offset => SExpr::CodeRegionOffset { target },
+                    CodeRegionIntrinsicKind::Len => SExpr::CodeRegionLen { target },
                 };
                 self.emit_expr_with_origin(SemOrigin::Expr(expr), ty, lowered)
             }
@@ -878,6 +872,28 @@ impl<'a, 'db> SmirLowerCtxt<'a, 'db> {
                 self.lower_const_intrinsic(expr, callable, *kind)
             }
         }
+    }
+
+    fn lower_code_region_target(
+        &self,
+        call_expr: ExprId,
+        region_arg: ExprId,
+    ) -> SemanticCodeRegionTarget<'db> {
+        self.typed_body
+            .expr_code_region_ref(self.db, region_arg)
+            .map(SemanticCodeRegionTarget::Resolved)
+            .unwrap_or_else(|| {
+                let ty = self.expr_ty(region_arg);
+                if ty.has_param(self.db) || ty.has_var(self.db) {
+                    SemanticCodeRegionTarget::Deferred {
+                        arg: region_arg, ty
+                    }
+                } else {
+                    panic!(
+                        "typed code-region intrinsic is missing instantiated code-region ref: call={call_expr:?} arg={region_arg:?} ty={ty:?}"
+                    )
+                }
+            })
     }
 
     fn lower_callable_expr(

--- a/crates/hir/src/analysis/semantic/lower/body.rs
+++ b/crates/hir/src/analysis/semantic/lower/body.rs
@@ -10,9 +10,10 @@ use crate::{
         HirAnalysisDb,
         semantic::{
             CallSiteId, FieldIndex, Mutability, SBlock, SBlockId, SConst, SExpr, SLocal, SLocalId,
-            SOperand, SPlace, SStmt, SStmtKind, STerminator, STerminatorKind, SValueId, SemOrigin,
-            SemanticBody, SemanticLocalRole, VariantIndex, bool_const, bytes_const, int_const,
-            runtime_size_bytes, sem_const_from_ty, unit_const,
+            SOperand, SPlace, SStmt, SStmtKind, STerminator, STerminatorKind, SValueId,
+            SemConstValue, SemOrigin, SemanticBody, SemanticLocalRole, VariantIndex, bool_const,
+            bytes_const, int_const, reify_runtime_const_for_ty, runtime_size_bytes,
+            sem_const_from_ty, unit_const,
         },
         ty::{
             const_ty::const_ty_or_abstract_from_assoc_const_use,
@@ -613,6 +614,36 @@ impl<'a, 'db> SmirLowerCtxt<'a, 'db> {
 
     fn lower_const_ref(&mut self, expr: ExprId, const_ref: ConstRef<'db>) -> SValueId {
         let ty = self.expr_ty(expr);
+        if let ConstRef::TraitConst(assoc) = const_ref
+            && let Some(const_ty) = const_ty_or_abstract_from_assoc_const_use(self.db, assoc, ty)
+                .map(|const_ty| TyId::const_ty(self.db, const_ty))
+            && let Some(mut symbolic) = sem_const_from_ty(self.db, const_ty)
+        {
+            if matches!(symbolic.value(self.db), SemConstValue::TypeLevel { .. })
+                && let Some(runtime) =
+                    reify_runtime_const_for_ty(self.db, self.instance, ty, symbolic)
+            {
+                symbolic = runtime;
+            }
+
+            let instance_has_generic_args = self
+                .instance
+                .key(self.db)
+                .subst(self.db)
+                .generic_args(self.db)
+                .iter()
+                .any(|arg| arg.has_param(self.db) || arg.has_var(self.db));
+            if !matches!(symbolic.value(self.db), SemConstValue::TypeLevel { .. })
+                || instance_has_generic_args
+            {
+                return self.emit_expr_with_origin(
+                    SemOrigin::Expr(expr),
+                    ty,
+                    SExpr::Const(SConst::Value(symbolic)),
+                );
+            }
+        }
+
         if let Some(const_ref) =
             resolve_semantic_const_ref(self.db, const_ref, ty, SemOrigin::Expr(expr))
         {
@@ -623,22 +654,7 @@ impl<'a, 'db> SmirLowerCtxt<'a, 'db> {
             );
         }
 
-        let symbolic = match const_ref {
-            ConstRef::TraitConst(assoc) => {
-                const_ty_or_abstract_from_assoc_const_use(self.db, assoc, ty)
-                    .map(|const_ty| TyId::const_ty(self.db, const_ty))
-                    .and_then(|const_ty| sem_const_from_ty(self.db, const_ty))
-            }
-            ConstRef::Const(_) => None,
-        };
-        let Some(symbolic) = symbolic else {
-            panic!("const ref should resolve to a semantic instance: {const_ref:?}");
-        };
-        self.emit_expr_with_origin(
-            SemOrigin::Expr(expr),
-            ty,
-            SExpr::Const(SConst::Value(symbolic)),
-        )
+        panic!("const ref should resolve to a semantic instance: {const_ref:?}");
     }
 
     fn lower_path_expr(&mut self, expr: ExprId) -> SValueId {

--- a/crates/hir/tests/attr_semantics.rs
+++ b/crates/hir/tests/attr_semantics.rs
@@ -2,7 +2,7 @@ use fe_hir::test_db::HirAnalysisTestDb;
 use fe_hir::{
     analysis::{
         semantic::{
-            NExpr, NSStmtKind, SExpr, SStmtKind, SemanticCodeRegionRef,
+            NExpr, NSStmtKind, SExpr, SStmtKind, SemanticCodeRegionRef, SemanticCodeRegionTarget,
             get_or_build_semantic_instance, identity_semantic_instance_key,
             normalize_semantic_body,
         },
@@ -337,12 +337,20 @@ fn runtime() uses (evm: mut Evm) {}"#,
         .collect::<Vec<_>>();
     assert!(exprs.iter().any(|expr| matches!(
         expr,
-        SExpr::CodeRegionLen { region: SemanticCodeRegionRef::ManualContractRoot { func } }
+        SExpr::CodeRegionLen {
+            target: SemanticCodeRegionTarget::Resolved(
+                SemanticCodeRegionRef::ManualContractRoot { func },
+            ),
+        }
             if *func == runtime
     )));
     assert!(exprs.iter().any(|expr| matches!(
         expr,
-        SExpr::CodeRegionOffset { region: SemanticCodeRegionRef::ManualContractRoot { func } }
+        SExpr::CodeRegionOffset {
+            target: SemanticCodeRegionTarget::Resolved(
+                SemanticCodeRegionRef::ManualContractRoot { func },
+            ),
+        }
             if *func == runtime
     )));
 }
@@ -474,12 +482,20 @@ fn runtime() uses (evm: mut Evm) {}"#,
         {
             saw_len |= matches!(
                 expr,
-                SExpr::CodeRegionLen { region: SemanticCodeRegionRef::ManualContractRoot { func } }
+                SExpr::CodeRegionLen {
+                    target: SemanticCodeRegionTarget::Resolved(
+                        SemanticCodeRegionRef::ManualContractRoot { func },
+                    ),
+                }
                     if *func == runtime
             );
             saw_offset |= matches!(
                 expr,
-                SExpr::CodeRegionOffset { region: SemanticCodeRegionRef::ManualContractRoot { func } }
+                SExpr::CodeRegionOffset {
+                    target: SemanticCodeRegionTarget::Resolved(
+                        SemanticCodeRegionRef::ManualContractRoot { func },
+                    ),
+                }
                     if *func == runtime
             );
         }

--- a/crates/mir/src/runtime/lower/body.rs
+++ b/crates/mir/src/runtime/lower/body.rs
@@ -3,7 +3,8 @@ use hir::analysis::{
     semantic::{
         EffectProviderSubst, FieldIndex, GenericSubst, ImplEnv, SBlockId, SConst, SLocalId,
         SemConstId, SemConstScalar, SemConstValue, SemanticCalleeRef, SemanticCodeRegionRef,
-        SemanticInstance, SemanticInstanceKey, SemanticLocalKind, VariantIndex,
+        SemanticCodeRegionTarget, SemanticInstance, SemanticInstanceKey, SemanticLocalKind,
+        VariantIndex,
         borrowck::{
             NBorrowRoot, NBorrowRootId, NEffectArg, NExpr, NLocalOrigin, NOperand, NSPlace,
             NSPlaceRoot, NSStmt, NSStmtKind, NSTerminator, NSTerminatorKind,
@@ -816,24 +817,30 @@ impl<'db> RmirEmitter<'db> {
             } => {
                 self.lower_extract_enum_field(bb, dst, *value, *variant, *field);
             }
-            NExpr::CodeRegionOffset { region } => self.push_stmt(
-                bb,
-                RStmt::Assign {
-                    dst,
-                    expr: RExpr::Builtin(crate::runtime::RuntimeBuiltin::CodeRegionOffset {
-                        region: self.lower_code_region_ref(region),
-                    }),
-                },
-            ),
-            NExpr::CodeRegionLen { region } => self.push_stmt(
-                bb,
-                RStmt::Assign {
-                    dst,
-                    expr: RExpr::Builtin(crate::runtime::RuntimeBuiltin::CodeRegionLen {
-                        region: self.lower_code_region_ref(region),
-                    }),
-                },
-            ),
+            NExpr::CodeRegionOffset { target } => {
+                let region = self.lower_code_region_target(target);
+                self.push_stmt(
+                    bb,
+                    RStmt::Assign {
+                        dst,
+                        expr: RExpr::Builtin(crate::runtime::RuntimeBuiltin::CodeRegionOffset {
+                            region,
+                        }),
+                    },
+                );
+            }
+            NExpr::CodeRegionLen { target } => {
+                let region = self.lower_code_region_target(target);
+                self.push_stmt(
+                    bb,
+                    RStmt::Assign {
+                        dst,
+                        expr: RExpr::Builtin(crate::runtime::RuntimeBuiltin::CodeRegionLen {
+                            region,
+                        }),
+                    },
+                );
+            }
             NExpr::Call {
                 callee,
                 args,
@@ -871,6 +878,21 @@ impl<'db> RmirEmitter<'db> {
 
     fn lower_code_region_ref(&self, region: &SemanticCodeRegionRef<'db>) -> RuntimeCodeRegion<'db> {
         runtime_code_region_for_semantic_ref(self.db, region)
+    }
+
+    fn lower_code_region_target(
+        &self,
+        target: &SemanticCodeRegionTarget<'db>,
+    ) -> RuntimeCodeRegion<'db> {
+        match target {
+            SemanticCodeRegionTarget::Resolved(region) => self.lower_code_region_ref(region),
+            SemanticCodeRegionTarget::Deferred { arg, ty } => {
+                panic!(
+                    "deferred generic code-region target reached runtime lowering: owner={:?}; arg={arg:?}; ty={ty:?}",
+                    self.current_semantic_key(),
+                )
+            }
+        }
     }
 
     fn lower_const_into(&mut self, bb: RBlockId, dst: RLocalId, const_: &SConst<'db>) {

--- a/ingots/core/src/num.fe
+++ b/ingots/core/src/num.fe
@@ -1,5 +1,6 @@
 use super::ops::*
 use super::default::Default
+use super::marker::Copy
 use super::option::Option::{self, *}
 use super::panic
 
@@ -402,7 +403,7 @@ pub trait IntDowncast<T> {
     const fn downcast_unchecked(self) -> T
 }
 
-pub trait IntWord {
+pub trait IntWord: Copy {
     const MASK: u256
     const SIGN_BIT: u256
     const IS_SIGNED: bool

--- a/newsfragments/1429.bugfix.1.md
+++ b/newsfragments/1429.bugfix.1.md
@@ -1,0 +1,1 @@
+Fixed a compiler panic when code_region_len or code_region_offset was called on an unresolved generic contract runtime parameter.

--- a/newsfragments/1429.bugfix.md
+++ b/newsfragments/1429.bugfix.md
@@ -1,0 +1,1 @@
+Fixed a compiler panic when generic associated constants were used in const expressions before their concrete types were known.

--- a/newsfragments/validate_files.py
+++ b/newsfragments/validate_files.py
@@ -8,13 +8,13 @@ import pathlib
 import sys
 
 ALLOWED_EXTENSIONS = {
-    '.bugfix.md',
-    '.doc.md',
-    '.feature.md',
-    '.internal.md',
-    '.misc.md',
-    '.performance.md',
-    '.removal.md',
+    '.bugfix',
+    '.doc',
+    '.feature',
+    '.internal',
+    '.misc',
+    '.performance',
+    '.removal',
 }
 
 ALLOWED_FILES = {
@@ -37,8 +37,14 @@ for fragment_file in THIS_DIR.iterdir():
     if fragment_file.name in ALLOWED_FILES:
         continue
     elif num_args == 0:
-        full_extension = "".join(fragment_file.suffixes)
-        if full_extension not in ALLOWED_EXTENSIONS:
+        suffixes = fragment_file.suffixes
+        has_counter = len(suffixes) >= 3 and suffixes[-2].lstrip('.').isdigit()
+        type_idx = -3 if has_counter else -2
+        if (
+            len(suffixes) < 2
+            or suffixes[-1] != '.md'
+            or suffixes[type_idx] not in ALLOWED_EXTENSIONS
+        ):
             raise Exception(f"Unexpected file: {fragment_file}")
         elif not ends_with_newline(fragment_file):
             raise Exception(


### PR DESCRIPTION
Fixes `fe check` of core and std ingots. Added a cli test to ensure this doesn't break again.