### PR TITLE
Option ok or

### DIFF
--- a/crates/codegen/tests/fixtures/sonatina_ir/code_region.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/code_region.snap
@@ -89,7 +89,7 @@ func private %child_init(v0.objref<@layout_1>) {
         v1.i256 = sym_size &__Child_runtime;
         v2.i256 = sym_addr &__Child_runtime;
         call %std__lib__evm__effects__impl_trait_Evm_0098__codecopy_48e9_0 v0 0.i256 v2 v1;
-        call %std__lib__evm__effects__impl_trait_Evm_0098__return_data_5f25_0 0.i256 v1;
+        call %std__lib__evm__effects__impl_trait_Evm_0098__return_data_5f25_1 0.i256 v1;
         unreachable;
 }
 
@@ -99,7 +99,7 @@ func private %child_runtime(v0.objref<@layout_1>) {
 
     block1:
         call %calldatacopy v0 0.i256 0.i256 4.i256;
-        call %std__lib__evm__effects__impl_trait_Evm_0098__return_data_5f25_1 0.i256 4.i256;
+        call %std__lib__evm__effects__impl_trait_Evm_0098__return_data_5f25_2 0.i256 4.i256;
         unreachable;
 }
 
@@ -178,7 +178,7 @@ func private %init(v0.objref<@layout_1>) {
         v10.i256 = sym_addr &__Foo_runtime;
         v11.i256 = call %allocate v9 v0;
         call %std__lib__evm__effects__impl_trait_Evm_0098__codecopy_48e9 v0 v11 v10 v9;
-        call %std__lib__evm__effects__impl_trait_Evm_0098__return_data_5f25_2 v11 v9;
+        call %std__lib__evm__effects__impl_trait_Evm_0098__return_data_5f25 v11 v9;
         unreachable;
 }
 
@@ -339,7 +339,7 @@ func private %runtime(v0.objref<@layout_1>) {
         br v4 block3 block6;
 
     block2:
-        call %std__lib__evm__effects__impl_trait_Evm_0098__return_data_5f25 0.i256 0.i256;
+        call %std__lib__evm__effects__impl_trait_Evm_0098__return_data_5f25_0 0.i256 0.i256;
         unreachable;
 
     block3:

--- a/crates/codegen/tests/fixtures/sonatina_ir/create_contract.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/create_contract.snap
@@ -1512,7 +1512,7 @@ func private %std__lib__abi__sol__impl_SolDecoder_113c__new__g463e_ff02(v0.@layo
         jump block1;
 
     block1:
-        v2.@layout_6 = call %core__lib__abi__impl_Cursor_1a04__new__g463e_15c7 v0;
+        v2.@layout_6 = call %core__lib__abi__impl_Cursor_1a04__new__g463e_15c7_0 v0;
         v4.objref<@layout_7> = obj.alloc @layout_7;
         v5.objref<@layout_6> = obj.proj v4 0.i256;
         v6.objref<@layout_5> = obj.proj v5 0.i256;
@@ -1537,7 +1537,7 @@ func private %std__lib__abi__sol__impl_SolDecoder_113c__new__g463e_ff02_0(v0.@la
         jump block1;
 
     block1:
-        v2.@layout_6 = call %core__lib__abi__impl_Cursor_1a04__new__g463e_15c7_0 v0;
+        v2.@layout_6 = call %core__lib__abi__impl_Cursor_1a04__new__g463e_15c7 v0;
         v4.objref<@layout_7> = obj.alloc @layout_7;
         v5.objref<@layout_6> = obj.proj v4 0.i256;
         v6.objref<@layout_5> = obj.proj v5 0.i256;

--- a/crates/codegen/tests/fixtures/sonatina_ir/storage_map_contract.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/storage_map_contract.snap
@@ -157,7 +157,7 @@ func private %init(v0.objref<@layout_1>) {
         v1.i256 = sym_size &__BalanceMap_runtime;
         v2.i256 = sym_addr &__BalanceMap_runtime;
         call %codecopy v0 0.i256 v2 v1;
-        call %std__lib__evm__effects__impl_trait_Evm_0098__return_data_ad81_0 0.i256 v1;
+        call %std__lib__evm__effects__impl_trait_Evm_0098__return_data_ad81 0.i256 v1;
         unreachable;
 }
 
@@ -313,7 +313,7 @@ func private %runtime(v0.objref<@layout_1>) {
         unreachable;
 
     block7:
-        call %std__lib__evm__effects__impl_trait_Evm_0098__return_data_ad81 0.i256 0.i256;
+        call %std__lib__evm__effects__impl_trait_Evm_0098__return_data_ad81_0 0.i256 0.i256;
         unreachable;
 
     block8:

--- a/crates/fe/tests/fixtures/fe_test/option_ok_or.fe
+++ b/crates/fe/tests/fixtures/fe_test/option_ok_or.fe
@@ -1,0 +1,36 @@
+// Tests for `Option::ok_or` — converting Option<T> to Result<E, T>.
+//
+// Behaviour:
+//   Option::Some(v).ok_or(err) → Result::Ok(v)
+//   Option::None.ok_or(err)    → Result::Err(err)
+//
+// When chained with `Result::unwrap()`, an `Err(ErrorVariant)` payload is
+// emitted as a Solidity-compatible custom-error revert via `panic_with_value`.
+
+use core::result::Result::{self, Ok, Err}
+
+#[error]
+struct MyError {
+    pub code: u256,
+}
+
+#[test]
+fn test_some_becomes_ok() {
+    let opt: Option<u256> = Option::Some(42)
+    let r: Result<MyError, u256> = opt.ok_or(MyError { code: 7 })
+    assert(r.unwrap() == 42)
+}
+
+#[test]
+fn test_none_becomes_err() {
+    let opt: Option<u256> = Option::None
+    let r: Result<MyError, u256> = opt.ok_or(MyError { code: 7 })
+    assert(r.unwrap_err().code == 7)
+}
+
+#[test(should_revert, panic = 0x31)]
+fn test_unwrap_after_ok_or_panic_emits_solidity_panic() uses (evm: mut Evm) {
+    let opt: Option<u256> = Option::None
+    let r: Result<Panic, u256> = opt.ok_or(Panic { code: 0x31 })
+    r.unwrap()
+}

--- a/crates/fe/tests/fixtures/fe_test/option_ok_or.fe
+++ b/crates/fe/tests/fixtures/fe_test/option_ok_or.fe
@@ -1,17 +1,35 @@
-// Tests for `Option::ok_or` — converting Option<T> to Result<E, T>.
+// Tests for `Option::ok_or` and `Option::ok_or_else` — converting
+// Option<T> to Result<E, T>.
 //
 // Behaviour:
-//   Option::Some(v).ok_or(err) → Result::Ok(v)
-//   Option::None.ok_or(err)    → Result::Err(err)
+//   Option::Some(v).ok_or(err)         → Result::Ok(v)
+//   Option::None.ok_or(err)            → Result::Err(err)
+//   Option::Some(v).ok_or_else(f)      → Result::Ok(v)         (f not called)
+//   Option::None.ok_or_else(f)         → Result::Err(f())
 //
 // When chained with `Result::unwrap()`, an `Err(ErrorVariant)` payload is
 // emitted as a Solidity-compatible custom-error revert via `panic_with_value`.
 
 use core::result::Result::{self, Ok, Err}
+use core::functional::Fn
 
 #[error]
 struct MyError {
     pub code: u256,
+}
+
+struct MakeMyError {}
+impl Fn<(), MyError> for MakeMyError {
+    fn call(self, _ args: own ()) -> MyError {
+        MyError { code: 7 }
+    }
+}
+
+struct MakePanic {}
+impl Fn<(), Panic> for MakePanic {
+    fn call(self, _ args: own ()) -> Panic {
+        Panic { code: 0x31 }
+    }
 }
 
 #[test]
@@ -32,5 +50,26 @@ fn test_none_becomes_err() {
 fn test_unwrap_after_ok_or_panic_emits_solidity_panic() uses (evm: mut Evm) {
     let opt: Option<u256> = Option::None
     let r: Result<Panic, u256> = opt.ok_or(Panic { code: 0x31 })
+    r.unwrap()
+}
+
+#[test]
+fn test_ok_or_else_some_becomes_ok() {
+    let opt: Option<u256> = Option::Some(42)
+    let r: Result<MyError, u256> = opt.ok_or_else(MakeMyError{})
+    assert(r.unwrap() == 42)
+}
+
+#[test]
+fn test_ok_or_else_none_calls_func() {
+    let opt: Option<u256> = Option::None
+    let r: Result<MyError, u256> = opt.ok_or_else(MakeMyError{})
+    assert(r.unwrap_err().code == 7)
+}
+
+#[test(should_revert, panic = 0x31)]
+fn test_unwrap_after_ok_or_else_panic_emits_solidity_panic() uses (evm: mut Evm) {
+    let opt: Option<u256> = Option::None
+    let r: Result<Panic, u256> = opt.ok_or_else(MakePanic{})
     r.unwrap()
 }

--- a/crates/fe/tests/fixtures/fe_test/option_ok_or.fe
+++ b/crates/fe/tests/fixtures/fe_test/option_ok_or.fe
@@ -73,3 +73,11 @@ fn test_unwrap_after_ok_or_else_panic_emits_solidity_panic() uses (evm: mut Evm)
     let r: Result<Panic, u256> = opt.ok_or_else(MakePanic{})
     r.unwrap()
 }
+
+#[test(should_revert, panic = 0x31)]
+fn test_panic_from_in_ok_or_chain() uses (evm: mut Evm) {
+    // `Panic::from(code)` is a one-arg shorthand for `Panic { code: code }`,
+    // which keeps the `ok_or` chain readable when picking a specific code.
+    let opt: Option<u256> = Option::None
+    opt.ok_or(Panic::from(0x31)).unwrap()
+}

--- a/crates/uitest/fixtures/ty_check/ambiguous_pattern_reachability.snap
+++ b/crates/uitest/fixtures/ty_check/ambiguous_pattern_reachability.snap
@@ -12,7 +12,7 @@ error[2-0004]: `Some` is ambiguous
 16 │     let _ = Some(1)
    │             ^^^^ `Some` is ambiguous
    │
-   ┌─ src/option.fe:9:5
+   ┌─ src/option.fe:10:5
    │
- 9 │     Some(T),
+10 │     Some(T),
    │     ---- candidate 1 (from implicit import)

--- a/crates/uitest/fixtures/ty_check/method_bound/arg_bound.snap
+++ b/crates/uitest/fixtures/ty_check/method_bound/arg_bound.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/uitest/tests/ty_check.rs
-assertion_line: 27
 expression: diags
 input_file: fixtures/ty_check/method_bound/arg_bound.fe
 ---
@@ -13,9 +12,9 @@ error[2-0004]: `Some` is ambiguous
 58 │     let opt = Some(1)
    │               ^^^^ `Some` is ambiguous
    │
-   ┌─ src/option.fe:9:5
+   ┌─ src/option.fe:10:5
    │
- 9 │     Some(T),
+10 │     Some(T),
    │     ---- candidate 1 (from implicit import)
 
 error[6-0003]: trait bound is not satisfied

--- a/ingots/core/src/option.fe
+++ b/ingots/core/src/option.fe
@@ -3,6 +3,7 @@ use ingot::Fn
 use ingot::Functor
 use ingot::Applicative
 use ingot::Monad
+use ingot::Result
 use ingot::panic
 
 pub enum Option<T> {
@@ -33,6 +34,13 @@ impl<T> Option<T> {
         match self {
             Self::Some(value) => func.call(value)
             Self::None => Option::None
+        }
+    }
+
+    pub fn ok_or<E>(own self, _ err: own E) -> Result<E, T> {
+        match self {
+            Self::Some(value) => Result::Ok(value)
+            Self::None => Result::Err(err)
         }
     }
 

--- a/ingots/core/src/option.fe
+++ b/ingots/core/src/option.fe
@@ -44,6 +44,13 @@ impl<T> Option<T> {
         }
     }
 
+    pub fn ok_or_else<E, F: Fn<(), E>>(own self, _ err_func: F) -> Result<E, T> {
+        match self {
+            Self::Some(value) => Result::Ok(value)
+            Self::None => Result::Err(err_func.call(()))
+        }
+    }
+
     pub fn unwrap(own self) -> T {
         match self {
             Self::Some(t) => t

--- a/ingots/std/src/evm/panic.fe
+++ b/ingots/std/src/evm/panic.fe
@@ -3,6 +3,12 @@ pub struct Panic {
     pub code: u256
 }
 
+impl Panic {
+    pub fn from(_ code: u256) -> Self {
+        Panic { code: code }
+    }
+}
+
 pub const PANIC_GENERIC: u256 = 0x00
 pub const PANIC_ASSERT: u256 = 0x01
 pub const PANIC_OVERFLOW: u256 = 0x11

--- a/newsfragments/1430.feature.md
+++ b/newsfragments/1430.feature.md
@@ -1,0 +1,1 @@
+Added `Option::ok_or` and `Option::ok_or_else` to `core`, mirroring Rust's API, plus a `Panic::from(code)` shorthand constructor. Combined with `Result::unwrap`, this lets users attach a typed error value (e.g. `Panic::from(POP_EMPTY)`) to an Option-unwrap so reverts carry meaningful Solidity-compatible selectors instead of always landing on `Panic(0x01)`.


### PR DESCRIPTION
## Summary                                                                                                                                                                                                        
                                                                                                                                                                                                                    
  Adds three small additions to `core` / `std` that compose to give users a way to attach typed Solidity-conformant Panic codes (or any other custom error) to an `Option`-unwrap:                                  
                                                                                                                                                                                                                    
  - `Option::ok_or<E>` — convert `None` into a typed error.                                                                                                                                                         
  - `Option::ok_or_else<E, F>` — same, with lazy error construction.
  - `Panic::from(code)` — shorthand for `Panic { code: code }`.                                                                                                                                                     
                                                                                                                                                                                                                    
  Combined with the existing `Result::unwrap`, this gives a one-liner pattern for the previously verbose "unwrap-or-revert-with-specific-code" use case:                                                            
                                                                                                                                                                                                                    
  ```fe                                                                                                                                                                                                             
  opt.ok_or(Panic::from(POP_EMPTY)).unwrap()             
  ```                                                                                                                                                                                                               
   
  ## Motivation                                                                                                                                                                                                     
                                                         
  Today, `Option::unwrap` is the only way to extract the inner value of an `Option` while reverting on `None`. Its revert payload is hard-coded to `Panic(0x01)` (PANIC_ASSERT) because it lowers to the no-arg     
  `panic()`. There is no built-in way to tell the unwrap site "if this is `None`, revert with this specific panic code / custom error".
                                                                                                                                                                                                                    
  This came up while porting OpenZeppelin's `DoubleEndedQueue` to Fe. OZ's `pop_back` / `pop_front` revert with `Panic(0x31)` (POP_EMPTY); `at` reverts with `Panic(0x32)` (INDEX_OOB). To preserve those semantics 
  today, users have to either write a `match` at every callsite or hand-roll a small extension trait — purely to bridge an obvious gap in the standard library.                                                     
   
  `Option::ok_or` is the canonical Rust answer, and works through Fe's existing infrastructure:                                                                                                                     
                                                                                                                                                                                                                    
  ```fe
  self.try_pop_back().ok_or(Panic::from(PANIC_POP_EMPTY)).unwrap()                                                                                                                                                  
  //                  ^^^^^                           ^^^^^^^^                                                                                                                                                      
  //                  Option<T> → Result<Panic, T>    lowers to revert_error(Panic{...})
  ```                                                                                                                                                                                                               
                                                         
  This composes because `Result::unwrap` already lowers an `Err(e)` arm via `panic_with_value(e)`, and `panic_with_value` is wired to dispatch to `revert_error` whenever `e` is an `ErrorVariant` (see             
  `crates/mir/src/runtime/lower/body.rs` → `lower_panic_with_value` / `resolve_panic_payload_revert`). The infrastructure was already there; only the `Option` → `Result` bridge and a slightly nicer `Panic`
  constructor were missing.                                                                                                                                                                                         
                                                         
  ## API additions

  ```fe
  // ingots/core/src/option.fe
  impl<T> Option<T> {                                                                                                                                                                                               
      pub fn ok_or<E>(own self, _ err: own E) -> Result<E, T> {
          match self {                                                                                                                                                                                              
              Self::Some(value) => Result::Ok(value)     
              Self::None => Result::Err(err)                                                                                                                                                                        
          }                                                                                                                                                                                                         
      }
                                                                                                                                                                                                                    
      pub fn ok_or_else<E, F: Fn<(), E>>(own self, _ err_func: F) -> Result<E, T> {
          match self {                                                                                                                                                                                              
              Self::Some(value) => Result::Ok(value)
              Self::None => Result::Err(err_func.call(()))                                                                                                                                                          
          }                                              
  }                                                                                                                                                                                                                 
                                                         
  // ingots/std/src/evm/panic.fe
  impl Panic {                  
      pub fn from(_ code: u256) -> Self {                                                                                                                                                                           
          Panic { code: code }           
      }                                                                                                                                                                                                             
  }                                                      
  ```
                                                                                                                                                                                                                    
  `ok_or_else` is symmetric to the existing `unwrap_or_else` — useful when constructing the error value is non-trivial. `Panic::from(code)` is a thin shorthand that keeps the `ok_or` chain readable when picking a
   specific code.                                                                                                                                                                                                   
                                                         
  ## Test plan                                                                                                                                                                                                      
                                                         
  New fixture `crates/fe/tests/fixtures/fe_test/option_ok_or.fe` covers seven cases:
                                                                                                                                                                                                                    
  | Test | Verifies |
  |---|---|                                                                                                                                                                                                         
  | `test_some_becomes_ok` | `Some(v).ok_or(err)` → `Ok(v)` |
  | `test_none_becomes_err` | `None.ok_or(err)` → `Err(err)` (error value preserved) |                                                                                                                              
  | `test_unwrap_after_ok_or_panic_emits_solidity_panic` | `None.ok_or(Panic { code: 0x31 }).unwrap()` reverts with a real `Panic(0x31)` (verified via `#[test(should_revert, panic = 0x31)]`) |                    
  | `test_ok_or_else_some_becomes_ok` | `Some(v).ok_or_else(f)` → `Ok(v)` |                                                                                                                                         
  | `test_ok_or_else_none_calls_func` | `None.ok_or_else(f)` → `Err(f())` |                                                                                                                                         
  | `test_unwrap_after_ok_or_else_panic_emits_solidity_panic` | end-to-end revert via the lazy variant |                                                                                                            
  | `test_panic_from_in_ok_or_chain` | `opt.ok_or(Panic::from(0x31)).unwrap()` reverts with `Panic(0x31)` |                                                                                                         
                                                                                                                                                                                                                    
  The three `should_revert, panic = ...` tests are the load-bearing ones: they prove the full `Option → Result → panic_with_value → revert_error` pipeline produces Solidity-conformant Panic codes from an         
  `Option`-unwrap, and that `Panic::from(...)` slots in cleanly.                                                                                                                                                    
                                                                                                                                                                                                                    
  Adjacent fixtures left untouched and verified still passing:                                                                                                                                                      
  - `crates/fe/tests/fixtures/fe_test/option_mut_scalar_match_regression.fe`                                                                                                                                        
  - `crates/fe/tests/fixtures/fe_test/result_map_chain_infers_independently.fe`
  - `crates/fe/tests/fixtures/fe_test_runner/custom_error_revert.fe` (already exercises the `Result<Panic, T>::unwrap()` path this PR builds on)                                                                    
                                                                                                                                                                                                                    
  ## Backwards compatibility                                                                                                                                                                                        
                                                                                                                                                                                                                    
  Pure addition. No existing API is changed and no existing tests needed updates.                                           