### PR TITLE
bump sonatina; faster `-O1` and `-O0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6423,7 +6423,7 @@ dependencies = [
 [[package]]
 name = "sonatina-codegen"
 version = "0.0.3-alpha"
-source = "git+https://github.com/fe-lang/sonatina?rev=507104d#507104d5bbcf44d8886a35bd4129adaa9966f718"
+source = "git+https://github.com/fe-lang/sonatina?rev=5987a72#5987a721df740a30b65e2d66b63b3f4e3110babf"
 dependencies = [
  "bit-set",
  "cranelift-entity 0.126.2",
@@ -6443,7 +6443,7 @@ dependencies = [
 [[package]]
 name = "sonatina-ir"
 version = "0.0.3-alpha"
-source = "git+https://github.com/fe-lang/sonatina?rev=507104d#507104d5bbcf44d8886a35bd4129adaa9966f718"
+source = "git+https://github.com/fe-lang/sonatina?rev=5987a72#5987a721df740a30b65e2d66b63b3f4e3110babf"
 dependencies = [
  "bit-set",
  "bitflags 2.11.0",
@@ -6466,7 +6466,7 @@ dependencies = [
 [[package]]
 name = "sonatina-macros"
 version = "0.0.3-alpha"
-source = "git+https://github.com/fe-lang/sonatina?rev=507104d#507104d5bbcf44d8886a35bd4129adaa9966f718"
+source = "git+https://github.com/fe-lang/sonatina?rev=5987a72#5987a721df740a30b65e2d66b63b3f4e3110babf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6476,7 +6476,7 @@ dependencies = [
 [[package]]
 name = "sonatina-parser"
 version = "0.0.3-alpha"
-source = "git+https://github.com/fe-lang/sonatina?rev=507104d#507104d5bbcf44d8886a35bd4129adaa9966f718"
+source = "git+https://github.com/fe-lang/sonatina?rev=5987a72#5987a721df740a30b65e2d66b63b3f4e3110babf"
 dependencies = [
  "annotate-snippets",
  "bimap",
@@ -6497,7 +6497,7 @@ dependencies = [
 [[package]]
 name = "sonatina-triple"
 version = "0.0.3-alpha"
-source = "git+https://github.com/fe-lang/sonatina?rev=507104d#507104d5bbcf44d8886a35bd4129adaa9966f718"
+source = "git+https://github.com/fe-lang/sonatina?rev=5987a72#5987a721df740a30b65e2d66b63b3f4e3110babf"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -6505,7 +6505,7 @@ dependencies = [
 [[package]]
 name = "sonatina-verifier"
 version = "0.0.3-alpha"
-source = "git+https://github.com/fe-lang/sonatina?rev=507104d#507104d5bbcf44d8886a35bd4129adaa9966f718"
+source = "git+https://github.com/fe-lang/sonatina?rev=5987a72#5987a721df740a30b65e2d66b63b3f4e3110babf"
 dependencies = [
  "cranelift-entity 0.126.2",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,10 +48,10 @@ tracing-tree = "0.4.0"
 wasm-bindgen-test = "0.3"
 semver = "1.0.26"
 petgraph = "0.8"
-sonatina-ir = { git = "https://github.com/fe-lang/sonatina", rev = "507104d" }
-sonatina-triple = { git = "https://github.com/fe-lang/sonatina", rev = "507104d" }
-sonatina-codegen = { git = "https://github.com/fe-lang/sonatina", rev = "507104d" }
-sonatina-verifier = { git = "https://github.com/fe-lang/sonatina", rev = "507104d" }
+sonatina-ir = { git = "https://github.com/fe-lang/sonatina", rev = "5987a72" }
+sonatina-triple = { git = "https://github.com/fe-lang/sonatina", rev = "5987a72" }
+sonatina-codegen = { git = "https://github.com/fe-lang/sonatina", rev = "5987a72" }
+sonatina-verifier = { git = "https://github.com/fe-lang/sonatina", rev = "5987a72" }
 
 [profile.dev]
 # Set to 0 to make the build faster and debugging more difficult.

--- a/crates/codegen/src/backend.rs
+++ b/crates/codegen/src/backend.rs
@@ -8,6 +8,7 @@ use crate::TargetDataLayout;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum OptLevel {
     O0,
+    O1,
     Os,
     #[default]
     O2,
@@ -19,8 +20,9 @@ impl std::str::FromStr for OptLevel {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "0" => Ok(OptLevel::O0),
+            "1" => Ok(OptLevel::O1),
             "s" => Ok(OptLevel::Os),
-            "1" | "2" => Ok(OptLevel::O2),
+            "2" => Ok(OptLevel::O2),
             _ => Err(format!(
                 "unknown optimization level: {s} (expected '0', '1', '2', or 's')"
             )),
@@ -38,6 +40,7 @@ impl fmt::Display for OptLevel {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             OptLevel::O0 => write!(f, "0"),
+            OptLevel::O1 => write!(f, "1"),
             OptLevel::Os => write!(f, "s"),
             OptLevel::O2 => write!(f, "2"),
         }

--- a/crates/codegen/src/sonatina/mod.rs
+++ b/crates/codegen/src/sonatina/mod.rs
@@ -8,10 +8,7 @@ use hir::hir_def::{HirIngot, TopLevelMod};
 use mir::runtime::ir::RuntimePackagePlan;
 use mir::{RuntimePackage, build_runtime_package, build_test_runtime_package};
 use rustc_hash::FxHashSet;
-use sonatina_codegen::{
-    isa::evm::EvmBackend,
-    object::{CompileOptions, ObjectArtifact, compile_all_objects},
-};
+use sonatina_codegen::{EvmCompile, OptLevel as SonatinaOptLevel};
 use sonatina_ir::{
     Module,
     ir_writer::{FuncWriter, ModuleWriter},
@@ -160,32 +157,39 @@ fn diagnostic_func_ref(location: &Location) -> Option<FuncRef> {
     }
 }
 
-fn run_sonatina_optimization_pipeline(module: &mut Module, opt_level: OptLevel) {
+fn to_sonatina_opt_level(opt_level: OptLevel) -> SonatinaOptLevel {
     match opt_level {
-        OptLevel::O0 => {}
-        OptLevel::Os => sonatina_codegen::optim::Pipeline::size().run(module),
-        OptLevel::O2 => sonatina_codegen::optim::Pipeline::speed().run(module),
+        OptLevel::O0 => SonatinaOptLevel::O0,
+        OptLevel::O1 => SonatinaOptLevel::O1,
+        OptLevel::Os => SonatinaOptLevel::Os,
+        OptLevel::O2 => SonatinaOptLevel::O2,
     }
 }
 
-fn compile_all_runtime_objects(
-    module: &Module,
+fn evm_compile(module: Module, opt_level: OptLevel, emit_observability: bool) -> EvmCompile {
+    EvmCompile::new(module)
+        .with_opt_level(to_sonatina_opt_level(opt_level))
+        .with_observability(emit_observability)
+}
+
+fn format_object_compile_errors(errors: &[sonatina_codegen::object::ObjectCompileError]) -> String {
+    errors
+        .iter()
+        .map(|error| format!("{error:?}"))
+        .collect::<Vec<_>>()
+        .join("; ")
+}
+
+fn compile_runtime_objects(
+    module: Module,
+    opt_level: OptLevel,
     emit_observability: bool,
-) -> Result<Vec<ObjectArtifact>, LowerError> {
-    let mut options = CompileOptions::default();
-    let mut verifier_cfg = VerifierConfig::for_level(VerificationLevel::Full);
-    verifier_cfg.allow_detached_entities = true;
-    options.verifier_cfg = verifier_cfg;
-    options.emit_observability = emit_observability;
-    compile_all_objects(module, &EvmBackend::new(create_evm_isa()), &options).map_err(|errors| {
-        LowerError::Internal(
-            errors
-                .iter()
-                .map(|error| format!("{error:?}"))
-                .collect::<Vec<_>>()
-                .join("; "),
-        )
-    })
+) -> Result<Vec<sonatina_codegen::object::ObjectArtifact>, LowerError> {
+    let mut compile = evm_compile(module, opt_level, emit_observability);
+    ensure_module_sonatina_ir_valid(compile.optimize())?;
+    compile
+        .compile()
+        .map_err(|errors| LowerError::Internal(format_object_compile_errors(&errors)))
 }
 
 fn section_name_for_runtime(name: &mir::RuntimeSectionName) -> sonatina_ir::SectionName {
@@ -488,11 +492,12 @@ pub fn emit_runtime_package_sonatina_ir_optimized(
     opt_level: OptLevel,
 ) -> Result<String, LowerError> {
     ensure_runtime_package_has_roots(db, package, "Sonatina IR")?;
-    let mut module = compile_runtime_package_sonatina(db, package, layout)?;
+    let module = compile_runtime_package_sonatina(db, package, layout)?;
     ensure_module_sonatina_ir_valid(&module)?;
-    run_sonatina_optimization_pipeline(&mut module, opt_level);
-    ensure_module_sonatina_ir_valid(&module)?;
-    let mut writer = ModuleWriter::new(&module);
+    let mut compile = evm_compile(module, opt_level, false);
+    let optimized = compile.optimize();
+    ensure_module_sonatina_ir_valid(optimized)?;
+    let mut writer = ModuleWriter::new(optimized);
     Ok(writer.dump_string())
 }
 
@@ -503,11 +508,9 @@ pub fn emit_runtime_package_sonatina_bytecode(
     opt_level: OptLevel,
 ) -> Result<BTreeMap<String, SonatinaContractBytecode>, LowerError> {
     ensure_runtime_package_has_roots(db, package, "Sonatina bytecode")?;
-    let mut module = compile_runtime_package_sonatina(db, package, layout)?;
+    let module = compile_runtime_package_sonatina(db, package, layout)?;
     ensure_module_sonatina_ir_valid(&module)?;
-    run_sonatina_optimization_pipeline(&mut module, opt_level);
-    ensure_module_sonatina_ir_valid(&module)?;
-    let artifacts = compile_all_runtime_objects(&module, false)?;
+    let artifacts = compile_runtime_objects(module, opt_level, false)?;
     let artifacts_by_name = artifacts
         .iter()
         .map(|artifact| (artifact.object.0.as_str(), artifact))
@@ -683,11 +686,9 @@ pub fn emit_test_module_sonatina(
     if package.root_objects(db).is_empty() {
         return Ok(TestModuleOutput { tests: Vec::new() });
     }
-    let mut module = compile_runtime_package_sonatina(db, &package, crate::EVM_LAYOUT)?;
+    let module = compile_runtime_package_sonatina(db, &package, crate::EVM_LAYOUT)?;
     ensure_module_sonatina_ir_valid(&module)?;
-    run_sonatina_optimization_pipeline(&mut module, opt_level);
-    ensure_module_sonatina_ir_valid(&module)?;
-    let artifacts = compile_all_runtime_objects(&module, options.emit_observability)?;
+    let artifacts = compile_runtime_objects(module, opt_level, options.emit_observability)?;
     let artifacts_by_name = artifacts
         .iter()
         .map(|artifact| (artifact.object.0.as_str(), artifact))
@@ -774,6 +775,14 @@ mod tests {
     }
 
     #[test]
+    fn fe_opt_levels_map_to_sonatina_opt_levels() {
+        assert_eq!(to_sonatina_opt_level(OptLevel::O0), SonatinaOptLevel::O0);
+        assert_eq!(to_sonatina_opt_level(OptLevel::O1), SonatinaOptLevel::O1);
+        assert_eq!(to_sonatina_opt_level(OptLevel::Os), SonatinaOptLevel::Os);
+        assert_eq!(to_sonatina_opt_level(OptLevel::O2), SonatinaOptLevel::O2);
+    }
+
+    #[test]
     fn module_sonatina_bytecode_respects_contract_filter() {
         let mut db = DriverDataBase::default();
         let fixture_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -817,7 +826,7 @@ mod tests {
         let package = build_test_runtime_package(&db, top_mod, None)
             .expect("test runtime package should build");
 
-        let mut module = compile_runtime_package_sonatina(&db, &package, crate::EVM_LAYOUT)
+        let module = compile_runtime_package_sonatina(&db, &package, crate::EVM_LAYOUT)
             .expect("test runtime package should lower to Sonatina IR");
         let dumped = ModuleWriter::new(&module).dump_string();
         let map_helpers = dumped
@@ -847,11 +856,8 @@ mod tests {
         if let Err(err) = ensure_module_sonatina_ir_valid(&module) {
             panic!("pre-opt test module should verify: {err}\n\n{dumped}");
         }
-        run_sonatina_optimization_pipeline(&mut module, OptLevel::O0);
-        if let Err(err) = ensure_module_sonatina_ir_valid(&module) {
-            panic!("post-opt test module should verify: {err}\n\n{dumped}");
-        }
-        compile_all_runtime_objects(&module, false).expect("test runtime package should compile");
+        compile_runtime_objects(module, OptLevel::O0, false)
+            .expect("test runtime package should compile");
     }
 
     #[test]
@@ -872,18 +878,15 @@ mod tests {
         let package = build_test_runtime_package(&db, top_mod, None)
             .expect("test runtime package should build");
 
-        let mut module = compile_runtime_package_sonatina(&db, &package, crate::EVM_LAYOUT)
+        let module = compile_runtime_package_sonatina(&db, &package, crate::EVM_LAYOUT)
             .expect("test runtime package should lower to Sonatina IR");
         let dumped = ModuleWriter::new(&module).dump_string();
 
         if let Err(err) = ensure_module_sonatina_ir_valid(&module) {
             panic!("pre-opt test module should verify: {err}\n\n{dumped}");
         }
-        run_sonatina_optimization_pipeline(&mut module, OptLevel::O0);
-        if let Err(err) = ensure_module_sonatina_ir_valid(&module) {
-            panic!("post-opt test module should verify: {err}\n\n{dumped}");
-        }
-        compile_all_runtime_objects(&module, false).expect("test runtime package should compile");
+        compile_runtime_objects(module, OptLevel::O0, false)
+            .expect("test runtime package should compile");
     }
 
     #[test]
@@ -904,18 +907,15 @@ mod tests {
         let package = build_test_runtime_package(&db, top_mod, None)
             .expect("test runtime package should build");
 
-        let mut module = compile_runtime_package_sonatina(&db, &package, crate::EVM_LAYOUT)
+        let module = compile_runtime_package_sonatina(&db, &package, crate::EVM_LAYOUT)
             .expect("test runtime package should lower to Sonatina IR");
         let dumped = ModuleWriter::new(&module).dump_string();
 
         if let Err(err) = ensure_module_sonatina_ir_valid(&module) {
             panic!("pre-opt test module should verify: {err}\n\n{dumped}");
         }
-        run_sonatina_optimization_pipeline(&mut module, OptLevel::O0);
-        if let Err(err) = ensure_module_sonatina_ir_valid(&module) {
-            panic!("post-opt test module should verify: {err}\n\n{dumped}");
-        }
-        compile_all_runtime_objects(&module, false).expect("test runtime package should compile");
+        compile_runtime_objects(module, OptLevel::O0, false)
+            .expect("test runtime package should compile");
     }
 
     #[test]

--- a/crates/fe/src/main.rs
+++ b/crates/fe/src/main.rs
@@ -22,7 +22,7 @@ use std::fs;
 use build::build;
 use camino::Utf8PathBuf;
 use check::check;
-use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
+use clap::{Args, CommandFactory, Parser, Subcommand, ValueEnum};
 use colored::Colorize;
 use fmt as fe_fmt;
 use similar::{ChangeTag, TextDiff};
@@ -69,6 +69,34 @@ pub struct Options {
     pub command: Command,
 }
 
+#[derive(Debug, Clone, Args)]
+pub struct OptimizeArgs {
+    /// Optimization level.
+    ///
+    /// 0 = none
+    /// 1 = fast compilation, usually close to `2` gas and bytecode size with Sonatina
+    /// 2 = optimizes heavily for runtime gas
+    /// s = size-oriented (currently similar to `2`)
+    ///
+    /// Defaults to `1`
+    ///
+    /// Note: with `--backend yul`, optimize levels `s`, `1`, and `2` are currently equivalent.
+    #[arg(
+        long = "optimize",
+        short = 'O',
+        value_name = "LEVEL",
+        value_parser = ["0", "1", "2", "s"],
+        verbatim_doc_comment
+    )]
+    optimize: Option<String>,
+}
+
+impl OptimizeArgs {
+    fn as_deref(&self) -> Option<&str> {
+        self.optimize.as_deref()
+    }
+}
+
 #[derive(Debug, Clone, Subcommand)]
 pub enum Command {
     /// Compile Fe code to EVM bytecode.
@@ -90,23 +118,8 @@ pub enum Command {
         /// Code generation backend to use (yul or sonatina).
         #[arg(long, default_value = "sonatina")]
         backend: String,
-        /// Optimization level (0 = none, s = size-oriented, 2 = speed-oriented).
-        ///
-        /// Defaults to `2`.
-        ///
-        /// Note: with `--backend yul`, optimize levels `s`, `1`, and `2` are currently equivalent.
-        ///
-        /// `1` is currently an alias for `2`.
-        ///
-        /// - Sonatina backend: controls the optimization pipeline.
-        /// - Yul backend: controls whether solc optimization is enabled (0 = disabled, s/1/2 = enabled).
-        #[arg(
-            long = "optimize",
-            short = 'O',
-            value_name = "LEVEL",
-            value_parser = ["0", "1", "2", "s"]
-        )]
-        optimize: Option<String>,
+        #[command(flatten)]
+        optimize: OptimizeArgs,
         /// solc binary to use (overrides FE_SOLC_PATH).
         ///
         /// Only used with `--backend yul` (ignored with a warning otherwise).
@@ -259,23 +272,8 @@ pub enum Command {
         /// Only used with `--backend yul` (ignored with a warning otherwise).
         #[arg(long)]
         solc: Option<String>,
-        /// Optimization level (0 = none, s = size-oriented, 1/2 = speed-oriented).
-        ///
-        /// Defaults to `2`.
-        ///
-        /// Note: with `--backend yul`, optimize levels `s`, `1`, and `2` are currently equivalent.
-        ///
-        /// `1` is currently an alias for `2`.
-        ///
-        /// - Sonatina backend: controls the optimization pipeline.
-        /// - Yul backend: controls whether solc optimization is enabled (0 = disabled, s/1/2 = enabled).
-        #[arg(
-            long = "optimize",
-            short = 'O',
-            value_name = "LEVEL",
-            value_parser = ["0", "1", "2", "s"]
-        )]
-        optimize: Option<String>,
+        #[command(flatten)]
+        optimize: OptimizeArgs,
         /// Trace executed EVM opcodes while running tests.
         #[arg(long)]
         trace_evm: bool,
@@ -1094,7 +1092,11 @@ fn effective_opt_level(
     backend_kind: codegen::BackendKind,
     optimize: Option<&str>,
 ) -> Result<codegen::OptLevel, String> {
-    let level: codegen::OptLevel = optimize.unwrap_or("2").parse()?;
+    let default_optimize = match backend_kind {
+        codegen::BackendKind::Sonatina => "1",
+        codegen::BackendKind::Yul => "2",
+    };
+    let level: codegen::OptLevel = optimize.unwrap_or(default_optimize).parse()?;
 
     if backend_kind == codegen::BackendKind::Yul
         && let Some(optimize @ ("1" | "2")) = optimize

--- a/newsfragments/1435.bugfix.md
+++ b/newsfragments/1435.bugfix.md
@@ -1,0 +1,4 @@
+Sonatina:
+- Fixed EVM encoded-pointer provenance across calls and memory operations, with more precise escape summaries for i256 pointer carriers, aggregates, malloc-derived pointers, and local/argument/nonlocal storage. This also improves memory-planning performance by avoiding unnecessarily conservative escape assumptions.
+- Fixed GVN value-phi materialization so cached/generated value phis are rejected unless they cover the currently reachable predecessors.
+- Improved stackify spill slot reuse logic. This fixes a bug where a scratch slot could be reused for values that overlap during phi/control-flow transitions.

--- a/newsfragments/1435.feature.md
+++ b/newsfragments/1435.feature.md
@@ -1,0 +1,4 @@
+Improved optimization options for the default Sonatina backend:
+
+- `-O1`/`--optimize 1` is now distinct from `-O2` and is the default optimization level. It keeps Sonatina's optimization pipeline enabled while using lower exact-search caps for stack shuffling; usually getting close to `-O2` gas and bytecode while substantially reducing compile time.
+- `-O0`/`--optimize 0` now and disables the stack shuffling exact solver entirely in favor of a greedy heuristic, making unoptimized builds much faster.

--- a/newsfragments/1435.performance.md
+++ b/newsfragments/1435.performance.md
@@ -1,0 +1,3 @@
+Sonatina:
+- Improved stack shuffling performance via cache improvements and short-circuiting trivial operand-prep cases.
+- Improved memory placement performance.


### PR DESCRIPTION
@g-r-a-n-t This drastically improves the chz `fe test` time.
26.1.0 -O2: 175s
this pr -O2: 44s
this pr -O1: 21s

Would be nice if it was much faster still; we'll get there.