### PR TITLE
core: add fixed `String<N>` primitives

### DIFF
--- a/crates/codegen/tests/fixtures/sonatina_ir/code_region_qualified.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/code_region_qualified.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/codegen/tests/sonatina_ir.rs
+assertion_line: 402
 expression: output
 input_file: crates/codegen/tests/fixtures/code_region_qualified.fe
 ---

--- a/crates/codegen/tests/fixtures/sonatina_ir/create_contract.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/create_contract.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/codegen/tests/sonatina_ir.rs
+assertion_line: 403
 expression: output
 input_file: crates/codegen/tests/fixtures/create_contract.fe
 ---

--- a/crates/codegen/tests/fixtures/sonatina_ir/erc20.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/erc20.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/codegen/tests/sonatina_ir.rs
+assertion_line: 431
 expression: output
 input_file: crates/codegen/tests/fixtures/erc20.fe
 ---
@@ -138,8 +139,7 @@ func private %__CoolCoin_recv_0_6() -> i256 {
         jump block1;
 
     block1:
-        v1.i256 = zext 4859225033734580590.i64 i256;
-        return v1;
+        return 4859225033734580590.i256;
 }
 
 func private %__CoolCoin_recv_0_7() -> i256 {
@@ -147,7 +147,7 @@ func private %__CoolCoin_recv_0_7() -> i256 {
         jump block1;
 
     block1:
-        v1.i256 = zext 1129271116.i32 i256;
+        v1.i256 = zext 1129271116.i64 i256;
         return v1;
 }
 
@@ -290,16 +290,16 @@ func private %abi_field_size__gda9b(v0.i1) -> i256 {
         return v7;
 }
 
-func private %abi_field_size__g5535(v0.i256) -> i256 {
+func private %abi_field_size__g79ff(v0.i8) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
+        v1.*i8 = alloca i8;
+        mstore v1 v0 i8;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = call %core__lib__abi__impl_trait_String_c06e__payload_size__g3eb7_dfa6_0 v2;
-        br 1.i1 block2 block3;
+        v2.i8 = mload v1 i8;
+        v3.i256 = call %core__lib__abi__trait_AbiSize__payload_size__g79ff_f3e8_0 v2;
+        br 0.i1 block2 block3;
 
     block2:
         (v7.i256, v8.i1) = uaddo 32.i256 v3;
@@ -328,7 +328,7 @@ func private %abi_field_size__g65da(v0.i256) -> i256 {
 
     block1:
         v2.i256 = mload v1 i256;
-        v3.i256 = call %core__lib__abi__impl_trait_String_c06e__payload_size__gc7cf_9b7d_0 v2;
+        v3.i256 = call %core__lib__abi__impl_trait_String_c06e__payload_size__gc7cf_4aab_0 v2;
         br 1.i1 block2 block3;
 
     block2:
@@ -350,16 +350,16 @@ func private %abi_field_size__g65da(v0.i256) -> i256 {
         return v7;
 }
 
-func private %abi_field_size__g79ff(v0.i8) -> i256 {
+func private %abi_field_size__g5535(v0.i256) -> i256 {
     block0:
-        v1.*i8 = alloca i8;
-        mstore v1 v0 i8;
+        v1.*i256 = alloca i256;
+        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i8 = mload v1 i8;
-        v3.i256 = call %core__lib__abi__trait_AbiSize__payload_size__g79ff_f3e8_0 v2;
-        br 0.i1 block2 block3;
+        v2.i256 = mload v1 i256;
+        v3.i256 = call %core__lib__abi__impl_trait_String_c06e__payload_size__g3eb7_f656_0 v2;
+        br 1.i1 block2 block3;
 
     block2:
         (v7.i256, v8.i1) = uaddo 32.i256 v3;
@@ -485,18 +485,6 @@ func private %abi_single_root_size__g65da(v0.i256) -> i256 {
         return v3;
 }
 
-func private %abi_single_root_size__g5535(v0.i256) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
-        jump block1;
-
-    block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = call %abi_field_size__g5535 v2;
-        return v3;
-}
-
 func private %abi_single_root_size__g79ff(v0.i8) -> i256 {
     block0:
         v1.*i8 = alloca i8;
@@ -518,6 +506,18 @@ func private %abi_single_root_size__ge513(v0.i256) -> i256 {
     block1:
         v2.i256 = mload v1 i256;
         v3.i256 = call %abi_field_size__ge513 v2;
+        return v3;
+}
+
+func private %abi_single_root_size__g5535(v0.i256) -> i256 {
+    block0:
+        v1.*i256 = alloca i256;
+        mstore v1 v0 i256;
+        jump block1;
+
+    block1:
+        v2.i256 = mload v1 i256;
+        v3.i256 = call %abi_field_size__g5535 v2;
         return v3;
 }
 
@@ -3956,21 +3956,12 @@ func private %core__lib__abi__impl_trait_u256_d99e__encode__g426c_2015(v0.i256, 
         return;
 }
 
-func private %core__lib__abi__impl_trait_u256_d99e__encode__g426c_2910(v0.i256, v1.objref<@layout_4>) {
-    block0:
-        jump block1;
-
-    block1:
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_8eda v1 v0;
-        return;
-}
-
 func private %encode__g3cd9(v0.i256, v1.objref<@layout_4>) {
     block0:
         jump block1;
 
     block1:
-        v3.i256 = call %core__lib__num__impl_trait_String_8f88__to_word__g3eb7_e974 v0;
+        v3.i256 = call %core__lib__num__impl_trait_String_8f88__to_word__g3eb7_4283 v0;
         v4.i256 = call %core__lib__abi__packed_string_len_c13a v3;
         call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_0617 v1 v4;
         v8.i1 = eq v4 0.i256;
@@ -3993,12 +3984,21 @@ func private %encode__g3cd9(v0.i256, v1.objref<@layout_4>) {
         return;
 }
 
+func private %core__lib__abi__impl_trait_u256_d99e__encode__g426c_2910(v0.i256, v1.objref<@layout_4>) {
+    block0:
+        jump block1;
+
+    block1:
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_8eda v1 v0;
+        return;
+}
+
 func private %encode__gbe21(v0.i256, v1.objref<@layout_4>) {
     block0:
         jump block1;
 
     block1:
-        v3.i256 = call %core__lib__num__impl_trait_String_8f88__to_word__gc7cf_810c v0;
+        v3.i256 = call %core__lib__num__impl_trait_String_8f88__to_word__gc7cf_de49 v0;
         v4.i256 = call %core__lib__abi__packed_string_len_29ef v3;
         call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_7a95 v1 v4;
         v8.i1 = eq v4 0.i256;
@@ -4659,51 +4659,6 @@ func private %encode_field__ge927(v0.i1, v1.objref<@layout_4>, v2.i256) {
         return;
 }
 
-func private %encode_field__g859f(v0.i256, v1.objref<@layout_4>, v2.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        br 1.i1 block2 block3;
-
-    block2:
-        v5.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_25d4 v1;
-        v8.i256 = call %core__lib__abi__impl_trait_String_c06e__payload_size__g3eb7_dfa6 v0;
-        v9.i256 = mload v2 i256;
-        v10.i256 = sub v9 v5;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_1ad1 v1 v10;
-        v12.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_d8ed v1;
-        v13.i256 = mload v2 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_c5ff v1 v13;
-        v15.i256 = mload v2 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_7410 v1 v15;
-        call %encode__g3cd9 v0 v1;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_c5ff v1 v5;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_7410 v1 v12;
-        v20.i256 = mload v2 i256;
-        v21.i256 = add v20 v8;
-        mstore v2 v21 i256;
-        return;
-
-    block3:
-        jump block4;
-
-    block4:
-        br 0.i1 block5 block6;
-
-    block5:
-        v24.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_d8ed v1;
-        call %encode_to_ptr__g4320 v0 v24;
-        unreachable;
-
-    block6:
-        jump block7;
-
-    block7:
-        call %encode__g3cd9 v0 v1;
-        return;
-}
-
 func private %core__lib__abi__encode_field__g2e64_555f(v0.i256, v1.objref<@layout_4>, v2.i256) {
     block0:
         jump block1;
@@ -4760,7 +4715,7 @@ func private %encode_field__g6d7e(v0.i256, v1.objref<@layout_4>, v2.i256) {
 
     block2:
         v5.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_6030 v1;
-        v8.i256 = call %core__lib__abi__impl_trait_String_c06e__payload_size__gc7cf_9b7d v0;
+        v8.i256 = call %core__lib__abi__impl_trait_String_c06e__payload_size__gc7cf_4aab v0;
         v9.i256 = mload v2 i256;
         v10.i256 = sub v9 v5;
         call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_406d v1 v10;
@@ -4793,6 +4748,51 @@ func private %encode_field__g6d7e(v0.i256, v1.objref<@layout_4>, v2.i256) {
 
     block7:
         call %encode__gbe21 v0 v1;
+        return;
+}
+
+func private %encode_field__g859f(v0.i256, v1.objref<@layout_4>, v2.i256) {
+    block0:
+        jump block1;
+
+    block1:
+        br 1.i1 block2 block3;
+
+    block2:
+        v5.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_25d4 v1;
+        v8.i256 = call %core__lib__abi__impl_trait_String_c06e__payload_size__g3eb7_f656 v0;
+        v9.i256 = mload v2 i256;
+        v10.i256 = sub v9 v5;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_1ad1 v1 v10;
+        v12.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_d8ed v1;
+        v13.i256 = mload v2 i256;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_c5ff v1 v13;
+        v15.i256 = mload v2 i256;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_7410 v1 v15;
+        call %encode__g3cd9 v0 v1;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_c5ff v1 v5;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_7410 v1 v12;
+        v20.i256 = mload v2 i256;
+        v21.i256 = add v20 v8;
+        mstore v2 v21 i256;
+        return;
+
+    block3:
+        jump block4;
+
+    block4:
+        br 0.i1 block5 block6;
+
+    block5:
+        v24.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_d8ed v1;
+        call %encode_to_ptr__g4320 v0 v24;
+        unreachable;
+
+    block6:
+        jump block7;
+
+    block7:
+        call %encode__g3cd9 v0 v1;
         return;
 }
 
@@ -4838,20 +4838,6 @@ func private %encode_single_root__g859f(v0.i256, v1.objref<@layout_4>) {
         return;
 }
 
-func private %encode_single_root__g2e64(v0.i256, v1.objref<@layout_4>) {
-    block0:
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_fd6f v1;
-        v6.i256 = add v4 32.i256;
-        mstore v2 v6 i256;
-        v7.i256 = ptr_to_int v2 i256;
-        call %core__lib__abi__encode_field__g2e64_555f v0 v1 v7;
-        return;
-}
-
 func private %encode_single_root__g6d7e(v0.i256, v1.objref<@layout_4>) {
     block0:
         v2.*i256 = alloca i256;
@@ -4866,54 +4852,18 @@ func private %encode_single_root__g6d7e(v0.i256, v1.objref<@layout_4>) {
         return;
 }
 
-func private %encode_single_root_alloc__g472d(v0.i256) -> @layout_24 {
+func private %encode_single_root__g2e64(v0.i256, v1.objref<@layout_4>) {
     block0:
+        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v2.i256 = call %abi_single_root_size__g5535 v0;
-        v3.@layout_4 = call %std__lib__abi__sol__impl_trait_Sol_1f5f__encoder_new_a948 v2;
-        v4.objref<@layout_4> = obj.alloc @layout_4;
-        v6.objref<i256> = obj.proj v4 0.i256;
-        v7.i256 = extract_value v3 0.i256;
-        obj.store v6 v7;
-        v9.objref<i256> = obj.proj v4 1.i256;
-        v10.i256 = extract_value v3 1.i256;
-        obj.store v9 v10;
-        v11.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_25d4 v4;
-        call %encode_single_root__g859f v0 v4;
-        v13.objref<@layout_24> = obj.alloc @layout_24;
-        v14.objref<i256> = obj.proj v13 0.i256;
-        obj.store v14 v11;
-        v15.objref<i256> = obj.proj v13 1.i256;
-        obj.store v15 v2;
-        v16.@layout_24 = obj.load v13;
-        return v16;
-}
-
-func private %encode_single_root_alloc__g0c18(v0.i256) -> @layout_24 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.i256 = call %abi_single_root_size__g65da v0;
-        v3.@layout_4 = call %std__lib__abi__sol__impl_trait_Sol_1f5f__encoder_new_30df v2;
-        v4.objref<@layout_4> = obj.alloc @layout_4;
-        v6.objref<i256> = obj.proj v4 0.i256;
-        v7.i256 = extract_value v3 0.i256;
-        obj.store v6 v7;
-        v9.objref<i256> = obj.proj v4 1.i256;
-        v10.i256 = extract_value v3 1.i256;
-        obj.store v9 v10;
-        v11.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_6030 v4;
-        call %encode_single_root__g6d7e v0 v4;
-        v13.objref<@layout_24> = obj.alloc @layout_24;
-        v14.objref<i256> = obj.proj v13 0.i256;
-        obj.store v14 v11;
-        v15.objref<i256> = obj.proj v13 1.i256;
-        obj.store v15 v2;
-        v16.@layout_24 = obj.load v13;
-        return v16;
+        v4.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_fd6f v1;
+        v6.i256 = add v4 32.i256;
+        mstore v2 v6 i256;
+        v7.i256 = ptr_to_int v2 i256;
+        call %core__lib__abi__encode_field__g2e64_555f v0 v1 v7;
+        return;
 }
 
 func private %encode_single_root_alloc__gcb0a(v0.i8) -> @layout_24 {
@@ -4966,6 +4916,31 @@ func private %encode_single_root_alloc__gac80(v0.i256) -> @layout_24 {
         return v16;
 }
 
+func private %encode_single_root_alloc__g0c18(v0.i256) -> @layout_24 {
+    block0:
+        jump block1;
+
+    block1:
+        v2.i256 = call %abi_single_root_size__g65da v0;
+        v3.@layout_4 = call %std__lib__abi__sol__impl_trait_Sol_1f5f__encoder_new_30df v2;
+        v4.objref<@layout_4> = obj.alloc @layout_4;
+        v6.objref<i256> = obj.proj v4 0.i256;
+        v7.i256 = extract_value v3 0.i256;
+        obj.store v6 v7;
+        v9.objref<i256> = obj.proj v4 1.i256;
+        v10.i256 = extract_value v3 1.i256;
+        obj.store v9 v10;
+        v11.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_6030 v4;
+        call %encode_single_root__g6d7e v0 v4;
+        v13.objref<@layout_24> = obj.alloc @layout_24;
+        v14.objref<i256> = obj.proj v13 0.i256;
+        obj.store v14 v11;
+        v15.objref<i256> = obj.proj v13 1.i256;
+        obj.store v15 v2;
+        v16.@layout_24 = obj.load v13;
+        return v16;
+}
+
 func private %encode_single_root_alloc__g09ca(v0.i1) -> @layout_24 {
     block0:
         jump block1;
@@ -4991,6 +4966,31 @@ func private %encode_single_root_alloc__g09ca(v0.i1) -> @layout_24 {
         return v16;
 }
 
+func private %encode_single_root_alloc__g472d(v0.i256) -> @layout_24 {
+    block0:
+        jump block1;
+
+    block1:
+        v2.i256 = call %abi_single_root_size__g5535 v0;
+        v3.@layout_4 = call %std__lib__abi__sol__impl_trait_Sol_1f5f__encoder_new_a948 v2;
+        v4.objref<@layout_4> = obj.alloc @layout_4;
+        v6.objref<i256> = obj.proj v4 0.i256;
+        v7.i256 = extract_value v3 0.i256;
+        obj.store v6 v7;
+        v9.objref<i256> = obj.proj v4 1.i256;
+        v10.i256 = extract_value v3 1.i256;
+        obj.store v9 v10;
+        v11.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_25d4 v4;
+        call %encode_single_root__g859f v0 v4;
+        v13.objref<@layout_24> = obj.alloc @layout_24;
+        v14.objref<i256> = obj.proj v13 0.i256;
+        obj.store v14 v11;
+        v15.objref<i256> = obj.proj v13 1.i256;
+        obj.store v15 v2;
+        v16.@layout_24 = obj.load v13;
+        return v16;
+}
+
 func private %core__lib__abi__impl_trait_u256_d99e__encode_to_ptr__gf13e_1b98(v0.i256, v1.i256) {
     block0:
         v2.*i256 = alloca i256;
@@ -5001,6 +5001,16 @@ func private %core__lib__abi__impl_trait_u256_d99e__encode_to_ptr__gf13e_1b98(v0
         v3.i256 = mload v2 i256;
         call %std__lib__abi__sol__impl_trait_Sol_1f5f__store_word_2361 v3 v0;
         return;
+}
+
+func private %encode_to_ptr__g4320(v0.i256, v1.i256) {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        evm_invalid;
 }
 
 func private %impl_trait_bool__encode_to_ptr__gf13e(v0.i1, v1.i256) {
@@ -5027,16 +5037,6 @@ func private %impl_trait_bool__encode_to_ptr__gf13e(v0.i1, v1.i256) {
 }
 
 func private %encode_to_ptr__g30cc(v0.i256, v1.i256) {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        evm_invalid;
-}
-
-func private %encode_to_ptr__g4320(v0.i256, v1.i256) {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -8380,6 +8380,52 @@ func private %core__lib__abi__trait_AbiSize__payload_size__ge513_3812_1(v0.i256)
         return 32.i256;
 }
 
+func private %core__lib__abi__impl_trait_String_c06e__payload_size__gc7cf_4aab(v0.i256) -> i256 {
+    block0:
+        v1.*i256 = alloca i256;
+        mstore v1 v0 i256;
+        jump block1;
+
+    block1:
+        v3.i256 = mload v1 i256;
+        v4.i256 = call %core__lib__num__impl_trait_String_8f88__to_word__gc7cf_518a v3;
+        v5.i256 = call %core__lib__abi__packed_string_len_ecb6 v4;
+        v6.i256 = call %core__lib__abi__round_up_words_a41d v5;
+        (v7.i256, v8.i1) = uaddo 32.i256 v6;
+        br v8 block2 block3;
+
+    block2:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block3:
+        return v7;
+}
+
+func private %core__lib__abi__impl_trait_String_c06e__payload_size__gc7cf_4aab_0(v0.i256) -> i256 {
+    block0:
+        v1.*i256 = alloca i256;
+        mstore v1 v0 i256;
+        jump block1;
+
+    block1:
+        v3.i256 = mload v1 i256;
+        v4.i256 = call %core__lib__num__impl_trait_String_8f88__to_word__gc7cf_518a_0 v3;
+        v5.i256 = call %core__lib__abi__packed_string_len_ecb6_0 v4;
+        v6.i256 = call %core__lib__abi__round_up_words_a41d_0 v5;
+        (v7.i256, v8.i1) = uaddo 32.i256 v6;
+        br v8 block2 block3;
+
+    block2:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block3:
+        return v7;
+}
+
 func private %core__lib__abi__trait_AbiSize__payload_size__ge513_77e5(v0.i256) -> i256 {
     block0:
         v1.*i256 = alloca i256;
@@ -8398,52 +8444,6 @@ func private %core__lib__abi__trait_AbiSize__payload_size__ge513_77e5_0(v0.i256)
 
     block1:
         return 32.i256;
-}
-
-func private %core__lib__abi__impl_trait_String_c06e__payload_size__gc7cf_9b7d(v0.i256) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v1 i256;
-        v4.i256 = call %core__lib__num__impl_trait_String_8f88__to_word__gc7cf_9de4 v3;
-        v5.i256 = call %core__lib__abi__packed_string_len_ecb6 v4;
-        v6.i256 = call %core__lib__abi__round_up_words_a41d v5;
-        (v7.i256, v8.i1) = uaddo 32.i256 v6;
-        br v8 block2 block3;
-
-    block2:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block3:
-        return v7;
-}
-
-func private %core__lib__abi__impl_trait_String_c06e__payload_size__gc7cf_9b7d_0(v0.i256) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v1 i256;
-        v4.i256 = call %core__lib__num__impl_trait_String_8f88__to_word__gc7cf_9de4_0 v3;
-        v5.i256 = call %core__lib__abi__packed_string_len_ecb6_0 v4;
-        v6.i256 = call %core__lib__abi__round_up_words_a41d_0 v5;
-        (v7.i256, v8.i1) = uaddo 32.i256 v6;
-        br v8 block2 block3;
-
-    block2:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block3:
-        return v7;
 }
 
 func private %core__lib__abi__trait_AbiSize__payload_size__ge513_a6ac(v0.i256) -> i256 {
@@ -8504,52 +8504,6 @@ func private %core__lib__abi__trait_AbiSize__payload_size__gda9b_b33d_0(v0.i1) -
 
     block1:
         return 32.i256;
-}
-
-func private %core__lib__abi__impl_trait_String_c06e__payload_size__g3eb7_dfa6(v0.i256) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v1 i256;
-        v4.i256 = call %core__lib__num__impl_trait_String_8f88__to_word__g3eb7_2617 v3;
-        v5.i256 = call %core__lib__abi__packed_string_len_225d v4;
-        v6.i256 = call %core__lib__abi__round_up_words_b13c v5;
-        (v7.i256, v8.i1) = uaddo 32.i256 v6;
-        br v8 block2 block3;
-
-    block2:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block3:
-        return v7;
-}
-
-func private %core__lib__abi__impl_trait_String_c06e__payload_size__g3eb7_dfa6_0(v0.i256) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v1 i256;
-        v4.i256 = call %core__lib__num__impl_trait_String_8f88__to_word__g3eb7_2617_0 v3;
-        v5.i256 = call %core__lib__abi__packed_string_len_225d_0 v4;
-        v6.i256 = call %core__lib__abi__round_up_words_b13c_0 v5;
-        (v7.i256, v8.i1) = uaddo 32.i256 v6;
-        br v8 block2 block3;
-
-    block2:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block3:
-        return v7;
 }
 
 func private %std__lib__evm__panic__impl_trait_Panic_bf0a__payload_size_ec06(v0.@layout_3) -> i256 {
@@ -8627,6 +8581,52 @@ func private %core__lib__abi__trait_AbiSize__payload_size__g79ff_f3e8_0(v0.i8) -
 
     block1:
         return 32.i256;
+}
+
+func private %core__lib__abi__impl_trait_String_c06e__payload_size__g3eb7_f656(v0.i256) -> i256 {
+    block0:
+        v1.*i256 = alloca i256;
+        mstore v1 v0 i256;
+        jump block1;
+
+    block1:
+        v3.i256 = mload v1 i256;
+        v4.i256 = call %core__lib__num__impl_trait_String_8f88__to_word__g3eb7_38b3 v3;
+        v5.i256 = call %core__lib__abi__packed_string_len_225d v4;
+        v6.i256 = call %core__lib__abi__round_up_words_b13c v5;
+        (v7.i256, v8.i1) = uaddo 32.i256 v6;
+        br v8 block2 block3;
+
+    block2:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block3:
+        return v7;
+}
+
+func private %core__lib__abi__impl_trait_String_c06e__payload_size__g3eb7_f656_0(v0.i256) -> i256 {
+    block0:
+        v1.*i256 = alloca i256;
+        mstore v1 v0 i256;
+        jump block1;
+
+    block1:
+        v3.i256 = mload v1 i256;
+        v4.i256 = call %core__lib__num__impl_trait_String_8f88__to_word__g3eb7_38b3_0 v3;
+        v5.i256 = call %core__lib__abi__packed_string_len_225d_0 v4;
+        v6.i256 = call %core__lib__abi__round_up_words_b13c_0 v5;
+        (v7.i256, v8.i1) = uaddo 32.i256 v6;
+        br v8 block2 block3;
+
+    block2:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block3:
+        return v7;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g8f43_03cc(v0.objref<@layout_7>) -> i256 {
@@ -12971,7 +12971,7 @@ func private %std__lib__evm__word__impl_trait_u256_1f9e__to_word_05d2_0(v0.i256)
         return v0;
 }
 
-func private %core__lib__num__impl_trait_String_8f88__to_word__g3eb7_2617(v0.i256) -> i256 {
+func private %core__lib__num__impl_trait_String_8f88__to_word__g3eb7_38b3(v0.i256) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         mstore v1 v0 i256;
@@ -12979,10 +12979,11 @@ func private %core__lib__num__impl_trait_String_8f88__to_word__g3eb7_2617(v0.i25
 
     block1:
         v2.i256 = mload v1 i256;
-        return v2;
+        v9.i256 = and v2 452312848583266388373324160190187140051835877600158453279131187530910662655.i256;
+        return v9;
 }
 
-func private %core__lib__num__impl_trait_String_8f88__to_word__g3eb7_2617_0(v0.i256) -> i256 {
+func private %core__lib__num__impl_trait_String_8f88__to_word__g3eb7_38b3_0(v0.i256) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         mstore v1 v0 i256;
@@ -12990,7 +12991,8 @@ func private %core__lib__num__impl_trait_String_8f88__to_word__g3eb7_2617_0(v0.i
 
     block1:
         v2.i256 = mload v1 i256;
-        return v2;
+        v9.i256 = and v2 452312848583266388373324160190187140051835877600158453279131187530910662655.i256;
+        return v9;
 }
 
 func private %std__lib__evm__word__impl_trait_u256_1f9e__to_word_3e9f(v0.i256) -> i256 {
@@ -13001,7 +13003,7 @@ func private %std__lib__evm__word__impl_trait_u256_1f9e__to_word_3e9f(v0.i256) -
         return v0;
 }
 
-func private %core__lib__num__impl_trait_String_8f88__to_word__gc7cf_810c(v0.i256) -> i256 {
+func private %core__lib__num__impl_trait_String_8f88__to_word__g3eb7_4283(v0.i256) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         mstore v1 v0 i256;
@@ -13009,10 +13011,11 @@ func private %core__lib__num__impl_trait_String_8f88__to_word__gc7cf_810c(v0.i25
 
     block1:
         v2.i256 = mload v1 i256;
-        return v2;
+        v9.i256 = and v2 452312848583266388373324160190187140051835877600158453279131187530910662655.i256;
+        return v9;
 }
 
-func private %core__lib__num__impl_trait_String_8f88__to_word__gc7cf_9de4(v0.i256) -> i256 {
+func private %core__lib__num__impl_trait_String_8f88__to_word__gc7cf_518a(v0.i256) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         mstore v1 v0 i256;
@@ -13020,10 +13023,11 @@ func private %core__lib__num__impl_trait_String_8f88__to_word__gc7cf_9de4(v0.i25
 
     block1:
         v2.i256 = mload v1 i256;
-        return v2;
+        v8.i256 = and v2 18446744073709551615.i256;
+        return v8;
 }
 
-func private %core__lib__num__impl_trait_String_8f88__to_word__gc7cf_9de4_0(v0.i256) -> i256 {
+func private %core__lib__num__impl_trait_String_8f88__to_word__gc7cf_518a_0(v0.i256) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         mstore v1 v0 i256;
@@ -13031,10 +13035,11 @@ func private %core__lib__num__impl_trait_String_8f88__to_word__gc7cf_9de4_0(v0.i
 
     block1:
         v2.i256 = mload v1 i256;
-        return v2;
+        v8.i256 = and v2 18446744073709551615.i256;
+        return v8;
 }
 
-func private %core__lib__num__impl_trait_String_8f88__to_word__g3eb7_e974(v0.i256) -> i256 {
+func private %core__lib__num__impl_trait_String_8f88__to_word__gc7cf_de49(v0.i256) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         mstore v1 v0 i256;
@@ -13042,7 +13047,8 @@ func private %core__lib__num__impl_trait_String_8f88__to_word__g3eb7_e974(v0.i25
 
     block1:
         v2.i256 = mload v1 i256;
-        return v2;
+        v8.i256 = and v2 18446744073709551615.i256;
+        return v8;
 }
 
 func private %impl_trait_bool__to_word(v0.i1) -> i256 {

--- a/crates/codegen/tests/fixtures/sonatina_ir/match_fn_call.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/match_fn_call.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/codegen/tests/sonatina_ir.rs
+assertion_line: 403
 expression: output
 input_file: crates/codegen/tests/fixtures/match_fn_call.fe
 ---

--- a/crates/codegen/tests/fixtures/sonatina_ir/revert.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/revert.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/codegen/tests/sonatina_ir.rs
+assertion_line: 403
 expression: output
 input_file: crates/codegen/tests/fixtures/revert.fe
 ---

--- a/crates/common/src/stdlib.rs
+++ b/crates/common/src/stdlib.rs
@@ -22,7 +22,13 @@ fn is_library_file(path: &Utf8Path) -> bool {
 fn initialize_builtin<E: Embed>(db: &mut dyn InputDb, base_url: &str) {
     let base = Url::parse(base_url).unwrap();
 
-    for path in E::iter().map(|path| Utf8PathBuf::from(path.to_string())) {
+    // Ensure deterministic file insertion order across platforms/builds.
+    // This matters because downstream iteration over workspace tries is depth-first.
+    let mut paths = E::iter()
+        .map(|path| Utf8PathBuf::from(path.to_string()))
+        .collect::<Vec<_>>();
+    paths.sort();
+    for path in paths {
         if !is_library_file(&path) {
             continue;
         }
@@ -44,14 +50,22 @@ fn load_library_dir(db: &mut dyn InputDb, base_url: &str, root: &Utf8Path) -> Re
 
     while let Some(dir) = stack.pop() {
         let entries = fs::read_dir(dir.as_std_path())
-            .map_err(|err| format!("Failed to read {}: {err}", dir))?;
-        for entry in entries {
-            let entry = entry.map_err(|err| format!("Failed to read entry: {err}"))?;
-            let path = Utf8PathBuf::from_path_buf(entry.path())
-                .map_err(|_| "Library path is not UTF-8".to_string())?;
-            let file_type = entry
-                .file_type()
-                .map_err(|err| format!("Failed to read file type: {err}"))?;
+            .map_err(|err| format!("Failed to read {}: {err}", dir))?
+            .map(|entry| {
+                let entry = entry.map_err(|err| format!("Failed to read entry: {err}"))?;
+                let path = Utf8PathBuf::from_path_buf(entry.path())
+                    .map_err(|_| "Library path is not UTF-8".to_string())?;
+                let file_type = entry
+                    .file_type()
+                    .map_err(|err| format!("Failed to read file type: {err}"))?;
+                Ok((path, file_type))
+            })
+            .collect::<Result<Vec<_>, String>>()?;
+
+        // Ensure deterministic traversal order across platforms/filesystems.
+        let mut entries = entries;
+        entries.sort_by(|(lhs, _), (rhs, _)| lhs.cmp(rhs));
+        for (path, file_type) in entries {
             if file_type.is_dir() {
                 stack.push(path);
                 continue;

--- a/crates/fe/tests/fixtures/fe_test_runner/fixed_string_primitives.fe
+++ b/crates/fe/tests/fixtures/fe_test_runner/fixed_string_primitives.fe
@@ -1,0 +1,101 @@
+use core::abi::{ByteInput, MemoryInput, encode_alloc}
+use core::concat
+use std::abi::Sol
+
+fn fifth_byte(_ s: String<8>) -> u8 {
+    let bytes: [u8; 8] = s.as_bytes()
+    bytes[4]
+}
+
+#[test]
+fn test_string_len_runtime() {
+    let s: String<8> = "COOL"
+    assert(s.len() == 4)
+}
+
+#[test]
+fn test_string_as_bytes_runtime() {
+    let s: String<8> = "COOL"
+    let bytes: [u8; 8] = s.as_bytes()
+    assert(bytes[0] == 0)
+    assert(bytes[3] == 0)
+    assert(bytes[4] == 67)
+    assert(bytes[7] == 76)
+}
+
+#[test]
+fn test_string_as_bytes_param_runtime() {
+    let encoded: (u256, u256) = encode_alloc<Sol, String<8>>("COOL")
+    let input = MemoryInput {
+        base: encoded.0,
+        len: encoded.1,
+    }
+
+    let mut padded: [u8; 8] = [0; 8]
+    padded[4] = input.byte_at(32)
+    padded[5] = input.byte_at(33)
+    padded[6] = input.byte_at(34)
+    padded[7] = input.byte_at(35)
+
+    let s: String<8> = String::from_bytes(padded)
+    assert(fifth_byte(s) == 67)
+}
+
+#[test]
+fn test_string_roundtrip_bytes_runtime() {
+    let bytes: [u8; 8] = [0, 0, 0, 0, 67, 79, 79, 76]
+    let s: String<8> = String::from_bytes(bytes)
+    assert(s == "COOL")
+}
+
+#[test]
+fn test_string_from_bytes_expression_runtime() {
+    let s: String<8> = String::from_bytes([0, 0, 0, 0, 67, 79, 79, 76])
+    assert(s == "COOL")
+}
+
+#[test]
+fn test_string_concat_runtime() {
+    let a: String<8> = "COOL"
+    let b: String<8> = "COIN"
+    let c: String<8> = concat(a, b)
+    assert(c == "COOLCOIN")
+}
+
+#[test]
+fn test_string_concat_expression_args_runtime() {
+    let left: String<2> = "CO"
+    let right: String<2> = "OL"
+    let c: String<4> = concat((left), (right))
+    assert(c == "COOL")
+}
+
+#[test]
+fn test_string_concat_uses_effective_len_runtime() {
+    let a: String<4> = "C"
+    let b: String<4> = "O"
+    let c: String<4> = concat(a, b)
+    assert(c == "CO")
+}
+
+#[test]
+fn test_string_concat_overflow_truncates() {
+    let a: String<4> = "ABCD"
+    let b: String<4> = "EFGH"
+    let c: String<6> = concat(a, b)
+    assert(c == "ABCDEF")
+}
+
+#[test]
+fn test_string_abi_encoding_ignores_hidden_high_bytes() {
+    let s: String<4> = 0x01000000434f4f4c as String<4>
+    let encoded: (u256, u256) = encode_alloc<Sol, String<4>>(s)
+    let input = MemoryInput {
+        base: encoded.0,
+        len: encoded.1,
+    }
+
+    assert(input.word_at(0) == 4)
+    assert(input.byte_at(32) == 67)
+    assert(input.byte_at(35) == 76)
+}

--- a/crates/fe/tests/fixtures/fe_test_runner/fixed_string_primitives.snap
+++ b/crates/fe/tests/fixtures/fe_test_runner/fixed_string_primitives.snap
@@ -1,0 +1,20 @@
+---
+source: crates/fe/tests/cli_output.rs
+expression: output
+input_file: tests/fixtures/fe_test_runner/fixed_string_primitives.fe
+---
+=== STDOUT ===
+PASS  [<time>] test_string_len_runtime
+PASS  [<time>] test_string_as_bytes_runtime
+PASS  [<time>] test_string_as_bytes_param_runtime
+PASS  [<time>] test_string_roundtrip_bytes_runtime
+PASS  [<time>] test_string_from_bytes_expression_runtime
+PASS  [<time>] test_string_concat_runtime
+PASS  [<time>] test_string_concat_expression_args_runtime
+PASS  [<time>] test_string_concat_uses_effective_len_runtime
+PASS  [<time>] test_string_concat_overflow_truncates
+PASS  [<time>] test_string_abi_encoding_ignores_hidden_high_bytes
+
+test result: ok. 10 passed; 0 failed
+
+=== EXIT CODE: 0 ===

--- a/crates/hir/src/analysis/semantic/consts.rs
+++ b/crates/hir/src/analysis/semantic/consts.rs
@@ -143,7 +143,52 @@ pub fn sem_const_eq<'db>(
     lhs: SemConstId<'db>,
     rhs: SemConstId<'db>,
 ) -> bool {
-    fn fixed_string_bytes_eq(a: &[u8], b: &[u8]) -> bool {
+    fn fixed_string_capacity_bytes<'db>(
+        db: &'db dyn HirAnalysisDb,
+        ty: TyId<'db>,
+    ) -> Option<usize> {
+        if !ty.is_string(db) {
+            return None;
+        }
+        let (_, args) = ty.decompose_ty_app(db);
+        let len_ty = args.first().copied()?;
+        let TyData::ConstTy(const_ty) = len_ty.data(db) else {
+            return None;
+        };
+        match const_ty.data(db) {
+            ConstTyData::Evaluated(EvaluatedConstTy::LitInt(int_id), _) => {
+                int_id.data(db).to_usize()
+            }
+            _ => None,
+        }
+    }
+
+    fn fixed_string_runtime_bytes<'db>(
+        db: &'db dyn HirAnalysisDb,
+        ty: TyId<'db>,
+        bytes: &[u8],
+    ) -> Vec<u8> {
+        let Some(len) = fixed_string_capacity_bytes(db, ty) else {
+            return bytes.to_vec();
+        };
+        let suffix = if bytes.len() > len {
+            &bytes[bytes.len() - len..]
+        } else {
+            bytes
+        };
+        let mut out = vec![0u8; len];
+        let offset = len - suffix.len();
+        out[offset..].copy_from_slice(suffix);
+        out
+    }
+
+    fn fixed_string_bytes_eq<'db>(
+        db: &'db dyn HirAnalysisDb,
+        lhs_ty: TyId<'db>,
+        lhs_bytes: &[u8],
+        rhs_ty: TyId<'db>,
+        rhs_bytes: &[u8],
+    ) -> bool {
         fn trim_leading_zeros(bytes: &[u8]) -> &[u8] {
             let mut idx = 0usize;
             while idx < bytes.len() && bytes[idx] == 0 {
@@ -152,7 +197,9 @@ pub fn sem_const_eq<'db>(
             &bytes[idx..]
         }
 
-        trim_leading_zeros(a) == trim_leading_zeros(b)
+        let lhs_bytes = fixed_string_runtime_bytes(db, lhs_ty, lhs_bytes);
+        let rhs_bytes = fixed_string_runtime_bytes(db, rhs_ty, rhs_bytes);
+        trim_leading_zeros(&lhs_bytes) == trim_leading_zeros(&rhs_bytes)
     }
 
     fn is_string_like<'db>(db: &'db dyn HirAnalysisDb, ty: TyId<'db>) -> bool {
@@ -188,7 +235,13 @@ pub fn sem_const_eq<'db>(
                 && let (SemConstScalar::Bytes(lhs_bytes), SemConstScalar::Bytes(rhs_bytes)) =
                     (&lhs_value, &rhs_value)
             {
-                return fixed_string_bytes_eq(lhs_bytes.as_slice(), rhs_bytes.as_slice());
+                return fixed_string_bytes_eq(
+                    db,
+                    lhs_ty,
+                    lhs_bytes.as_slice(),
+                    rhs_ty,
+                    rhs_bytes.as_slice(),
+                );
             }
             if lhs_ty != rhs_ty {
                 return false;

--- a/crates/hir/src/analysis/semantic/consts.rs
+++ b/crates/hir/src/analysis/semantic/consts.rs
@@ -8,7 +8,7 @@ use crate::analysis::{
     semantic::{SemanticInstance, instantiate_with_generic_args},
     ty::{
         const_ty::{ConstTyData, EvaluatedConstTy, evaluate_type_level_int_const_expr},
-        ty_def::{PrimTy, TyBase, TyData, TyId, prim_int_bits},
+        ty_def::{PrimTy, TyBase, TyData, TyId, TyVarSort, prim_int_bits},
     },
 };
 
@@ -143,6 +143,31 @@ pub fn sem_const_eq<'db>(
     lhs: SemConstId<'db>,
     rhs: SemConstId<'db>,
 ) -> bool {
+    fn fixed_string_bytes_eq(a: &[u8], b: &[u8]) -> bool {
+        fn trim_leading_zeros(bytes: &[u8]) -> &[u8] {
+            let mut idx = 0usize;
+            while idx < bytes.len() && bytes[idx] == 0 {
+                idx += 1;
+            }
+            &bytes[idx..]
+        }
+
+        trim_leading_zeros(a) == trim_leading_zeros(b)
+    }
+
+    fn is_string_like<'db>(db: &'db dyn HirAnalysisDb, ty: TyId<'db>) -> bool {
+        let ty = ty.as_capability(db).map(|(_, inner)| inner).unwrap_or(ty);
+        if ty.is_string(db) {
+            return true;
+        }
+
+        let base = ty.base_ty(db);
+        matches!(
+            base.data(db),
+            TyData::TyVar(var) if matches!(var.sort, TyVarSort::String { .. })
+        )
+    }
+
     if lhs == rhs {
         return true;
     }
@@ -157,7 +182,19 @@ pub fn sem_const_eq<'db>(
                 ty: rhs_ty,
                 value: rhs_value,
             },
-        ) => lhs_ty == rhs_ty && lhs_value == rhs_value,
+        ) => {
+            if is_string_like(db, lhs_ty)
+                && is_string_like(db, rhs_ty)
+                && let (SemConstScalar::Bytes(lhs_bytes), SemConstScalar::Bytes(rhs_bytes)) =
+                    (&lhs_value, &rhs_value)
+            {
+                return fixed_string_bytes_eq(lhs_bytes.as_slice(), rhs_bytes.as_slice());
+            }
+            if lhs_ty != rhs_ty {
+                return false;
+            }
+            lhs_value == rhs_value
+        }
         (
             SemConstValue::TypeLevel {
                 ty: lhs_ty,

--- a/crates/hir/src/analysis/semantic/ctfe/machine.rs
+++ b/crates/hir/src/analysis/semantic/ctfe/machine.rs
@@ -1963,13 +1963,41 @@ impl<'db> CtfeMachine<'db> {
         let [value] = args else {
             return Err(CtfeError::NotConstEvaluable { origin });
         };
-        let bytes = self.const_as_bytes(value, origin)?;
+        let mut bytes = self.const_as_bytes(value, origin)?;
         if let Some(len) = array_len(self.db, result_ty)
             && bytes.len() != len
         {
-            return Err(CtfeError::NotConstEvaluable { origin });
+            if let Some(string_bytes) = self.fixed_string_bytes_for_len(value, len) {
+                bytes = string_bytes;
+            } else {
+                return Err(CtfeError::NotConstEvaluable { origin });
+            }
         }
         Ok(CtfeConstValue::bytes(result_ty, bytes))
+    }
+
+    fn fixed_string_bytes_for_len(
+        &self,
+        value: &CtfeConstValue<'db>,
+        len: usize,
+    ) -> Option<Vec<u8>> {
+        let value = self.expand_interned(value.clone());
+        let CtfeConstKind::Bytes { ty, bytes } = &value.kind else {
+            return None;
+        };
+        if !ty.is_string(self.db) {
+            return None;
+        }
+
+        let mut out = vec![0u8; len];
+        let suffix = if bytes.len() > len {
+            &bytes[bytes.len() - len..]
+        } else {
+            bytes.as_ref()
+        };
+        let offset = len - suffix.len();
+        out[offset..].copy_from_slice(suffix);
+        Some(out)
     }
 
     fn eval_intrinsic_keccak(
@@ -2922,6 +2950,26 @@ impl<'db> CtfeMachine<'db> {
         value: CtfeConstValue<'db>,
         origin: SemOrigin<'db>,
     ) -> Result<CtfeValue<'db>, CtfeError<'db>> {
+        fn fixed_string_capacity_bytes<'db>(
+            db: &'db dyn HirAnalysisDb,
+            ty: TyId<'db>,
+        ) -> Option<usize> {
+            if !ty.is_string(db) {
+                return None;
+            }
+            let (_, args) = ty.decompose_ty_app(db);
+            let len_ty = args.first().copied()?;
+            let TyData::ConstTy(const_ty) = len_ty.data(db) else {
+                return None;
+            };
+            match const_ty.data(db) {
+                ConstTyData::Evaluated(EvaluatedConstTy::LitInt(int_id), _) => {
+                    int_id.data(db).to_usize()
+                }
+                _ => None,
+            }
+        }
+
         let value = self.expand_interned(value);
         match &value.kind {
             CtfeConstKind::Bool(value) if int_ty_shape(self.db, result_ty).is_some() => {
@@ -2941,6 +2989,36 @@ impl<'db> CtfeMachine<'db> {
             CtfeConstKind::Int { value, .. } if int_ty_shape(self.db, result_ty).is_some() => Ok(
                 CtfeValue::Value(CtfeConstValue::int(self.db, result_ty, value.to_bigint())),
             ),
+            CtfeConstKind::Int { value, .. } if result_ty.is_string(self.db) => {
+                fixed_string_capacity_bytes(self.db, result_ty)
+                    .ok_or(CtfeError::NotConstEvaluable { origin })?;
+                let word = value.to_u256();
+                Ok(CtfeValue::Value(CtfeConstValue::bytes(
+                    result_ty,
+                    word.to_be_bytes::<32>().to_vec(),
+                )))
+            }
+            CtfeConstKind::Bytes { bytes, .. }
+                if matches!(int_ty_shape(self.db, result_ty), Some((_, false))) =>
+            {
+                let Some((bits, false)) = int_ty_shape(self.db, result_ty) else {
+                    unreachable!("match guard should ensure unsigned int shape");
+                };
+                let width = usize::from(bits / 8);
+                if bytes.len() > width && bytes[..bytes.len() - width].iter().any(|byte| *byte != 0)
+                {
+                    return Err(CtfeError::NotConstEvaluable { origin });
+                }
+                let suffix = if bytes.len() > width {
+                    &bytes[bytes.len() - width..]
+                } else {
+                    bytes.as_ref()
+                };
+                let value = BigInt::from(BigUint::from_bytes_be(suffix));
+                Ok(CtfeValue::Value(CtfeConstValue::int(
+                    self.db, result_ty, value,
+                )))
+            }
             CtfeConstKind::Bytes { bytes, .. } => Ok(CtfeValue::Value(CtfeConstValue::bytes(
                 result_ty,
                 bytes.to_vec(),

--- a/crates/hir/src/analysis/semantic/lower/body.rs
+++ b/crates/hir/src/analysis/semantic/lower/body.rs
@@ -1,5 +1,6 @@
 use cranelift_entity::EntityRef;
 use num_bigint::BigInt;
+use num_traits::ToPrimitive;
 use rustc_hash::FxHashMap;
 
 use crate::{
@@ -16,14 +17,14 @@ use crate::{
             runtime_size_bytes, sem_const_from_ty, unit_const,
         },
         ty::{
-            const_ty::const_ty_or_abstract_from_assoc_const_use,
+            const_ty::{ConstTyData, EvaluatedConstTy, const_ty_or_abstract_from_assoc_const_use},
             normalize::normalize_ty,
             ty_check::{
                 BodyOwner, CodeRegionIntrinsicKind, ConstIntrinsicKind, ConstRef, LocalBinding,
                 PathReadSemantics, RecordInitLowering, RecordLike, SemanticExprLowering, TypedBody,
                 ValuePathRef,
             },
-            ty_def::{BorrowKind, TyId},
+            ty_def::{BorrowKind, TyData, TyId},
         },
     },
     hir_def::{
@@ -194,6 +195,23 @@ pub(super) struct LoopScope {
 }
 
 impl<'a, 'db> SmirLowerCtxt<'a, 'db> {
+    pub(super) fn fixed_string_capacity_bytes(&self, ty: TyId<'db>) -> Option<usize> {
+        if !ty.is_string(self.db) {
+            return None;
+        }
+        let (_, args) = ty.decompose_ty_app(self.db);
+        let len_ty = args.first().copied()?;
+        let TyData::ConstTy(const_ty) = len_ty.data(self.db) else {
+            return None;
+        };
+        match const_ty.data(self.db) {
+            ConstTyData::Evaluated(EvaluatedConstTy::LitInt(int_id), _) => {
+                int_id.data(self.db).to_usize()
+            }
+            _ => None,
+        }
+    }
+
     fn new(
         db: &'db dyn HirAnalysisDb,
         instance: SemanticInstance<'db>,
@@ -590,7 +608,15 @@ impl<'a, 'db> SmirLowerCtxt<'a, 'db> {
         let value = match lit {
             LitKind::Int(int_id) => int_const(self.db, ty, int_id.data(self.db).clone().into()),
             LitKind::String(string_id) => {
-                bytes_const(self.db, ty, string_id.data(self.db).as_bytes().to_vec())
+                let mut bytes = string_id.data(self.db).as_bytes().to_vec();
+                if let Some(capacity) = self.fixed_string_capacity_bytes(ty)
+                    && bytes.len() < capacity
+                {
+                    let mut padded = vec![0u8; capacity - bytes.len()];
+                    padded.extend(bytes);
+                    bytes = padded;
+                }
+                bytes_const(self.db, ty, bytes)
             }
             LitKind::Bool(value) => bool_const(self.db, *value),
         };

--- a/crates/hir/src/analysis/semantic/lower/pattern.rs
+++ b/crates/hir/src/analysis/semantic/lower/pattern.rs
@@ -647,7 +647,15 @@ impl<'a, 'db> SmirLowerCtxt<'a, 'db> {
                 int_const(self.db, ty, BigInt::from(int_id.data(self.db).clone()))
             }
             LitKind::String(string_id) => {
-                bytes_const(self.db, ty, string_id.data(self.db).as_bytes().to_vec())
+                let mut bytes = string_id.data(self.db).as_bytes().to_vec();
+                if let Some(capacity) = self.fixed_string_capacity_bytes(ty)
+                    && bytes.len() < capacity
+                {
+                    let mut padded = vec![0u8; capacity - bytes.len()];
+                    padded.extend(bytes);
+                    bytes = padded;
+                }
+                bytes_const(self.db, ty, bytes)
             }
             LitKind::Bool(value) => bool_const(self.db, value),
         };

--- a/crates/hir/src/analysis/ty/method_table.rs
+++ b/crates/hir/src/analysis/ty/method_table.rs
@@ -6,7 +6,8 @@ use salsa::Update;
 use super::{
     binder::Binder,
     canonical::Canonical,
-    ty_def::{TyBase, TyId, strip_derived_adt_layout_args},
+    const_ty::ConstTyId,
+    ty_def::{InvalidCause, TyBase, TyId, strip_derived_adt_layout_args},
     unify::UnificationTable,
 };
 use crate::analysis::{HirAnalysisDb, ty::ty_def::TyData};
@@ -19,8 +20,10 @@ pub(crate) fn collect_methods<'db>(
 ) -> MethodTable<'db> {
     let mut collector = MethodCollector::new(db, ingot);
 
-    let impls = ingot.all_impls(db);
-    collector.collect_impls(impls);
+    for (_, external) in ingot.resolved_external_ingots(db).iter() {
+        collector.collect_impls(external.all_impls(db));
+    }
+    collector.collect_impls(ingot.all_impls(db));
     collector.finalize()
 }
 
@@ -128,6 +131,7 @@ impl<'db> MethodBucket<'db> {
     ) -> Vec<CallableDef<'db>> {
         let mut methods = vec![];
         let ty = strip_derived_adt_layout_args(table.db, ty);
+        let ty = saturate_ty_for_method_probe(table.db, ty);
         for (&cand_ty, funcs) in self.methods.iter() {
             let snapshot = table.snapshot();
 
@@ -146,6 +150,23 @@ impl<'db> MethodBucket<'db> {
 
         methods
     }
+}
+
+fn saturate_ty_for_method_probe<'db>(db: &'db dyn HirAnalysisDb, mut ty: TyId<'db>) -> TyId<'db> {
+    while !ty.is_star_kind(db) {
+        let Some(prop) = ty.applicable_ty(db) else {
+            break;
+        };
+
+        let arg = if let Some(const_ty) = prop.const_ty {
+            TyId::const_ty(db, ConstTyId::hole_with_ty(db, const_ty))
+        } else {
+            TyId::invalid(db, InvalidCause::Other)
+        };
+
+        ty = TyId::app(db, ty, arg);
+    }
+    ty
 }
 
 struct MethodCollector<'db> {

--- a/crates/hir/src/analysis/ty/ty_check/expr.rs
+++ b/crates/hir/src/analysis/ty/ty_check/expr.rs
@@ -508,6 +508,11 @@ impl<'db> TyChecker<'db> {
             inner_expr.data(self.db, self.body())
         {
             let value = int_id.data(self.db);
+            if to.is_string(self.db) && self.int_literal_fits_in_ty(value, TyId::u256(self.db)) {
+                let _ = self.table.unify(from, TyId::u256(self.db));
+                return ExprProp::new(to, true);
+            }
+
             if self.int_literal_fits_in_ty(value, to) {
                 // Unify the literal's type variable with the target leaf type
                 // so it doesn't remain unresolved.

--- a/crates/hir/src/core/hir_def/module_tree.rs
+++ b/crates/hir/src/core/hir_def/module_tree.rs
@@ -183,6 +183,20 @@ pub(crate) fn module_tree_impl<'db>(db: &'db dyn HirDb, ingot: Ingot<'db>) -> Mo
 
     // Collect source modules
     let files = ingot.files(db);
+    // NOTE: `files.iter()` traverses a radix trie in depth-first order, which can vary based on
+    // insertion order. Sort source files by their path so module tree construction is
+    // deterministic across platforms/builds.
+    let mut source_files = files
+        .iter()
+        .filter_map(|(_, file)| match file.kind(db) {
+            Some(IngotFileKind::Source) => Some((
+                file.path(db).as_ref().expect("couldn't get path").clone(),
+                file,
+            )),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    source_files.sort_by(|(lhs, _), (rhs, _)| lhs.cmp(rhs));
 
     // If the ingot has no files at all (e.g. it was deleted during an
     // incremental workspace change), return a degenerate empty tree.
@@ -200,14 +214,11 @@ pub(crate) fn module_tree_impl<'db>(db: &'db dyn HirDb, ingot: Ingot<'db>) -> Mo
         };
     }
 
-    for (_, file) in files.iter() {
-        if let Some(IngotFileKind::Source) = file.kind(db) {
-            let top_mod = map_file_to_mod_impl(db, file);
-            let module_id = module_tree.push(ModuleTreeNode::new(top_mod));
-            let path = file.path(db).as_ref().expect("couldn't get path").clone();
-            path_map.insert(path, module_id);
-            mod_map.insert(top_mod, module_id);
-        }
+    for (path, file) in &source_files {
+        let top_mod = map_file_to_mod_impl(db, *file);
+        let module_id = module_tree.push(ModuleTreeNode::new(top_mod));
+        path_map.insert(path.clone(), module_id);
+        mod_map.insert(top_mod, module_id);
     }
 
     // Find root - if there's no root file, use the first source file as fallback
@@ -216,14 +227,7 @@ pub(crate) fn module_tree_impl<'db>(db: &'db dyn HirDb, ingot: Ingot<'db>) -> Mo
         Err(_) => {
             // No root file found - use first source file as fallback root
             // This handles non-conformant ingots (e.g., directories without src/lib.fe)
-            let first_source = files.iter().find_map(|(_, file)| {
-                if matches!(file.kind(db), Some(IngotFileKind::Source)) {
-                    Some(file)
-                } else {
-                    None
-                }
-            });
-            match first_source {
+            match source_files.first().map(|(_, file)| *file) {
                 Some(file) => file,
                 None => {
                     tracing::warn!(
@@ -257,20 +261,20 @@ pub(crate) fn module_tree_impl<'db>(db: &'db dyn HirDb, ingot: Ingot<'db>) -> Mo
     let root = mod_map[&root_mod];
 
     // Build parent-child relationships
-    for (_, child_file) in files.iter() {
+    for (_, child_file) in &source_files {
+        let child_file = *child_file;
         if child_file == root_file {
             continue;
         }
 
-        if let Some(IngotFileKind::Source) = child_file.kind(db)
-            && let Some(parent_id) = find_parent_module(db, child_file, root_file, &path_map)
-        {
-            let child_mod = map_file_to_mod_impl(db, child_file);
-            let child_id = mod_map[&child_mod];
+        let Some(parent_id) = find_parent_module(db, child_file, root_file, &path_map) else {
+            continue;
+        };
+        let child_mod = map_file_to_mod_impl(db, child_file);
+        let child_id = mod_map[&child_mod];
 
-            module_tree[parent_id].children.push(child_id);
-            module_tree[child_id].parent = Some(parent_id);
-        }
+        module_tree[parent_id].children.push(child_id);
+        module_tree[child_id].parent = Some(parent_id);
     }
 
     ModuleTree {

--- a/crates/hir/tests/semantic_ctfe.rs
+++ b/crates/hir/tests/semantic_ctfe.rs
@@ -212,6 +212,10 @@ const fn high_word_string_roundtrip() -> u256 {
     (0x01000000434f4f4c as String<4>) as u256
 }
 
+const fn high_word_string_value() -> String<4> {
+    0x01000000434f4f4c as String<4>
+}
+
 const fn high_word_string_as_bytes() -> [u8; 4] {
     let s: String<4> = 0x01000000434f4f4c as String<4>
     intrinsic::__as_bytes(s)
@@ -431,6 +435,17 @@ const fn high_word_string_as_bytes() -> [u8; 4] {
 
     let high_bytes = eval_bytes(&db, find_func(&db, top_mod, "high_word_string_as_bytes"));
     assert_eq!(high_bytes, vec![67, 79, 79, 76]);
+
+    let high_word_const = eval_body_owner_const(
+        &db,
+        BodyOwner::Func(find_func(&db, top_mod, "high_word_string_value")),
+        Vec::new(),
+    )
+    .expect("expected const evaluation success");
+    assert!(
+        fe_hir::analysis::semantic::sem_const_eq(&db, high_word_const, literal_4_const),
+        "CTFE string equality should ignore hidden high bytes outside String<N> capacity"
+    );
 }
 
 #[test]

--- a/crates/hir/tests/semantic_ctfe.rs
+++ b/crates/hir/tests/semantic_ctfe.rs
@@ -19,6 +19,7 @@ use fe_hir::{
     hir_def::{ItemKind, Partial},
     span::LazySpan,
 };
+use num_traits::ToPrimitive;
 
 #[test]
 fn canonicalize_folds_const_calls_into_nested_aggregate_consts() {
@@ -106,6 +107,380 @@ fn semantic_ctfe_evaluates_as_bytes_const_fns() {
             value.value(&db),
             ty.pretty_print(&db)
         );
+    }
+}
+
+#[test]
+fn semantic_ctfe_evaluates_fixed_string_primitives() {
+    let mut db = HirAnalysisTestDb::default();
+    let file = db.new_stand_alone(
+        "semantic_ctfe_string.fe".into(),
+        r#"
+use core::concat
+use core::intrinsic
+
+const fn padded_bytes() -> [u8; 8] {
+    let s: String<8> = "COOL"
+    s.as_bytes()
+}
+
+const fn roundtrip_bytes() -> [u8; 8] {
+    let s: String<8> = "COOL"
+    let bytes: [u8; 8] = s.as_bytes()
+    let t: String<8> = String::from_bytes(bytes)
+    t.as_bytes()
+}
+
+const fn cool_len() -> usize {
+    let s: String<8> = "COOL"
+    s.len()
+}
+
+const fn concat_bytes() -> [u8; 8] {
+    let a: String<8> = "COOL"
+    let b: String<8> = "COIN"
+    let c: String<8> = concat(a, b)
+    c.as_bytes()
+}
+
+const fn concat_uses_effective_len() -> [u8; 4] {
+    let a: String<4> = "C"
+    let b: String<4> = "O"
+    let c: String<4> = concat(a, b)
+    c.as_bytes()
+}
+
+const fn eq_true() -> bool {
+    let a: String<8> = "COOL"
+    let b: String<8> = "COOL"
+    a == b
+}
+
+const fn eq_false() -> bool {
+    let a: String<8> = "COOL"
+    let b: String<8> = "COIN"
+    a == b
+}
+
+const fn eq_from_bytes_matches_literal() -> bool {
+    let bytes: [u8; 8] = [0, 0, 0, 0, 67, 79, 79, 76]
+    let s: String<8> = String::from_bytes(bytes)
+    s == "COOL"
+}
+
+const fn from_bytes_value() -> String<8> {
+    let bytes: [u8; 8] = [0, 0, 0, 0, 67, 79, 79, 76]
+    String::from_bytes(bytes)
+}
+
+const fn literal_value_4() -> String<4> {
+    "COOL"
+}
+
+const fn literal_value_8() -> String<8> {
+    "COOL"
+}
+
+const fn rhs_word_in_eq_from_bytes() -> u256 {
+    let bytes: [u8; 8] = [0, 0, 0, 0, 67, 79, 79, 76]
+    let s: String<8> = String::from_bytes(bytes)
+    let rhs = "COOL"
+    let _ok: bool = s == rhs
+    rhs as u256
+}
+
+const fn s_word_in_eq_from_bytes() -> u256 {
+    let bytes: [u8; 8] = [0, 0, 0, 0, 67, 79, 79, 76]
+    let s: String<8> = String::from_bytes(bytes)
+    s as u256
+}
+
+const fn rhs_value_in_eq_from_bytes() -> String<8> {
+    let bytes: [u8; 8] = [0, 0, 0, 0, 67, 79, 79, 76]
+    let s: String<8> = String::from_bytes(bytes)
+    let rhs = "COOL"
+    let _ok: bool = s == rhs
+    rhs
+}
+
+const fn s_value_in_eq_from_bytes() -> String<8> {
+    let bytes: [u8; 8] = [0, 0, 0, 0, 67, 79, 79, 76]
+    String::from_bytes(bytes)
+}
+
+const fn high_word_string_roundtrip() -> u256 {
+    (0x01000000434f4f4c as String<4>) as u256
+}
+
+const fn high_word_string_as_bytes() -> [u8; 4] {
+    let s: String<4> = 0x01000000434f4f4c as String<4>
+    intrinsic::__as_bytes(s)
+}
+"#,
+    );
+    let (top_mod, _) = db.top_mod(file);
+
+    fn find_func<'db>(
+        db: &'db HirAnalysisTestDb,
+        top_mod: fe_hir::hir_def::TopLevelMod<'db>,
+        name: &str,
+    ) -> fe_hir::hir_def::Func<'db> {
+        top_mod
+            .all_funcs(db)
+            .iter()
+            .copied()
+            .find(|func| matches!(func.name(db), Partial::Present(found) if found.data(db) == name))
+            .unwrap_or_else(|| panic!("missing const fn `{name}`"))
+    }
+
+    fn eval_bytes<'db>(db: &'db HirAnalysisTestDb, func: fe_hir::hir_def::Func<'db>) -> Vec<u8> {
+        let value = eval_body_owner_const(db, BodyOwner::Func(func), Vec::new()).unwrap_or_else(
+            |err| {
+                let name = func
+                    .name(db)
+                    .to_opt()
+                    .map_or("<anon>", |n| n.data(db).as_str());
+                let (diags, _) = check_func_body(db, func).clone();
+                let mut note = String::new();
+                for diag in diags.iter() {
+                    if let FuncBodyDiag::NameRes(fe_hir::analysis::name_resolution::diagnostics::PathResDiag::MethodNotFound { method_name, .. }) = diag {
+                        note.push_str(&format!("method-not-found: {}\n", method_name.data(db)));
+                    }
+                }
+                panic!("semantic CTFE failed for `{name}`: {err:?}\n{note}{diags:#?}");
+            },
+        );
+        match value.value(db) {
+            SemConstValue::Scalar {
+                value: SemConstScalar::Bytes(bytes),
+                ..
+            } => bytes.clone(),
+            SemConstValue::Array { elems, .. } => elems
+                .iter()
+                .map(|elem| match elem.value(db) {
+                    SemConstValue::Scalar {
+                        value: SemConstScalar::Int { value },
+                        ..
+                    } => value
+                        .to_u8()
+                        .unwrap_or_else(|| panic!("expected u8 int const, got {value}")),
+                    other => panic!("expected u8 scalar const element, got {other:?}"),
+                })
+                .collect(),
+            other => panic!("expected bytes scalar const, got {other:?}"),
+        }
+    }
+
+    fn eval_usize<'db>(db: &'db HirAnalysisTestDb, func: fe_hir::hir_def::Func<'db>) -> usize {
+        let value =
+            eval_body_owner_const(db, BodyOwner::Func(func), Vec::new()).unwrap_or_else(|err| {
+                let name = func
+                    .name(db)
+                    .to_opt()
+                    .map_or("<anon>", |n| n.data(db).as_str());
+                let (diags, _) = check_func_body(db, func).clone();
+                panic!("semantic CTFE failed for `{name}`: {err:?}\n{diags:#?}");
+            });
+        match value.value(db) {
+            SemConstValue::Scalar {
+                value: SemConstScalar::Int { value },
+                ..
+            } => value
+                .to_usize()
+                .unwrap_or_else(|| panic!("expected usize-sized int const, got {value}")),
+            other => panic!("expected int scalar const, got {other:?}"),
+        }
+    }
+
+    fn eval_bool<'db>(db: &'db HirAnalysisTestDb, func: fe_hir::hir_def::Func<'db>) -> bool {
+        let value =
+            eval_body_owner_const(db, BodyOwner::Func(func), Vec::new()).unwrap_or_else(|err| {
+                let name = func
+                    .name(db)
+                    .to_opt()
+                    .map_or("<anon>", |n| n.data(db).as_str());
+                let (diags, _) = check_func_body(db, func).clone();
+                panic!("semantic CTFE failed for `{name}`: {err:?}\n{diags:#?}");
+            });
+        match value.value(db) {
+            SemConstValue::Scalar {
+                value: SemConstScalar::Bool(flag),
+                ..
+            } => flag,
+            other => panic!("expected bool scalar const, got {other:?}"),
+        }
+    }
+
+    let padded = eval_bytes(&db, find_func(&db, top_mod, "padded_bytes"));
+    assert_eq!(padded, vec![0, 0, 0, 0, 67, 79, 79, 76]);
+
+    let roundtrip = eval_bytes(&db, find_func(&db, top_mod, "roundtrip_bytes"));
+    assert_eq!(roundtrip, padded);
+
+    let len = eval_usize(&db, find_func(&db, top_mod, "cool_len"));
+    assert_eq!(len, 4);
+
+    let concat_bytes = eval_bytes(&db, find_func(&db, top_mod, "concat_bytes"));
+    assert_eq!(concat_bytes, vec![67, 79, 79, 76, 67, 79, 73, 78]);
+
+    let effective = eval_bytes(&db, find_func(&db, top_mod, "concat_uses_effective_len"));
+    assert_eq!(effective, vec![0, 0, 67, 79]);
+
+    assert!(eval_bool(&db, find_func(&db, top_mod, "eq_true")));
+    assert!(!eval_bool(&db, find_func(&db, top_mod, "eq_false")));
+    let eq_from_bytes = eval_bool(
+        &db,
+        find_func(&db, top_mod, "eq_from_bytes_matches_literal"),
+    );
+
+    let from_bytes_const = eval_body_owner_const(
+        &db,
+        BodyOwner::Func(find_func(&db, top_mod, "from_bytes_value")),
+        Vec::new(),
+    )
+    .expect("expected const evaluation success");
+    let literal_4_const = eval_body_owner_const(
+        &db,
+        BodyOwner::Func(find_func(&db, top_mod, "literal_value_4")),
+        Vec::new(),
+    )
+    .expect("expected const evaluation success");
+    let literal_8_const = eval_body_owner_const(
+        &db,
+        BodyOwner::Func(find_func(&db, top_mod, "literal_value_8")),
+        Vec::new(),
+    )
+    .expect("expected const evaluation success");
+    let sem_eq = fe_hir::analysis::semantic::sem_const_eq(&db, from_bytes_const, literal_4_const);
+    let sem_eq_lit8 =
+        fe_hir::analysis::semantic::sem_const_eq(&db, from_bytes_const, literal_8_const);
+    if !eq_from_bytes || !sem_eq {
+        let from_dbg = match from_bytes_const.value(&db) {
+            SemConstValue::Scalar {
+                ty,
+                value: SemConstScalar::Bytes(bytes),
+            } => format!("{} {:?}", ty.pretty_print(&db), bytes),
+            other => format!("{other:?}"),
+        };
+        let lit_dbg = match literal_4_const.value(&db) {
+            SemConstValue::Scalar {
+                ty,
+                value: SemConstScalar::Bytes(bytes),
+            } => format!("{} {:?}", ty.pretty_print(&db), bytes),
+            other => format!("{other:?}"),
+        };
+        let rhs_word = eval_body_owner_const(
+            &db,
+            BodyOwner::Func(find_func(&db, top_mod, "rhs_word_in_eq_from_bytes")),
+            Vec::new(),
+        )
+        .ok()
+        .and_then(|value| match value.value(&db) {
+            SemConstValue::Scalar {
+                value: SemConstScalar::Int { value },
+                ..
+            } => Some(value.clone()),
+            _ => None,
+        });
+        let s_word = eval_body_owner_const(
+            &db,
+            BodyOwner::Func(find_func(&db, top_mod, "s_word_in_eq_from_bytes")),
+            Vec::new(),
+        )
+        .ok()
+        .and_then(|value| match value.value(&db) {
+            SemConstValue::Scalar {
+                value: SemConstScalar::Int { value },
+                ..
+            } => Some(value.clone()),
+            _ => None,
+        });
+        let rhs_value_eq = eval_body_owner_const(
+            &db,
+            BodyOwner::Func(find_func(&db, top_mod, "rhs_value_in_eq_from_bytes")),
+            Vec::new(),
+        )
+        .ok()
+        .map(|value| value.value(&db).clone());
+        let s_value_eq = eval_body_owner_const(
+            &db,
+            BodyOwner::Func(find_func(&db, top_mod, "s_value_in_eq_from_bytes")),
+            Vec::new(),
+        )
+        .ok()
+        .map(|value| value.value(&db).clone());
+        panic!(
+            "unexpected equality results: eq_from_bytes_matches_literal={eq_from_bytes} sem_const_eq(lit4)={sem_eq} sem_const_eq(lit8)={sem_eq_lit8}\nfrom_bytes_value={from_dbg}\nliteral_value_4={lit_dbg}\nliteral_value_8={:?}\ns_word_in_eq_from_bytes={s_word:?}\nrhs_word_in_eq_from_bytes={rhs_word:?}\ns_value_in_eq_from_bytes={s_value_eq:?}\nrhs_value_in_eq_from_bytes={rhs_value_eq:?}",
+            literal_8_const.value(&db),
+        );
+    }
+
+    let high_roundtrip = eval_body_owner_const(
+        &db,
+        BodyOwner::Func(find_func(&db, top_mod, "high_word_string_roundtrip")),
+        Vec::new(),
+    )
+    .expect("expected const evaluation success");
+    match high_roundtrip.value(&db) {
+        SemConstValue::Scalar {
+            value: SemConstScalar::Int { value },
+            ..
+        } => assert_eq!(value, num_bigint::BigInt::from(0x01000000434f4f4cu64)),
+        other => panic!("expected int scalar const, got {other:?}"),
+    }
+
+    let high_bytes = eval_bytes(&db, find_func(&db, top_mod, "high_word_string_as_bytes"));
+    assert_eq!(high_bytes, vec![67, 79, 79, 76]);
+}
+
+#[test]
+fn semantic_ctfe_fixed_string_concat_overflow_truncates() {
+    let mut db = HirAnalysisTestDb::default();
+    let file = db.new_stand_alone(
+        "semantic_ctfe_string_overflow.fe".into(),
+        r#"
+use core::concat
+
+const fn truncated_concat() -> [u8; 6] {
+    let a: String<4> = "ABCD"
+    let b: String<4> = "EFGH"
+    let c: String<6> = concat(a, b)
+    c.as_bytes()
+}
+"#,
+    );
+    let (top_mod, _) = db.top_mod(file);
+    let func = top_mod
+        .all_funcs(&db)
+        .iter()
+        .copied()
+        .find(|func| {
+            matches!(func.name(&db), Partial::Present(found) if found.data(&db) == "truncated_concat")
+        })
+        .expect("missing const fn `truncated_concat`");
+
+    let value = eval_body_owner_const(&db, BodyOwner::Func(func), Vec::new()).unwrap();
+    match value.value(&db) {
+        SemConstValue::Scalar {
+            value: SemConstScalar::Bytes(bytes),
+            ..
+        } => assert_eq!(bytes, vec![65, 66, 67, 68, 69, 70]),
+        SemConstValue::Array { elems, .. } => {
+            let bytes = elems
+                .iter()
+                .map(|elem| match elem.value(&db) {
+                    SemConstValue::Scalar {
+                        value: SemConstScalar::Int { value },
+                        ..
+                    } => value
+                        .to_u8()
+                        .unwrap_or_else(|| panic!("expected u8 int const, got {value}")),
+                    other => panic!("expected u8 scalar const element, got {other:?}"),
+                })
+                .collect::<Vec<_>>();
+            assert_eq!(bytes, vec![65, 66, 67, 68, 69, 70]);
+        }
+        other => panic!("expected bytes scalar const, got {other:?}"),
     }
 }
 

--- a/crates/mir/src/runtime/lower/type_info.rs
+++ b/crates/mir/src/runtime/lower/type_info.rs
@@ -492,7 +492,9 @@ fn scalar_class_from_repr_ty<'db>(db: &'db dyn MirDb, ty: TyId<'db>) -> Option<S
                 signed: true,
             },
             PrimTy::String => ScalarRepr::FixedBytes {
-                len: MAX_INLINE_STRING_BYTES as u16,
+                // Fixed strings have at most 31 payload bytes, but casts and
+                // `to_word` operate on the full EVM word.
+                len: (MAX_INLINE_STRING_BYTES + 1) as u16,
             },
             PrimTy::Array
             | PrimTy::Tuple(_)

--- a/crates/mir/src/runtime/package.rs
+++ b/crates/mir/src/runtime/package.rs
@@ -1234,7 +1234,12 @@ fn collect_region_embeds<'db>(
     let mut seen = FxHashSet::default();
     let mut embeds = Vec::new();
     let mut instances = reachable.iter().copied().collect::<Vec<_>>();
-    instances.sort_by_cached_key(|instance| runtime_instance_sort_key(db, *instance));
+    instances.sort_by_cached_key(|instance| {
+        (
+            runtime_instance_sort_key(db, *instance),
+            runtime_instance_symbol_key(db, *instance),
+        )
+    });
     for instance in instances {
         let Some(node) = graph.nodes.get(&instance) else {
             continue;
@@ -1304,7 +1309,12 @@ fn collect_const_regions_for_reachable<'db>(
     let mut seen = FxHashSet::default();
     let mut regions = Vec::new();
     let mut instances = reachable.iter().copied().collect::<Vec<_>>();
-    instances.sort_by_cached_key(|instance| runtime_instance_sort_key(db, *instance));
+    instances.sort_by_cached_key(|instance| {
+        (
+            runtime_instance_sort_key(db, *instance),
+            runtime_instance_symbol_key(db, *instance),
+        )
+    });
     for instance in instances {
         let Some(node) = graph.nodes.get(&instance) else {
             continue;
@@ -1740,7 +1750,12 @@ fn collect_runtime_functions<'db>(
     graph: &RuntimeGraph<'db>,
 ) -> Vec<RuntimeFunction<'db>> {
     let mut instances = graph.nodes.keys().copied().collect::<Vec<_>>();
-    instances.sort_by_cached_key(|instance| runtime_instance_sort_key(db, *instance));
+    instances.sort_by_cached_key(|instance| {
+        (
+            runtime_instance_sort_key(db, *instance),
+            runtime_instance_symbol_key(db, *instance),
+        )
+    });
     let instance_symbols = instances
         .into_iter()
         .map(|instance| {
@@ -2532,7 +2547,12 @@ fn collect_const_regions<'db>(
     let mut seen = FxHashSet::default();
     let mut regions = Vec::new();
     let mut instances = graph.nodes.keys().copied().collect::<Vec<_>>();
-    instances.sort_by_cached_key(|instance| runtime_instance_sort_key(db, *instance));
+    instances.sort_by_cached_key(|instance| {
+        (
+            runtime_instance_sort_key(db, *instance),
+            runtime_instance_symbol_key(db, *instance),
+        )
+    });
     for instance in instances {
         for region in graph
             .nodes

--- a/ingots/core/src/lib.fe
+++ b/ingots/core/src/lib.fe
@@ -8,6 +8,7 @@ pub use message::MsgVariant
 pub use error::ErrorVariant
 pub use ops::{self, *}
 pub use bytes::{AsBytes, keccak}
+pub use string::{self, concat}
 pub use intrinsic::{contract_field_slot, size_of}
 pub use functional::{Fn, Functor, Applicative, Monad}
 pub use effect_ref::{EffectHandle, EffectHandleMut, EffectRef, EffectRefMut, MemPtr, StorPtr}

--- a/ingots/core/src/num.fe
+++ b/ingots/core/src/num.fe
@@ -423,7 +423,12 @@ impl<T> WordValue for T
 }
 
 impl<const LEN: usize> WordValue for String<LEN> {
-    fn to_word(self) -> u256 { __bitcast(self) }
+    fn to_word(self) -> u256 {
+        let word: u256 = __bitcast(self)
+        let width_bits: u256 = (LEN * 8) as u256
+        let mask: u256 = (1 << width_bits) - 1
+        word & mask
+    }
 }
 
 impl IntWord for u8 {

--- a/ingots/core/src/string.fe
+++ b/ingots/core/src/string.fe
@@ -1,0 +1,114 @@
+use super::ops::Eq
+use super::num::IntDowncast
+
+/// Fixed-size string utilities.
+///
+/// `String<N>` values are represented as a packed word and are left-padded with zero bytes.
+/// The "effective length" of a string is defined as the number of bytes after removing leading
+/// zero-padding from its `N`-byte representation.
+
+impl<const N: usize> String<N> {
+    /// Returns the fixed-width byte representation of this string (including padding).
+    pub const fn as_bytes(self) -> [u8; N] {
+        let raw: u256 = self as u256
+        let width_bits: u256 = (N * 8) as u256
+        let mask: u256 = (1 << width_bits) - 1
+        let word: u256 = raw & mask
+        let mut out: [u8; N] = [0; N]
+        let mut i: usize = 0
+        while i < N {
+            let shift: u256 = ((N - 1 - i) * 8) as u256
+            out[i] = (word >> shift).downcast_truncate()
+            i += 1
+        }
+        out
+    }
+
+    /// Constructs a `String<N>` from its fixed-width byte representation (including padding).
+    pub const fn from_bytes(_ bytes: [u8; N]) -> Self {
+        let mut word: u256 = 0
+        let mut i: usize = 0
+        while i < N {
+            word = (word << 8) + (bytes[i] as u256)
+            i += 1
+        }
+        word as Self
+    }
+
+    /// Returns the effective (unpadded) length in bytes.
+    pub const fn len(self) -> usize {
+        let bytes: [u8; N] = self.as_bytes()
+        let mut i: usize = 0
+        while i < N {
+            if bytes[i] != 0 {
+                return N - i
+            }
+            i += 1
+        }
+        0
+    }
+}
+
+/// Concatenates two fixed-size strings using their effective (unpadded) lengths.
+///
+/// The result is left-padded with zeros to fill `OUT` bytes.
+///
+/// If `a.len() + b.len() > OUT`, the result is truncated on the right (i.e. it
+/// keeps as much of `a` as possible, then as much of `b` as fits).
+pub const fn concat<const A: usize, const B: usize, const OUT: usize>(
+    _ a: String<A>,
+    _ b: String<B>,
+) -> String<OUT> {
+    let a_bytes: [u8; A] = a.as_bytes()
+    let b_bytes: [u8; B] = b.as_bytes()
+    let a_len: usize = a.len()
+    let b_len: usize = b.len()
+    let mut a_take: usize = a_len
+    if a_take > OUT {
+        a_take = OUT
+    }
+    let mut b_take: usize = b_len
+    if a_take + b_take > OUT {
+        b_take = OUT - a_take
+    }
+    let used: usize = a_take + b_take
+
+    let mut out: [u8; OUT] = [0; OUT]
+
+    let dst_base: usize = OUT - used
+    let a_src_base: usize = A - a_len
+    let b_src_base: usize = B - b_len
+
+    let mut i: usize = 0
+    while i < a_take {
+        out[dst_base + i] = a_bytes[a_src_base + i]
+        i += 1
+    }
+
+    let mut j: usize = 0
+    while j < b_take {
+        out[dst_base + a_take + j] = b_bytes[b_src_base + j]
+        j += 1
+    }
+
+    String::from_bytes(out)
+}
+
+impl<const N: usize> Eq for String<N> {
+    const fn eq(self, _ other: String<N>) -> bool {
+        let a: [u8; N] = self.as_bytes()
+        let b: [u8; N] = other.as_bytes()
+        let mut i: usize = 0
+        while i < N {
+            if a[i] != b[i] {
+                return false
+            }
+            i += 1
+        }
+        true
+    }
+
+    const fn ne(self, _ other: String<N>) -> bool {
+        !self.eq(other)
+    }
+}

--- a/newsfragments/1437.feature.md
+++ b/newsfragments/1437.feature.md
@@ -1,0 +1,1 @@
+Added core `String<N>` utilities for fixed-width byte round-trips, effective byte length, concatenation, and equality in const and runtime code.


### PR DESCRIPTION
Added core `String<N>` utilities for fixed-width byte round-trips, effective byte length, concatenation, and equality in const and runtime code.

closes #1435 