### PR TITLE
Fix dynamic ABI tail encoding

### DIFF
--- a/crates/codegen/tests/fixtures/sonatina_ir/erc20.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/erc20.snap
@@ -439,7 +439,7 @@ func private %core__lib__abi__abi_payload_size__geb2e_fde6(v0.objref<@layout_3>)
         jump block1;
 
     block1:
-        v2.i256 = call %core__lib__abi__trait_AbiSize__payload_size__geb2e_f424 v0;
+        v2.i256 = call %std__lib__evm__panic__impl_trait_Panic_bf0a__payload_size_1e4f v0;
         return v2;
 }
 
@@ -448,7 +448,7 @@ func private %core__lib__abi__abi_payload_size__geb2e_fde6_0(v0.objref<@layout_3
         jump block1;
 
     block1:
-        v2.i256 = call %core__lib__abi__trait_AbiSize__payload_size__geb2e_f424_0 v0;
+        v2.i256 = call %std__lib__evm__panic__impl_trait_Panic_bf0a__payload_size_1e4f_0 v0;
         return v2;
 }
 
@@ -457,7 +457,7 @@ func private %core__lib__abi__abi_payload_size__geb2e_fde6_1(v0.objref<@layout_3
         jump block1;
 
     block1:
-        v2.i256 = call %core__lib__abi__trait_AbiSize__payload_size__geb2e_f424_1 v0;
+        v2.i256 = call %std__lib__evm__panic__impl_trait_Panic_bf0a__payload_size_1e4f_1 v0;
         return v2;
 }
 
@@ -3998,7 +3998,7 @@ func private %decoder_new(v0.@layout_5) -> @layout_7 {
         return v2;
 }
 
-func private %core__lib__abi__dynamic_payload_size__ge513_455a(v0.i256) -> i256 {
+func private %core__lib__abi__dynamic_payload_size__ge513_7ef0(v0.i256) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         mstore v1 v0 i256;
@@ -4009,7 +4009,7 @@ func private %core__lib__abi__dynamic_payload_size__ge513_455a(v0.i256) -> i256 
 
     block2:
         v3.i256 = mload v1 i256;
-        v4.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_c755 v3;
+        v4.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_a6ac v3;
         return v4;
 
     block3:
@@ -4019,7 +4019,7 @@ func private %core__lib__abi__dynamic_payload_size__ge513_455a(v0.i256) -> i256 
         return 0.i256;
 }
 
-func private %core__lib__abi__dynamic_payload_size__ge513_455a_0(v0.i256) -> i256 {
+func private %core__lib__abi__dynamic_payload_size__ge513_7ef0_0(v0.i256) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         mstore v1 v0 i256;
@@ -4030,7 +4030,7 @@ func private %core__lib__abi__dynamic_payload_size__ge513_455a_0(v0.i256) -> i25
 
     block2:
         v3.i256 = mload v1 i256;
-        v4.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_c755_0 v3;
+        v4.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_a6ac_0 v3;
         return v4;
 
     block3:
@@ -4040,7 +4040,7 @@ func private %core__lib__abi__dynamic_payload_size__ge513_455a_0(v0.i256) -> i25
         return 0.i256;
 }
 
-func private %core__lib__abi__dynamic_payload_size__ge513_455a_1(v0.i256) -> i256 {
+func private %core__lib__abi__dynamic_payload_size__ge513_7ef0_1(v0.i256) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         mstore v1 v0 i256;
@@ -4051,7 +4051,7 @@ func private %core__lib__abi__dynamic_payload_size__ge513_455a_1(v0.i256) -> i25
 
     block2:
         v3.i256 = mload v1 i256;
-        v4.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_c755_1 v3;
+        v4.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_a6ac_1 v3;
         return v4;
 
     block3:
@@ -4169,16 +4169,15 @@ func private %std__lib__evm__panic__impl_trait_Panic_2bdd__encode__g9c6f_02eb(v0
     block0:
         v2.objref<@layout_3> = obj.alloc @layout_3;
         v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        v6.objref<i256> = obj.proj v2 0.i256;
-        v7.i256 = extract_value v0 0.i256;
-        obj.store v6 v7;
+        v5.objref<i256> = obj.proj v2 0.i256;
+        v6.i256 = extract_value v0 0.i256;
+        obj.store v5 v6;
         jump block1;
 
     block1:
-        v9.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_7aef v1;
-        (v11.i256, v12.i1) = uaddo v9 32.i256;
-        br v12 block2 block3;
+        v8.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_7aef v1;
+        (v10.i256, v11.i1) = uaddo v8 32.i256;
+        br v11 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -4186,20 +4185,11 @@ func private %std__lib__evm__panic__impl_trait_Panic_2bdd__encode__g9c6f_02eb(v0
         evm_revert 0.i256 36.i256;
 
     block3:
-        mstore v3 v11 i256;
-        v17.objref<i256> = obj.proj v2 0.i256;
-        v18.i256 = obj.load v17;
-        v19.i256 = ptr_to_int v3 i256;
-        call %core__lib__abi__encode_field__g2e64_1064 v18 v1 v19;
-        v22.i256 = call %core__lib__abi__dynamic_payload_size__ge513_455a v18;
-        v23.i256 = mload v3 i256;
-        (v24.i256, v25.i1) = uaddo v23 v22;
-        br v25 block2 block4;
-
-    block4:
-        mstore v4 v24 i256;
-        v26.i256 = mload v4 i256;
-        mstore v3 v26 i256;
+        mstore v3 v10 i256;
+        v16.objref<i256> = obj.proj v2 0.i256;
+        v17.i256 = obj.load v16;
+        v18.i256 = ptr_to_int v3 i256;
+        call %core__lib__abi__encode_field__g2e64_1064 v17 v1 v18;
         return;
 }
 
@@ -4207,16 +4197,15 @@ func private %std__lib__evm__panic__impl_trait_Panic_2bdd__encode__g9c6f_02eb_0(
     block0:
         v2.objref<@layout_3> = obj.alloc @layout_3;
         v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        v6.objref<i256> = obj.proj v2 0.i256;
-        v7.i256 = extract_value v0 0.i256;
-        obj.store v6 v7;
+        v5.objref<i256> = obj.proj v2 0.i256;
+        v6.i256 = extract_value v0 0.i256;
+        obj.store v5 v6;
         jump block1;
 
     block1:
-        v9.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_7aef_0 v1;
-        (v11.i256, v12.i1) = uaddo v9 32.i256;
-        br v12 block2 block3;
+        v8.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_7aef_0 v1;
+        (v10.i256, v11.i1) = uaddo v8 32.i256;
+        br v11 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -4224,20 +4213,11 @@ func private %std__lib__evm__panic__impl_trait_Panic_2bdd__encode__g9c6f_02eb_0(
         evm_revert 0.i256 36.i256;
 
     block3:
-        mstore v3 v11 i256;
-        v17.objref<i256> = obj.proj v2 0.i256;
-        v18.i256 = obj.load v17;
-        v19.i256 = ptr_to_int v3 i256;
-        call %core__lib__abi__encode_field__g2e64_1064_0 v18 v1 v19;
-        v22.i256 = call %core__lib__abi__dynamic_payload_size__ge513_455a_0 v18;
-        v23.i256 = mload v3 i256;
-        (v24.i256, v25.i1) = uaddo v23 v22;
-        br v25 block2 block4;
-
-    block4:
-        mstore v4 v24 i256;
-        v26.i256 = mload v4 i256;
-        mstore v3 v26 i256;
+        mstore v3 v10 i256;
+        v16.objref<i256> = obj.proj v2 0.i256;
+        v17.i256 = obj.load v16;
+        v18.i256 = ptr_to_int v3 i256;
+        call %core__lib__abi__encode_field__g2e64_1064_0 v17 v1 v18;
         return;
 }
 
@@ -4245,16 +4225,15 @@ func private %std__lib__evm__panic__impl_trait_Panic_2bdd__encode__g9c6f_02eb_1(
     block0:
         v2.objref<@layout_3> = obj.alloc @layout_3;
         v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        v6.objref<i256> = obj.proj v2 0.i256;
-        v7.i256 = extract_value v0 0.i256;
-        obj.store v6 v7;
+        v5.objref<i256> = obj.proj v2 0.i256;
+        v6.i256 = extract_value v0 0.i256;
+        obj.store v5 v6;
         jump block1;
 
     block1:
-        v9.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_7aef_1 v1;
-        (v11.i256, v12.i1) = uaddo v9 32.i256;
-        br v12 block2 block3;
+        v8.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_7aef_1 v1;
+        (v10.i256, v11.i1) = uaddo v8 32.i256;
+        br v11 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -4262,20 +4241,11 @@ func private %std__lib__evm__panic__impl_trait_Panic_2bdd__encode__g9c6f_02eb_1(
         evm_revert 0.i256 36.i256;
 
     block3:
-        mstore v3 v11 i256;
-        v17.objref<i256> = obj.proj v2 0.i256;
-        v18.i256 = obj.load v17;
-        v19.i256 = ptr_to_int v3 i256;
-        call %core__lib__abi__encode_field__g2e64_1064_1 v18 v1 v19;
-        v22.i256 = call %core__lib__abi__dynamic_payload_size__ge513_455a_1 v18;
-        v23.i256 = mload v3 i256;
-        (v24.i256, v25.i1) = uaddo v23 v22;
-        br v25 block2 block4;
-
-    block4:
-        mstore v4 v24 i256;
-        v26.i256 = mload v4 i256;
-        mstore v3 v26 i256;
+        mstore v3 v10 i256;
+        v16.objref<i256> = obj.proj v2 0.i256;
+        v17.i256 = obj.load v16;
+        v18.i256 = ptr_to_int v3 i256;
+        call %core__lib__abi__encode_field__g2e64_1064_1 v17 v1 v18;
         return;
 }
 
@@ -7163,6 +7133,66 @@ func private %core__lib__abi__trait_AbiSize__payload_size__ge513_0454(v0.i256) -
         return 32.i256;
 }
 
+func private %std__lib__evm__panic__impl_trait_Panic_bf0a__payload_size_1e4f(v0.objref<@layout_3>) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.objref<i256> = obj.proj v0 0.i256;
+        v5.i256 = obj.load v4;
+        v6.i256 = call %core__lib__abi__dynamic_payload_size__ge513_7ef0 v5;
+        (v7.i256, v8.i1) = uaddo 32.i256 v6;
+        br v8 block2 block3;
+
+    block2:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block3:
+        return v7;
+}
+
+func private %std__lib__evm__panic__impl_trait_Panic_bf0a__payload_size_1e4f_0(v0.objref<@layout_3>) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.objref<i256> = obj.proj v0 0.i256;
+        v5.i256 = obj.load v4;
+        v6.i256 = call %core__lib__abi__dynamic_payload_size__ge513_7ef0_0 v5;
+        (v7.i256, v8.i1) = uaddo 32.i256 v6;
+        br v8 block2 block3;
+
+    block2:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block3:
+        return v7;
+}
+
+func private %std__lib__evm__panic__impl_trait_Panic_bf0a__payload_size_1e4f_1(v0.objref<@layout_3>) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.objref<i256> = obj.proj v0 0.i256;
+        v5.i256 = obj.load v4;
+        v6.i256 = call %core__lib__abi__dynamic_payload_size__ge513_7ef0_1 v5;
+        (v7.i256, v8.i1) = uaddo 32.i256 v6;
+        br v8 block2 block3;
+
+    block2:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block3:
+        return v7;
+}
+
 func private %core__lib__abi__trait_AbiSize__payload_size__ge513_3812(v0.i256) -> i256 {
     block0:
         v1.*i256 = alloca i256;
@@ -7259,6 +7289,36 @@ func private %core__lib__abi__impl_trait_String_c06e__payload_size__gc7cf_9b7d_0
         return v7;
 }
 
+func private %core__lib__abi__trait_AbiSize__payload_size__ge513_a6ac(v0.i256) -> i256 {
+    block0:
+        v1.*i256 = alloca i256;
+        mstore v1 v0 i256;
+        jump block1;
+
+    block1:
+        return 32.i256;
+}
+
+func private %core__lib__abi__trait_AbiSize__payload_size__ge513_a6ac_0(v0.i256) -> i256 {
+    block0:
+        v1.*i256 = alloca i256;
+        mstore v1 v0 i256;
+        jump block1;
+
+    block1:
+        return 32.i256;
+}
+
+func private %core__lib__abi__trait_AbiSize__payload_size__ge513_a6ac_1(v0.i256) -> i256 {
+    block0:
+        v1.*i256 = alloca i256;
+        mstore v1 v0 i256;
+        jump block1;
+
+    block1:
+        return 32.i256;
+}
+
 func private %core__lib__abi__trait_AbiSize__payload_size__ge513_a81c(v0.i256) -> i256 {
     block0:
         v1.*i256 = alloca i256;
@@ -7283,36 +7343,6 @@ func private %core__lib__abi__trait_AbiSize__payload_size__gda9b_b33d_0(v0.i1) -
     block0:
         v1.*i1 = alloca i1;
         mstore v1 v0 i1;
-        jump block1;
-
-    block1:
-        return 32.i256;
-}
-
-func private %core__lib__abi__trait_AbiSize__payload_size__ge513_c755(v0.i256) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
-        jump block1;
-
-    block1:
-        return 32.i256;
-}
-
-func private %core__lib__abi__trait_AbiSize__payload_size__ge513_c755_0(v0.i256) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
-        jump block1;
-
-    block1:
-        return 32.i256;
-}
-
-func private %core__lib__abi__trait_AbiSize__payload_size__ge513_c755_1(v0.i256) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
@@ -7379,30 +7409,6 @@ func private %core__lib__abi__trait_AbiSize__payload_size__g79ff_f3e8_0(v0.i8) -
     block0:
         v1.*i8 = alloca i8;
         mstore v1 v0 i8;
-        jump block1;
-
-    block1:
-        return 32.i256;
-}
-
-func private %core__lib__abi__trait_AbiSize__payload_size__geb2e_f424(v0.objref<@layout_3>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        return 32.i256;
-}
-
-func private %core__lib__abi__trait_AbiSize__payload_size__geb2e_f424_0(v0.objref<@layout_3>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        return 32.i256;
-}
-
-func private %core__lib__abi__trait_AbiSize__payload_size__geb2e_f424_1(v0.objref<@layout_3>) -> i256 {
-    block0:
         jump block1;
 
     block1:

--- a/crates/codegen/tests/fixtures/sonatina_ir/ref_is_not_a_copy.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/ref_is_not_a_copy.snap
@@ -16,7 +16,7 @@ func private %abi_payload_size(v0.objref<@layout_0>) -> i256 {
         jump block1;
 
     block1:
-        v2.i256 = call %payload_size__geb2e v0;
+        v2.i256 = call %impl_trait_Panic__payload_size v0;
         return v2;
 }
 
@@ -138,7 +138,7 @@ func private %dynamic_payload_size(v0.i256) -> i256 {
 
     block2:
         v3.i256 = mload v1 i256;
-        v4.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_7da2 v3;
+        v4.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_4dac v3;
         return v4;
 
     block3:
@@ -152,16 +152,15 @@ func private %encode__g9c6f(v0.@layout_0, v1.objref<@layout_1>) {
     block0:
         v2.objref<@layout_0> = obj.alloc @layout_0;
         v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        v6.objref<i256> = obj.proj v2 0.i256;
-        v7.i256 = extract_value v0 0.i256;
-        obj.store v6 v7;
+        v5.objref<i256> = obj.proj v2 0.i256;
+        v6.i256 = extract_value v0 0.i256;
+        obj.store v5 v6;
         jump block1;
 
     block1:
-        v9.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_28e3 v1;
-        (v11.i256, v12.i1) = uaddo v9 32.i256;
-        br v12 block2 block3;
+        v8.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_28e3 v1;
+        (v10.i256, v11.i1) = uaddo v8 32.i256;
+        br v11 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -169,20 +168,11 @@ func private %encode__g9c6f(v0.@layout_0, v1.objref<@layout_1>) {
         evm_revert 0.i256 36.i256;
 
     block3:
-        mstore v3 v11 i256;
-        v17.objref<i256> = obj.proj v2 0.i256;
-        v18.i256 = obj.load v17;
-        v19.i256 = ptr_to_int v3 i256;
-        call %encode_field v18 v1 v19;
-        v22.i256 = call %dynamic_payload_size v18;
-        v23.i256 = mload v3 i256;
-        (v24.i256, v25.i1) = uaddo v23 v22;
-        br v25 block2 block4;
-
-    block4:
-        mstore v4 v24 i256;
-        v26.i256 = mload v4 i256;
-        mstore v3 v26 i256;
+        mstore v3 v10 i256;
+        v16.objref<i256> = obj.proj v2 0.i256;
+        v17.i256 = obj.load v16;
+        v18.i256 = ptr_to_int v3 i256;
+        call %encode_field v17 v1 v18;
         return;
 }
 
@@ -411,18 +401,10 @@ func private %new(v0.i256) -> @layout_1 {
         return v13;
 }
 
-func private %core__lib__abi__trait_AbiSize__payload_size__ge513_7da2(v0.i256) -> i256 {
+func private %core__lib__abi__trait_AbiSize__payload_size__ge513_4dac(v0.i256) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         mstore v1 v0 i256;
-        jump block1;
-
-    block1:
-        return 32.i256;
-}
-
-func private %payload_size__geb2e(v0.objref<@layout_0>) -> i256 {
-    block0:
         jump block1;
 
     block1:
@@ -437,6 +419,26 @@ func private %core__lib__abi__trait_AbiSize__payload_size__ge513_98c3(v0.i256) -
 
     block1:
         return 32.i256;
+}
+
+func private %impl_trait_Panic__payload_size(v0.objref<@layout_0>) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.objref<i256> = obj.proj v0 0.i256;
+        v5.i256 = obj.load v4;
+        v6.i256 = call %dynamic_payload_size v5;
+        (v7.i256, v8.i1) = uaddo 32.i256 v6;
+        br v8 block2 block3;
+
+    block2:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block3:
+        return v7;
 }
 
 func private %pos(v0.objref<@layout_1>) -> i256 {

--- a/crates/fe/tests/fixtures/fe_test/abi_dynamic_payload.fe
+++ b/crates/fe/tests/fixtures/fe_test/abi_dynamic_payload.fe
@@ -1,4 +1,68 @@
-use std::evm::encode_abi_payload
+use std::abi::DynString
+use std::evm::{Evm, encode_abi_payload, mem}
+
+msg DynamicPayloadMsg {
+    #[selector = 0x01]
+    Check { first: Bytes, marker: u256, second: Bytes } -> u256,
+}
+
+#[error]
+pub struct DynamicPayloadError {
+    pub first: DynString,
+    pub marker: u256,
+    pub second: DynString,
+}
+
+pub contract DynamicPayloadReceiver {
+    recv DynamicPayloadMsg {
+        Check { first, marker, second } -> u256 {
+            assert(marker == 0xabcdef)
+            assert(first.len() == 33)
+            assert(first.byte_at(0) == 0x11)
+            assert(first.byte_at(31) == 0x11)
+            assert(first.byte_at(32) == 0x22)
+            assert(second.len() == 1)
+            assert(second.byte_at(0) == 0x33)
+            first.len() + second.len()
+        }
+    }
+}
+
+fn two_word_bytes() -> Bytes
+uses (evm: mut Evm)
+{
+    let payload_len: u256 = 33
+    let payload_size: u256 = 96
+    let data_ptr = mem::alloc(payload_size)
+
+    evm.mstore(addr: data_ptr, value: payload_len)
+    evm.mstore(
+        addr: data_ptr + 32,
+        value: 0x1111111111111111111111111111111111111111111111111111111111111111,
+    )
+    evm.mstore(
+        addr: data_ptr + 64,
+        value: 0x2200000000000000000000000000000000000000000000000000000000000000,
+    )
+
+    Bytes { data: data_ptr, len: payload_len, size: payload_size }
+}
+
+fn one_byte_bytes() -> Bytes
+uses (evm: mut Evm)
+{
+    let payload_len: u256 = 1
+    let payload_size: u256 = 64
+    let data_ptr = mem::alloc(payload_size)
+
+    evm.mstore(addr: data_ptr, value: payload_len)
+    evm.mstore(
+        addr: data_ptr + 32,
+        value: 0x3300000000000000000000000000000000000000000000000000000000000000,
+    )
+
+    Bytes { data: data_ptr, len: payload_len, size: payload_size }
+}
 
 #[test]
 fn test_abi_dynamic_payload_tuple_encoding() uses (evm: Evm) {
@@ -9,4 +73,39 @@ fn test_abi_dynamic_payload_tuple_encoding() uses (evm: Evm) {
     assert(evm.mload(ptr) == 0xdeadbeef)
     assert(evm.mload(ptr + 32) == 64)
     assert(evm.mload(ptr + 64) == 0)
+}
+
+#[test]
+fn test_msg_dynamic_payload_tail_encoding() uses (evm: mut Evm) {
+    let receiver = evm.create2<DynamicPayloadReceiver>(value: 0, args: (), salt: 0)
+    assert(receiver.inner != 0)
+
+    let result: u256 = evm.call(
+        addr: receiver,
+        gas: 1000000,
+        value: 0,
+        message: DynamicPayloadMsg::Check {
+            first: two_word_bytes(),
+            marker: 0xabcdef,
+            second: one_byte_bytes(),
+        },
+    )
+
+    assert(result == 34)
+}
+
+#[test]
+fn test_error_dynamic_payload_tail_encoding() uses (evm: mut Evm) {
+    let (ptr, len) = encode_abi_payload(DynamicPayloadError {
+        first: DynString::empty(),
+        marker: 0xabcdef,
+        second: DynString::empty(),
+    })
+
+    assert(len == 160)
+    assert(evm.mload(ptr) == 96)
+    assert(evm.mload(ptr + 32) == 0xabcdef)
+    assert(evm.mload(ptr + 64) == 128)
+    assert(evm.mload(ptr + 96) == 0)
+    assert(evm.mload(ptr + 128) == 0)
 }

--- a/crates/fe/tests/fixtures/fe_test/msg_multiple_dynamic_bytes.fe
+++ b/crates/fe/tests/fixtures/fe_test/msg_multiple_dynamic_bytes.fe
@@ -1,0 +1,37 @@
+use std::abi::sol
+use std::evm::{Ctx, Evm, RawMem}
+
+msg M {
+    #[selector = sol("foo(bytes,bytes)")]
+    Foo { a: Bytes, b: Bytes },
+}
+
+pub contract C uses (ctx: Ctx, mem: mut RawMem) {
+    init() {}
+
+    recv M {
+        Foo { a, b } uses () { return }
+    }
+}
+
+fn build_bytes() -> Bytes
+uses (mem: mut RawMem)
+{
+    let data = std::evm::mem::alloc(64)
+    mem.mstore(addr: data, value: 32)
+    Bytes { data: data, len: 32, size: 64 }
+}
+
+#[test]
+fn test_msg_call_with_two_dynamic_bytes_fields()
+uses (evm: mut Evm, mem: mut RawMem)
+{
+    let c = evm.create2<C>(value: 0, args: (), salt: 0)
+
+    evm.call(
+        addr: c,
+        gas: 2000000,
+        value: 0,
+        message: M::Foo { a: build_bytes(), b: build_bytes() },
+    )
+}

--- a/crates/hir/src/core/lower/error.rs
+++ b/crates/hir/src/core/lower/error.rs
@@ -7,7 +7,7 @@ use super::{
     hir_builder::HirBuilder,
     msg::{
         build_head_size_body_expr, create_direct_encode_assoc_const, create_head_size_assoc_const,
-        create_is_dynamic_assoc_const,
+        create_is_dynamic_assoc_const, create_payload_size_func,
     },
 };
 use crate::{
@@ -411,15 +411,22 @@ fn lower_error_abi_size_impl<'db>(
     let trait_path = PathId::from_ident(db, roots.core)
         .push_str(db, "abi")
         .push_str(db, "AbiSize");
-    let trait_ref = TraitRefId::new(db, Partial::Present(trait_path));
-
-    builder.impl_trait_assocs_build(trait_ref, self_ty, |builder| {
-        let consts = vec![
-            create_head_size_assoc_const(builder, field_specs),
-            create_is_dynamic_assoc_const(builder, field_specs),
-        ];
-        (vec![], consts)
-    });
+    let trait_ref = Partial::Present(TraitRefId::new(db, Partial::Present(trait_path)));
+    let ty = Partial::Present(self_ty);
+    let impl_trait_idx = builder.ctxt().next_impl_trait_idx();
+    builder.with_item_scope(
+        TrackedItemVariant::ImplTrait(impl_trait_idx),
+        |builder, id| {
+            let consts = vec![
+                create_head_size_assoc_const(builder, field_specs),
+                create_is_dynamic_assoc_const(builder, field_specs),
+            ];
+            let impl_trait =
+                builder.new_impl_trait(id, trait_ref, ty, vec![], consts, builder.origin());
+            create_payload_size_func(builder, field_specs);
+            impl_trait
+        },
+    );
 }
 
 fn lower_error_encode_impl<'db>(

--- a/crates/hir/src/core/lower/hir_builder.rs
+++ b/crates/hir/src/core/lower/hir_builder.rs
@@ -648,9 +648,6 @@ where
         let self_expr = self.path_expr(PathId::from_ident(db, IdentId::make_self(db)));
         let tail_ident = IdentId::new(db, "__tail".to_string());
         let base_ident = IdentId::new(db, "base".to_string());
-        let dynamic_payload_size_path = PathId::from_ident(db, self.roots.core)
-            .push_str(db, "abi")
-            .push_str(db, "dynamic_payload_size");
         let head_size = self.abi_size_assoc_expr(TypeId::fallback_self_ty(db), "HEAD_SIZE");
         let encoder_expr = self.ident_expr(encoder_ident);
         let base_expr = self.method_call_expr(encoder_expr, base_ident, vec![]);
@@ -675,9 +672,6 @@ where
                 Partial::Present(FieldIndex::Ident(field)),
             ));
             self.emit_stmt(Stmt::Let(field_pat, None, Some(receiver)));
-            let field_expr = self.ident_expr(field_ident);
-            let dynamic_payload_size = self.path_expr(dynamic_payload_size_path);
-            let field_size = self.call_expr(dynamic_payload_size, vec![field_expr]);
             let encode_field_args = GenericArgListId::given(
                 db,
                 vec![
@@ -705,15 +699,6 @@ where
                 vec![field_value, encoder_arg, tail_arg],
             );
             self.emit_expr_stmt(call);
-            let tail_value = self.ident_expr(tail_ident);
-            let tail_next = self.push_expr(Expr::Bin(
-                tail_value,
-                field_size,
-                BinOp::Arith(ArithBinOp::Add),
-            ));
-            let tail_place = self.ident_expr(tail_ident);
-            let assign = self.push_expr(Expr::Assign(tail_place, tail_next));
-            self.emit_expr_stmt(assign);
         }
     }
 

--- a/crates/hir/src/core/lower/msg.rs
+++ b/crates/hir/src/core/lower/msg.rs
@@ -149,54 +149,56 @@ fn lower_msg_variant_abi_size_impl<'db>(
             ];
             let impl_trait =
                 builder.new_impl_trait(id, trait_ref, ty, vec![], consts, builder.origin());
-            let payload_size_ident = builder.ident("payload_size");
-            let params = builder.params([FuncParam {
-                mode: FuncParamMode::View,
-                is_mut: false,
-                has_ref_prefix: false,
-                has_own_prefix: false,
-                is_label_suppressed: false,
-                name: Partial::Present(FuncParamName::Ident(IdentId::make_self(builder.db()))),
-                ty: Partial::Present(builder.self_ty()),
-                self_ty_fallback: true,
-            }]);
-            let ret_ty = builder.ty_ident(builder.ident("u256"));
-            let roots = builder.roots();
-            builder.func_with_body(
-                payload_size_ident,
-                builder.empty_generic_params(),
-                params,
-                Some(ret_ty),
-                FuncModifiers::new(Visibility::Private, false, false, false),
-                |body| {
-                    let db = body.db();
-                    let self_expr = body.path_expr(PathId::from_ident(db, IdentId::make_self(db)));
-                    let dynamic_payload_size_path = PathId::from_ident(db, roots.core)
-                        .push_str(db, "abi")
-                        .push_str(db, "dynamic_payload_size");
-                    let mut expr =
-                        body.abi_size_assoc_expr(TypeId::fallback_self_ty(db), "HEAD_SIZE");
-
-                    for (field_name, _) in field_specs.iter().copied() {
-                        let field_expr = body.push_expr(Expr::Field(
-                            self_expr,
-                            Partial::Present(FieldIndex::Ident(field_name)),
-                        ));
-                        let dynamic_payload_size = body.path_expr(dynamic_payload_size_path);
-                        let field_size = body.call_expr(dynamic_payload_size, vec![field_expr]);
-                        expr = body.push_expr(Expr::Bin(
-                            expr,
-                            field_size,
-                            BinOp::Arith(ArithBinOp::Add),
-                        ));
-                    }
-
-                    body.emit_return(Some(expr));
-                },
-            );
+            create_payload_size_func(builder, &field_specs);
             impl_trait
         },
     )
+}
+
+pub(super) fn create_payload_size_func<'db, O: Clone + Into<crate::span::DesugaredOrigin>>(
+    builder: &mut HirBuilder<'_, 'db, O>,
+    field_specs: &[(IdentId<'db>, TypeId<'db>)],
+) {
+    let payload_size_ident = builder.ident("payload_size");
+    let params = builder.params([FuncParam {
+        mode: FuncParamMode::View,
+        is_mut: false,
+        has_ref_prefix: false,
+        has_own_prefix: false,
+        is_label_suppressed: false,
+        name: Partial::Present(FuncParamName::Ident(IdentId::make_self(builder.db()))),
+        ty: Partial::Present(builder.self_ty()),
+        self_ty_fallback: true,
+    }]);
+    let ret_ty = builder.ty_ident(builder.ident("u256"));
+    let roots = builder.roots();
+    builder.func_with_body(
+        payload_size_ident,
+        builder.empty_generic_params(),
+        params,
+        Some(ret_ty),
+        FuncModifiers::new(Visibility::Private, false, false, false),
+        |body| {
+            let db = body.db();
+            let self_expr = body.path_expr(PathId::from_ident(db, IdentId::make_self(db)));
+            let dynamic_payload_size_path = PathId::from_ident(db, roots.core)
+                .push_str(db, "abi")
+                .push_str(db, "dynamic_payload_size");
+            let mut expr = body.abi_size_assoc_expr(TypeId::fallback_self_ty(db), "HEAD_SIZE");
+
+            for (field_name, _) in field_specs.iter().copied() {
+                let field_expr = body.push_expr(Expr::Field(
+                    self_expr,
+                    Partial::Present(FieldIndex::Ident(field_name)),
+                ));
+                let dynamic_payload_size = body.path_expr(dynamic_payload_size_path);
+                let field_size = body.call_expr(dynamic_payload_size, vec![field_expr]);
+                expr = body.push_expr(Expr::Bin(expr, field_size, BinOp::Arith(ArithBinOp::Add)));
+            }
+
+            body.emit_return(Some(expr));
+        },
+    );
 }
 
 fn lower_msg_variant_encode_impl<'db>(

--- a/crates/hir/test_files/desugar/error_basic.snap
+++ b/crates/hir/test_files/desugar/error_basic.snap
@@ -15,6 +15,10 @@ impl core::error::ErrorVariant<std::abi::Sol> for Unauthorized {
 impl core::abi::AbiSize for Unauthorized {
     const HEAD_SIZE: u256 = 0
     const IS_DYNAMIC: bool = false
+
+    fn payload_size(self) -> u256 {
+        return <Self as core::abi::AbiSize>::HEAD_SIZE
+    }
 }
 
 impl core::abi::Encode<std::abi::Sol> for Unauthorized {

--- a/crates/hir/test_files/desugar/error_multiple_fields.snap
+++ b/crates/hir/test_files/desugar/error_multiple_fields.snap
@@ -18,6 +18,10 @@ impl core::error::ErrorVariant<std::abi::Sol> for InsufficientBalance {
 impl core::abi::AbiSize for InsufficientBalance {
     const HEAD_SIZE: u256 = 0 + u256::HEAD_SIZE + u256::HEAD_SIZE
     const IS_DYNAMIC: bool = false || u256::IS_DYNAMIC || u256::IS_DYNAMIC
+
+    fn payload_size(self) -> u256 {
+        return <Self as core::abi::AbiSize>::HEAD_SIZE + core::abi::dynamic_payload_size(self.balance) + core::abi::dynamic_payload_size(self.required)
+    }
 }
 
 impl core::abi::Encode<std::abi::Sol> for InsufficientBalance {
@@ -27,10 +31,8 @@ impl core::abi::Encode<std::abi::Sol> for InsufficientBalance {
         let mut __tail = e.base() + <Self as core::abi::AbiSize>::HEAD_SIZE
         let __field_0 = self.balance
         core::abi::encode_field<std::abi::Sol, u256, E>(__field_0, e, mut __tail)
-        __tail = __tail + core::abi::dynamic_payload_size(__field_0)
         let __field_1 = self.required
         core::abi::encode_field<std::abi::Sol, u256, E>(__field_1, e, mut __tail)
-        __tail = __tail + core::abi::dynamic_payload_size(__field_1)
     }
 
     fn encode_to_ptr(own self, _ ptr: u256) {

--- a/crates/hir/test_files/desugar/msg.snap
+++ b/crates/hir/test_files/desugar/msg.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/hir/tests/desugar.rs
-assertion_line: 28
 expression: output
 input_file: test_files/desugar/msg.fe
 ---
@@ -99,7 +98,6 @@ mod CounterMsg {
             let mut __tail = e.base() + <Self as core::abi::AbiSize>::HEAD_SIZE
             let __field_0 = self.val
             core::abi::encode_field<std::abi::Sol, u64, E>(__field_0, e, mut __tail)
-            __tail = __tail + core::abi::dynamic_payload_size(__field_0)
         }
 
         fn encode_to_ptr(own self, _ ptr: u256) {

--- a/crates/uitest/fixtures/ty_check/error_unsupported_field_type.snap
+++ b/crates/uitest/fixtures/ty_check/error_unsupported_field_type.snap
@@ -19,6 +19,20 @@ error[6-0003]: trait bound is not satisfied
   4 │ │ struct Bad {
   5 │ │     value: StorageMap<Address, u256, 0>,
   6 │ │ }
+    │ ╰─^ `StorageMap<Address, u256, 0>` doesn't implement `AbiSize`
+    │
+    ┌─ src/abi.fe:208:32
+    │
+208 │ pub fn dynamic_payload_size<T: AbiSize>(_ value: T) -> u256 {
+    │                                ------- required by this bound on `dynamic_payload_size`
+
+error[6-0003]: trait bound is not satisfied
+    ┌─ error_unsupported_field_type.fe:3:1
+    │
+  3 │ ╭ #[error]
+  4 │ │ struct Bad {
+  5 │ │     value: StorageMap<Address, u256, 0>,
+  6 │ │ }
     │ ╰─^ `StorageMap<Address, u256, 0>` doesn't implement `Encode<Sol>`
     │
     ┌─ src/abi.fe:270:14
@@ -39,17 +53,3 @@ error[6-0003]: trait bound is not satisfied
     │
 270 │     where T: Encode<A> + AbiSize, E: AbiEncoder<A>
     │                          ------- required by this bound on `encode_field`
-
-error[6-0003]: trait bound is not satisfied
-    ┌─ error_unsupported_field_type.fe:3:1
-    │
-  3 │ ╭ #[error]
-  4 │ │ struct Bad {
-  5 │ │     value: StorageMap<Address, u256, 0>,
-  6 │ │ }
-    │ ╰─^ `StorageMap<Address, u256, 0>` doesn't implement `AbiSize`
-    │
-    ┌─ src/abi.fe:208:32
-    │
-208 │ pub fn dynamic_payload_size<T: AbiSize>(_ value: T) -> u256 {
-    │                                ------- required by this bound on `dynamic_payload_size`

--- a/newsfragments/1439.bugfix.md
+++ b/newsfragments/1439.bugfix.md
@@ -1,0 +1,1 @@
+Fixed ABfI encoding for `evm.call` message payloads with multiple dynamic fields, and for dynamic custom error payloads.


### PR DESCRIPTION
Fixes #1423 

Generated caller code was manually advancing `__tail` after calling `encode_field`, but that's handled by `encode_field`, so the tail was being advanced twice, which could put later dynamic payloads at the wrong offsets.

Also discovered that, `#[error]` `AbiSize` impls were missing `payload_size`, so dynamic custom error payloads were sized like they only had heads. This reuses the msg payload-size lowering for errors, so msg variants and custom errors now agree on dynamic payload sizing.

Added fe_test fixtures that exercise this code.