### PR TITLE
sonatina: support gasprice builtin

### DIFF
--- a/crates/codegen/src/sonatina/lower_runtime.rs
+++ b/crates/codegen/src/sonatina/lower_runtime.rs
@@ -43,8 +43,8 @@ use sonatina_ir::{
             EvmAddMod, EvmAddress, EvmBaseFee, EvmBlockHash, EvmCall, EvmCallValue,
             EvmCalldataCopy, EvmCalldataLoad, EvmCalldataSize, EvmCaller, EvmChainId, EvmCodeCopy,
             EvmCodeSize, EvmCoinBase, EvmCreate, EvmCreate2, EvmDelegateCall, EvmExp, EvmGas,
-            EvmGasLimit, EvmInvalid, EvmKeccak256, EvmLog0, EvmLog1, EvmLog2, EvmLog3, EvmLog4,
-            EvmMalloc, EvmMcopy, EvmMsize, EvmMstore8, EvmMulMod, EvmNumber, EvmOrigin,
+            EvmGasLimit, EvmGasPrice, EvmInvalid, EvmKeccak256, EvmLog0, EvmLog1, EvmLog2, EvmLog3,
+            EvmLog4, EvmMalloc, EvmMcopy, EvmMsize, EvmMstore8, EvmMulMod, EvmNumber, EvmOrigin,
             EvmPrevRandao, EvmReturn, EvmReturnDataCopy, EvmReturnDataSize, EvmRevert, EvmSdiv,
             EvmSelfBalance, EvmSelfDestruct, EvmSignExtend, EvmSload, EvmSmod, EvmSstore,
             EvmStaticCall, EvmStop, EvmTimestamp, EvmTload, EvmTstore, EvmUdiv, EvmUmod,
@@ -1479,11 +1479,9 @@ impl<'ctx, 'db, 'a> FunctionLowerer<'ctx, 'db, 'a> {
             RuntimeBuiltin::Origin => self
                 .fb
                 .insert_inst(EvmOrigin::new(self.module.inst_set()), Type::I256),
-            RuntimeBuiltin::GasPrice => {
-                return Err(LowerError::Unsupported(
-                    "gasprice is not supported by the Sonatina backend".to_string(),
-                ));
-            }
+            RuntimeBuiltin::GasPrice => self
+                .fb
+                .insert_inst(EvmGasPrice::new(self.module.inst_set()), Type::I256),
             RuntimeBuiltin::CoinBase => self
                 .fb
                 .insert_inst(EvmCoinBase::new(self.module.inst_set()), Type::I256),

--- a/crates/codegen/tests/sonatina_gasprice.rs
+++ b/crates/codegen/tests/sonatina_gasprice.rs
@@ -1,0 +1,63 @@
+use common::{InputDb, ingot::IngotBaseUrl, stdlib::BUILTIN_STD_BASE_URL};
+use driver::DriverDataBase;
+use fe_codegen::emit_module_sonatina_ir;
+use url::Url;
+
+#[test]
+fn sonatina_lower_runtime_supports_gasprice() {
+    let mut db = DriverDataBase::default();
+
+    // `std::evm::ops::gasprice` exists but is not exported publicly. For this test, expose a
+    // small wrapper in the in-memory builtin stdlib so we can exercise the lowering path.
+    let std_base = Url::parse(BUILTIN_STD_BASE_URL).expect("builtin std base url should parse");
+    std_base.touch(
+        &mut db,
+        "src/evm/gasprice_test.fe".into(),
+        Some(
+            r#"
+use ingot::evm::ops
+
+pub fn gasprice() -> u256 {
+    ops::gasprice()
+}
+"#
+            .to_string(),
+        ),
+    );
+
+    let evm_url = std_base
+        .join("src/evm.fe")
+        .expect("builtin std evm module url should join");
+    let evm_file = db
+        .workspace()
+        .get(&db, &evm_url)
+        .expect("builtin std evm module should exist");
+    let mut evm_text = evm_file.text(&db).to_string();
+    if !evm_text.contains("gasprice_test") {
+        evm_text.push_str("\npub use gasprice_test::{self, *}\n");
+        db.workspace().update(&mut db, evm_url, evm_text);
+    }
+
+    let module = r#"
+use std::evm::gasprice
+
+pub fn main() -> u256 {
+    gasprice()
+}
+"#;
+
+    let file_url = Url::parse("file:///sonatina_gasprice.fe").expect("test URL should parse");
+    db.workspace()
+        .touch(&mut db, file_url.clone(), Some(module.to_string()));
+    let file = db
+        .workspace()
+        .get(&db, &file_url)
+        .expect("test file should be loaded");
+    let top_mod = db.top_mod(file);
+
+    let ir = emit_module_sonatina_ir(&db, top_mod).expect("Sonatina IR should emit");
+    assert!(
+        ir.contains("evm_gas_price"),
+        "expected Sonatina IR to contain evm_gas_price instruction:\n{ir}"
+    );
+}

--- a/crates/language-server/benches/doc_reload.rs
+++ b/crates/language-server/benches/doc_reload.rs
@@ -6,6 +6,8 @@
 //!
 //! Run: cargo bench -p fe-language-server --bench doc_reload
 
+#![allow(clippy::print_stderr)]
+
 use common::InputDb;
 use criterion::{Criterion, SamplingMode, criterion_group, criterion_main};
 use driver::DriverDataBase;


### PR DESCRIPTION
Fixes #1442 by adding Sonatina backend lowering for `gasprice` (`RuntimeBuiltin::GasPrice`), emitting Sonatina IR `evm_gas_price` instead of returning `unsupported`.

## Changes

- Lower `RuntimeBuiltin::GasPrice` via Sonatina `EvmGasPrice` (`crates/codegen/src/sonatina/lower_runtime.rs`).
- Add regression test asserting `evm_gas_price` appears in emitted Sonatina IR (`crates/codegen/tests/sonatina_gasprice.rs`).

## Notes

There are other `LowerError::Unsupported` cases in Sonatina lowering, but they fall into broader categories (const-global encoding gaps, provider/object-ref vs raw-pointer/address-space constraints, and general place/copy/store lowering limitations).