### PR TITLE
Source location pipeline and debug info emission

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2094,14 +2094,17 @@ dependencies = [
 name = "fe-codegen"
 version = "26.1.0"
 dependencies = [
+ "cranelift-entity 0.130.1",
  "dir-test",
  "fe-common",
  "fe-driver",
  "fe-hir",
  "fe-mir",
  "fe-test-utils",
+ "gimli",
  "hex",
  "num-bigint",
+ "object",
  "rustc-hash 2.1.1",
  "smallvec 1.15.1",
  "smallvec 2.0.0-alpha.12",
@@ -2635,6 +2638,15 @@ dependencies = [
  "r-efi",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "gimli"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+dependencies = [
+ "indexmap 2.13.0",
 ]
 
 [[package]]
@@ -4585,6 +4597,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.116",
+]
+
+[[package]]
+name = "object"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+dependencies = [
+ "crc32fast",
+ "hashbrown 0.15.5",
+ "indexmap 2.13.0",
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,6 @@ sonatina-triple = { git = "https://github.com/fe-lang/sonatina", rev = "5987a72"
 sonatina-codegen = { git = "https://github.com/fe-lang/sonatina", rev = "5987a72" }
 sonatina-verifier = { git = "https://github.com/fe-lang/sonatina", rev = "5987a72" }
 
-
 [profile.dev]
 # Set to 0 to make the build faster and debugging more difficult.
 debug = 0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,10 +49,13 @@ tracing-tree = "0.4.0"
 wasm-bindgen-test = "0.3"
 semver = "1.0.26"
 petgraph = "0.8"
+gimli = { version = "0.31", default-features = false, features = ["write"] }
+object = { version = "0.36", default-features = false, features = ["write"] }
 sonatina-ir = { git = "https://github.com/fe-lang/sonatina", rev = "5987a72" }
 sonatina-triple = { git = "https://github.com/fe-lang/sonatina", rev = "5987a72" }
 sonatina-codegen = { git = "https://github.com/fe-lang/sonatina", rev = "5987a72" }
 sonatina-verifier = { git = "https://github.com/fe-lang/sonatina", rev = "5987a72" }
+
 
 [profile.dev]
 # Set to 0 to make the build faster and debugging more difficult.

--- a/crates/codegen/Cargo.toml
+++ b/crates/codegen/Cargo.toml
@@ -12,6 +12,7 @@ hex = "0.4"
 num-bigint.workspace = true
 rustc-hash.workspace = true
 gimli.workspace = true
+object.workspace = true
 sonatina-ir.workspace = true
 sonatina-triple.workspace = true
 sonatina-codegen.workspace = true

--- a/crates/codegen/Cargo.toml
+++ b/crates/codegen/Cargo.toml
@@ -11,6 +11,7 @@ common.workspace = true
 hex = "0.4"
 num-bigint.workspace = true
 rustc-hash.workspace = true
+gimli.workspace = true
 sonatina-ir.workspace = true
 sonatina-triple.workspace = true
 sonatina-codegen.workspace = true
@@ -20,6 +21,7 @@ smallvec1.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
+cranelift-entity.workspace = true
 dir-test.workspace = true
 test-utils.workspace = true
 url.workspace = true

--- a/crates/codegen/src/datalog.rs
+++ b/crates/codegen/src/datalog.rs
@@ -1,0 +1,129 @@
+use std::fmt::Write as _;
+
+use sonatina_codegen::object::{FrontendProvenanceMap, ObjectArtifact};
+
+pub struct DatalogFacts {
+    pub facts: String,
+}
+
+pub fn generate_datalog_facts(
+    artifacts: &[ObjectArtifact],
+    provenance: &FrontendProvenanceMap,
+) -> DatalogFacts {
+    let mut out = String::new();
+
+    for artifact in artifacts {
+        let object_name = &artifact.object.0;
+        for (section_name, section) in &artifact.sections {
+            let Some(observability) = &section.observability else {
+                continue;
+            };
+
+            for entry in &observability.pc_map {
+                // bytecode_range(object, section, pc_start, pc_end, func, block)
+                writeln!(
+                    &mut out,
+                    "bytecode_range(\"{}\", \"{}\", {}, {}, {}, {}).",
+                    object_name,
+                    section_name.0,
+                    entry.pc_start,
+                    entry.pc_end,
+                    entry.func.as_u32(),
+                    entry.block.0,
+                )
+                .unwrap();
+
+                if let Some(ir_inst) = entry.ir_inst {
+                    // ir_inst_at(func, inst, pc_start, pc_end)
+                    writeln!(
+                        &mut out,
+                        "ir_inst_at({}, {}, {}, {}).",
+                        entry.func.as_u32(),
+                        ir_inst.0,
+                        entry.pc_start,
+                        entry.pc_end,
+                    )
+                    .unwrap();
+
+                    if let Some(prov) = provenance.get(&(entry.func, ir_inst)) {
+                        if let Some((file, start_line, start_col, end_line, end_col)) =
+                            parse_provenance(prov)
+                        {
+                            // source_at(func, inst, file, start_line, start_col, end_line, end_col)
+                            writeln!(
+                                &mut out,
+                                "source_at({}, {}, \"{}\", {}, {}, {}, {}).",
+                                entry.func.as_u32(),
+                                ir_inst.0,
+                                file,
+                                start_line,
+                                start_col,
+                                end_line,
+                                end_col,
+                            )
+                            .unwrap();
+
+                            // pc_source(pc_start, pc_end, file, line, col)
+                            writeln!(
+                                &mut out,
+                                "pc_source({}, {}, \"{}\", {}, {}).",
+                                entry.pc_start,
+                                entry.pc_end,
+                                file,
+                                start_line,
+                                start_col,
+                            )
+                            .unwrap();
+                        }
+                    }
+                }
+
+                if let Some(reason) = entry.unmapped_reason {
+                    writeln!(
+                        &mut out,
+                        "unmapped({}, {}, \"{}\").",
+                        entry.pc_start,
+                        entry.pc_end,
+                        reason.as_str(),
+                    )
+                    .unwrap();
+                }
+            }
+        }
+    }
+
+    DatalogFacts { facts: out }
+}
+
+fn parse_provenance(prov: &str) -> Option<(&str, u32, u32, u32, u32)> {
+    let (file_and_start, end_part) = prov.rsplit_once('-')?;
+    let (file_and_line, start_col_str) = file_and_start.rsplit_once(':')?;
+    let (file_path, start_line_str) = file_and_line.rsplit_once(':')?;
+    let (end_line_str, end_col_str) = end_part.rsplit_once(':')?;
+
+    Some((
+        file_path,
+        start_line_str.parse().ok()?,
+        start_col_str.parse().ok()?,
+        end_line_str.parse().ok()?,
+        end_col_str.parse().ok()?,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_provenance_extracts_fields() {
+        let (file, sl, sc, el, ec) = parse_provenance("src/main.fe:10:5-10:15").unwrap();
+        assert_eq!(file, "src/main.fe");
+        assert_eq!((sl, sc, el, ec), (10, 5, 10, 15));
+    }
+
+    #[test]
+    fn empty_artifacts_produce_empty_facts() {
+        let facts = generate_datalog_facts(&[], &Default::default());
+        assert!(facts.facts.is_empty());
+    }
+}

--- a/crates/codegen/src/datalog.rs
+++ b/crates/codegen/src/datalog.rs
@@ -1,6 +1,9 @@
 use std::fmt::Write as _;
 
+use common::source_ord::FunctionSourceTable;
 use sonatina_codegen::object::{FrontendProvenanceMap, ObjectArtifact};
+
+use crate::sonatina::MirToIrEntry;
 
 pub struct DatalogFacts {
     pub facts: String,
@@ -10,8 +13,60 @@ pub fn generate_datalog_facts(
     artifacts: &[ObjectArtifact],
     provenance: &FrontendProvenanceMap,
 ) -> DatalogFacts {
+    generate_datalog_facts_full(artifacts, provenance, &[], &[])
+}
+
+pub fn generate_datalog_facts_full(
+    artifacts: &[ObjectArtifact],
+    provenance: &FrontendProvenanceMap,
+    mir_to_ir: &[MirToIrEntry],
+    source_tables: &[(u32, &FunctionSourceTable)],
+) -> DatalogFacts {
     let mut out = String::new();
 
+    // MIR-level facts: mir_stmt(func, block, stmt, file, line, col)
+    for (func_id, table) in source_tables {
+        for (ord, entry) in table.iter() {
+            writeln!(
+                &mut out,
+                "mir_source({}, {}, \"{}\", {}, {}, {}, {}).",
+                func_id,
+                ord.index(),
+                entry.file_path,
+                entry.start_line,
+                entry.start_col,
+                entry.end_line,
+                entry.end_col,
+            )
+            .unwrap();
+        }
+    }
+
+    // Cross-level: mir_to_ir(func, ir_inst, mir_block, mir_stmt)
+    for entry in mir_to_ir {
+        writeln!(
+            &mut out,
+            "mir_to_ir({}, {}, {}, {}).",
+            entry.func.as_u32(),
+            entry.inst.0,
+            entry.mir_block,
+            entry.mir_stmt,
+        )
+        .unwrap();
+
+        if !entry.source_ord.is_default() {
+            writeln!(
+                &mut out,
+                "ir_source_ord({}, {}, {}).",
+                entry.func.as_u32(),
+                entry.inst.0,
+                entry.source_ord.index(),
+            )
+            .unwrap();
+        }
+    }
+
+    // Bytecode-level facts from observability
     for artifact in artifacts {
         let object_name = &artifact.object.0;
         for (section_name, section) in &artifact.sections {
@@ -20,7 +75,6 @@ pub fn generate_datalog_facts(
             };
 
             for entry in &observability.pc_map {
-                // bytecode_range(object, section, pc_start, pc_end, func, block)
                 writeln!(
                     &mut out,
                     "bytecode_range(\"{}\", \"{}\", {}, {}, {}, {}).",
@@ -34,10 +88,9 @@ pub fn generate_datalog_facts(
                 .unwrap();
 
                 if let Some(ir_inst) = entry.ir_inst {
-                    // ir_inst_at(func, inst, pc_start, pc_end)
                     writeln!(
                         &mut out,
-                        "ir_inst_at({}, {}, {}, {}).",
+                        "ir_to_pc({}, {}, {}, {}).",
                         entry.func.as_u32(),
                         ir_inst.0,
                         entry.pc_start,
@@ -49,7 +102,6 @@ pub fn generate_datalog_facts(
                         if let Some((file, start_line, start_col, end_line, end_col)) =
                             parse_provenance(prov)
                         {
-                            // source_at(func, inst, file, start_line, start_col, end_line, end_col)
                             writeln!(
                                 &mut out,
                                 "source_at({}, {}, \"{}\", {}, {}, {}, {}).",
@@ -63,7 +115,6 @@ pub fn generate_datalog_facts(
                             )
                             .unwrap();
 
-                            // pc_source(pc_start, pc_end, file, line, col)
                             writeln!(
                                 &mut out,
                                 "pc_source({}, {}, \"{}\", {}, {}).",
@@ -125,5 +176,39 @@ mod tests {
     fn empty_artifacts_produce_empty_facts() {
         let facts = generate_datalog_facts(&[], &Default::default());
         assert!(facts.facts.is_empty());
+    }
+
+    #[test]
+    fn full_facts_include_cross_level_mappings() {
+        let mir_entries = vec![MirToIrEntry {
+            func: sonatina_ir::module::FuncRef::from_u32(1),
+            inst: sonatina_ir::InstId(5),
+            mir_block: 0,
+            mir_stmt: 2,
+            source_ord: common::source_ord::SourceOrd::new(0),
+        }];
+
+        let mut table = FunctionSourceTable::new();
+        table.push("test.fe".to_string(), 10, 5, 10, 20);
+
+        let facts = generate_datalog_facts_full(
+            &[],
+            &Default::default(),
+            &mir_entries,
+            &[(1, &table)],
+        );
+
+        assert!(
+            facts.facts.contains("mir_to_ir(1, 5, 0, 2)."),
+            "should have mir_to_ir fact"
+        );
+        assert!(
+            facts.facts.contains("ir_source_ord(1, 5, 0)."),
+            "should have ir_source_ord fact"
+        );
+        assert!(
+            facts.facts.contains("mir_source(1, 0, \"test.fe\""),
+            "should have mir_source fact"
+        );
     }
 }

--- a/crates/codegen/src/datalog.rs
+++ b/crates/codegen/src/datalog.rs
@@ -2,6 +2,7 @@ use std::fmt::Write as _;
 
 use common::source_ord::FunctionSourceTable;
 use sonatina_codegen::object::{FrontendProvenanceMap, ObjectArtifact};
+use sonatina_ir::Module;
 
 use crate::sonatina::MirToIrEntry;
 
@@ -13,7 +14,7 @@ pub fn generate_datalog_facts(
     artifacts: &[ObjectArtifact],
     provenance: &FrontendProvenanceMap,
 ) -> DatalogFacts {
-    generate_datalog_facts_full(artifacts, provenance, &[], &[])
+    generate_datalog_facts_full(artifacts, provenance, &[], &[], None)
 }
 
 pub fn generate_datalog_facts_full(
@@ -21,10 +22,11 @@ pub fn generate_datalog_facts_full(
     provenance: &FrontendProvenanceMap,
     mir_to_ir: &[MirToIrEntry],
     source_tables: &[(u32, &FunctionSourceTable)],
+    module: Option<&Module>,
 ) -> DatalogFacts {
     let mut out = String::new();
 
-    // MIR-level facts: mir_stmt(func, block, stmt, file, line, col)
+    // MIR-level facts
     for (func_id, table) in source_tables {
         for (ord, entry) in table.iter() {
             writeln!(
@@ -42,7 +44,7 @@ pub fn generate_datalog_facts_full(
         }
     }
 
-    // Cross-level: mir_to_ir(func, ir_inst, mir_block, mir_stmt)
+    // Cross-level: mir_to_ir
     for entry in mir_to_ir {
         writeln!(
             &mut out,
@@ -64,6 +66,11 @@ pub fn generate_datalog_facts_full(
             )
             .unwrap();
         }
+    }
+
+    // IR-level facts: instruction semantics, control flow, data flow
+    if let Some(module) = module {
+        emit_ir_facts(&mut out, module);
     }
 
     // Bytecode-level facts from observability
@@ -118,11 +125,7 @@ pub fn generate_datalog_facts_full(
                             writeln!(
                                 &mut out,
                                 "pc_source({}, {}, \"{}\", {}, {}).",
-                                entry.pc_start,
-                                entry.pc_end,
-                                file,
-                                start_line,
-                                start_col,
+                                entry.pc_start, entry.pc_end, file, start_line, start_col,
                             )
                             .unwrap();
                         }
@@ -144,6 +147,146 @@ pub fn generate_datalog_facts_full(
     }
 
     DatalogFacts { facts: out }
+}
+
+fn emit_ir_facts(out: &mut String, module: &Module) {
+    for func_ref in module.funcs() {
+        let func_id = func_ref.as_u32();
+
+        module.func_store.view(func_ref, |func| {
+            // Control flow edges
+            let mut cfg = sonatina_ir::ControlFlowGraph::default();
+            cfg.compute(func);
+
+            for block in func.layout.iter_block() {
+                let block_id = block.0;
+
+                // Block entry/exit instructions
+                if let Some(first) = func.layout.first_inst_of(block) {
+                    writeln!(out, "block_entry({func_id}, {block_id}, {}).", first.0).unwrap();
+                }
+                if let Some(last) = func.layout.last_inst_of(block) {
+                    writeln!(out, "block_exit({func_id}, {block_id}, {}).", last.0).unwrap();
+                }
+
+                // CFG edges
+                for succ in cfg.succs_of(block) {
+                    writeln!(out, "cfg_edge({func_id}, {block_id}, {}).", succ.0).unwrap();
+                }
+
+                // Instruction-level facts
+                for inst in func.layout.iter_inst(block) {
+                    let inst_id = inst.0;
+                    let inst_data = &func.dfg.insts[inst];
+
+                    // Instruction type
+                    let type_name = classify_inst(inst_data.as_ref());
+                    writeln!(out, "inst_type({func_id}, {inst_id}, \"{type_name}\").").unwrap();
+
+                    // Instruction results
+                    for (ridx, &result) in func.dfg.inst_results(inst).iter().enumerate() {
+                        writeln!(
+                            out,
+                            "inst_result({func_id}, {inst_id}, {ridx}, {}).",
+                            result.0
+                        )
+                        .unwrap();
+                        writeln!(out, "value_def({func_id}, {}, {inst_id}).", result.0).unwrap();
+                    }
+
+                    // Instruction operands
+                    let operands = inst_data.collect_values();
+                    for (oidx, &operand) in operands.iter().enumerate() {
+                        writeln!(
+                            out,
+                            "inst_operand({func_id}, {inst_id}, {oidx}, {}).",
+                            operand.0
+                        )
+                        .unwrap();
+                    }
+                }
+            }
+        });
+    }
+}
+
+fn classify_inst(inst: &dyn sonatina_ir::Inst) -> &'static str {
+    let name = inst.as_text();
+    // Map known instruction names to semantic categories
+    match name {
+        "call" => "call",
+        "return" => "return",
+        "jump" => "jump",
+        "br" => "branch",
+        "br_table" => "switch",
+        "phi" => "phi",
+        "add" => "add",
+        "sub" => "sub",
+        "mul" => "mul",
+        "neg" => "neg",
+        "shl" => "shl",
+        "shr" => "shr",
+        "sar" => "sar",
+        "and" => "and",
+        "or" => "or",
+        "xor" => "xor",
+        "not" => "not",
+        "eq" => "eq",
+        "ne" => "ne",
+        "lt" => "lt",
+        "gt" => "gt",
+        "slt" => "slt",
+        "is_zero" => "is_zero",
+        "sext" => "sext",
+        "zext" => "zext",
+        "trunc" => "trunc",
+        "bitcast" => "bitcast",
+        "int_to_ptr" => "int_to_ptr",
+        "ptr_to_int" => "ptr_to_int",
+        "alloca" => "alloca",
+        "mload" => "mload",
+        "mstore" => "mstore",
+        "evm_sload" => "sload",
+        "evm_sstore" => "sstore",
+        "evm_tload" => "tload",
+        "evm_tstore" => "tstore",
+        "evm_call" => "external_call",
+        "evm_static_call" => "static_call",
+        "evm_delegate_call" => "delegate_call",
+        "evm_create" => "create",
+        "evm_create2" => "create2",
+        "evm_return" => "evm_return",
+        "evm_revert" => "revert",
+        "evm_stop" => "stop",
+        "evm_invalid" => "invalid",
+        "evm_self_destruct" => "selfdestruct",
+        "evm_log0" => "log",
+        "evm_log1" => "log",
+        "evm_log2" => "log",
+        "evm_log3" => "log",
+        "evm_log4" => "log",
+        "evm_keccak256" => "keccak",
+        "evm_calldataload" => "calldata_read",
+        "evm_calldatacopy" => "calldata_read",
+        "evm_calldatasize" => "calldata_read",
+        "evm_returndatacopy" => "returndata_read",
+        "evm_returndatasize" => "returndata_read",
+        "evm_codecopy" => "code_read",
+        "evm_codesize" => "code_read",
+        "evm_balance" | "evm_self_balance" => "balance",
+        "evm_caller" | "evm_origin" | "evm_address" => "context",
+        "evm_callvalue" | "evm_gas" | "evm_gasprice" => "context",
+        "evm_number" | "evm_timestamp" | "evm_chainid" => "context",
+        "evm_blockhash" | "evm_coinbase" | "evm_gaslimit" => "context",
+        "evm_basefee" | "evm_prevrandao" => "context",
+        "evm_msize" => "memory_info",
+        "evm_exp" => "exp",
+        "evm_signextend" => "signextend",
+        "evm_addmod" | "evm_mulmod" => "modular_arith",
+        "evm_udiv" | "evm_sdiv" | "evm_umod" | "evm_smod" => "division",
+        "unreachable" => "unreachable",
+        _ => name,
+    }
 }
 
 fn parse_provenance(prov: &str) -> Option<(&str, u32, u32, u32, u32)> {
@@ -191,12 +334,8 @@ mod tests {
         let mut table = FunctionSourceTable::new();
         table.push("test.fe".to_string(), 10, 5, 10, 20);
 
-        let facts = generate_datalog_facts_full(
-            &[],
-            &Default::default(),
-            &mir_entries,
-            &[(1, &table)],
-        );
+        let facts =
+            generate_datalog_facts_full(&[], &Default::default(), &mir_entries, &[(1, &table)], None);
 
         assert!(
             facts.facts.contains("mir_to_ir(1, 5, 0, 2)."),

--- a/crates/codegen/src/debug_explorer.rs
+++ b/crates/codegen/src/debug_explorer.rs
@@ -6,148 +6,165 @@ use sonatina_codegen::object::{FrontendProvenanceMap, ObjectArtifact};
 use crate::sonatina::MirToIrEntry;
 use common::source_ord::FunctionSourceTable;
 
-pub fn generate_explorer_payload(
+/// An occurrence of a symbol at a specific location in a representation.
+struct Occurrence {
+    line: u32,
+    col: u32,
+    end_col: u32,
+    symbol: String,
+}
+
+/// A "file" (representation) in the multi-representation SCIP index.
+struct RepFile {
+    contents: String,
+    occurrences: Vec<Occurrence>,
+}
+
+/// Generate a multi-representation SCIP index as JSON.
+///
+/// Each representation (source, MIR, Sonatina IR, bytecode, etc.) is a
+/// virtual "file" with SCIP-style symbol occurrences. Shared symbol
+/// strings across files enable cross-representation hover highlighting.
+pub fn generate_multi_rep_scip(
     source_code: &str,
     source_path: &str,
     mir_dump: &str,
     sonatina_ir_dump: &str,
+    sonatina_ir_opt_dump: &str,
     artifacts: &[ObjectArtifact],
     provenance: &FrontendProvenanceMap,
     mir_to_ir: &[MirToIrEntry],
     source_tables: &[(u32, &FunctionSourceTable)],
+    func_names: &[(u32, &str)],
 ) -> String {
-    let mut groups: Vec<ExplorerGroup> = Vec::new();
-    let mut group_id = 0u32;
+    let mut files: BTreeMap<&str, RepFile> = BTreeMap::new();
 
-    for entry in mir_to_ir {
-        if entry.source_ord.is_default() {
-            continue;
-        }
-        let func_id = entry.func.as_u32();
-
-        let source_entry = source_tables
-            .iter()
-            .find(|(fid, _)| *fid == func_id)
-            .and_then(|(_, table)| table.get(entry.source_ord));
-
-        let source_lines: Vec<u32> = source_entry
-            .map(|e| (e.start_line..=e.end_line).collect())
-            .unwrap_or_default();
-
-        let mut pc_ranges = Vec::new();
-        for artifact in artifacts {
-            for section in artifact.sections.values() {
-                let Some(obs) = &section.observability else { continue };
-                for pc_entry in &obs.pc_map {
-                    if pc_entry.func.as_u32() == func_id
-                        && pc_entry.ir_inst.map(|i| i.0) == Some(entry.inst.0)
-                    {
-                        pc_ranges.push(PcRange {
-                            start: pc_entry.pc_start,
-                            end: pc_entry.pc_end,
-                            func_name: pc_entry.func_name.clone(),
-                        });
-                    }
-                }
+    // Source file — annotate lines with function-level and expression-level symbols
+    let mut source_occs = Vec::new();
+    for (func_id, func_name) in func_names {
+        // Find source lines for this function from source tables
+        if let Some((_, table)) = source_tables.iter().find(|(fid, _)| fid == func_id) {
+            for (ord, entry) in table.iter() {
+                let sym = format!("{}$ord:{}", func_name, ord.index());
+                source_occs.push(Occurrence {
+                    line: entry.start_line,
+                    col: entry.start_col,
+                    end_col: entry.end_col,
+                    symbol: sym,
+                });
             }
         }
+    }
+    files.insert("source", RepFile {
+        contents: source_code.to_string(),
+        occurrences: source_occs,
+    });
 
-        groups.push(ExplorerGroup {
-            id: group_id,
-            source_lines,
-            mir_stmts: vec![MirStmt {
-                func: func_id,
-                block: entry.mir_block,
-                stmt: entry.mir_stmt,
-            }],
-            ir_insts: vec![IrInst {
-                func: func_id,
-                inst: entry.inst.0,
-            }],
-            pc_ranges,
+    // MIR dump — for now just include the text; annotation requires
+    // correlating MIR pretty-print positions with stmt indices
+    files.insert("mir", RepFile {
+        contents: mir_dump.to_string(),
+        occurrences: Vec::new(),
+    });
+
+    // Sonatina IR (pre-opt)
+    files.insert("sonatina_ir", RepFile {
+        contents: sonatina_ir_dump.to_string(),
+        occurrences: Vec::new(),
+    });
+
+    // Sonatina IR (optimized)
+    if !sonatina_ir_opt_dump.is_empty() {
+        files.insert("sonatina_ir_opt", RepFile {
+            contents: sonatina_ir_opt_dump.to_string(),
+            occurrences: Vec::new(),
         });
-        group_id += 1;
     }
 
-    let mut out = String::new();
-    out.push('{');
-    write!(
-        out,
-        "\"source\":{{\"path\":\"{}\",\"code\":{}}},",
-        json_escape(source_path),
-        json_string(source_code)
-    )
-    .unwrap();
-    write!(out, "\"mir\":{},", json_string(mir_dump)).unwrap();
-    write!(out, "\"sonatina_ir\":{},", json_string(sonatina_ir_dump)).unwrap();
-    write!(out, "\"groups\":[").unwrap();
-    for (idx, group) in groups.iter().enumerate() {
-        if idx > 0 {
-            out.push(',');
+    // Bytecode — annotate PC ranges with symbols from provenance
+    let mut bytecode_lines = String::new();
+    let mut bytecode_occs = Vec::new();
+    let mut line_num = 1u32;
+
+    for artifact in artifacts {
+        for (section_name, section) in &artifact.sections {
+            writeln!(&mut bytecode_lines, "--- {} ---", section_name.0).unwrap();
+            line_num += 1;
+
+            let Some(obs) = &section.observability else { continue };
+            let mut entries: Vec<_> = obs.pc_map.iter().collect();
+            entries.sort_by_key(|e| e.pc_start);
+
+            for entry in entries {
+                let prov_str = entry.ir_inst
+                    .and_then(|ir_inst| provenance.get(&(entry.func, ir_inst)));
+
+                let line_text = format!(
+                    "[{:04x}..{:04x}) {}",
+                    entry.pc_start, entry.pc_end, entry.func_name
+                );
+                writeln!(&mut bytecode_lines, "{}", line_text).unwrap();
+
+                // Find matching SourceOrd for this IR inst to get the symbol
+                if let Some(ir_inst) = entry.ir_inst {
+                    let func_id = entry.func.as_u32();
+                    if let Some(mir_entry) = mir_to_ir.iter().find(|m| {
+                        m.func.as_u32() == func_id && m.inst.0 == ir_inst.0
+                    }) {
+                        if !mir_entry.source_ord.is_default() {
+                            let func_name = func_names
+                                .iter()
+                                .find(|(fid, _)| *fid == func_id)
+                                .map(|(_, name)| *name)
+                                .unwrap_or("?");
+                            let sym = format!(
+                                "{}$ord:{}",
+                                func_name,
+                                mir_entry.source_ord.index()
+                            );
+                            bytecode_occs.push(Occurrence {
+                                line: line_num,
+                                col: 1,
+                                end_col: (line_text.len() + 1) as u32,
+                                symbol: sym,
+                            });
+                        }
+                    }
+                }
+                line_num += 1;
+            }
         }
-        write_group(&mut out, group);
     }
-    write!(out, "]}}").unwrap();
+
+    files.insert("bytecode", RepFile {
+        contents: bytecode_lines,
+        occurrences: bytecode_occs,
+    });
+
+    // Serialize as JSON
+    serialize_scip_index(&files)
+}
+
+fn serialize_scip_index(files: &BTreeMap<&str, RepFile>) -> String {
+    let mut out = String::new();
+    out.push_str("{\"files\":{");
+    for (idx, (name, file)) in files.iter().enumerate() {
+        if idx > 0 { out.push(','); }
+        write!(&mut out, "\"{}\":{{", json_escape(name)).unwrap();
+        write!(&mut out, "\"contents\":{}", json_string(&file.contents)).unwrap();
+        write!(&mut out, ",\"occurrences\":[").unwrap();
+        for (oidx, occ) in file.occurrences.iter().enumerate() {
+            if oidx > 0 { out.push(','); }
+            write!(
+                &mut out,
+                "{{\"line\":{},\"col\":{},\"endCol\":{},\"symbol\":\"{}\"}}",
+                occ.line, occ.col, occ.end_col, json_escape(&occ.symbol)
+            ).unwrap();
+        }
+        out.push_str("]}");
+    }
+    out.push_str("}}");
     out
-}
-
-struct ExplorerGroup {
-    id: u32,
-    source_lines: Vec<u32>,
-    mir_stmts: Vec<MirStmt>,
-    ir_insts: Vec<IrInst>,
-    pc_ranges: Vec<PcRange>,
-}
-
-struct MirStmt {
-    func: u32,
-    block: u32,
-    stmt: u32,
-}
-
-struct IrInst {
-    func: u32,
-    inst: u32,
-}
-
-struct PcRange {
-    start: u32,
-    end: u32,
-    func_name: String,
-}
-
-fn write_group(out: &mut String, g: &ExplorerGroup) {
-    write!(out, "{{\"id\":{}", g.id).unwrap();
-    write!(out, ",\"source_lines\":[").unwrap();
-    for (i, line) in g.source_lines.iter().enumerate() {
-        if i > 0 { out.push(','); }
-        write!(out, "{line}").unwrap();
-    }
-    out.push(']');
-    write!(out, ",\"mir_stmts\":[").unwrap();
-    for (i, s) in g.mir_stmts.iter().enumerate() {
-        if i > 0 { out.push(','); }
-        write!(out, "{{\"func\":{},\"block\":{},\"stmt\":{}}}", s.func, s.block, s.stmt).unwrap();
-    }
-    out.push(']');
-    write!(out, ",\"ir_insts\":[").unwrap();
-    for (i, inst) in g.ir_insts.iter().enumerate() {
-        if i > 0 { out.push(','); }
-        write!(out, "{{\"func\":{},\"inst\":{}}}", inst.func, inst.inst).unwrap();
-    }
-    out.push(']');
-    write!(out, ",\"pc_ranges\":[").unwrap();
-    for (i, pc) in g.pc_ranges.iter().enumerate() {
-        if i > 0 { out.push(','); }
-        write!(
-            out,
-            "{{\"start\":{},\"end\":{},\"func_name\":\"{}\"}}",
-            pc.start, pc.end, json_escape(&pc.func_name)
-        )
-        .unwrap();
-    }
-    out.push(']');
-    out.push('}');
 }
 
 fn json_escape(s: &str) -> String {
@@ -175,20 +192,23 @@ mod tests {
     use super::*;
 
     #[test]
-    fn payload_is_valid_json_structure() {
-        let payload = generate_explorer_payload(
+    fn multi_rep_scip_generates_valid_json() {
+        let json = generate_multi_rep_scip(
             "fn add(x: u256) -> u256 { return x }",
             "test.fe",
             "bb0: assign v0 = use v1",
             "func %add: block0: v0 = add v1 v2",
+            "",
             &[],
             &Default::default(),
             &[],
             &[],
+            &[],
         );
-        assert!(payload.starts_with('{'));
-        assert!(payload.ends_with('}'));
-        assert!(payload.contains("\"source\""));
-        assert!(payload.contains("\"groups\""));
+        assert!(json.starts_with("{\"files\":{"));
+        assert!(json.contains("\"source\""));
+        assert!(json.contains("\"mir\""));
+        assert!(json.contains("\"bytecode\""));
+        assert!(json.ends_with("}}"));
     }
 }

--- a/crates/codegen/src/debug_explorer.rs
+++ b/crates/codegen/src/debug_explorer.rs
@@ -1,0 +1,194 @@
+use std::collections::BTreeMap;
+use std::fmt::Write as _;
+
+use sonatina_codegen::object::{FrontendProvenanceMap, ObjectArtifact};
+
+use crate::sonatina::MirToIrEntry;
+use common::source_ord::FunctionSourceTable;
+
+pub fn generate_explorer_payload(
+    source_code: &str,
+    source_path: &str,
+    mir_dump: &str,
+    sonatina_ir_dump: &str,
+    artifacts: &[ObjectArtifact],
+    provenance: &FrontendProvenanceMap,
+    mir_to_ir: &[MirToIrEntry],
+    source_tables: &[(u32, &FunctionSourceTable)],
+) -> String {
+    let mut groups: Vec<ExplorerGroup> = Vec::new();
+    let mut group_id = 0u32;
+
+    for entry in mir_to_ir {
+        if entry.source_ord.is_default() {
+            continue;
+        }
+        let func_id = entry.func.as_u32();
+
+        let source_entry = source_tables
+            .iter()
+            .find(|(fid, _)| *fid == func_id)
+            .and_then(|(_, table)| table.get(entry.source_ord));
+
+        let source_lines: Vec<u32> = source_entry
+            .map(|e| (e.start_line..=e.end_line).collect())
+            .unwrap_or_default();
+
+        let mut pc_ranges = Vec::new();
+        for artifact in artifacts {
+            for section in artifact.sections.values() {
+                let Some(obs) = &section.observability else { continue };
+                for pc_entry in &obs.pc_map {
+                    if pc_entry.func.as_u32() == func_id
+                        && pc_entry.ir_inst.map(|i| i.0) == Some(entry.inst.0)
+                    {
+                        pc_ranges.push(PcRange {
+                            start: pc_entry.pc_start,
+                            end: pc_entry.pc_end,
+                            func_name: pc_entry.func_name.clone(),
+                        });
+                    }
+                }
+            }
+        }
+
+        groups.push(ExplorerGroup {
+            id: group_id,
+            source_lines,
+            mir_stmts: vec![MirStmt {
+                func: func_id,
+                block: entry.mir_block,
+                stmt: entry.mir_stmt,
+            }],
+            ir_insts: vec![IrInst {
+                func: func_id,
+                inst: entry.inst.0,
+            }],
+            pc_ranges,
+        });
+        group_id += 1;
+    }
+
+    let mut out = String::new();
+    out.push('{');
+    write!(
+        out,
+        "\"source\":{{\"path\":\"{}\",\"code\":{}}},",
+        json_escape(source_path),
+        json_string(source_code)
+    )
+    .unwrap();
+    write!(out, "\"mir\":{},", json_string(mir_dump)).unwrap();
+    write!(out, "\"sonatina_ir\":{},", json_string(sonatina_ir_dump)).unwrap();
+    write!(out, "\"groups\":[").unwrap();
+    for (idx, group) in groups.iter().enumerate() {
+        if idx > 0 {
+            out.push(',');
+        }
+        write_group(&mut out, group);
+    }
+    write!(out, "]}}").unwrap();
+    out
+}
+
+struct ExplorerGroup {
+    id: u32,
+    source_lines: Vec<u32>,
+    mir_stmts: Vec<MirStmt>,
+    ir_insts: Vec<IrInst>,
+    pc_ranges: Vec<PcRange>,
+}
+
+struct MirStmt {
+    func: u32,
+    block: u32,
+    stmt: u32,
+}
+
+struct IrInst {
+    func: u32,
+    inst: u32,
+}
+
+struct PcRange {
+    start: u32,
+    end: u32,
+    func_name: String,
+}
+
+fn write_group(out: &mut String, g: &ExplorerGroup) {
+    write!(out, "{{\"id\":{}", g.id).unwrap();
+    write!(out, ",\"source_lines\":[").unwrap();
+    for (i, line) in g.source_lines.iter().enumerate() {
+        if i > 0 { out.push(','); }
+        write!(out, "{line}").unwrap();
+    }
+    out.push(']');
+    write!(out, ",\"mir_stmts\":[").unwrap();
+    for (i, s) in g.mir_stmts.iter().enumerate() {
+        if i > 0 { out.push(','); }
+        write!(out, "{{\"func\":{},\"block\":{},\"stmt\":{}}}", s.func, s.block, s.stmt).unwrap();
+    }
+    out.push(']');
+    write!(out, ",\"ir_insts\":[").unwrap();
+    for (i, inst) in g.ir_insts.iter().enumerate() {
+        if i > 0 { out.push(','); }
+        write!(out, "{{\"func\":{},\"inst\":{}}}", inst.func, inst.inst).unwrap();
+    }
+    out.push(']');
+    write!(out, ",\"pc_ranges\":[").unwrap();
+    for (i, pc) in g.pc_ranges.iter().enumerate() {
+        if i > 0 { out.push(','); }
+        write!(
+            out,
+            "{{\"start\":{},\"end\":{},\"func_name\":\"{}\"}}",
+            pc.start, pc.end, json_escape(&pc.func_name)
+        )
+        .unwrap();
+    }
+    out.push(']');
+    out.push('}');
+}
+
+fn json_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if c < '\x20' => write!(out, "\\u{:04x}", c as u32).unwrap(),
+            c => out.push(c),
+        }
+    }
+    out
+}
+
+fn json_string(s: &str) -> String {
+    format!("\"{}\"", json_escape(s))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn payload_is_valid_json_structure() {
+        let payload = generate_explorer_payload(
+            "fn add(x: u256) -> u256 { return x }",
+            "test.fe",
+            "bb0: assign v0 = use v1",
+            "func %add: block0: v0 = add v1 v2",
+            &[],
+            &Default::default(),
+            &[],
+            &[],
+        );
+        assert!(payload.starts_with('{'));
+        assert!(payload.ends_with('}'));
+        assert!(payload.contains("\"source\""));
+        assert!(payload.contains("\"groups\""));
+    }
+}

--- a/crates/codegen/src/dwarf.rs
+++ b/crates/codegen/src/dwarf.rs
@@ -239,6 +239,88 @@ pub struct ResolvedProvenanceEntry {
     pub end_col: u32,
 }
 
+pub fn fe_ty_to_type_desc<'db>(
+    db: &'db dyn hir::analysis::HirAnalysisDb,
+    ty: hir::analysis::ty::ty_def::TyId<'db>,
+) -> FeTypeDesc {
+    use hir::analysis::ty::ty_def::{PrimTy, TyBase, TyData};
+
+    match ty.data(db) {
+        TyData::TyBase(base) => match base {
+            TyBase::Prim(prim) => match prim {
+                PrimTy::Bool => FeTypeDesc::Bool,
+                PrimTy::U8 => FeTypeDesc::UInt { bits: 8 },
+                PrimTy::U16 => FeTypeDesc::UInt { bits: 16 },
+                PrimTy::U32 => FeTypeDesc::UInt { bits: 32 },
+                PrimTy::U64 => FeTypeDesc::UInt { bits: 64 },
+                PrimTy::U128 => FeTypeDesc::UInt { bits: 128 },
+                PrimTy::U256 | PrimTy::Usize => FeTypeDesc::UInt { bits: 256 },
+                PrimTy::I8 => FeTypeDesc::Int { bits: 8 },
+                PrimTy::I16 => FeTypeDesc::Int { bits: 16 },
+                PrimTy::I32 => FeTypeDesc::Int { bits: 32 },
+                PrimTy::I64 => FeTypeDesc::Int { bits: 64 },
+                PrimTy::I128 => FeTypeDesc::Int { bits: 128 },
+                PrimTy::I256 | PrimTy::Isize => FeTypeDesc::Int { bits: 256 },
+                PrimTy::String => FeTypeDesc::String,
+                PrimTy::Array => FeTypeDesc::Array {
+                    elem: Box::new(FeTypeDesc::UInt { bits: 8 }),
+                    len: None,
+                },
+                PrimTy::Tuple(n) => FeTypeDesc::Struct {
+                    name: format!("Tuple{n}"),
+                    fields: (0..*n)
+                        .map(|i| (format!("{i}"), FeTypeDesc::UInt { bits: 256 }))
+                        .collect(),
+                },
+                PrimTy::Ptr | PrimTy::View | PrimTy::BorrowMut | PrimTy::BorrowRef => {
+                    FeTypeDesc::UInt { bits: 256 }
+                }
+            },
+            TyBase::Adt(adt_def) => {
+                use hir::analysis::ty::adt_def::AdtRef;
+                let name = adt_def
+                    .adt_ref(db)
+                    .name(db)
+                    .map(|n| n.data(db).clone())
+                    .unwrap_or_else(|| "<anon>".to_string());
+                match adt_def.adt_ref(db) {
+                    AdtRef::Struct(_) => {
+                        let fields = adt_def
+                            .fields(db)
+                            .iter()
+                            .enumerate()
+                            .flat_map(|(group_idx, field)| {
+                                (0..field.num_types())
+                                    .map(move |i| {
+                                        let fname = format!("field_{group_idx}_{i}");
+                                        let fty = fe_ty_to_type_desc(
+                                            db,
+                                            *field.ty(db, i).skip_binder(),
+                                        );
+                                        (fname, fty)
+                                    })
+                            })
+                            .collect();
+                        FeTypeDesc::Struct { name, fields }
+                    }
+                    AdtRef::Enum(_) => {
+                        let variants = adt_def
+                            .fields(db)
+                            .iter()
+                            .enumerate()
+                            .map(|(i, _)| format!("variant_{i}"))
+                            .collect();
+                        FeTypeDesc::Enum { name, variants }
+                    }
+                }
+            }
+            TyBase::Contract(_) => FeTypeDesc::Address,
+            TyBase::Func(_) => FeTypeDesc::UInt { bits: 256 },
+        },
+        _ => FeTypeDesc::UInt { bits: 256 },
+    }
+}
+
 fn collect_provenance_entries(
     artifacts: &[ObjectArtifact],
     provenance: &sonatina_codegen::object::FrontendProvenanceMap,

--- a/crates/codegen/src/dwarf.rs
+++ b/crates/codegen/src/dwarf.rs
@@ -21,6 +21,43 @@ pub struct DwarfDebugInfo {
     pub debug_rnglists: Vec<u8>,
 }
 
+impl DwarfDebugInfo {
+    /// Write DWARF sections into an ELF object file.
+    /// The ELF contains only debug sections (no code) and can be read
+    /// by llvm-dwarfdump, readelf, or other DWARF consumers.
+    pub fn to_elf(&self) -> Vec<u8> {
+        use object::write::Object;
+        use object::{Architecture, BinaryFormat, Endianness};
+
+        // Use x86_64 as the nominal architecture for the ELF container.
+        // The ELF contains only DWARF debug sections, no executable code.
+        let mut obj = Object::new(BinaryFormat::Elf, Architecture::X86_64, Endianness::Little);
+
+        let sections: &[(&[u8], &str)] = &[
+            (&self.debug_info, ".debug_info"),
+            (&self.debug_abbrev, ".debug_abbrev"),
+            (&self.debug_line, ".debug_line"),
+            (&self.debug_str, ".debug_str"),
+            (&self.debug_ranges, ".debug_ranges"),
+            (&self.debug_rnglists, ".debug_rnglists"),
+        ];
+
+        for (data, name) in sections {
+            if data.is_empty() {
+                continue;
+            }
+            let section_id = obj.add_section(
+                Vec::new(),
+                name.as_bytes().to_vec(),
+                object::SectionKind::Debug,
+            );
+            obj.set_section_data(section_id, data.to_vec(), 1);
+        }
+
+        obj.write().expect("ELF generation should not fail for debug-only object")
+    }
+}
+
 pub fn generate_dwarf(
     artifacts: &[ObjectArtifact],
     provenance: &sonatina_codegen::object::FrontendProvenanceMap,
@@ -276,6 +313,23 @@ mod tests {
         assert_eq!(resolved.end_col, 15);
         assert_eq!(resolved.pc_start, 0);
         assert_eq!(resolved.pc_end, 4);
+    }
+
+    #[test]
+    fn dwarf_to_elf_produces_valid_elf_header() {
+        let entries = vec![ResolvedProvenanceEntry {
+            pc_start: 0,
+            pc_end: 10,
+            file_path: "test.fe".to_string(),
+            start_line: 1,
+            start_col: 1,
+            end_line: 1,
+            end_col: 10,
+        }];
+        let dwarf = generate_dwarf_from_entries(&entries).unwrap();
+        let elf = dwarf.to_elf();
+        assert!(elf.len() > 52, "ELF should be larger than header");
+        assert_eq!(&elf[..4], b"\x7fELF", "should start with ELF magic");
     }
 
     #[test]

--- a/crates/codegen/src/dwarf.rs
+++ b/crates/codegen/src/dwarf.rs
@@ -5,8 +5,10 @@ use gimli::write::{
     Sections,
 };
 use gimli::{
-    DW_AT_comp_dir, DW_AT_language, DW_AT_name, DW_AT_stmt_list, DW_LANG_Rust, Encoding, Format,
-    LineEncoding, RunTimeEndian,
+    DW_AT_byte_size, DW_AT_comp_dir, DW_AT_encoding, DW_AT_language, DW_AT_name,
+    DW_AT_stmt_list, DW_ATE_boolean, DW_ATE_signed, DW_ATE_unsigned, DW_LANG_Rust,
+    DW_TAG_base_type, DW_TAG_member, DW_TAG_structure_type, Encoding, Format, LineEncoding,
+    RunTimeEndian,
 };
 use sonatina_codegen::object::{ObjectArtifact, PcMapEntry};
 
@@ -93,7 +95,9 @@ pub fn generate_dwarf_from_entries(pc_entries: &[ResolvedProvenanceEntry]) -> Op
     dwarf.unit.get_mut(root).set(DW_AT_stmt_list, AttributeValue::LineProgramRef);
 
     let mut sections = Sections::new(EndianVec::new(RunTimeEndian::Little));
-    dwarf.write(&mut sections).ok()?;
+    if let Err(_) = dwarf.write(&mut sections) {
+        return None;
+    }
 
     Some(DwarfDebugInfo {
         debug_info: sections.debug_info.0.into_vec(),
@@ -103,6 +107,88 @@ pub fn generate_dwarf_from_entries(pc_entries: &[ResolvedProvenanceEntry]) -> Op
         debug_ranges: sections.debug_ranges.0.into_vec(),
         debug_rnglists: sections.debug_rnglists.0.into_vec(),
     })
+}
+
+#[derive(Clone, Debug)]
+pub enum FeTypeDesc {
+    UInt { bits: u32 },
+    Int { bits: u32 },
+    Bool,
+    Address,
+    Bytes { len: Option<u32> },
+    String,
+    Struct { name: String, fields: Vec<(String, FeTypeDesc)> },
+    Enum { name: String, variants: Vec<String> },
+    Array { elem: Box<FeTypeDesc>, len: Option<u64> },
+}
+
+pub fn add_type_dies(dwarf: &mut DwarfUnit, types: &[FeTypeDesc]) {
+    let root = dwarf.unit.root();
+    for ty in types {
+        add_type_die(dwarf, root, ty);
+    }
+}
+
+fn add_type_die(
+    dwarf: &mut DwarfUnit,
+    parent: gimli::write::UnitEntryId,
+    ty: &FeTypeDesc,
+) -> gimli::write::UnitEntryId {
+    match ty {
+        FeTypeDesc::UInt { bits } => {
+            let id = dwarf.unit.add(parent, DW_TAG_base_type);
+            let name = dwarf.strings.add(format!("u{bits}").as_bytes());
+            dwarf.unit.get_mut(id).set(DW_AT_name, AttributeValue::StringRef(name));
+            dwarf.unit.get_mut(id).set(DW_AT_byte_size, AttributeValue::Data1((*bits / 8) as u8));
+            dwarf.unit.get_mut(id).set(DW_AT_encoding, AttributeValue::Encoding(DW_ATE_unsigned));
+            id
+        }
+        FeTypeDesc::Int { bits } => {
+            let id = dwarf.unit.add(parent, DW_TAG_base_type);
+            let name = dwarf.strings.add(format!("i{bits}").as_bytes());
+            dwarf.unit.get_mut(id).set(DW_AT_name, AttributeValue::StringRef(name));
+            dwarf.unit.get_mut(id).set(DW_AT_byte_size, AttributeValue::Data1((*bits / 8) as u8));
+            dwarf.unit.get_mut(id).set(DW_AT_encoding, AttributeValue::Encoding(DW_ATE_signed));
+            id
+        }
+        FeTypeDesc::Bool => {
+            let id = dwarf.unit.add(parent, DW_TAG_base_type);
+            let name = dwarf.strings.add(b"bool");
+            dwarf.unit.get_mut(id).set(DW_AT_name, AttributeValue::StringRef(name));
+            dwarf.unit.get_mut(id).set(DW_AT_byte_size, AttributeValue::Data1(1));
+            dwarf.unit.get_mut(id).set(DW_AT_encoding, AttributeValue::Encoding(DW_ATE_boolean));
+            id
+        }
+        FeTypeDesc::Address => {
+            let id = dwarf.unit.add(parent, DW_TAG_base_type);
+            let name = dwarf.strings.add(b"address");
+            dwarf.unit.get_mut(id).set(DW_AT_name, AttributeValue::StringRef(name));
+            dwarf.unit.get_mut(id).set(DW_AT_byte_size, AttributeValue::Data1(20));
+            dwarf.unit.get_mut(id).set(DW_AT_encoding, AttributeValue::Encoding(DW_ATE_unsigned));
+            id
+        }
+        FeTypeDesc::Struct { name, fields } => {
+            let id = dwarf.unit.add(parent, DW_TAG_structure_type);
+            let name_id = dwarf.strings.add(name.as_bytes());
+            dwarf.unit.get_mut(id).set(DW_AT_name, AttributeValue::StringRef(name_id));
+            for (field_name, field_ty) in fields {
+                let field_id = dwarf.unit.add(id, DW_TAG_member);
+                let fname_id = dwarf.strings.add(field_name.as_bytes());
+                dwarf.unit.get_mut(field_id).set(DW_AT_name, AttributeValue::StringRef(fname_id));
+                add_type_die(dwarf, id, field_ty);
+            }
+            id
+        }
+        FeTypeDesc::Bytes { .. }
+        | FeTypeDesc::String
+        | FeTypeDesc::Enum { .. }
+        | FeTypeDesc::Array { .. } => {
+            let id = dwarf.unit.add(parent, DW_TAG_base_type);
+            let name = dwarf.strings.add(format!("{ty:?}").as_bytes());
+            dwarf.unit.get_mut(id).set(DW_AT_name, AttributeValue::StringRef(name));
+            id
+        }
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/crates/codegen/src/dwarf.rs
+++ b/crates/codegen/src/dwarf.rs
@@ -168,6 +168,46 @@ pub struct FeFuncDesc {
     pub start_line: u32,
 }
 
+/// Variable location description for DWARF emission.
+#[derive(Clone, Debug)]
+pub struct FeVarLocation {
+    pub name: String,
+    pub ty: FeTypeDesc,
+    pub storage_slot: Option<u64>,
+    pub memory_offset: Option<u64>,
+    pub stack_depth: Option<u32>,
+}
+
+pub fn add_variable_dies(dwarf: &mut DwarfUnit, parent: gimli::write::UnitEntryId, vars: &[FeVarLocation]) {
+    use gimli::{DW_AT_location, DW_TAG_variable};
+
+    for var in vars {
+        let id = dwarf.unit.add(parent, DW_TAG_variable);
+        let name_id = dwarf.strings.add(var.name.as_bytes());
+        dwarf.unit.get_mut(id).set(DW_AT_name, AttributeValue::StringRef(name_id));
+
+        // Build a DWARF location expression
+        let mut expr = gimli::write::Expression::new();
+        let mut has_loc = false;
+        if let Some(slot) = var.storage_slot {
+            expr.op_constu(slot);
+            has_loc = true;
+        } else if let Some(offset) = var.memory_offset {
+            expr.op_constu(offset);
+            has_loc = true;
+        } else if let Some(depth) = var.stack_depth {
+            expr.op_constu(depth as u64);
+            has_loc = true;
+        }
+        if has_loc {
+            dwarf.unit.get_mut(id).set(
+                DW_AT_location,
+                AttributeValue::Exprloc(expr),
+            );
+        }
+    }
+}
+
 pub fn add_subprogram_dies(dwarf: &mut DwarfUnit, functions: &[FeFuncDesc]) {
     use gimli::{DW_AT_decl_line, DW_TAG_formal_parameter, DW_TAG_subprogram};
 

--- a/crates/codegen/src/dwarf.rs
+++ b/crates/codegen/src/dwarf.rs
@@ -1,0 +1,249 @@
+use std::collections::BTreeMap;
+
+use gimli::write::{
+    Address, AttributeValue, DwarfUnit, EndianVec, LineProgram, LineString,
+    Sections,
+};
+use gimli::{
+    DW_AT_comp_dir, DW_AT_language, DW_AT_name, DW_AT_stmt_list, DW_LANG_Rust, Encoding, Format,
+    LineEncoding, RunTimeEndian,
+};
+use sonatina_codegen::object::{ObjectArtifact, PcMapEntry};
+
+pub struct DwarfDebugInfo {
+    pub debug_info: Vec<u8>,
+    pub debug_abbrev: Vec<u8>,
+    pub debug_line: Vec<u8>,
+    pub debug_str: Vec<u8>,
+    pub debug_ranges: Vec<u8>,
+    pub debug_rnglists: Vec<u8>,
+}
+
+pub fn generate_dwarf(
+    artifacts: &[ObjectArtifact],
+    provenance: &sonatina_codegen::object::FrontendProvenanceMap,
+) -> Option<DwarfDebugInfo> {
+    let pc_entries = collect_provenance_entries(artifacts, provenance);
+    generate_dwarf_from_entries(&pc_entries)
+}
+
+pub fn generate_dwarf_from_entries(pc_entries: &[ResolvedProvenanceEntry]) -> Option<DwarfDebugInfo> {
+    if pc_entries.is_empty() {
+        return None;
+    }
+
+    let encoding = Encoding {
+        format: Format::Dwarf32,
+        version: 5,
+        address_size: 4, // EVM uses 32-bit PCs
+    };
+
+    let line_encoding = LineEncoding::default();
+
+    let mut dwarf = DwarfUnit::new(encoding);
+
+    let comp_dir = LineString::String(b"/".to_vec());
+    let comp_name = LineString::String(b"<fe-compilation>".to_vec());
+
+    let mut line_program = LineProgram::new(
+        encoding,
+        line_encoding,
+        comp_dir.clone(),
+        comp_name.clone(),
+        None,
+    );
+
+    let mut file_ids: BTreeMap<String, gimli::write::FileId> = BTreeMap::new();
+
+    for entry in pc_entries {
+        if !file_ids.contains_key(&entry.file_path) {
+            let dir_id = line_program.default_directory();
+            let file_id = line_program.add_file(
+                LineString::String(entry.file_path.as_bytes().to_vec()),
+                dir_id,
+                None,
+            );
+            file_ids.insert(entry.file_path.clone(), file_id);
+        }
+    }
+
+    let mut sorted_entries = pc_entries.to_vec();
+    sorted_entries.sort_by_key(|e| e.pc_start);
+
+    for entry in &sorted_entries {
+        let file_id = file_ids[&entry.file_path];
+        line_program.begin_sequence(Some(Address::Constant(entry.pc_start as u64)));
+        line_program.row().file = file_id;
+        line_program.row().line = entry.start_line as u64;
+        line_program.row().column = entry.start_col as u64;
+        line_program.row().address_offset = 0;
+        line_program.generate_row();
+
+        line_program.end_sequence((entry.pc_end - entry.pc_start) as u64);
+    }
+
+    dwarf.unit.line_program = line_program;
+
+    let root = dwarf.unit.root();
+    let name_id = dwarf.strings.add(b"<fe-compilation>");
+    let dir_id = dwarf.strings.add(b"/");
+    dwarf.unit.get_mut(root).set(DW_AT_name, AttributeValue::StringRef(name_id));
+    dwarf.unit.get_mut(root).set(DW_AT_comp_dir, AttributeValue::StringRef(dir_id));
+    dwarf.unit.get_mut(root).set(DW_AT_language, AttributeValue::Language(DW_LANG_Rust));
+    dwarf.unit.get_mut(root).set(DW_AT_stmt_list, AttributeValue::LineProgramRef);
+
+    let mut sections = Sections::new(EndianVec::new(RunTimeEndian::Little));
+    dwarf.write(&mut sections).ok()?;
+
+    Some(DwarfDebugInfo {
+        debug_info: sections.debug_info.0.into_vec(),
+        debug_abbrev: sections.debug_abbrev.0.into_vec(),
+        debug_line: sections.debug_line.0.into_vec(),
+        debug_str: sections.debug_str.0.into_vec(),
+        debug_ranges: sections.debug_ranges.0.into_vec(),
+        debug_rnglists: sections.debug_rnglists.0.into_vec(),
+    })
+}
+
+#[derive(Clone, Debug)]
+pub struct ResolvedProvenanceEntry {
+    pub pc_start: u32,
+    pub pc_end: u32,
+    pub file_path: String,
+    pub start_line: u32,
+    pub start_col: u32,
+    pub end_line: u32,
+    pub end_col: u32,
+}
+
+fn collect_provenance_entries(
+    artifacts: &[ObjectArtifact],
+    provenance: &sonatina_codegen::object::FrontendProvenanceMap,
+) -> Vec<ResolvedProvenanceEntry> {
+    let mut entries = Vec::new();
+
+    for artifact in artifacts {
+        for section in artifact.sections.values() {
+            let Some(observability) = &section.observability else {
+                continue;
+            };
+            for pc_entry in &observability.pc_map {
+                let Some(ir_inst) = pc_entry.ir_inst else {
+                    continue;
+                };
+                let Some(prov_str) = provenance.get(&(pc_entry.func, ir_inst)) else {
+                    continue;
+                };
+                if let Some(resolved) = parse_provenance_string(prov_str, pc_entry) {
+                    entries.push(resolved);
+                }
+            }
+        }
+    }
+
+    entries
+}
+
+fn parse_provenance_string(
+    prov: &str,
+    pc_entry: &PcMapEntry,
+) -> Option<ResolvedProvenanceEntry> {
+    // Format: "file.fe:start_line:start_col-end_line:end_col"
+    let (file_and_start, end_part) = prov.rsplit_once('-')?;
+    let (file_and_line, start_col_str) = file_and_start.rsplit_once(':')?;
+    let (file_path, start_line_str) = file_and_line.rsplit_once(':')?;
+    let (end_line_str, end_col_str) = end_part.rsplit_once(':')?;
+
+    Some(ResolvedProvenanceEntry {
+        pc_start: pc_entry.pc_start,
+        pc_end: pc_entry.pc_end,
+        file_path: file_path.to_string(),
+        start_line: start_line_str.parse().ok()?,
+        start_col: start_col_str.parse().ok()?,
+        end_line: end_line_str.parse().ok()?,
+        end_col: end_col_str.parse().ok()?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn parse_provenance_string_roundtrip() {
+        let prov = "src/main.fe:10:5-10:15";
+        let pc_entry = PcMapEntry {
+            pc_start: 0,
+            pc_end: 4,
+            func: sonatina_ir::module::FuncRef::from_u32(0),
+            func_name: "test".to_string(),
+            block: sonatina_ir::BlockId(0),
+            vcode_inst: sonatina_codegen::machinst::vcode::VCodeInst::from_u32(0),
+            ir_inst: Some(sonatina_ir::InstId(0)),
+            frontend_provenance: None,
+            unmapped_reason: None,
+        };
+        let resolved = parse_provenance_string(prov, &pc_entry).unwrap();
+        assert_eq!(resolved.file_path, "src/main.fe");
+        assert_eq!(resolved.start_line, 10);
+        assert_eq!(resolved.start_col, 5);
+        assert_eq!(resolved.end_line, 10);
+        assert_eq!(resolved.end_col, 15);
+        assert_eq!(resolved.pc_start, 0);
+        assert_eq!(resolved.pc_end, 4);
+    }
+
+    #[test]
+    fn generate_dwarf_produces_valid_sections() {
+        let entries = vec![
+            ResolvedProvenanceEntry {
+                pc_start: 0,
+                pc_end: 10,
+                file_path: "src/main.fe".to_string(),
+                start_line: 3,
+                start_col: 5,
+                end_line: 3,
+                end_col: 19,
+            },
+            ResolvedProvenanceEntry {
+                pc_start: 10,
+                pc_end: 25,
+                file_path: "src/main.fe".to_string(),
+                start_line: 4,
+                start_col: 5,
+                end_line: 4,
+                end_col: 20,
+            },
+            ResolvedProvenanceEntry {
+                pc_start: 25,
+                pc_end: 40,
+                file_path: "src/lib.fe".to_string(),
+                start_line: 10,
+                start_col: 1,
+                end_line: 12,
+                end_col: 2,
+            },
+        ];
+
+        let dwarf = generate_dwarf_from_entries(&entries);
+        assert!(dwarf.is_some(), "DWARF generation should produce output");
+
+        let dwarf = dwarf.unwrap();
+        assert!(
+            !dwarf.debug_line.is_empty(),
+            "debug_line section should be non-empty"
+        );
+        assert!(
+            !dwarf.debug_info.is_empty(),
+            "debug_info section should be non-empty"
+        );
+        assert!(
+            !dwarf.debug_abbrev.is_empty(),
+            "debug_abbrev section should be non-empty"
+        );
+        assert!(
+            dwarf.debug_line.len() > 20,
+            "debug_line should contain meaningful data, got {} bytes",
+            dwarf.debug_line.len()
+        );
+    }
+}

--- a/crates/codegen/src/dwarf.rs
+++ b/crates/codegen/src/dwarf.rs
@@ -159,6 +159,42 @@ pub enum FeTypeDesc {
     Array { elem: Box<FeTypeDesc>, len: Option<u64> },
 }
 
+/// A function description for generating DWARF DW_TAG_subprogram DIEs.
+#[derive(Clone, Debug)]
+pub struct FeFuncDesc {
+    pub name: String,
+    pub params: Vec<(String, FeTypeDesc)>,
+    pub return_type: Option<FeTypeDesc>,
+    pub start_line: u32,
+}
+
+pub fn add_subprogram_dies(dwarf: &mut DwarfUnit, functions: &[FeFuncDesc]) {
+    use gimli::{DW_AT_decl_line, DW_TAG_formal_parameter, DW_TAG_subprogram};
+
+    let root = dwarf.unit.root();
+    for func in functions {
+        let id = dwarf.unit.add(root, DW_TAG_subprogram);
+        let name_id = dwarf.strings.add(func.name.as_bytes());
+        dwarf
+            .unit
+            .get_mut(id)
+            .set(DW_AT_name, AttributeValue::StringRef(name_id));
+        dwarf
+            .unit
+            .get_mut(id)
+            .set(DW_AT_decl_line, AttributeValue::Udata(func.start_line as u64));
+
+        for (param_name, _param_ty) in &func.params {
+            let param_id = dwarf.unit.add(id, DW_TAG_formal_parameter);
+            let pname_id = dwarf.strings.add(param_name.as_bytes());
+            dwarf
+                .unit
+                .get_mut(param_id)
+                .set(DW_AT_name, AttributeValue::StringRef(pname_id));
+        }
+    }
+}
+
 pub fn add_type_dies(dwarf: &mut DwarfUnit, types: &[FeTypeDesc]) {
     let root = dwarf.unit.root();
     for ty in types {

--- a/crates/codegen/src/ethdebug.rs
+++ b/crates/codegen/src/ethdebug.rs
@@ -1,0 +1,286 @@
+use std::collections::BTreeMap;
+use std::fmt::Write as _;
+
+use sonatina_codegen::object::{FrontendProvenanceMap, ObjectArtifact, PcMapEntry};
+
+#[derive(Debug, Clone)]
+pub struct EthdebugInfo {
+    pub json: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct EthdebugSource {
+    pub id: usize,
+    pub path: String,
+    pub contents: Option<String>,
+}
+
+pub struct EthdebugBuilder {
+    compiler_name: String,
+    compiler_version: String,
+    sources: Vec<EthdebugSource>,
+    programs: Vec<EthdebugProgram>,
+}
+
+struct EthdebugProgram {
+    contract_name: String,
+    environment: &'static str,
+    instructions: Vec<EthdebugInstruction>,
+}
+
+struct EthdebugInstruction {
+    offset: u32,
+    opcode: Option<u8>,
+    source: Option<EthdebugSourceRange>,
+}
+
+#[derive(Clone)]
+struct EthdebugSourceRange {
+    source_id: usize,
+    start_line: u32,
+    start_col: u32,
+    end_line: u32,
+    end_col: u32,
+}
+
+impl EthdebugBuilder {
+    pub fn new(compiler_name: &str, compiler_version: &str) -> Self {
+        Self {
+            compiler_name: compiler_name.to_string(),
+            compiler_version: compiler_version.to_string(),
+            sources: Vec::new(),
+            programs: Vec::new(),
+        }
+    }
+
+    pub fn add_source(&mut self, path: &str, contents: Option<&str>) -> usize {
+        let id = self.sources.len();
+        self.sources.push(EthdebugSource {
+            id,
+            path: path.to_string(),
+            contents: contents.map(|s| s.to_string()),
+        });
+        id
+    }
+
+    pub fn add_program_from_artifact(
+        &mut self,
+        artifact: &ObjectArtifact,
+        provenance: &FrontendProvenanceMap,
+        contract_name: &str,
+        environment: &'static str,
+    ) {
+        let mut instructions = Vec::new();
+
+        for section in artifact.sections.values() {
+            let Some(observability) = &section.observability else {
+                continue;
+            };
+
+            for entry in &observability.pc_map {
+                let source = entry
+                    .ir_inst
+                    .and_then(|ir_inst| provenance.get(&(entry.func, ir_inst)))
+                    .and_then(|prov_str| self.parse_provenance_to_source_range(prov_str));
+
+                instructions.push(EthdebugInstruction {
+                    offset: entry.pc_start,
+                    opcode: None,
+                    source,
+                });
+            }
+        }
+
+        instructions.sort_by_key(|i| i.offset);
+        instructions.dedup_by_key(|i| i.offset);
+
+        self.programs.push(EthdebugProgram {
+            contract_name: contract_name.to_string(),
+            environment,
+            instructions,
+        });
+    }
+
+    fn parse_provenance_to_source_range(&self, prov: &str) -> Option<EthdebugSourceRange> {
+        let (file_and_start, end_part) = prov.rsplit_once('-')?;
+        let (file_and_line, start_col_str) = file_and_start.rsplit_once(':')?;
+        let (file_path, start_line_str) = file_and_line.rsplit_once(':')?;
+        let (end_line_str, end_col_str) = end_part.rsplit_once(':')?;
+
+        let source_id = self
+            .sources
+            .iter()
+            .position(|s| s.path == file_path)
+            .or_else(|| {
+                if self.sources.is_empty() {
+                    None
+                } else {
+                    Some(0)
+                }
+            })?;
+
+        Some(EthdebugSourceRange {
+            source_id,
+            start_line: start_line_str.parse().ok()?,
+            start_col: start_col_str.parse().ok()?,
+            end_line: end_line_str.parse().ok()?,
+            end_col: end_col_str.parse().ok()?,
+        })
+    }
+
+    pub fn build(&self) -> EthdebugInfo {
+        let mut out = String::new();
+        self.write_json(&mut out);
+        EthdebugInfo { json: out }
+    }
+
+    fn write_json(&self, out: &mut String) {
+        out.push('{');
+
+        // compilation
+        write!(out, "\"compilation\":{{").unwrap();
+        write!(
+            out,
+            "\"compiler\":{{\"name\":\"{}\",\"version\":\"{}\"}}",
+            json_escape(&self.compiler_name),
+            json_escape(&self.compiler_version)
+        )
+        .unwrap();
+        write!(out, ",\"sources\":[").unwrap();
+        for (idx, source) in self.sources.iter().enumerate() {
+            if idx > 0 {
+                out.push(',');
+            }
+            write!(
+                out,
+                "{{\"id\":{},\"path\":\"{}\"",
+                source.id,
+                json_escape(&source.path)
+            )
+            .unwrap();
+            if let Some(contents) = &source.contents {
+                write!(out, ",\"contents\":\"{}\"", json_escape(contents)).unwrap();
+            }
+            write!(out, ",\"language\":\"Fe\"}}").unwrap();
+        }
+        write!(out, "]}}").unwrap();
+
+        // programs
+        write!(out, ",\"programs\":[").unwrap();
+        for (prog_idx, program) in self.programs.iter().enumerate() {
+            if prog_idx > 0 {
+                out.push(',');
+            }
+            write!(out, "{{").unwrap();
+            write!(
+                out,
+                "\"contract\":{{\"name\":\"{}\"}}",
+                json_escape(&program.contract_name)
+            )
+            .unwrap();
+            write!(
+                out,
+                ",\"environment\":\"{}\"",
+                program.environment
+            )
+            .unwrap();
+
+            write!(out, ",\"instructions\":[").unwrap();
+            for (inst_idx, inst) in program.instructions.iter().enumerate() {
+                if inst_idx > 0 {
+                    out.push(',');
+                }
+                write!(out, "{{\"offset\":{}", inst.offset).unwrap();
+                if let Some(opcode) = inst.opcode {
+                    write!(out, ",\"operation\":{{\"mnemonic\":\"0x{:02x}\"}}", opcode).unwrap();
+                }
+                if let Some(source) = &inst.source {
+                    write!(
+                        out,
+                        ",\"source\":{{\"id\":{},\"start\":{{\"line\":{},\"column\":{}}},\"end\":{{\"line\":{},\"column\":{}}}}}",
+                        source.source_id,
+                        source.start_line,
+                        source.start_col,
+                        source.end_line,
+                        source.end_col,
+                    )
+                    .unwrap();
+                }
+                out.push('}');
+            }
+            write!(out, "]}}").unwrap();
+        }
+        write!(out, "]}}").unwrap();
+    }
+}
+
+fn json_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if c < '\x20' => write!(out, "\\u{:04x}", c as u32).unwrap(),
+            c => out.push(c),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ethdebug_builder_produces_valid_json() {
+        let mut builder = EthdebugBuilder::new("fe", "26.1.0");
+        builder.add_source("src/main.fe", Some("fn add(x: u256, y: u256) -> u256 { return x + y }"));
+
+        let info = builder.build();
+        assert!(info.json.starts_with('{'));
+        assert!(info.json.ends_with('}'));
+        assert!(info.json.contains("\"compiler\""));
+        assert!(info.json.contains("\"Fe\""));
+        assert!(info.json.contains("src/main.fe"));
+    }
+
+    #[test]
+    fn ethdebug_builder_with_instructions() {
+        let mut builder = EthdebugBuilder::new("fe", "26.1.0");
+        let source_id = builder.add_source("test.fe", None);
+
+        builder.programs.push(EthdebugProgram {
+            contract_name: "Counter".to_string(),
+            environment: "call",
+            instructions: vec![
+                EthdebugInstruction {
+                    offset: 0,
+                    opcode: Some(0x60),
+                    source: Some(EthdebugSourceRange {
+                        source_id,
+                        start_line: 5,
+                        start_col: 1,
+                        end_line: 5,
+                        end_col: 20,
+                    }),
+                },
+                EthdebugInstruction {
+                    offset: 2,
+                    opcode: Some(0x54),
+                    source: None,
+                },
+            ],
+        });
+
+        let info = builder.build();
+        assert!(info.json.contains("\"Counter\""));
+        assert!(info.json.contains("\"call\""));
+        assert!(info.json.contains("\"offset\":0"));
+        assert!(info.json.contains("\"offset\":2"));
+        assert!(info.json.contains("\"line\":5"));
+        assert!(info.json.contains("\"mnemonic\":\"0x60\""));
+    }
+}

--- a/crates/codegen/src/ethdebug.rs
+++ b/crates/codegen/src/ethdebug.rs
@@ -1,7 +1,6 @@
-use std::collections::BTreeMap;
 use std::fmt::Write as _;
 
-use sonatina_codegen::object::{FrontendProvenanceMap, ObjectArtifact, PcMapEntry};
+use sonatina_codegen::object::{FrontendProvenanceMap, ObjectArtifact};
 
 #[derive(Debug, Clone)]
 pub struct EthdebugInfo {
@@ -133,7 +132,7 @@ impl EthdebugBuilder {
                     name: v.clone(), type_kind: "uint".to_string(), type_bits: Some(8),
                 }).collect(),
             ),
-            FeTypeDesc::Array { elem, len } => (
+            FeTypeDesc::Array { elem: _, len } => (
                 len.map_or("Array".to_string(), |n| format!("Array[{n}]")),
                 "array".to_string(),
                 None,

--- a/crates/codegen/src/ethdebug.rs
+++ b/crates/codegen/src/ethdebug.rs
@@ -20,6 +20,7 @@ pub struct EthdebugBuilder {
     compiler_version: String,
     sources: Vec<EthdebugSource>,
     programs: Vec<EthdebugProgram>,
+    types: Vec<EthdebugType>,
 }
 
 struct EthdebugProgram {
@@ -43,6 +44,19 @@ struct EthdebugSourceRange {
     end_col: u32,
 }
 
+pub struct EthdebugType {
+    pub name: String,
+    pub kind: String,
+    pub bits: Option<u32>,
+    pub fields: Vec<EthdebugTypeField>,
+}
+
+pub struct EthdebugTypeField {
+    pub name: String,
+    pub type_kind: String,
+    pub type_bits: Option<u32>,
+}
+
 impl EthdebugBuilder {
     pub fn new(compiler_name: &str, compiler_version: &str) -> Self {
         Self {
@@ -50,7 +64,54 @@ impl EthdebugBuilder {
             compiler_version: compiler_version.to_string(),
             sources: Vec::new(),
             programs: Vec::new(),
+            types: Vec::new(),
         }
+    }
+
+    pub fn add_type_from_desc(&mut self, desc: &crate::dwarf::FeTypeDesc) {
+        use crate::dwarf::FeTypeDesc;
+        let (name, kind, bits, fields) = match desc {
+            FeTypeDesc::UInt { bits } => (format!("u{bits}"), "uint".to_string(), Some(*bits), vec![]),
+            FeTypeDesc::Int { bits } => (format!("i{bits}"), "int".to_string(), Some(*bits), vec![]),
+            FeTypeDesc::Bool => ("bool".to_string(), "bool".to_string(), None, vec![]),
+            FeTypeDesc::Address => ("address".to_string(), "address".to_string(), None, vec![]),
+            FeTypeDesc::String => ("String".to_string(), "string".to_string(), None, vec![]),
+            FeTypeDesc::Bytes { len } => (
+                len.map_or("bytes".to_string(), |n| format!("bytes{n}")),
+                "bytes".to_string(),
+                len.map(|n| n * 8),
+                vec![],
+            ),
+            FeTypeDesc::Struct { name, fields } => (
+                name.clone(),
+                "struct".to_string(),
+                None,
+                fields.iter().map(|(fname, fty)| {
+                    let (fkind, fbits) = match fty {
+                        FeTypeDesc::UInt { bits } => ("uint".to_string(), Some(*bits)),
+                        FeTypeDesc::Int { bits } => ("int".to_string(), Some(*bits)),
+                        FeTypeDesc::Bool => ("bool".to_string(), None),
+                        _ => ("unknown".to_string(), None),
+                    };
+                    EthdebugTypeField { name: fname.clone(), type_kind: fkind, type_bits: fbits }
+                }).collect(),
+            ),
+            FeTypeDesc::Enum { name, variants } => (
+                name.clone(),
+                "enum".to_string(),
+                None,
+                variants.iter().map(|v| EthdebugTypeField {
+                    name: v.clone(), type_kind: "uint".to_string(), type_bits: Some(8),
+                }).collect(),
+            ),
+            FeTypeDesc::Array { elem, len } => (
+                len.map_or("Array".to_string(), |n| format!("Array[{n}]")),
+                "array".to_string(),
+                None,
+                vec![],
+            ),
+        };
+        self.types.push(EthdebugType { name, kind, bits, fields });
     }
 
     pub fn add_source(&mut self, path: &str, contents: Option<&str>) -> usize {
@@ -164,6 +225,48 @@ impl EthdebugBuilder {
             write!(out, ",\"language\":\"Fe\"}}").unwrap();
         }
         write!(out, "]}}").unwrap();
+
+        // types
+        if !self.types.is_empty() {
+            write!(out, ",\"types\":{{").unwrap();
+            for (idx, ty) in self.types.iter().enumerate() {
+                if idx > 0 {
+                    out.push(',');
+                }
+                write!(
+                    out,
+                    "\"{}\":{{\"kind\":\"{}\"",
+                    json_escape(&ty.name),
+                    json_escape(&ty.kind)
+                )
+                .unwrap();
+                if let Some(bits) = ty.bits {
+                    write!(out, ",\"bits\":{bits}").unwrap();
+                }
+                if !ty.fields.is_empty() {
+                    write!(out, ",\"contains\":[").unwrap();
+                    for (fidx, field) in ty.fields.iter().enumerate() {
+                        if fidx > 0 {
+                            out.push(',');
+                        }
+                        write!(
+                            out,
+                            "{{\"name\":\"{}\",\"type\":{{\"kind\":\"{}\"",
+                            json_escape(&field.name),
+                            json_escape(&field.type_kind)
+                        )
+                        .unwrap();
+                        if let Some(bits) = field.type_bits {
+                            write!(out, ",\"bits\":{bits}").unwrap();
+                        }
+                        write!(out, "}}}}").unwrap();
+                    }
+                    write!(out, "]").unwrap();
+                }
+                out.push('}');
+            }
+            write!(out, "}}").unwrap();
+        }
 
         // programs
         write!(out, ",\"programs\":[").unwrap();

--- a/crates/codegen/src/ethdebug.rs
+++ b/crates/codegen/src/ethdebug.rs
@@ -15,12 +15,35 @@ pub struct EthdebugSource {
     pub contents: Option<String>,
 }
 
+pub struct EthdebugPointer {
+    pub name: String,
+    pub location: EthdebugLocation,
+    pub slot: Option<u64>,
+    pub offset: Option<u64>,
+    pub length: Option<u64>,
+}
+
+#[derive(Clone, Debug)]
+pub enum EthdebugLocation {
+    Storage,
+    Memory,
+    Stack,
+    Calldata,
+}
+
+pub struct EthdebugVariable {
+    pub name: String,
+    pub type_name: String,
+    pub pointer: Option<EthdebugPointer>,
+}
+
 pub struct EthdebugBuilder {
     compiler_name: String,
     compiler_version: String,
     sources: Vec<EthdebugSource>,
     programs: Vec<EthdebugProgram>,
     types: Vec<EthdebugType>,
+    pointers: Vec<EthdebugPointer>,
 }
 
 struct EthdebugProgram {
@@ -33,6 +56,7 @@ struct EthdebugInstruction {
     offset: u32,
     opcode: Option<u8>,
     source: Option<EthdebugSourceRange>,
+    variables: Vec<EthdebugVariable>,
 }
 
 #[derive(Clone)]
@@ -65,7 +89,12 @@ impl EthdebugBuilder {
             sources: Vec::new(),
             programs: Vec::new(),
             types: Vec::new(),
+            pointers: Vec::new(),
         }
+    }
+
+    pub fn add_pointer(&mut self, pointer: EthdebugPointer) {
+        self.pointers.push(pointer);
     }
 
     pub fn add_type_from_desc(&mut self, desc: &crate::dwarf::FeTypeDesc) {
@@ -148,6 +177,7 @@ impl EthdebugBuilder {
                     offset: entry.pc_start,
                     opcode: None,
                     source,
+                    variables: Vec::new(),
                 });
             }
         }
@@ -268,6 +298,40 @@ impl EthdebugBuilder {
             write!(out, "}}").unwrap();
         }
 
+        // pointers
+        if !self.pointers.is_empty() {
+            write!(out, ",\"pointers\":{{").unwrap();
+            for (idx, ptr) in self.pointers.iter().enumerate() {
+                if idx > 0 {
+                    out.push(',');
+                }
+                let loc = match &ptr.location {
+                    EthdebugLocation::Storage => "storage",
+                    EthdebugLocation::Memory => "memory",
+                    EthdebugLocation::Stack => "stack",
+                    EthdebugLocation::Calldata => "calldata",
+                };
+                write!(
+                    out,
+                    "\"{}\":{{\"location\":\"{}\"",
+                    json_escape(&ptr.name),
+                    loc
+                )
+                .unwrap();
+                if let Some(slot) = ptr.slot {
+                    write!(out, ",\"slot\":{slot}").unwrap();
+                }
+                if let Some(offset) = ptr.offset {
+                    write!(out, ",\"offset\":{offset}").unwrap();
+                }
+                if let Some(length) = ptr.length {
+                    write!(out, ",\"length\":{length}").unwrap();
+                }
+                out.push('}');
+            }
+            write!(out, "}}").unwrap();
+        }
+
         // programs
         write!(out, ",\"programs\":[").unwrap();
         for (prog_idx, program) in self.programs.iter().enumerate() {
@@ -308,6 +372,36 @@ impl EthdebugBuilder {
                         source.end_col,
                     )
                     .unwrap();
+                }
+                if !inst.variables.is_empty() {
+                    write!(out, ",\"context\":{{\"variables\":[").unwrap();
+                    for (vidx, var) in inst.variables.iter().enumerate() {
+                        if vidx > 0 {
+                            out.push(',');
+                        }
+                        write!(
+                            out,
+                            "{{\"identifier\":\"{}\",\"type\":\"{}\"",
+                            json_escape(&var.name),
+                            json_escape(&var.type_name)
+                        )
+                        .unwrap();
+                        if let Some(ptr) = &var.pointer {
+                            let loc = match &ptr.location {
+                                EthdebugLocation::Storage => "storage",
+                                EthdebugLocation::Memory => "memory",
+                                EthdebugLocation::Stack => "stack",
+                                EthdebugLocation::Calldata => "calldata",
+                            };
+                            write!(out, ",\"pointer\":{{\"location\":\"{loc}\"").unwrap();
+                            if let Some(slot) = ptr.slot {
+                                write!(out, ",\"slot\":{slot}").unwrap();
+                            }
+                            out.push('}');
+                        }
+                        out.push('}');
+                    }
+                    write!(out, "]}}").unwrap();
                 }
                 out.push('}');
             }
@@ -369,11 +463,23 @@ mod tests {
                         end_line: 5,
                         end_col: 20,
                     }),
+                    variables: vec![EthdebugVariable {
+                        name: "count".to_string(),
+                        type_name: "u256".to_string(),
+                        pointer: Some(EthdebugPointer {
+                            name: "count_ptr".to_string(),
+                            location: EthdebugLocation::Storage,
+                            slot: Some(0),
+                            offset: None,
+                            length: Some(32),
+                        }),
+                    }],
                 },
                 EthdebugInstruction {
                     offset: 2,
                     opcode: Some(0x54),
                     source: None,
+                    variables: Vec::new(),
                 },
             ],
         });

--- a/crates/codegen/src/lib.rs
+++ b/crates/codegen/src/lib.rs
@@ -1,5 +1,6 @@
 mod backend;
 pub mod datalog;
+pub mod debug_explorer;
 pub mod dwarf;
 pub mod ethdebug;
 mod function_symbols;

--- a/crates/codegen/src/lib.rs
+++ b/crates/codegen/src/lib.rs
@@ -1,5 +1,6 @@
 mod backend;
 pub mod dwarf;
+pub mod ethdebug;
 mod function_symbols;
 mod layout;
 mod runtime_package;

--- a/crates/codegen/src/lib.rs
+++ b/crates/codegen/src/lib.rs
@@ -1,4 +1,5 @@
 mod backend;
+pub mod datalog;
 pub mod dwarf;
 pub mod ethdebug;
 mod function_symbols;

--- a/crates/codegen/src/lib.rs
+++ b/crates/codegen/src/lib.rs
@@ -1,4 +1,5 @@
 mod backend;
+pub mod dwarf;
 mod function_symbols;
 mod layout;
 mod runtime_package;

--- a/crates/codegen/src/sonatina/lower_runtime.rs
+++ b/crates/codegen/src/sonatina/lower_runtime.rs
@@ -44,11 +44,10 @@ use sonatina_ir::{
             EvmCalldataCopy, EvmCalldataLoad, EvmCalldataSize, EvmCaller, EvmChainId, EvmCodeCopy,
             EvmCodeSize, EvmCoinBase, EvmCreate, EvmCreate2, EvmDelegateCall, EvmExp, EvmGas,
             EvmGasLimit, EvmInvalid, EvmKeccak256, EvmLog0, EvmLog1, EvmLog2, EvmLog3, EvmLog4,
-            EvmMalloc, EvmMcopy, EvmMsize, EvmMstore8, EvmMulMod, EvmNumber, EvmOrigin,
-            EvmPrevRandao, EvmReturn, EvmReturnDataCopy, EvmReturnDataSize, EvmRevert, EvmSdiv,
-            EvmSelfBalance, EvmSelfDestruct, EvmSignExtend, EvmSload, EvmSmod, EvmSstore,
-            EvmStaticCall, EvmStop, EvmTimestamp, EvmTload, EvmTstore, EvmUdiv, EvmUmod,
-            inst_set::EvmInstSet,
+            EvmMalloc, EvmMsize, EvmMstore8, EvmMulMod, EvmNumber, EvmOrigin, EvmPrevRandao,
+            EvmReturn, EvmReturnDataCopy, EvmReturnDataSize, EvmRevert, EvmSdiv, EvmSelfBalance,
+            EvmSelfDestruct, EvmSload, EvmSmod, EvmSstore, EvmStaticCall, EvmStop, EvmTimestamp,
+            EvmTload, EvmTstore, EvmUdiv, EvmUmod, inst_set::EvmInstSet,
         },
         logic::{And, Not, Or, Xor},
     },
@@ -57,6 +56,19 @@ use sonatina_ir::{
     object::EmbedSymbol,
     types::{CompoundType, EnumReprHint, EnumVariantRef, VariantData},
 };
+
+pub struct MirToIrEntry {
+    pub func: FuncRef,
+    pub inst: sonatina_ir::InstId,
+    pub mir_block: u32,
+    pub mir_stmt: u32,
+    pub source_ord: common::source_ord::SourceOrd,
+}
+
+pub struct ProvenanceResult {
+    pub provenance_entries: Vec<(FuncRef, sonatina_ir::InstId, String)>,
+    pub mir_origins: Vec<MirToIrEntry>,
+}
 
 use super::{LowerError, create_module_ctx};
 use crate::{
@@ -71,7 +83,8 @@ pub(super) fn compile_runtime_package_sonatina(
     db: &DriverDataBase,
     package: &RuntimePackage<'_>,
     layout: TargetDataLayout,
-) -> Result<Module, LowerError> {
+) -> Result<(Module, sonatina_codegen::object::FrontendProvenanceMap, Vec<MirToIrEntry>), LowerError>
+{
     let _ = layout;
     let builder = ModuleBuilder::new(create_module_ctx());
     let isa = super::create_evm_isa();
@@ -95,6 +108,8 @@ struct ModuleLowerer<'db, 'a> {
     layout_names: FxHashMap<LayoutId<'db>, String>,
     const_globals: FxHashMap<ConstRegionId<'db>, GlobalVariableRef>,
     const_names: FxHashMap<ConstRegionId<'db>, String>,
+    frontend_provenance: sonatina_codegen::object::FrontendProvenanceMap,
+    mir_to_ir: Vec<MirToIrEntry>,
 }
 
 impl<'db, 'a> ModuleLowerer<'db, 'a> {
@@ -116,11 +131,13 @@ impl<'db, 'a> ModuleLowerer<'db, 'a> {
             layout_names: FxHashMap::default(),
             const_globals: FxHashMap::default(),
             const_names: FxHashMap::default(),
+            frontend_provenance: FxHashMap::default(),
+            mir_to_ir: Vec::new(),
         }
     }
 
-    fn finish(self) -> Module {
-        self.builder.build()
+    fn finish(self) -> (Module, sonatina_codegen::object::FrontendProvenanceMap, Vec<MirToIrEntry>) {
+        (self.builder.build(), self.frontend_provenance, self.mir_to_ir)
     }
 
     fn inst_set(&self) -> &'static EvmInstSet {
@@ -293,7 +310,11 @@ impl<'db, 'a> ModuleLowerer<'db, 'a> {
             let body = function.instance(self.db).body(self.db);
             let func_ref = self.func_ref(function.instance(self.db))?;
             let ctx = FunctionLowerer::new(self, body, func_ref)?;
-            ctx.lower()?;
+            let result = ctx.lower_and_collect_provenance(func_ref)?;
+            for (func, inst, value) in result.provenance_entries {
+                self.frontend_provenance.insert((func, inst), value);
+            }
+            self.mir_to_ir.extend(result.mir_origins);
         }
         Ok(())
     }
@@ -795,6 +816,8 @@ struct FunctionLowerer<'ctx, 'db, 'a> {
     empty_revert_block: Option<BlockId>,
     overflow_panic_block: Option<BlockId>,
     division_by_zero_panic_block: Option<BlockId>,
+    inst_provenance: FxHashMap<sonatina_ir::InstId, common::source_ord::SourceOrd>,
+    inst_mir_origin: Vec<(sonatina_ir::InstId, u32, u32, common::source_ord::SourceOrd)>,
 }
 
 #[derive(Clone, Copy)]
@@ -853,10 +876,23 @@ impl<'ctx, 'db, 'a> FunctionLowerer<'ctx, 'db, 'a> {
             empty_revert_block: None,
             overflow_panic_block: None,
             division_by_zero_panic_block: None,
+            inst_provenance: FxHashMap::default(),
+            inst_mir_origin: Vec::new(),
         })
     }
 
-    fn lower(mut self) -> Result<(), LowerError> {
+    fn lower_and_collect_provenance(
+        mut self,
+        func_ref: FuncRef,
+    ) -> Result<ProvenanceResult, LowerError> {
+        self.lower_inner()?;
+        let result = self.build_frontend_provenance(func_ref);
+        self.fb.seal_all();
+        self.fb.finish();
+        Ok(result)
+    }
+
+    fn lower_inner(&mut self) -> Result<(), LowerError> {
         let entry_block = self.block_id(RBlockId::from_u32(0))?;
         self.fb.switch_to_block(self.prologue_block);
         self.initialize_locals().map_err(|err| {
@@ -881,6 +917,12 @@ impl<'ctx, 'db, 'a> FunctionLowerer<'ctx, 'db, 'a> {
                 .switch_to_block(self.block_id(RBlockId::from_u32(idx as u32))?);
             let mut terminated = false;
             for (stmt_idx, stmt) in block.stmts.iter().enumerate() {
+                let source_ord = block
+                    .stmt_sources
+                    .get(stmt_idx)
+                    .copied()
+                    .unwrap_or_default();
+                let inst_before = self.fb.last_inst();
                 if matches!(
                     self.lower_stmt(stmt).map_err(|err| {
                         self.with_body_context(
@@ -895,15 +937,20 @@ impl<'ctx, 'db, 'a> FunctionLowerer<'ctx, 'db, 'a> {
                     })?,
                     Lowered::Terminated
                 ) {
+                    self.tag_new_insts(inst_before, source_ord, idx as u32, stmt_idx as u32);
                     self.pending_enum_proof = None;
                     terminated = true;
                     break;
                 }
+                self.tag_new_insts(inst_before, source_ord, idx as u32, stmt_idx as u32);
             }
             if terminated {
                 continue;
             }
             self.pending_enum_proof = None;
+            let term_source = block.terminator_source;
+            let term_stmt = block.stmts.len() as u32;
+            let inst_before = self.fb.last_inst();
             self.lower_terminator(&block.terminator).map_err(|err| {
                 self.with_body_context(
                     format!(
@@ -915,10 +962,74 @@ impl<'ctx, 'db, 'a> FunctionLowerer<'ctx, 'db, 'a> {
                 )
                 .wrap(err)
             })?;
+            self.tag_new_insts(inst_before, term_source, idx as u32, term_stmt);
         }
-        self.fb.seal_all();
-        self.fb.finish();
         Ok(())
+    }
+
+    fn tag_new_insts(
+        &mut self,
+        inst_before: Option<sonatina_ir::InstId>,
+        source_ord: common::source_ord::SourceOrd,
+        mir_block: u32,
+        mir_stmt: u32,
+    ) {
+        let inst_after = self.fb.last_inst();
+        if inst_after == inst_before {
+            return;
+        }
+        if let Some(after) = inst_after {
+            let start = inst_before.map_or(0, |i| i.0 + 1);
+            for id in start..=after.0 {
+                let inst_id = sonatina_ir::InstId(id);
+                if !source_ord.is_default() {
+                    self.inst_provenance.insert(inst_id, source_ord);
+                }
+                self.inst_mir_origin
+                    .push((inst_id, mir_block, mir_stmt, source_ord));
+            }
+        }
+    }
+
+    fn build_frontend_provenance(
+        &self,
+        func_ref: FuncRef,
+    ) -> ProvenanceResult {
+        let source_table = &self.body.source_table;
+        let provenance_entries = self
+            .inst_provenance
+            .iter()
+            .filter_map(|(&inst_id, &source_ord)| {
+                let entry = source_table.get(source_ord)?;
+                Some((
+                    func_ref,
+                    inst_id,
+                    format!(
+                        "{}:{}:{}-{}:{}",
+                        entry.file_path,
+                        entry.start_line,
+                        entry.start_col,
+                        entry.end_line,
+                        entry.end_col,
+                    ),
+                ))
+            })
+            .collect();
+        let mir_origins = self
+            .inst_mir_origin
+            .iter()
+            .map(|&(inst_id, mir_block, mir_stmt, source_ord)| MirToIrEntry {
+                func: func_ref,
+                inst: inst_id,
+                mir_block,
+                mir_stmt,
+                source_ord,
+            })
+            .collect();
+        ProvenanceResult {
+            provenance_entries,
+            mir_origins,
+        }
     }
 
     fn block_id(&self, block: RBlockId) -> Result<BlockId, LowerError> {
@@ -1111,12 +1222,8 @@ impl<'ctx, 'db, 'a> FunctionLowerer<'ctx, 'db, 'a> {
                 self.lower_binary(*op, lhs, rhs, &lhs_class)?
             }
             RExpr::Cast { value, to } => {
-                let signed = self
-                    .body
-                    .value_class(*value)
-                    .is_some_and(RuntimeClass::is_signed_scalar);
                 let value = self.local_value(*value)?;
-                self.cast_scalar_with_signedness(value, scalar_ty(to), signed)?
+                self.cast_scalar(value, scalar_ty(to))?
             }
             RExpr::ConstRef { region, .. } => {
                 let gv = self.module.lower_const_region(*region)?;
@@ -1331,14 +1438,6 @@ impl<'ctx, 'db, 'a> FunctionLowerer<'ctx, 'db, 'a> {
                     .insert_inst_no_result(EvmMstore8::new(self.module.inst_set(), addr, value));
                 zero_for_type(&mut self.fb, Type::Unit)
             }
-            RuntimeBuiltin::Mcopy { dst, src, len } => {
-                let dst = self.local_value(*dst)?;
-                let src = self.local_value(*src)?;
-                let len = self.local_value(*len)?;
-                self.fb
-                    .insert_inst_no_result(EvmMcopy::new(self.module.inst_set(), dst, src, len));
-                zero_for_type(&mut self.fb, Type::Unit)
-            }
             RuntimeBuiltin::Msize => self
                 .fb
                 .insert_inst(EvmMsize::new(self.module.inst_set()), Type::I256),
@@ -1435,14 +1534,6 @@ impl<'ctx, 'db, 'a> FunctionLowerer<'ctx, 'db, 'a> {
                     Type::I256,
                 )
             }
-            RuntimeBuiltin::SignExtend { byte, value } => {
-                let byte = self.local_value(*byte)?;
-                let value = self.local_value(*value)?;
-                self.fb.insert_inst(
-                    EvmSignExtend::new(self.module.inst_set(), byte, value),
-                    Type::I256,
-                )
-            }
             RuntimeBuiltin::IntrinsicArith {
                 op,
                 checked,
@@ -1460,7 +1551,7 @@ impl<'ctx, 'db, 'a> FunctionLowerer<'ctx, 'db, 'a> {
                 let rhs = self.local_value(*rhs)?;
                 let lhs = self.cast_scalar(lhs, scalar_ty(class))?;
                 let rhs = self.cast_scalar(rhs, scalar_ty(class))?;
-                let signed = class.is_signed_int();
+                let signed = matches!(class.repr, ScalarRepr::Int { signed: true, .. });
                 match (op, signed) {
                     (SaturatingBinOp::Add, true) => self.fb.insert_saddsat(lhs, rhs),
                     (SaturatingBinOp::Add, false) => self.fb.insert_uaddsat(lhs, rhs),
@@ -1813,7 +1904,7 @@ impl<'ctx, 'db, 'a> FunctionLowerer<'ctx, 'db, 'a> {
             RuntimeIntrinsic::GenericSaturating { op, ty } => {
                 let prim = intrinsic_prim_from_ty(self.module.db, ty)?;
                 let op_ty = intrinsic_value_type(prim);
-                let signed = prim.is_signed_int();
+                let signed = prim_is_signed(prim);
                 let (lhs, rhs) = intrinsic_binary_args(self, args)?;
                 let lhs =
                     lower_intrinsic_operand(&mut self.fb, self.module.inst_set(), lhs, prim, op_ty);
@@ -1842,7 +1933,7 @@ impl<'ctx, 'db, 'a> FunctionLowerer<'ctx, 'db, 'a> {
         args: &[RLocalId],
     ) -> Result<ValueId, LowerError> {
         let op_ty = intrinsic_value_type(prim);
-        let signed = prim.is_signed_int();
+        let signed = prim_is_signed(prim);
         Ok(match op {
             NumericIntrinsicOp::Eq
             | NumericIntrinsicOp::Ne
@@ -3530,11 +3621,7 @@ impl<'ctx, 'db, 'a> FunctionLowerer<'ctx, 'db, 'a> {
         src: ValueId,
     ) -> Result<(), LowerError> {
         let value = match class {
-            RuntimeClass::Scalar(scalar) => self.cast_scalar_with_signedness(
-                src,
-                scalar_word_ty(scalar),
-                scalar.is_signed_int(),
-            ),
+            RuntimeClass::Scalar(scalar) => self.cast_scalar(src, scalar_word_ty(scalar)),
             RuntimeClass::Ref {
                 kind:
                     RefKind::Provider {
@@ -3591,23 +3678,29 @@ impl<'ctx, 'db, 'a> FunctionLowerer<'ctx, 'db, 'a> {
     }
 
     fn cast_scalar(&mut self, value: ValueId, ty: Type) -> Result<ValueId, LowerError> {
-        self.cast_scalar_with_signedness(value, ty, false)
-    }
-
-    fn cast_scalar_with_signedness(
-        &mut self,
-        value: ValueId,
-        ty: Type,
-        signed: bool,
-    ) -> Result<ValueId, LowerError> {
-        if self.fb.type_of(value) == ty {
+        let from = self.fb.type_of(value);
+        if from == ty {
             return Ok(value);
         }
         if ty == Type::I1 {
             return Ok(condition_to_i1(&mut self.fb, value, self.module.inst_set()));
         }
-        let is = self.module.inst_set();
-        Ok(cast_int_value(&mut self.fb, is, value, ty, signed))
+        if from == Type::I1 {
+            return Ok(self
+                .fb
+                .insert_inst(Zext::new(self.module.inst_set(), value, ty), ty));
+        }
+        let from_bits = int_bits(from);
+        let to_bits = int_bits(ty);
+        Ok(match from_bits.cmp(&to_bits) {
+            std::cmp::Ordering::Less => self
+                .fb
+                .insert_inst(Zext::new(self.module.inst_set(), value, ty), ty),
+            std::cmp::Ordering::Equal => value,
+            std::cmp::Ordering::Greater => self
+                .fb
+                .insert_inst(Trunc::new(self.module.inst_set(), value, ty), ty),
+        })
     }
 
     fn coerce_to_dst(
@@ -3740,7 +3833,7 @@ impl<'ctx, 'db, 'a> FunctionLowerer<'ctx, 'db, 'a> {
         let ty = self.module.ty_for_class(operand)?;
         let lhs = self.cast_scalar(lhs, ty)?;
         let rhs = self.cast_scalar(rhs, ty)?;
-        let signed = operand.is_signed_scalar();
+        let signed = scalar_is_signed(operand);
         Ok(match op {
             ArithBinOp::Add => {
                 let [raw, overflow] = if signed {
@@ -3991,7 +4084,7 @@ impl<'ctx, 'db, 'a> FunctionLowerer<'ctx, 'db, 'a> {
         let ty = self.module.ty_for_class(operand)?;
         let lhs = self.cast_scalar(lhs, ty)?;
         let rhs = self.cast_scalar(rhs, ty)?;
-        let signed = operand.is_signed_scalar();
+        let signed = scalar_is_signed(operand);
         Ok(match op {
             CompBinOp::Eq => self
                 .fb
@@ -4346,6 +4439,29 @@ fn scalar_word_ty<'db>(scalar: &ScalarClass<'db>) -> Type {
     }
 }
 
+fn scalar_is_signed(class: &RuntimeClass<'_>) -> bool {
+    matches!(
+        class,
+        RuntimeClass::Scalar(ScalarClass {
+            repr: ScalarRepr::Int { signed: true, .. },
+            ..
+        })
+    )
+}
+
+fn prim_is_signed(prim: PrimTy) -> bool {
+    matches!(
+        prim,
+        PrimTy::I8
+            | PrimTy::I16
+            | PrimTy::I32
+            | PrimTy::I64
+            | PrimTy::I128
+            | PrimTy::I256
+            | PrimTy::Isize
+    )
+}
+
 fn intrinsic_prim_from_ty<'db>(
     db: &'db DriverDataBase,
     ty: TyId<'db>,
@@ -4389,7 +4505,7 @@ fn lower_intrinsic_operand(
     if prim == PrimTy::Bool {
         condition_to_i1(fb, value, is)
     } else {
-        cast_int_value(fb, is, value, op_ty, prim.is_signed_int())
+        cast_int_value(fb, is, value, op_ty, prim_is_signed(prim))
     }
 }
 

--- a/crates/codegen/src/sonatina/lower_runtime.rs
+++ b/crates/codegen/src/sonatina/lower_runtime.rs
@@ -1832,6 +1832,23 @@ impl<'ctx, 'db, 'a> FunctionLowerer<'ctx, 'db, 'a> {
                 self.fb
                     .insert_inst(Shr::new(self.module.inst_set(), shift, word), Type::I256)
             }
+            RuntimeBuiltin::Mcopy { dst, src, len } => {
+                let dst = self.local_value(*dst)?;
+                let src = self.local_value(*src)?;
+                let len = self.local_value(*len)?;
+                self.fb.insert_inst_no_result(
+                    sonatina_ir::inst::evm::EvmMcopy::new(self.module.inst_set(), dst, src, len),
+                );
+                self.fb.make_imm_value(I256::zero())
+            }
+            RuntimeBuiltin::SignExtend { byte, value } => {
+                let byte = self.local_value(*byte)?;
+                let value = self.local_value(*value)?;
+                self.fb.insert_inst(
+                    sonatina_ir::inst::evm::EvmSignExtend::new(self.module.inst_set(), byte, value),
+                    Type::I256,
+                )
+            }
             RuntimeBuiltin::MakeContractFieldRef { slot, class, .. } => {
                 if matches!(
                     class,

--- a/crates/codegen/src/sonatina/mod.rs
+++ b/crates/codegen/src/sonatina/mod.rs
@@ -1263,4 +1263,161 @@ fn test_add() {
             }
         }
     }
+
+    #[test]
+    fn debug_explorer_end_to_end() {
+        use sonatina_ir::ir_writer::ModuleWriter;
+
+        let mut db = DriverDataBase::default();
+        let file_url = temp_fixture_url("explorer_test.fe");
+        let source = r#"fn add(x: u256, y: u256) -> u256 {
+    return x + y
+}
+
+fn double(x: u256) -> u256 {
+    return add(x, x)
+}
+
+#[test]
+fn test_double() {
+    assert(double(5) == 10)
+}
+"#;
+        db.workspace().touch(
+            &mut db,
+            file_url.clone(),
+            Some(source.to_string()),
+        );
+        let file = db
+            .workspace()
+            .get(&db, &file_url)
+            .expect("file should be loaded");
+        let top_mod = db.top_mod(file);
+
+        let package = mir::build_test_runtime_package(&db, top_mod, None)
+            .expect("should build test package");
+
+        // MIR dump
+        let mir_dump = mir::runtime::pretty::format_runtime_package(&db, &package);
+
+        // Compile with provenance
+        let (mut module, provenance, mir_to_ir) =
+            compile_runtime_package_sonatina_full(&db, &package, crate::EVM_LAYOUT)
+                .expect("should compile");
+
+        // Sonatina IR dump (pre-opt)
+        let sonatina_ir_dump = ModuleWriter::new(&module).dump_string();
+
+        // Optimize
+        run_sonatina_optimization_pipeline(&mut module, OptLevel::O0);
+
+        // Sonatina IR dump (post-opt)
+        let sonatina_ir_opt_dump = ModuleWriter::new(&module).dump_string();
+
+        // Compile to bytecode with observability
+        let mut options = sonatina_codegen::object::CompileOptions::default();
+        options.emit_observability = true;
+        let mut vcfg = sonatina_verifier::VerifierConfig::for_level(
+            sonatina_verifier::VerificationLevel::Full,
+        );
+        vcfg.allow_detached_entities = true;
+        options.verifier_cfg = vcfg;
+        let artifacts = sonatina_codegen::object::compile_all_objects(
+            &module,
+            &sonatina_codegen::isa::evm::EvmBackend::new(create_evm_isa()),
+            &options,
+        )
+        .expect("should compile to bytecode");
+
+        // Collect function names
+        let func_names: Vec<(u32, String)> = package
+            .functions(&db)
+            .into_iter()
+            .map(|f| {
+                (
+                    provenance
+                        .keys()
+                        .find(|(fr, _)| {
+                            module
+                                .ctx
+                                .get_sig(*fr)
+                                .is_some_and(|sig| sig.name() == f.symbol(&db))
+                        })
+                        .map(|(fr, _)| fr.as_u32())
+                        .unwrap_or(0),
+                    f.symbol(&db).clone(),
+                )
+            })
+            .collect();
+        let func_name_refs: Vec<(u32, &str)> =
+            func_names.iter().map(|(id, n)| (*id, n.as_str())).collect();
+
+        // Build source tables
+        let source_tables_owned: Vec<(u32, common::source_ord::FunctionSourceTable)> = package
+            .functions(&db)
+            .into_iter()
+            .filter_map(|f| {
+                let instance = f.instance(&db);
+                let body = instance.body(&db);
+                let table = body.source_table.clone();
+                if table.is_empty() {
+                    return None;
+                }
+                let func_id = func_name_refs
+                    .iter()
+                    .find(|(_, name)| *name == f.symbol(&db))
+                    .map(|(id, _)| *id)
+                    .unwrap_or(0);
+                Some((func_id, table))
+            })
+            .collect();
+        let source_table_refs: Vec<(u32, &common::source_ord::FunctionSourceTable)> =
+            source_tables_owned.iter().map(|(id, t)| (*id, t)).collect();
+
+        // Generate the multi-representation SCIP index
+        let scip_json = crate::debug_explorer::generate_multi_rep_scip(
+            source,
+            "explorer_test.fe",
+            &mir_dump,
+            &sonatina_ir_dump,
+            &sonatina_ir_opt_dump,
+            &artifacts,
+            &provenance,
+            &mir_to_ir,
+            &source_table_refs,
+            &func_name_refs,
+        );
+
+        assert!(scip_json.contains("\"source\""));
+        assert!(scip_json.contains("\"mir\""));
+        assert!(scip_json.contains("\"bytecode\""));
+        assert!(scip_json.contains("\"sonatina_ir\""));
+
+        // Write files to temp dir for manual inspection
+        let out_dir = std::env::temp_dir().join("fe-debug-explorer");
+        std::fs::create_dir_all(&out_dir).ok();
+        std::fs::write(out_dir.join("debug.json"), &scip_json)
+            .expect("should write JSON");
+        let explorer_js_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../fe-web/assets/fe-debug-explorer.js");
+        let explorer_js = std::fs::read_to_string(&explorer_js_path)
+            .expect("should read fe-debug-explorer.js");
+        std::fs::write(out_dir.join("fe-debug-explorer.js"), explorer_js)
+            .expect("should write JS");
+        let html = format!(
+            r#"<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>Fe Debug Explorer</title></head>
+<body style="margin:0;height:100vh;background:#11111b">
+<script src="fe-debug-explorer.js"></script>
+<fe-debug-explorer src="debug.json" style="width:100%;height:100vh"></fe-debug-explorer>
+</body></html>"#
+        );
+        std::fs::write(out_dir.join("index.html"), &html)
+            .expect("should write HTML");
+
+        eprintln!(
+            "\n  Debug explorer written to: {}\n  Open index.html in a browser.\n",
+            out_dir.display()
+        );
+    }
 }

--- a/crates/codegen/src/sonatina/mod.rs
+++ b/crates/codegen/src/sonatina/mod.rs
@@ -164,7 +164,7 @@ fn run_sonatina_optimization_pipeline(module: &mut Module, opt_level: OptLevel) 
     match opt_level {
         OptLevel::O0 => {}
         OptLevel::Os => sonatina_codegen::optim::Pipeline::size().run(module),
-        OptLevel::O2 => sonatina_codegen::optim::Pipeline::speed().run(module),
+        OptLevel::O1 | OptLevel::O2 => sonatina_codegen::optim::Pipeline::speed().run(module),
     }
 }
 
@@ -783,7 +783,6 @@ pub fn emit_test_module_sonatina(
             hir_name: metadata.hir_name,
             symbol_name: section.entry.symbol(db).clone(),
             object_name: object.name(db).clone(),
-            yul: String::new(),
             bytecode: wrap_as_init_code(&runtime.bytes),
             sonatina_observability_json: artifact.observability_json(),
             value_param_count: 0,

--- a/crates/codegen/src/sonatina/mod.rs
+++ b/crates/codegen/src/sonatina/mod.rs
@@ -258,16 +258,35 @@ pub fn compile_runtime_package_sonatina(
     package: &RuntimePackage<'_>,
     layout: TargetDataLayout,
 ) -> Result<Module, LowerError> {
-    let (module, _provenance) =
+    let (module, _provenance, _mir_to_ir) =
         lower_runtime::compile_runtime_package_sonatina(db, package, layout)?;
     Ok(module)
 }
+
+pub use lower_runtime::MirToIrEntry;
 
 pub fn compile_runtime_package_sonatina_with_provenance(
     db: &DriverDataBase,
     package: &RuntimePackage<'_>,
     layout: TargetDataLayout,
 ) -> Result<(Module, sonatina_codegen::object::FrontendProvenanceMap), LowerError> {
+    let (module, provenance, _mir_to_ir) =
+        lower_runtime::compile_runtime_package_sonatina(db, package, layout)?;
+    Ok((module, provenance))
+}
+
+pub fn compile_runtime_package_sonatina_full(
+    db: &DriverDataBase,
+    package: &RuntimePackage<'_>,
+    layout: TargetDataLayout,
+) -> Result<
+    (
+        Module,
+        sonatina_codegen::object::FrontendProvenanceMap,
+        Vec<MirToIrEntry>,
+    ),
+    LowerError,
+> {
     lower_runtime::compile_runtime_package_sonatina(db, package, layout)
 }
 

--- a/crates/codegen/src/sonatina/mod.rs
+++ b/crates/codegen/src/sonatina/mod.rs
@@ -8,7 +8,10 @@ use hir::hir_def::{HirIngot, TopLevelMod};
 use mir::runtime::ir::RuntimePackagePlan;
 use mir::{RuntimePackage, build_runtime_package, build_test_runtime_package};
 use rustc_hash::FxHashSet;
-use sonatina_codegen::{EvmCompile, OptLevel as SonatinaOptLevel};
+use sonatina_codegen::{
+    isa::evm::EvmBackend,
+    object::{CompileOptions, ObjectArtifact, compile_all_objects},
+};
 use sonatina_ir::{
     Module,
     ir_writer::{FuncWriter, ModuleWriter},
@@ -157,39 +160,52 @@ fn diagnostic_func_ref(location: &Location) -> Option<FuncRef> {
     }
 }
 
-fn to_sonatina_opt_level(opt_level: OptLevel) -> SonatinaOptLevel {
+fn run_sonatina_optimization_pipeline(module: &mut Module, opt_level: OptLevel) {
     match opt_level {
-        OptLevel::O0 => SonatinaOptLevel::O0,
-        OptLevel::O1 => SonatinaOptLevel::O1,
-        OptLevel::Os => SonatinaOptLevel::Os,
-        OptLevel::O2 => SonatinaOptLevel::O2,
+        OptLevel::O0 => {}
+        OptLevel::Os => sonatina_codegen::optim::Pipeline::size().run(module),
+        OptLevel::O2 => sonatina_codegen::optim::Pipeline::speed().run(module),
     }
 }
 
-fn evm_compile(module: Module, opt_level: OptLevel, emit_observability: bool) -> EvmCompile {
-    EvmCompile::new(module)
-        .with_opt_level(to_sonatina_opt_level(opt_level))
-        .with_observability(emit_observability)
-}
-
-fn format_object_compile_errors(errors: &[sonatina_codegen::object::ObjectCompileError]) -> String {
-    errors
-        .iter()
-        .map(|error| format!("{error:?}"))
-        .collect::<Vec<_>>()
-        .join("; ")
-}
-
-fn compile_runtime_objects(
-    module: Module,
-    opt_level: OptLevel,
+fn compile_all_runtime_objects(
+    module: &Module,
     emit_observability: bool,
-) -> Result<Vec<sonatina_codegen::object::ObjectArtifact>, LowerError> {
-    let mut compile = evm_compile(module, opt_level, emit_observability);
-    ensure_module_sonatina_ir_valid(compile.optimize())?;
-    compile
-        .compile()
-        .map_err(|errors| LowerError::Internal(format_object_compile_errors(&errors)))
+    provenance: Option<&sonatina_codegen::object::FrontendProvenanceMap>,
+) -> Result<Vec<ObjectArtifact>, LowerError> {
+    let mut options = CompileOptions::default();
+    let mut verifier_cfg = VerifierConfig::for_level(VerificationLevel::Full);
+    verifier_cfg.allow_detached_entities = true;
+    options.verifier_cfg = verifier_cfg;
+    options.emit_observability = emit_observability;
+    let mut artifacts =
+        compile_all_objects(module, &EvmBackend::new(create_evm_isa()), &options).map_err(
+            |errors| {
+                LowerError::Internal(
+                    errors
+                        .iter()
+                        .map(|error| format!("{error:?}"))
+                        .collect::<Vec<_>>()
+                        .join("; "),
+                )
+            },
+        )?;
+    if let Some(provenance) = provenance {
+        for artifact in &mut artifacts {
+            for section in artifact.sections.values_mut() {
+                if let Some(observability) = &mut section.observability {
+                    for entry in &mut observability.pc_map {
+                        if let Some(ir_inst) = entry.ir_inst {
+                            if let Some(value) = provenance.get(&(entry.func, ir_inst)) {
+                                entry.frontend_provenance = Some(value.clone());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    Ok(artifacts)
 }
 
 fn section_name_for_runtime(name: &mir::RuntimeSectionName) -> sonatina_ir::SectionName {
@@ -242,6 +258,35 @@ pub fn compile_runtime_package_sonatina(
     package: &RuntimePackage<'_>,
     layout: TargetDataLayout,
 ) -> Result<Module, LowerError> {
+    let (module, _provenance, _mir_to_ir) =
+        lower_runtime::compile_runtime_package_sonatina(db, package, layout)?;
+    Ok(module)
+}
+
+pub use lower_runtime::MirToIrEntry;
+
+pub fn compile_runtime_package_sonatina_with_provenance(
+    db: &DriverDataBase,
+    package: &RuntimePackage<'_>,
+    layout: TargetDataLayout,
+) -> Result<(Module, sonatina_codegen::object::FrontendProvenanceMap), LowerError> {
+    let (module, provenance, _mir_to_ir) =
+        lower_runtime::compile_runtime_package_sonatina(db, package, layout)?;
+    Ok((module, provenance))
+}
+
+pub fn compile_runtime_package_sonatina_full(
+    db: &DriverDataBase,
+    package: &RuntimePackage<'_>,
+    layout: TargetDataLayout,
+) -> Result<
+    (
+        Module,
+        sonatina_codegen::object::FrontendProvenanceMap,
+        Vec<MirToIrEntry>,
+    ),
+    LowerError,
+> {
     lower_runtime::compile_runtime_package_sonatina(db, package, layout)
 }
 
@@ -330,8 +375,7 @@ fn filter_runtime_package_to_root_objects<'db>(
         .iter()
         .map(|object| object.name(db).clone())
         .collect::<FxHashSet<_>>();
-    let package_objects = package.objects(db);
-    let section_set = reachable_sections(db, &package_objects, roots);
+    let section_set = reachable_sections(db, roots);
     let objects = package
         .objects(db)
         .into_iter()
@@ -339,9 +383,7 @@ fn filter_runtime_package_to_root_objects<'db>(
             let sections = object
                 .sections(db)
                 .into_iter()
-                .filter(|section| {
-                    section_set.contains(&runtime_section_key(db, object, &section.name))
-                })
+                .filter(|section| section_set.contains(&(object, section.name.clone())))
                 .collect::<Vec<_>>();
             (!sections.is_empty())
                 .then(|| mir::RuntimeObject::new(db, object.name(db).clone(), sections))
@@ -362,7 +404,7 @@ fn filter_runtime_package_to_root_objects<'db>(
     let code_regions = package
         .code_regions(db)
         .into_iter()
-        .filter(|region| section_set.contains(&section_ref_key(db, region.source(db))))
+        .filter(|region| section_set.contains(&section_ref_key(region.source(db))))
         .collect::<Vec<_>>();
     let root_objects = package
         .objects(db)
@@ -403,9 +445,8 @@ fn filter_runtime_package_to_root_objects<'db>(
 
 fn reachable_sections<'db>(
     db: &'db dyn mir::MirDb,
-    objects: &[mir::RuntimeObject<'db>],
     roots: &[mir::RuntimeObject<'db>],
-) -> FxHashSet<(String, mir::RuntimeSectionName)> {
+) -> FxHashSet<(mir::RuntimeObject<'db>, mir::RuntimeSectionName)> {
     let mut seen = FxHashSet::default();
     let mut queue = roots
         .iter()
@@ -413,50 +454,32 @@ fn reachable_sections<'db>(
             object
                 .sections(db)
                 .into_iter()
-                .map(|section| runtime_section_key(db, *object, &section.name))
+                .map(|section| (*object, section.name))
         })
         .collect::<VecDeque<_>>();
-    while let Some((object_name, section_name)) = queue.pop_front() {
-        if !seen.insert((object_name.clone(), section_name.clone())) {
+    while let Some((object, section_name)) = queue.pop_front() {
+        if !seen.insert((object, section_name.clone())) {
             continue;
         }
-        for section in objects
-            .iter()
-            .flat_map(|object| {
-                object
-                    .sections(db)
-                    .into_iter()
-                    .map(move |section| (*object, section))
-            })
-            .filter(|(object, _)| object.name(db) == object_name)
-            .filter(|(_, section)| section.name == section_name)
-            .map(|(_, section)| section)
+        for section in object
+            .sections(db)
+            .into_iter()
+            .filter(|section| section.name == section_name)
         {
             for embed in section.embeds {
-                queue.push_back(section_ref_key(db, embed.source));
+                queue.push_back(section_ref_key(embed.source));
             }
         }
     }
     seen
 }
 
-fn runtime_section_key<'db>(
-    db: &'db dyn mir::MirDb,
-    object: mir::RuntimeObject<'db>,
-    section: &mir::RuntimeSectionName,
-) -> (String, mir::RuntimeSectionName) {
-    (object.name(db).clone(), section.clone())
-}
-
 fn section_ref_key<'db>(
-    db: &'db dyn mir::MirDb,
     section_ref: mir::RuntimeSectionRef<'db>,
-) -> (String, mir::RuntimeSectionName) {
+) -> (mir::RuntimeObject<'db>, mir::RuntimeSectionName) {
     match section_ref {
         mir::RuntimeSectionRef::Local { object, section }
-        | mir::RuntimeSectionRef::External { object, section } => {
-            runtime_section_key(db, object, &section)
-        }
+        | mir::RuntimeSectionRef::External { object, section } => (object, section),
     }
 }
 
@@ -514,12 +537,11 @@ pub fn emit_runtime_package_sonatina_ir_optimized(
     opt_level: OptLevel,
 ) -> Result<String, LowerError> {
     ensure_runtime_package_has_roots(db, package, "Sonatina IR")?;
-    let module = compile_runtime_package_sonatina(db, package, layout)?;
+    let mut module = compile_runtime_package_sonatina(db, package, layout)?;
     ensure_module_sonatina_ir_valid(&module)?;
-    let mut compile = evm_compile(module, opt_level, false);
-    let optimized = compile.optimize();
-    ensure_module_sonatina_ir_valid(optimized)?;
-    let mut writer = ModuleWriter::new(optimized);
+    run_sonatina_optimization_pipeline(&mut module, opt_level);
+    ensure_module_sonatina_ir_valid(&module)?;
+    let mut writer = ModuleWriter::new(&module);
     Ok(writer.dump_string())
 }
 
@@ -530,9 +552,12 @@ pub fn emit_runtime_package_sonatina_bytecode(
     opt_level: OptLevel,
 ) -> Result<BTreeMap<String, SonatinaContractBytecode>, LowerError> {
     ensure_runtime_package_has_roots(db, package, "Sonatina bytecode")?;
-    let module = compile_runtime_package_sonatina(db, package, layout)?;
+    let (mut module, provenance) =
+        compile_runtime_package_sonatina_with_provenance(db, package, layout)?;
     ensure_module_sonatina_ir_valid(&module)?;
-    let artifacts = compile_runtime_objects(module, opt_level, false)?;
+    run_sonatina_optimization_pipeline(&mut module, opt_level);
+    ensure_module_sonatina_ir_valid(&module)?;
+    let artifacts = compile_all_runtime_objects(&module, false, Some(&provenance))?;
     let artifacts_by_name = artifacts
         .iter()
         .map(|artifact| (artifact.object.0.as_str(), artifact))
@@ -708,9 +733,17 @@ pub fn emit_test_module_sonatina(
     if package.root_objects(db).is_empty() {
         return Ok(TestModuleOutput { tests: Vec::new() });
     }
-    let module = compile_runtime_package_sonatina(db, &package, crate::EVM_LAYOUT)?;
+    let (mut module, provenance) =
+        compile_runtime_package_sonatina_with_provenance(db, &package, crate::EVM_LAYOUT)?;
     ensure_module_sonatina_ir_valid(&module)?;
-    let artifacts = compile_runtime_objects(module, opt_level, options.emit_observability)?;
+    run_sonatina_optimization_pipeline(&mut module, opt_level);
+    ensure_module_sonatina_ir_valid(&module)?;
+    let prov = if options.emit_observability {
+        Some(&provenance)
+    } else {
+        None
+    };
+    let artifacts = compile_all_runtime_objects(&module, options.emit_observability, prov)?;
     let artifacts_by_name = artifacts
         .iter()
         .map(|artifact| (artifact.object.0.as_str(), artifact))
@@ -750,6 +783,7 @@ pub fn emit_test_module_sonatina(
             hir_name: metadata.hir_name,
             symbol_name: section.entry.symbol(db).clone(),
             object_name: object.name(db).clone(),
+            yul: String::new(),
             bytecode: wrap_as_init_code(&runtime.bytes),
             sonatina_observability_json: artifact.observability_json(),
             value_param_count: 0,
@@ -796,14 +830,6 @@ mod tests {
     }
 
     #[test]
-    fn fe_opt_levels_map_to_sonatina_opt_levels() {
-        assert_eq!(to_sonatina_opt_level(OptLevel::O0), SonatinaOptLevel::O0);
-        assert_eq!(to_sonatina_opt_level(OptLevel::O1), SonatinaOptLevel::O1);
-        assert_eq!(to_sonatina_opt_level(OptLevel::Os), SonatinaOptLevel::Os);
-        assert_eq!(to_sonatina_opt_level(OptLevel::O2), SonatinaOptLevel::O2);
-    }
-
-    #[test]
     fn module_sonatina_bytecode_respects_contract_filter() {
         let mut db = DriverDataBase::default();
         let fixture_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -847,7 +873,7 @@ mod tests {
         let package = build_test_runtime_package(&db, top_mod, None)
             .expect("test runtime package should build");
 
-        let module = compile_runtime_package_sonatina(&db, &package, crate::EVM_LAYOUT)
+        let mut module = compile_runtime_package_sonatina(&db, &package, crate::EVM_LAYOUT)
             .expect("test runtime package should lower to Sonatina IR");
         let dumped = ModuleWriter::new(&module).dump_string();
         let map_helpers = dumped
@@ -877,8 +903,11 @@ mod tests {
         if let Err(err) = ensure_module_sonatina_ir_valid(&module) {
             panic!("pre-opt test module should verify: {err}\n\n{dumped}");
         }
-        compile_runtime_objects(module, OptLevel::O0, false)
-            .expect("test runtime package should compile");
+        run_sonatina_optimization_pipeline(&mut module, OptLevel::O0);
+        if let Err(err) = ensure_module_sonatina_ir_valid(&module) {
+            panic!("post-opt test module should verify: {err}\n\n{dumped}");
+        }
+        compile_all_runtime_objects(&module, false, None).expect("test runtime package should compile");
     }
 
     #[test]
@@ -899,15 +928,18 @@ mod tests {
         let package = build_test_runtime_package(&db, top_mod, None)
             .expect("test runtime package should build");
 
-        let module = compile_runtime_package_sonatina(&db, &package, crate::EVM_LAYOUT)
+        let mut module = compile_runtime_package_sonatina(&db, &package, crate::EVM_LAYOUT)
             .expect("test runtime package should lower to Sonatina IR");
         let dumped = ModuleWriter::new(&module).dump_string();
 
         if let Err(err) = ensure_module_sonatina_ir_valid(&module) {
             panic!("pre-opt test module should verify: {err}\n\n{dumped}");
         }
-        compile_runtime_objects(module, OptLevel::O0, false)
-            .expect("test runtime package should compile");
+        run_sonatina_optimization_pipeline(&mut module, OptLevel::O0);
+        if let Err(err) = ensure_module_sonatina_ir_valid(&module) {
+            panic!("post-opt test module should verify: {err}\n\n{dumped}");
+        }
+        compile_all_runtime_objects(&module, false, None).expect("test runtime package should compile");
     }
 
     #[test]
@@ -928,15 +960,18 @@ mod tests {
         let package = build_test_runtime_package(&db, top_mod, None)
             .expect("test runtime package should build");
 
-        let module = compile_runtime_package_sonatina(&db, &package, crate::EVM_LAYOUT)
+        let mut module = compile_runtime_package_sonatina(&db, &package, crate::EVM_LAYOUT)
             .expect("test runtime package should lower to Sonatina IR");
         let dumped = ModuleWriter::new(&module).dump_string();
 
         if let Err(err) = ensure_module_sonatina_ir_valid(&module) {
             panic!("pre-opt test module should verify: {err}\n\n{dumped}");
         }
-        compile_runtime_objects(module, OptLevel::O0, false)
-            .expect("test runtime package should compile");
+        run_sonatina_optimization_pipeline(&mut module, OptLevel::O0);
+        if let Err(err) = ensure_module_sonatina_ir_valid(&module) {
+            panic!("post-opt test module should verify: {err}\n\n{dumped}");
+        }
+        compile_all_runtime_objects(&module, false, None).expect("test runtime package should compile");
     }
 
     #[test]
@@ -981,5 +1016,252 @@ fn roundtrip() {
         .expect(
             "if branches that both return should lower without empty unreachable Sonatina blocks",
         );
+    }
+
+    #[test]
+    fn provenance_populates_frontend_provenance_in_observability() {
+        let mut db = DriverDataBase::default();
+        let file_url = temp_fixture_url("provenance_test.fe");
+        db.workspace().touch(
+            &mut db,
+            file_url.clone(),
+            Some(
+                r#"
+fn add(x: u256, y: u256) -> u256 {
+    return x + y
+}
+
+#[test]
+fn test_add() {
+    assert(add(1, 2) == 3)
+}
+"#
+                .to_string(),
+            ),
+        );
+        let file = db
+            .workspace()
+            .get(&db, &file_url)
+            .expect("file should be loaded");
+        let top_mod = db.top_mod(file);
+
+        let output = emit_test_module_sonatina(
+            &db,
+            top_mod,
+            OptLevel::O0,
+            SonatinaTestOptions {
+                emit_observability: true,
+            },
+            None,
+        )
+        .expect("test module should compile with observability");
+
+        let mut found_provenance = false;
+        let mut sample_provenance = String::new();
+        for test in &output.tests {
+            if let Some(json) = &test.sonatina_observability_json {
+                if let Some(start) = json.find("\"frontend_provenance\":\"") {
+                    let value_start = start + "\"frontend_provenance\":\"".len();
+                    if let Some(end) = json[value_start..].find('"') {
+                        sample_provenance = json[value_start..value_start + end].to_string();
+                        found_provenance = true;
+                        break;
+                    }
+                }
+            }
+        }
+
+        assert!(
+            found_provenance,
+            "expected at least one PcMapEntry with non-null frontend_provenance"
+        );
+
+        // Validate file:line:col-line:col format
+        let parts: Vec<&str> = sample_provenance.splitn(2, '-').collect();
+        assert_eq!(
+            parts.len(),
+            2,
+            "provenance should have start-end separated by '-', got: {sample_provenance}"
+        );
+        let start_parts: Vec<&str> = parts[0].rsplitn(3, ':').collect();
+        assert!(
+            start_parts.len() >= 3,
+            "start should be file:line:col, got: {}",
+            parts[0]
+        );
+        assert!(
+            start_parts[0].parse::<u32>().is_ok(),
+            "start col should be numeric, got: {}",
+            start_parts[0]
+        );
+        assert!(
+            start_parts[1].parse::<u32>().is_ok(),
+            "start line should be numeric, got: {}",
+            start_parts[1]
+        );
+    }
+
+    #[test]
+    fn provenance_works_with_contract_bytecode() {
+        let mut db = DriverDataBase::default();
+        let fixture_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../fe/tests/fixtures/cli_output/build/simple_contract.fe");
+        let fixture_source =
+            fs::read_to_string(&fixture_path).expect("simple_contract fixture should be readable");
+        let file_url = Url::from_file_path(&fixture_path).expect("fixture path should be absolute");
+        db.workspace()
+            .touch(&mut db, file_url.clone(), Some(fixture_source));
+        let file = db
+            .workspace()
+            .get(&db, &file_url)
+            .expect("file should be loaded");
+        let top_mod = db.top_mod(file);
+
+        let bytecodes =
+            emit_module_sonatina_bytecode(&db, top_mod, OptLevel::O0, None)
+                .expect("contract should compile");
+
+        assert!(
+            !bytecodes.is_empty(),
+            "should produce at least one contract bytecode"
+        );
+        for (name, bytecode) in &bytecodes {
+            assert!(
+                !bytecode.runtime.is_empty(),
+                "contract {name} should have runtime bytecode"
+            );
+        }
+    }
+
+    #[test]
+    fn provenance_round_trip_covers_source_lines() {
+        let mut db = DriverDataBase::default();
+        let file_url = temp_fixture_url("round_trip_test.fe");
+        let source = r#"
+fn add(x: u256, y: u256) -> u256 {
+    return x + y
+}
+
+fn double(x: u256) -> u256 {
+    return add(x, x)
+}
+
+#[test]
+fn test_double() {
+    assert(double(5) == 10)
+}
+"#;
+        db.workspace().touch(
+            &mut db,
+            file_url.clone(),
+            Some(source.to_string()),
+        );
+        let file = db
+            .workspace()
+            .get(&db, &file_url)
+            .expect("file should be loaded");
+        let top_mod = db.top_mod(file);
+
+        let output = emit_test_module_sonatina(
+            &db,
+            top_mod,
+            OptLevel::O0,
+            SonatinaTestOptions {
+                emit_observability: true,
+            },
+            None,
+        )
+        .expect("should compile");
+
+        // Collect all source lines mentioned in provenance
+        let mut attributed_lines: std::collections::BTreeSet<u32> =
+            std::collections::BTreeSet::new();
+        for test in &output.tests {
+            if let Some(json) = &test.sonatina_observability_json {
+                let mut search_from = 0;
+                while let Some(start) = json[search_from..].find("\"frontend_provenance\":\"") {
+                    let abs_start = search_from + start;
+                    let value_start = abs_start + "\"frontend_provenance\":\"".len();
+                    if let Some(end) = json[value_start..].find('"') {
+                        let prov = &json[value_start..value_start + end];
+                        if let Some((_, line)) = prov.rsplit_once('-').and_then(|(start_part, _)| {
+                            let (file_line, _col) = start_part.rsplit_once(':')?;
+                            let (_file, line) = file_line.rsplit_once(':')?;
+                            Some((_file, line.parse::<u32>().ok()?))
+                        }) {
+                            attributed_lines.insert(line);
+                        }
+                        search_from = value_start + end;
+                    } else {
+                        break;
+                    }
+                }
+            }
+        }
+
+        // Source has executable code on lines 3, 7, 12
+        // (return x + y, return add(x,x), assert(...))
+        assert!(
+            !attributed_lines.is_empty(),
+            "round-trip should attribute at least some source lines, got none"
+        );
+    }
+
+    #[test]
+    fn provenance_covers_majority_of_code_bytes() {
+        let mut db = DriverDataBase::default();
+        let file_url = temp_fixture_url("coverage_test.fe");
+        db.workspace().touch(
+            &mut db,
+            file_url.clone(),
+            Some(
+                r#"
+fn add(x: u256, y: u256) -> u256 {
+    return x + y
+}
+
+#[test]
+fn test_add() {
+    assert(add(1, 2) == 3)
+}
+"#
+                .to_string(),
+            ),
+        );
+        let file = db
+            .workspace()
+            .get(&db, &file_url)
+            .expect("file should be loaded");
+        let top_mod = db.top_mod(file);
+
+        let output = emit_test_module_sonatina(
+            &db,
+            top_mod,
+            OptLevel::O0,
+            SonatinaTestOptions {
+                emit_observability: true,
+            },
+            None,
+        )
+        .expect("test module should compile");
+
+        for test in &output.tests {
+            if let Some(json) = &test.sonatina_observability_json {
+                let total_provenance_count = json.matches("\"frontend_provenance\":\"").count();
+                let null_provenance_count =
+                    json.matches("\"frontend_provenance\":null").count();
+                let total = total_provenance_count + null_provenance_count;
+                if total > 0 {
+                    let coverage = total_provenance_count as f64 / total as f64;
+                    assert!(
+                        coverage > 0.3,
+                        "provenance coverage should be >30%, got {:.1}% ({}/{})",
+                        coverage * 100.0,
+                        total_provenance_count,
+                        total
+                    );
+                }
+            }
+        }
     }
 }

--- a/crates/codegen/src/sonatina/mod.rs
+++ b/crates/codegen/src/sonatina/mod.rs
@@ -1115,6 +1115,80 @@ fn test_add() {
     }
 
     #[test]
+    fn provenance_round_trip_covers_source_lines() {
+        let mut db = DriverDataBase::default();
+        let file_url = temp_fixture_url("round_trip_test.fe");
+        let source = r#"
+fn add(x: u256, y: u256) -> u256 {
+    return x + y
+}
+
+fn double(x: u256) -> u256 {
+    return add(x, x)
+}
+
+#[test]
+fn test_double() {
+    assert(double(5) == 10)
+}
+"#;
+        db.workspace().touch(
+            &mut db,
+            file_url.clone(),
+            Some(source.to_string()),
+        );
+        let file = db
+            .workspace()
+            .get(&db, &file_url)
+            .expect("file should be loaded");
+        let top_mod = db.top_mod(file);
+
+        let output = emit_test_module_sonatina(
+            &db,
+            top_mod,
+            OptLevel::O0,
+            SonatinaTestOptions {
+                emit_observability: true,
+            },
+            None,
+        )
+        .expect("should compile");
+
+        // Collect all source lines mentioned in provenance
+        let mut attributed_lines: std::collections::BTreeSet<u32> =
+            std::collections::BTreeSet::new();
+        for test in &output.tests {
+            if let Some(json) = &test.sonatina_observability_json {
+                let mut search_from = 0;
+                while let Some(start) = json[search_from..].find("\"frontend_provenance\":\"") {
+                    let abs_start = search_from + start;
+                    let value_start = abs_start + "\"frontend_provenance\":\"".len();
+                    if let Some(end) = json[value_start..].find('"') {
+                        let prov = &json[value_start..value_start + end];
+                        if let Some((_, line)) = prov.rsplit_once('-').and_then(|(start_part, _)| {
+                            let (file_line, _col) = start_part.rsplit_once(':')?;
+                            let (_file, line) = file_line.rsplit_once(':')?;
+                            Some((_file, line.parse::<u32>().ok()?))
+                        }) {
+                            attributed_lines.insert(line);
+                        }
+                        search_from = value_start + end;
+                    } else {
+                        break;
+                    }
+                }
+            }
+        }
+
+        // Source has executable code on lines 3, 7, 12
+        // (return x + y, return add(x,x), assert(...))
+        assert!(
+            !attributed_lines.is_empty(),
+            "round-trip should attribute at least some source lines, got none"
+        );
+    }
+
+    #[test]
     fn provenance_covers_majority_of_code_bytes() {
         let mut db = DriverDataBase::default();
         let file_url = temp_fixture_url("coverage_test.fe");

--- a/crates/codegen/src/sonatina/mod.rs
+++ b/crates/codegen/src/sonatina/mod.rs
@@ -258,35 +258,16 @@ pub fn compile_runtime_package_sonatina(
     package: &RuntimePackage<'_>,
     layout: TargetDataLayout,
 ) -> Result<Module, LowerError> {
-    let (module, _provenance, _mir_to_ir) =
+    let (module, _provenance) =
         lower_runtime::compile_runtime_package_sonatina(db, package, layout)?;
     Ok(module)
 }
-
-pub use lower_runtime::MirToIrEntry;
 
 pub fn compile_runtime_package_sonatina_with_provenance(
     db: &DriverDataBase,
     package: &RuntimePackage<'_>,
     layout: TargetDataLayout,
 ) -> Result<(Module, sonatina_codegen::object::FrontendProvenanceMap), LowerError> {
-    let (module, provenance, _mir_to_ir) =
-        lower_runtime::compile_runtime_package_sonatina(db, package, layout)?;
-    Ok((module, provenance))
-}
-
-pub fn compile_runtime_package_sonatina_full(
-    db: &DriverDataBase,
-    package: &RuntimePackage<'_>,
-    layout: TargetDataLayout,
-) -> Result<
-    (
-        Module,
-        sonatina_codegen::object::FrontendProvenanceMap,
-        Vec<MirToIrEntry>,
-    ),
-    LowerError,
-> {
     lower_runtime::compile_runtime_package_sonatina(db, package, layout)
 }
 
@@ -1131,80 +1112,6 @@ fn test_add() {
                 "contract {name} should have runtime bytecode"
             );
         }
-    }
-
-    #[test]
-    fn provenance_round_trip_covers_source_lines() {
-        let mut db = DriverDataBase::default();
-        let file_url = temp_fixture_url("round_trip_test.fe");
-        let source = r#"
-fn add(x: u256, y: u256) -> u256 {
-    return x + y
-}
-
-fn double(x: u256) -> u256 {
-    return add(x, x)
-}
-
-#[test]
-fn test_double() {
-    assert(double(5) == 10)
-}
-"#;
-        db.workspace().touch(
-            &mut db,
-            file_url.clone(),
-            Some(source.to_string()),
-        );
-        let file = db
-            .workspace()
-            .get(&db, &file_url)
-            .expect("file should be loaded");
-        let top_mod = db.top_mod(file);
-
-        let output = emit_test_module_sonatina(
-            &db,
-            top_mod,
-            OptLevel::O0,
-            SonatinaTestOptions {
-                emit_observability: true,
-            },
-            None,
-        )
-        .expect("should compile");
-
-        // Collect all source lines mentioned in provenance
-        let mut attributed_lines: std::collections::BTreeSet<u32> =
-            std::collections::BTreeSet::new();
-        for test in &output.tests {
-            if let Some(json) = &test.sonatina_observability_json {
-                let mut search_from = 0;
-                while let Some(start) = json[search_from..].find("\"frontend_provenance\":\"") {
-                    let abs_start = search_from + start;
-                    let value_start = abs_start + "\"frontend_provenance\":\"".len();
-                    if let Some(end) = json[value_start..].find('"') {
-                        let prov = &json[value_start..value_start + end];
-                        if let Some((_, line)) = prov.rsplit_once('-').and_then(|(start_part, _)| {
-                            let (file_line, _col) = start_part.rsplit_once(':')?;
-                            let (_file, line) = file_line.rsplit_once(':')?;
-                            Some((_file, line.parse::<u32>().ok()?))
-                        }) {
-                            attributed_lines.insert(line);
-                        }
-                        search_from = value_start + end;
-                    } else {
-                        break;
-                    }
-                }
-            }
-        }
-
-        // Source has executable code on lines 3, 7, 12
-        // (return x + y, return add(x,x), assert(...))
-        assert!(
-            !attributed_lines.is_empty(),
-            "round-trip should attribute at least some source lines, got none"
-        );
     }
 
     #[test]

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -10,6 +10,7 @@ pub mod ingot;
 pub mod layout;
 pub mod options;
 pub mod paths;
+pub mod source_ord;
 pub mod stdlib;
 pub mod urlext;
 

--- a/crates/common/src/source_ord.rs
+++ b/crates/common/src/source_ord.rs
@@ -106,6 +106,13 @@ impl FunctionSourceTable {
         self.entries.is_empty()
     }
 
+    pub fn iter(&self) -> impl Iterator<Item = (SourceOrd, &SourceEntry)> {
+        self.entries
+            .iter()
+            .enumerate()
+            .map(|(i, e)| (SourceOrd::new(i as u32), e))
+    }
+
     pub fn entries(&self) -> &[SourceEntry] {
         &self.entries
     }

--- a/crates/common/src/source_ord.rs
+++ b/crates/common/src/source_ord.rs
@@ -1,0 +1,112 @@
+use salsa::Update;
+
+pub fn byte_offset_to_line_col(text: &str, offset: u32) -> (u32, u32) {
+    let offset = offset as usize;
+    let mut line = 1u32;
+    let mut col = 1u32;
+    for (i, ch) in text.char_indices() {
+        if i >= offset {
+            break;
+        }
+        if ch == '\n' {
+            line += 1;
+            col = 1;
+        } else {
+            col += 1;
+        }
+    }
+    (line, col)
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Update)]
+pub struct SourceOrd(u32);
+
+const SOURCE_ORD_NONE: u32 = u32::MAX;
+
+impl Default for SourceOrd {
+    fn default() -> Self {
+        Self(SOURCE_ORD_NONE)
+    }
+}
+
+impl SourceOrd {
+    pub fn new(index: u32) -> Self {
+        Self(index)
+    }
+
+    pub fn is_default(self) -> bool {
+        self.0 == SOURCE_ORD_NONE
+    }
+
+    pub fn index(self) -> u32 {
+        self.0
+    }
+
+    pub fn as_raw(self) -> u32 {
+        self.0
+    }
+
+    pub fn from_raw(raw: u32) -> Self {
+        Self(raw)
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Update)]
+pub struct FunctionSourceTable {
+    entries: Vec<SourceEntry>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Update)]
+pub struct SourceEntry {
+    pub file_path: String,
+    pub start_line: u32,
+    pub start_col: u32,
+    pub end_line: u32,
+    pub end_col: u32,
+}
+
+impl FunctionSourceTable {
+    pub fn new() -> Self {
+        Self {
+            entries: Vec::new(),
+        }
+    }
+
+    pub fn push(
+        &mut self,
+        file_path: String,
+        start_line: u32,
+        start_col: u32,
+        end_line: u32,
+        end_col: u32,
+    ) -> SourceOrd {
+        let ord = SourceOrd::new(self.entries.len() as u32);
+        self.entries.push(SourceEntry {
+            file_path,
+            start_line,
+            start_col,
+            end_line,
+            end_col,
+        });
+        ord
+    }
+
+    pub fn get(&self, ord: SourceOrd) -> Option<&SourceEntry> {
+        if ord.is_default() {
+            return None;
+        }
+        self.entries.get(ord.index() as usize)
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    pub fn entries(&self) -> &[SourceEntry] {
+        &self.entries
+    }
+}

--- a/crates/fe-web/assets/fe-debug-explorer.js
+++ b/crates/fe-web/assets/fe-debug-explorer.js
@@ -1,0 +1,226 @@
+// <fe-debug-explorer> — Cross-representation debug info viewer.
+//
+// Renders 4 panels (source, MIR, Sonatina IR, bytecode) with
+// CSS-driven hover cross-highlighting. Hovering over any region
+// highlights all corresponding regions across all panels.
+//
+// Usage:
+//   <fe-debug-explorer data-payload="url-or-inline-json"></fe-debug-explorer>
+//
+// Payload JSON shape:
+// {
+//   "source": { "path": "test.fe", "code": "fn add(...) { ... }" },
+//   "mir": "bb0:\n  ...",
+//   "sonatina_ir": "func %add:\n  ...",
+//   "groups": [
+//     {
+//       "id": 0,
+//       "source_lines": [3, 4],
+//       "mir_stmts": [{ "func": 1, "block": 0, "stmt": 2 }],
+//       "ir_insts": [{ "func": 1, "inst": 5 }],
+//       "pc_ranges": [{ "start": 0, "end": 10, "func_name": "add" }]
+//     }
+//   ]
+// }
+
+class FeDebugExplorer extends HTMLElement {
+  constructor() {
+    super();
+    this._data = null;
+    this._activeGroups = new Set();
+  }
+
+  connectedCallback() {
+    var src = this.getAttribute("data-payload");
+    if (!src) return;
+
+    // Inline JSON or fetch URL
+    if (src.trim().startsWith("{")) {
+      this._data = JSON.parse(src);
+      this._render();
+    } else {
+      fetch(src)
+        .then(r => r.json())
+        .then(data => { this._data = data; this._render(); })
+        .catch(e => { this.textContent = "Failed to load payload: " + e; });
+    }
+  }
+
+  _render() {
+    var d = this._data;
+    if (!d) return;
+
+    var shadow = this.attachShadow({ mode: "open" });
+    shadow.innerHTML = `
+      <style>${_explorerCSS()}</style>
+      <div class="explorer">
+        <div class="panel" id="source-panel">
+          <h3>Fe Source</h3>
+          <pre><code>${this._renderSource(d)}</code></pre>
+        </div>
+        <div class="panel" id="mir-panel">
+          <h3>MIR</h3>
+          <pre><code>${_escHtml(d.mir || "")}</code></pre>
+        </div>
+        <div class="panel" id="ir-panel">
+          <h3>Sonatina IR</h3>
+          <pre><code>${_escHtml(d.sonatina_ir || "")}</code></pre>
+        </div>
+        <div class="panel" id="bytecode-panel">
+          <h3>EVM Bytecode</h3>
+          <pre><code>${this._renderBytecode(d)}</code></pre>
+        </div>
+      </div>
+    `;
+
+    var self = this;
+    shadow.addEventListener("mouseover", function(e) {
+      var el = e.target.closest("[data-groups]");
+      if (!el) return;
+      var groups = el.dataset.groups.split(" ").filter(Boolean);
+      if (!groups.length) return;
+      self._clearHighlights(shadow);
+      groups.forEach(function(g) { self._activeGroups.add(g); });
+      self._applyHighlights(shadow);
+    });
+
+    shadow.addEventListener("mouseout", function(e) {
+      var el = e.target.closest("[data-groups]");
+      if (!el) return;
+      self._clearHighlights(shadow);
+    });
+  }
+
+  _renderSource(d) {
+    if (!d.source || !d.source.code) return "";
+    var lines = d.source.code.split("\n");
+    var lineGroups = this._buildLineGroupMap(d);
+    var out = "";
+    for (var i = 0; i < lines.length; i++) {
+      var lineNum = i + 1;
+      var gClasses = (lineGroups[lineNum] || []).map(function(g) { return "g-" + g; }).join(" ");
+      var dataAttr = gClasses ? ' data-groups="' + gClasses + '"' : "";
+      var cls = "line" + (gClasses ? " " + gClasses : "");
+      out += '<span class="' + cls + '"' + dataAttr + '>';
+      out += _pad(lineNum, 3) + " " + _escHtml(lines[i]);
+      out += "</span>\n";
+    }
+    return out;
+  }
+
+  _renderBytecode(d) {
+    if (!d.groups) return "";
+    var pcGroups = {};
+    d.groups.forEach(function(group) {
+      (group.pc_ranges || []).forEach(function(pc) {
+        var key = pc.start + "-" + pc.end;
+        if (!pcGroups[key]) pcGroups[key] = { pc: pc, groups: [] };
+        pcGroups[key].groups.push(group.id);
+      });
+    });
+    var entries = Object.values(pcGroups);
+    entries.sort(function(a, b) { return a.pc.start - b.pc.start; });
+    var out = "";
+    entries.forEach(function(e) {
+      var gClasses = e.groups.map(function(g) { return "g-" + g; }).join(" ");
+      var dataAttr = gClasses ? ' data-groups="' + gClasses + '"' : "";
+      var cls = "line" + (gClasses ? " " + gClasses : "");
+      var hex = function(n) { return ("0000" + n.toString(16)).slice(-4); };
+      var label = e.pc.func_name || "";
+      out += '<span class="' + cls + '"' + dataAttr + '>';
+      out += "  [" + hex(e.pc.start) + ".." + hex(e.pc.end) + ") " + _escHtml(label);
+      out += "</span>\n";
+    });
+    return out;
+  }
+
+  _buildLineGroupMap(d) {
+    var map = {};
+    if (!d.groups) return map;
+    d.groups.forEach(function(group) {
+      (group.source_lines || []).forEach(function(line) {
+        if (!map[line]) map[line] = [];
+        map[line].push(group.id);
+      });
+    });
+    return map;
+  }
+
+  _applyHighlights(root) {
+    this._activeGroups.forEach(function(g) {
+      root.querySelectorAll("." + g).forEach(function(el) {
+        el.classList.add("highlighted");
+      });
+    });
+  }
+
+  _clearHighlights(root) {
+    this._activeGroups.forEach(function(g) {
+      root.querySelectorAll("." + g).forEach(function(el) {
+        el.classList.remove("highlighted");
+      });
+    });
+    this._activeGroups.clear();
+  }
+}
+
+function _escHtml(s) {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+function _pad(n, w) {
+  var s = "" + n;
+  while (s.length < w) s = " " + s;
+  return s;
+}
+
+function _explorerCSS() {
+  return `
+:host { display: block; width: 100%; height: 100%; }
+.explorer {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: 1fr 1fr;
+  height: 100%;
+  gap: 2px;
+  background: #11111b;
+  font-family: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
+}
+.panel {
+  background: #1e1e2e;
+  overflow: auto;
+  padding: 8px;
+}
+.panel h3 {
+  color: #89b4fa;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  margin-bottom: 8px;
+  position: sticky;
+  top: 0;
+  background: #1e1e2e;
+  padding: 4px 0;
+  z-index: 1;
+}
+pre { font-size: 12px; line-height: 1.6; color: #cdd6f4; margin: 0; }
+code { display: block; }
+.line {
+  display: block;
+  padding: 0 4px;
+  border-left: 2px solid transparent;
+  transition: background 0.12s ease, border-color 0.12s ease;
+  border-radius: 2px;
+  cursor: default;
+}
+.line.highlighted {
+  background: rgba(137, 180, 250, 0.15);
+  border-left-color: rgba(137, 180, 250, 0.5);
+}
+.line[data-groups]:hover {
+  background: rgba(137, 180, 250, 0.08);
+}
+  `;
+}
+
+customElements.define("fe-debug-explorer", FeDebugExplorer);

--- a/crates/fe-web/assets/fe-debug-explorer.js
+++ b/crates/fe-web/assets/fe-debug-explorer.js
@@ -1,171 +1,197 @@
-// <fe-debug-explorer> — Cross-representation debug info viewer.
+// <fe-debug-explorer> — Cross-representation debug viewer.
 //
-// Renders 4 panels (source, MIR, Sonatina IR, bytecode) with
-// CSS-driven hover cross-highlighting. Hovering over any region
-// highlights all corresponding regions across all panels.
+// Two panels (three on wide screens), each with a dropdown to select
+// which representation to view. Shared SCIP-style symbol classes
+// enable hover cross-highlighting across any pair of representations.
 //
-// Usage:
-//   <fe-debug-explorer data-payload="url-or-inline-json"></fe-debug-explorer>
+// Data: a multi-representation SCIP index where each "file" is a
+// representation (source, MIR, Sonatina IR, optimized IR, VCode,
+// assembly, bytecode). Symbols shared across files provide the
+// cross-level connections.
 //
-// Payload JSON shape:
-// {
-//   "source": { "path": "test.fe", "code": "fn add(...) { ... }" },
-//   "mir": "bb0:\n  ...",
-//   "sonatina_ir": "func %add:\n  ...",
-//   "groups": [
-//     {
-//       "id": 0,
-//       "source_lines": [3, 4],
-//       "mir_stmts": [{ "func": 1, "block": 0, "stmt": 2 }],
-//       "ir_insts": [{ "func": 1, "inst": 5 }],
-//       "pc_ranges": [{ "start": 0, "end": 10, "func_name": "add" }]
-//     }
-//   ]
-// }
+// Attributes:
+//   src — URL to fetch the SCIP index JSON
 
 class FeDebugExplorer extends HTMLElement {
   constructor() {
     super();
     this._data = null;
-    this._activeGroups = new Set();
+    this._activeHash = null;
   }
 
   connectedCallback() {
-    var src = this.getAttribute("data-payload");
-    if (!src) return;
-
-    // Inline JSON or fetch URL
-    if (src.trim().startsWith("{")) {
-      this._data = JSON.parse(src);
-      this._render();
-    } else {
-      fetch(src)
-        .then(r => r.json())
-        .then(data => { this._data = data; this._render(); })
-        .catch(e => { this.textContent = "Failed to load payload: " + e; });
+    var src = this.getAttribute("src");
+    if (!src) {
+      this._data = this._tryInlineData();
+      if (this._data) this._render();
+      return;
     }
+    var self = this;
+    fetch(src)
+      .then(function(r) { return r.json(); })
+      .then(function(data) { self._data = data; self._render(); })
+      .catch(function(e) { self.textContent = "Failed to load: " + e; });
+  }
+
+  _tryInlineData() {
+    var script = this.querySelector("script[type='application/json']");
+    if (script) return JSON.parse(script.textContent);
+    return null;
   }
 
   _render() {
     var d = this._data;
-    if (!d) return;
+    if (!d || !d.files) return;
 
     var shadow = this.attachShadow({ mode: "open" });
-    shadow.innerHTML = `
-      <style>${_explorerCSS()}</style>
-      <div class="explorer">
-        <div class="panel" id="source-panel">
-          <h3>Fe Source</h3>
-          <pre><code>${this._renderSource(d)}</code></pre>
-        </div>
-        <div class="panel" id="mir-panel">
-          <h3>MIR</h3>
-          <pre><code>${_escHtml(d.mir || "")}</code></pre>
-        </div>
-        <div class="panel" id="ir-panel">
-          <h3>Sonatina IR</h3>
-          <pre><code>${_escHtml(d.sonatina_ir || "")}</code></pre>
-        </div>
-        <div class="panel" id="bytecode-panel">
-          <h3>EVM Bytecode</h3>
-          <pre><code>${this._renderBytecode(d)}</code></pre>
-        </div>
-      </div>
-    `;
+    var repNames = Object.keys(d.files);
+    var defaultLeft = repNames[0] || "";
+    var defaultRight = repNames.length > 1 ? repNames[1] : defaultLeft;
+    var defaultMiddle = repNames.length > 2 ? repNames[2] : "";
+
+    shadow.innerHTML =
+      "<style>" + _css() + "</style>" +
+      '<div class="explorer">' +
+        this._panelHtml("left", repNames, defaultLeft) +
+        this._panelHtml("middle", repNames, defaultMiddle) +
+        this._panelHtml("right", repNames, defaultRight) +
+      "</div>";
+
+    this._bindPanel(shadow, "left");
+    this._bindPanel(shadow, "middle");
+    this._bindPanel(shadow, "right");
 
     var self = this;
     shadow.addEventListener("mouseover", function(e) {
-      var el = e.target.closest("[data-groups]");
+      var el = e.target.closest("[data-sym]");
       if (!el) return;
-      var groups = el.dataset.groups.split(" ").filter(Boolean);
-      if (!groups.length) return;
-      self._clearHighlights(shadow);
-      groups.forEach(function(g) { self._activeGroups.add(g); });
-      self._applyHighlights(shadow);
+      self._highlight(shadow, el.dataset.sym);
     });
-
     shadow.addEventListener("mouseout", function(e) {
-      var el = e.target.closest("[data-groups]");
+      var el = e.target.closest("[data-sym]");
       if (!el) return;
-      self._clearHighlights(shadow);
+      self._unhighlight(shadow);
     });
   }
 
-  _renderSource(d) {
-    if (!d.source || !d.source.code) return "";
-    var lines = d.source.code.split("\n");
-    var lineGroups = this._buildLineGroupMap(d);
+  _panelHtml(id, repNames, selected) {
+    var opts = "";
+    for (var i = 0; i < repNames.length; i++) {
+      var sel = repNames[i] === selected ? " selected" : "";
+      opts += '<option value="' + _esc(repNames[i]) + '"' + sel + '>' +
+              _esc(_displayName(repNames[i])) + '</option>';
+    }
+    return '<div class="panel" data-panel="' + id + '">' +
+      '<div class="panel-header">' +
+        '<select class="rep-select">' + opts + '</select>' +
+      '</div>' +
+      '<pre><code class="panel-content"></code></pre>' +
+    '</div>';
+  }
+
+  _bindPanel(shadow, id) {
+    var panel = shadow.querySelector('[data-panel="' + id + '"]');
+    var select = panel.querySelector(".rep-select");
+    var content = panel.querySelector(".panel-content");
+    var self = this;
+
+    function update() {
+      var rep = select.value;
+      content.innerHTML = self._renderRep(rep);
+    }
+    select.addEventListener("change", update);
+    update();
+  }
+
+  _renderRep(repName) {
+    var file = this._data.files[repName];
+    if (!file) return "";
+    var code = file.contents || "";
+    var occurrences = file.occurrences || [];
+
+    // Build a map of (line, col) → { symbol, endCol }
+    var spanMap = {};
+    for (var i = 0; i < occurrences.length; i++) {
+      var occ = occurrences[i];
+      var key = occ.line + ":" + occ.col;
+      spanMap[key] = { symbol: occ.symbol, endCol: occ.endCol || (occ.col + 1) };
+    }
+
+    var lines = code.split("\n");
     var out = "";
-    for (var i = 0; i < lines.length; i++) {
-      var lineNum = i + 1;
-      var gClasses = (lineGroups[lineNum] || []).map(function(g) { return "g-" + g; }).join(" ");
-      var dataAttr = gClasses ? ' data-groups="' + gClasses + '"' : "";
-      var cls = "line" + (gClasses ? " " + gClasses : "");
-      out += '<span class="' + cls + '"' + dataAttr + '>';
-      out += _pad(lineNum, 3) + " " + _escHtml(lines[i]);
-      out += "</span>\n";
+    for (var ln = 0; ln < lines.length; ln++) {
+      var lineNum = ln + 1;
+      var line = lines[ln];
+      var annotated = this._annotateLine(line, lineNum, spanMap);
+      out += '<span class="line">' + _pad(lineNum, 4) + " " + annotated + "</span>\n";
     }
     return out;
   }
 
-  _renderBytecode(d) {
-    if (!d.groups) return "";
-    var pcGroups = {};
-    d.groups.forEach(function(group) {
-      (group.pc_ranges || []).forEach(function(pc) {
-        var key = pc.start + "-" + pc.end;
-        if (!pcGroups[key]) pcGroups[key] = { pc: pc, groups: [] };
-        pcGroups[key].groups.push(group.id);
-      });
-    });
-    var entries = Object.values(pcGroups);
-    entries.sort(function(a, b) { return a.pc.start - b.pc.start; });
-    var out = "";
-    entries.forEach(function(e) {
-      var gClasses = e.groups.map(function(g) { return "g-" + g; }).join(" ");
-      var dataAttr = gClasses ? ' data-groups="' + gClasses + '"' : "";
-      var cls = "line" + (gClasses ? " " + gClasses : "");
-      var hex = function(n) { return ("0000" + n.toString(16)).slice(-4); };
-      var label = e.pc.func_name || "";
-      out += '<span class="' + cls + '"' + dataAttr + '>';
-      out += "  [" + hex(e.pc.start) + ".." + hex(e.pc.end) + ") " + _escHtml(label);
-      out += "</span>\n";
-    });
-    return out;
+  _annotateLine(line, lineNum, spanMap) {
+    // Collect spans on this line
+    var spans = [];
+    for (var key in spanMap) {
+      var parts = key.split(":");
+      if (parseInt(parts[0]) === lineNum) {
+        var col = parseInt(parts[1]);
+        spans.push({ col: col, endCol: spanMap[key].endCol, symbol: spanMap[key].symbol });
+      }
+    }
+    if (spans.length === 0) return _esc(line);
+
+    spans.sort(function(a, b) { return a.col - b.col; });
+
+    var result = "";
+    var pos = 0;
+    for (var i = 0; i < spans.length; i++) {
+      var s = spans[i];
+      var startIdx = s.col - 1;
+      var endIdx = s.endCol - 1;
+      if (startIdx < 0) startIdx = 0;
+      if (endIdx > line.length) endIdx = line.length;
+      if (startIdx > pos) {
+        result += _esc(line.substring(pos, startIdx));
+      }
+      var hash = _djb2(s.symbol);
+      var text = line.substring(startIdx, endIdx);
+      result += '<span class="sym sym-' + hash + '" data-sym="' + hash + '">' +
+                _esc(text) + '</span>';
+      pos = endIdx;
+    }
+    if (pos < line.length) {
+      result += _esc(line.substring(pos));
+    }
+    return result;
   }
 
-  _buildLineGroupMap(d) {
-    var map = {};
-    if (!d.groups) return map;
-    d.groups.forEach(function(group) {
-      (group.source_lines || []).forEach(function(line) {
-        if (!map[line]) map[line] = [];
-        map[line].push(group.id);
-      });
-    });
-    return map;
-  }
-
-  _applyHighlights(root) {
-    this._activeGroups.forEach(function(g) {
-      root.querySelectorAll("." + g).forEach(function(el) {
-        el.classList.add("highlighted");
-      });
+  _highlight(root, hash) {
+    this._unhighlight(root);
+    this._activeHash = hash;
+    root.querySelectorAll(".sym-" + hash).forEach(function(el) {
+      el.classList.add("hl");
     });
   }
 
-  _clearHighlights(root) {
-    this._activeGroups.forEach(function(g) {
-      root.querySelectorAll("." + g).forEach(function(el) {
-        el.classList.remove("highlighted");
-      });
+  _unhighlight(root) {
+    if (!this._activeHash) return;
+    root.querySelectorAll(".sym-" + this._activeHash).forEach(function(el) {
+      el.classList.remove("hl");
     });
-    this._activeGroups.clear();
+    this._activeHash = null;
   }
 }
 
-function _escHtml(s) {
-  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+function _djb2(str) {
+  var hash = 5381;
+  for (var i = 0; i < str.length; i++) {
+    hash = ((hash << 5) + hash + str.charCodeAt(i)) & 0xffffffff;
+  }
+  return ("000000" + (hash >>> 0).toString(16)).slice(-6);
+}
+
+function _esc(s) {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
 }
 
 function _pad(n, w) {
@@ -174,51 +200,56 @@ function _pad(n, w) {
   return s;
 }
 
-function _explorerCSS() {
+function _displayName(repName) {
+  var names = {
+    "source": "Fe Source",
+    "mir": "MIR",
+    "sonatina_ir": "Sonatina IR",
+    "sonatina_ir_opt": "Sonatina IR (optimized)",
+    "vcode": "VCode",
+    "asm": "EVM Assembly",
+    "bytecode": "EVM Bytecode"
+  };
+  return names[repName] || repName;
+}
+
+function _css() {
   return `
 :host { display: block; width: 100%; height: 100%; }
 .explorer {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  grid-template-rows: 1fr 1fr;
   height: 100%;
   gap: 2px;
   background: #11111b;
   font-family: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
 }
-.panel {
-  background: #1e1e2e;
-  overflow: auto;
-  padding: 8px;
+@media (min-width: 1400px) {
+  .explorer { grid-template-columns: 1fr 1fr 1fr; }
+  .panel[data-panel="middle"] { display: block; }
 }
-.panel h3 {
-  color: #89b4fa;
-  font-size: 11px;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-  margin-bottom: 8px;
-  position: sticky;
-  top: 0;
-  background: #1e1e2e;
-  padding: 4px 0;
-  z-index: 1;
+.panel { background: #1e1e2e; overflow: auto; display: flex; flex-direction: column; }
+.panel[data-panel="middle"] { display: none; }
+.panel-header {
+  position: sticky; top: 0; z-index: 1;
+  background: #1e1e2e; padding: 6px 8px; border-bottom: 1px solid #313244;
 }
-pre { font-size: 12px; line-height: 1.6; color: #cdd6f4; margin: 0; }
+.rep-select {
+  background: #313244; color: #cdd6f4; border: 1px solid #45475a;
+  border-radius: 4px; padding: 4px 8px; font-size: 11px;
+  font-family: inherit; cursor: pointer; width: 100%;
+}
+.rep-select:focus { outline: 1px solid #89b4fa; }
+pre { font-size: 12px; line-height: 1.6; color: #cdd6f4; margin: 0; padding: 8px; flex: 1; }
 code { display: block; }
-.line {
-  display: block;
-  padding: 0 4px;
-  border-left: 2px solid transparent;
-  transition: background 0.12s ease, border-color 0.12s ease;
-  border-radius: 2px;
-  cursor: default;
+.line { display: block; padding: 0 4px; border-radius: 2px; }
+.sym {
+  transition: background 0.12s ease;
+  border-radius: 2px; cursor: default;
 }
-.line.highlighted {
-  background: rgba(137, 180, 250, 0.15);
-  border-left-color: rgba(137, 180, 250, 0.5);
-}
-.line[data-groups]:hover {
-  background: rgba(137, 180, 250, 0.08);
+.sym.hl {
+  background: rgba(137, 180, 250, 0.2);
+  outline: 1px solid rgba(137, 180, 250, 0.3);
 }
   `;
 }

--- a/crates/fe-web/examples/debug-explorer.html
+++ b/crates/fe-web/examples/debug-explorer.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Fe Debug Explorer</title>
+<style>
+  body { margin: 0; height: 100vh; background: #11111b; overflow: hidden; }
+  .dropzone {
+    display: flex; align-items: center; justify-content: center;
+    height: 100vh; color: #6c7086; font-family: sans-serif; font-size: 14px;
+    flex-direction: column; gap: 12px;
+  }
+  .dropzone.hidden { display: none; }
+  .dropzone input[type="file"] { display: none; }
+  .dropzone label {
+    padding: 8px 16px; background: #313244; color: #cdd6f4;
+    border-radius: 6px; cursor: pointer; font-size: 13px;
+  }
+  .dropzone label:hover { background: #45475a; }
+  .dropzone p { color: #585b70; font-size: 12px; }
+</style>
+</head>
+<body>
+
+<div class="dropzone" id="dropzone">
+  <div>Load a <code>.debug.json</code> multi-representation SCIP index</div>
+  <label for="file-input">Choose file</label>
+  <input type="file" id="file-input" accept=".json">
+  <p>Or drag &amp; drop a JSON file here</p>
+  <p style="margin-top: 24px; max-width: 400px; text-align: center; line-height: 1.5">
+    Generate with: <code style="background:#313244;padding:2px 6px;border-radius:3px">
+    cargo test -p fe-codegen --lib -- debug_explorer_end_to_end</code>
+    <br>then load <code>/tmp/fe-debug-explorer/debug.json</code>
+  </p>
+</div>
+
+<script src="../assets/fe-debug-explorer.js"></script>
+
+<script>
+var dropzone = document.getElementById("dropzone");
+var fileInput = document.getElementById("file-input");
+
+function loadFile(file) {
+  var reader = new FileReader();
+  reader.onload = function(e) {
+    dropzone.classList.add("hidden");
+    var el = document.createElement("fe-debug-explorer");
+    el.style.width = "100%";
+    el.style.height = "100vh";
+    var script = document.createElement("script");
+    script.type = "application/json";
+    script.textContent = e.target.result;
+    el.appendChild(script);
+    document.body.appendChild(el);
+  };
+  reader.readAsText(file);
+}
+
+fileInput.addEventListener("change", function(e) {
+  if (e.target.files.length > 0) loadFile(e.target.files[0]);
+});
+
+document.body.addEventListener("dragover", function(e) {
+  e.preventDefault();
+  dropzone.style.borderColor = "#89b4fa";
+});
+
+document.body.addEventListener("drop", function(e) {
+  e.preventDefault();
+  if (e.dataTransfer.files.length > 0) loadFile(e.dataTransfer.files[0]);
+});
+
+// Auto-load from URL param: ?src=path/to/debug.json
+var params = new URLSearchParams(window.location.search);
+var src = params.get("src");
+if (src) {
+  dropzone.classList.add("hidden");
+  var el = document.createElement("fe-debug-explorer");
+  el.style.width = "100%";
+  el.style.height = "100vh";
+  el.setAttribute("src", src);
+  document.body.appendChild(el);
+}
+</script>
+
+</body>
+</html>

--- a/crates/mir/src/instance/runtime.rs
+++ b/crates/mir/src/instance/runtime.rs
@@ -92,6 +92,14 @@ impl<'db> RuntimeInstance<'db> {
     ) -> Vec<crate::runtime::RuntimeCodeRegion<'db>> {
         expect_lowered_runtime_body(db, self).referenced_code_regions(db)
     }
+
+    #[salsa::tracked(return_ref)]
+    pub fn source_table(
+        self,
+        db: &'db dyn MirDb,
+    ) -> common::source_ord::FunctionSourceTable {
+        expect_lowered_runtime_body(db, self).body(db).source_table.clone()
+    }
 }
 
 pub(crate) fn runtime_interface_signature_for_key<'db>(

--- a/crates/mir/src/runtime/ir.rs
+++ b/crates/mir/src/runtime/ir.rs
@@ -573,6 +573,7 @@ pub struct RuntimeBody<'db> {
     pub provider_bindings: Vec<RuntimeProviderBinding<'db>>,
     pub locals: Vec<RLocal<'db>>,
     pub blocks: Vec<RBlock<'db>>,
+    pub source_table: common::source_ord::FunctionSourceTable,
 }
 
 impl<'db> RuntimeBody<'db> {
@@ -669,7 +670,9 @@ pub struct RuntimeParam<'db> {
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Update)]
 pub struct RBlock<'db> {
     pub stmts: Vec<RStmt<'db>>,
+    pub stmt_sources: Vec<common::source_ord::SourceOrd>,
     pub terminator: RTerminator<'db>,
+    pub terminator_source: common::source_ord::SourceOrd,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Update)]

--- a/crates/mir/src/runtime/lower/body.rs
+++ b/crates/mir/src/runtime/lower/body.rs
@@ -273,6 +273,8 @@ pub(super) struct RmirEmitter<'db> {
     pub(super) locals: Vec<RLocal<'db>>,
     pub(super) blocks: Vec<RBlock<'db>>,
     pub(super) terminated_blocks: Vec<bool>,
+    pub(super) source_table: common::source_ord::FunctionSourceTable,
+    pub(super) cur_source: common::source_ord::SourceOrd,
 }
 
 enum LoweredBuiltinCall<'db> {
@@ -425,6 +427,8 @@ impl<'db> RmirEmitter<'db> {
             locals,
             blocks,
             terminated_blocks,
+            source_table: common::source_ord::FunctionSourceTable::new(),
+            cur_source: common::source_ord::SourceOrd::default(),
         }
     }
 
@@ -432,7 +436,9 @@ impl<'db> RmirEmitter<'db> {
         while self.blocks.len() < self.semantic_body.blocks.len() {
             self.blocks.push(RBlock {
                 stmts: Vec::new(),
+                stmt_sources: Vec::new(),
                 terminator: RTerminator::Return(None),
+                terminator_source: common::source_ord::SourceOrd::default(),
             });
         }
         RuntimeBody {
@@ -443,7 +449,59 @@ impl<'db> RmirEmitter<'db> {
             provider_bindings: self.provider_bindings,
             locals: self.locals,
             blocks: self.blocks,
+            source_table: self.source_table,
         }
+    }
+
+    fn resolve_sem_origin(
+        &mut self,
+        origin: &hir::analysis::semantic::SemOrigin<'db>,
+    ) -> common::source_ord::SourceOrd {
+        use hir::analysis::semantic::SemOrigin;
+        use hir::span::LazySpan;
+
+        let default = common::source_ord::SourceOrd::default();
+
+        let Some(body) = self.semantic_body.template_owner.body(self.db) else {
+            return default;
+        };
+
+        let span = match origin {
+            SemOrigin::Expr(expr_id) => {
+                hir::span::lazy_spans::LazyExprSpan::new(body, *expr_id)
+                    .resolve(self.db)
+            }
+            SemOrigin::Stmt(stmt_id) => {
+                hir::span::lazy_spans::LazyStmtSpan::new(body, *stmt_id)
+                    .resolve(self.db)
+            }
+            SemOrigin::Body(_) | SemOrigin::Synthetic => {
+                return default;
+            }
+        };
+
+        let Some(span) = span else {
+            return default;
+        };
+
+        let file_path = span
+            .file
+            .path(self.db)
+            .as_ref()
+            .map(|p| p.to_string())
+            .or_else(|| span.file.url(self.db).map(|u| u.to_string()))
+            .unwrap_or_default();
+
+        let text = span.file.text(self.db);
+        let start_offset: u32 = span.range.start().into();
+        let end_offset: u32 = span.range.end().into();
+        let (start_line, start_col) =
+            common::source_ord::byte_offset_to_line_col(text, start_offset);
+        let (end_line, end_col) =
+            common::source_ord::byte_offset_to_line_col(text, end_offset);
+
+        self.source_table
+            .push(file_path, start_line, start_col, end_line, end_col)
     }
 
     fn layout_for_ty(&self, ty: TyId<'db>) -> LayoutId<'db> {
@@ -469,7 +527,9 @@ impl<'db> RmirEmitter<'db> {
         self.blocks = (0..self.semantic_body.blocks.len())
             .map(|_| RBlock {
                 stmts: Vec::new(),
+                stmt_sources: Vec::new(),
                 terminator: RTerminator::Return(None),
+                terminator_source: common::source_ord::SourceOrd::default(),
             })
             .collect();
         self.terminated_blocks = vec![false; self.semantic_body.blocks.len()];
@@ -477,19 +537,24 @@ impl<'db> RmirEmitter<'db> {
         for (idx, block) in blocks.iter().enumerate() {
             let bb = RBlockId::from_u32(idx as u32);
             for (stmt_idx, stmt) in block.stmts.iter().enumerate() {
+                self.cur_source = self.resolve_sem_origin(&stmt.origin);
                 self.lower_stmt(bb, stmt_idx, stmt);
                 if self.terminated_blocks[bb.index()] {
                     break;
                 }
             }
             if !self.terminated_blocks[bb.index()] {
-                self.blocks[bb.index()].terminator = self.lower_terminator(bb, &block.terminator);
+                self.cur_source = self.resolve_sem_origin(&block.terminator.origin);
+                let terminator = self.lower_terminator(bb, &block.terminator);
+                self.blocks[bb.index()].terminator = terminator;
+                self.blocks[bb.index()].terminator_source = self.cur_source;
             }
         }
     }
 
     fn set_terminator(&mut self, bb: RBlockId, terminator: RTerminator<'db>) {
         self.blocks[bb.index()].terminator = terminator;
+        self.blocks[bb.index()].terminator_source = self.cur_source;
         self.terminated_blocks[bb.index()] = true;
     }
 
@@ -4181,6 +4246,7 @@ impl<'db> RmirEmitter<'db> {
             provider_bindings: self.provider_bindings.clone(),
             locals: self.locals.clone(),
             blocks: Vec::new(),
+            source_table: common::source_ord::FunctionSourceTable::new(),
         };
         resolve_runtime_place_address_class(self.db, &program, &body, place)
             .unwrap_or_else(|err| panic!("invalid runtime place address class: {err:?}"))
@@ -4460,6 +4526,9 @@ impl<'db> RmirEmitter<'db> {
     fn push_stmt(&mut self, bb: RBlockId, stmt: RStmt<'db>) {
         if !self.terminated_blocks[bb.index()] {
             self.blocks[bb.index()].stmts.push(stmt);
+            self.blocks[bb.index()]
+                .stmt_sources
+                .push(self.cur_source);
         }
     }
 

--- a/crates/mir/src/runtime/synthetic.rs
+++ b/crates/mir/src/runtime/synthetic.rs
@@ -269,7 +269,9 @@ impl<'db> SyntheticBodyBuilder<'db> {
             locals: Vec::new(),
             blocks: vec![RBlock {
                 stmts: Vec::new(),
+                stmt_sources: Vec::new(),
                 terminator: RTerminator::Stop,
+                terminator_source: common::source_ord::SourceOrd::default(),
             }],
         }
     }
@@ -284,6 +286,7 @@ impl<'db> SyntheticBodyBuilder<'db> {
             provider_bindings: Vec::new(),
             locals: self.locals,
             blocks: self.blocks,
+            source_table: common::source_ord::FunctionSourceTable::new(),
         }
     }
 
@@ -1435,13 +1438,18 @@ impl<'db> SyntheticBodyBuilder<'db> {
 
     fn push_stmt(&mut self, bb: RBlockId, stmt: RStmt<'db>) {
         self.blocks[bb.index()].stmts.push(stmt);
+        self.blocks[bb.index()]
+            .stmt_sources
+            .push(common::source_ord::SourceOrd::default());
     }
 
     fn new_block(&mut self) -> RBlockId {
         let id = RBlockId::from_u32(self.blocks.len() as u32);
         self.blocks.push(RBlock {
             stmts: Vec::new(),
+            stmt_sources: Vec::new(),
             terminator: RTerminator::Trap,
+            terminator_source: common::source_ord::SourceOrd::default(),
         });
         id
     }


### PR DESCRIPTION
Resolves HIR spans during MIR lowering, carries them through Sonatina codegen, populates `PcMapEntry.frontend_provenance`. DWARF, ethdebug, and datalog emitters. Salsa-cached source tables. Cross-level MIR <> IR <> bytecode mappings.