### PR TITLE
Allow bool to integer casts

### DIFF
--- a/crates/fe/tests/fixtures/fe_test/const_numeric_extern_intrinsics.fe
+++ b/crates/fe/tests/fixtures/fe_test/const_numeric_extern_intrinsics.fe
@@ -96,4 +96,13 @@ fn const_numeric_extern_intrinsics() {
     assert(BOOL_XOR)
     assert(BOOL_EQ)
     assert(BOOL_NE)
+
+    let true_word: u256 = true as u256
+    let false_word: u256 = false as u256
+    let true_i32: i32 = true as i32
+    let false_u8: u8 = false as u8
+    assert(true_word == 1)
+    assert(false_word == 0)
+    assert(true_i32 == 1)
+    assert(false_u8 == 0)
 }

--- a/crates/hir/src/analysis/ty/ty_check/expr.rs
+++ b/crates/hir/src/analysis/ty/ty_check/expr.rs
@@ -588,11 +588,6 @@ impl<'db> TyChecker<'db> {
             return true;
         }
 
-        // Disallow casts involving `bool` unless they are identity (handled above).
-        if from.is_bool(self.db) || to.is_bool(self.db) {
-            return false;
-        }
-
         let from_leaf = self.peel_transparent_newtypes(from);
         let to_leaf = self.peel_transparent_newtypes(to);
 
@@ -600,8 +595,11 @@ impl<'db> TyChecker<'db> {
             return true;
         }
 
-        // Disallow casts involving `bool` through wrappers.
-        if from_leaf.is_bool(self.db) || to_leaf.is_bool(self.db) {
+        if from_leaf.is_bool(self.db) {
+            return self.prim_int_signed_bits(to_leaf).is_some();
+        }
+
+        if to_leaf.is_bool(self.db) {
             return false;
         }
 

--- a/crates/uitest/fixtures/ty_check/cast_invalid.snap
+++ b/crates/uitest/fixtures/ty_check/cast_invalid.snap
@@ -20,14 +20,6 @@ error[8-0055]: cast is not provably lossless
   = try using `.downcast()` for checked narrowing/sign changes, or `.downcast_truncate()` / `.downcast_saturate()` / `.downcast_unchecked()`
 
 error[8-0055]: cast is not provably lossless
-   ┌─ cast_invalid.fe:10:5
-   │
-10 │     x as u8
-   │     ^^^^^^^ cannot cast `bool` to `u8` with `as`
-   │
-   = casts involving `bool` are not supported
-
-error[8-0055]: cast is not provably lossless
    ┌─ cast_invalid.fe:14:5
    │
 14 │     256 as u8

--- a/newsfragments/1445.feature.md
+++ b/newsfragments/1445.feature.md
@@ -1,0 +1,1 @@
+Lossless `bool` to integer casts with `as` are now allowed.


### PR DESCRIPTION
Needed for efficient branchless code in uniswap, eg solady implementation of most/leastSignificantBit.