### PR TITLE
Fix expression short-circuit lowering

### DIFF
--- a/crates/codegen/tests/fixtures/logical_ops.fe
+++ b/crates/codegen/tests/fixtures/logical_ops.fe
@@ -1,3 +1,11 @@
-pub fn logical_ops() -> bool {
-    true && false
+fn logical_or(_ value: u8) -> bool {
+    value == 255 || value + 1 > 0
+}
+
+fn logical_and(_ value: u8) -> bool {
+    value != 255 && value + 1 > 0
+}
+
+pub fn logical_ops() -> (bool, bool) {
+    (logical_or(255), logical_and(255))
 }

--- a/crates/codegen/tests/fixtures/sonatina_ir/logical_ops.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/logical_ops.snap
@@ -5,12 +5,95 @@ input_file: crates/codegen/tests/fixtures/logical_ops.fe
 ---
 target = "evm-ethereum-osaka"
 
-func private %logical_ops() -> i1 {
+type @layout_0 = {i1, i1};
+
+func private %logical_and(v0.i8) -> i1 {
+    block0:
+        v1.*i8 = alloca i8;
+        mstore v1 v0 i8;
+        jump block1;
+
+    block1:
+        v2.i8 = mload v1 i8;
+        v4.i1 = eq v2 -1.i8;
+        v5.i1 = is_zero v4;
+        br v5 block5 block3;
+
+    block2:
+        jump block4;
+
+    block3:
+        jump block4;
+
+    block4:
+        v8.i1 = phi (1.i1 block2) (0.i1 block3);
+        return v8;
+
+    block5:
+        v9.i8 = mload v1 i8;
+        (v11.i8, v12.i1) = uaddo v9 1.i8;
+        br v12 block6 block7;
+
+    block6:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block7:
+        v19.i1 = gt v11 0.i8;
+        br v19 block2 block3;
+}
+
+func private %logical_ops() -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        return 0.i1;
+        v1.i1 = call %logical_or -1.i8;
+        v2.i1 = call %logical_and -1.i8;
+        v3.objref<@layout_0> = obj.alloc @layout_0;
+        v5.objref<i1> = obj.proj v3 0.i256;
+        obj.store v5 v1;
+        v7.objref<i1> = obj.proj v3 1.i256;
+        obj.store v7 v2;
+        v8.@layout_0 = obj.load v3;
+        return v8;
+}
+
+func private %logical_or(v0.i8) -> i1 {
+    block0:
+        v1.*i8 = alloca i8;
+        mstore v1 v0 i8;
+        jump block1;
+
+    block1:
+        v2.i8 = mload v1 i8;
+        v4.i1 = eq v2 -1.i8;
+        br v4 block2 block5;
+
+    block2:
+        jump block4;
+
+    block3:
+        jump block4;
+
+    block4:
+        v7.i1 = phi (1.i1 block2) (0.i1 block3);
+        return v7;
+
+    block5:
+        v8.i8 = mload v1 i8;
+        (v10.i8, v11.i1) = uaddo v8 1.i8;
+        br v11 block6 block7;
+
+    block6:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block7:
+        v18.i1 = gt v10 0.i8;
+        br v18 block2 block3;
 }
 
 func private %main_root() {
@@ -18,7 +101,7 @@ func private %main_root() {
         jump block1;
 
     block1:
-        v0.i1 = call %logical_ops;
+        v0.@layout_0 = call %logical_ops;
         evm_stop;
 }
 

--- a/crates/fe/tests/fixtures/fe_test/logical_short_circuit_expr.fe
+++ b/crates/fe/tests/fixtures/fe_test/logical_short_circuit_expr.fe
@@ -1,0 +1,15 @@
+#[test]
+fn logical_or_expression_skips_rhs_overflow() {
+    let value: u8 = 255
+    let result = value == 255 || value + 1 > 0
+
+    assert(result)
+}
+
+#[test]
+fn logical_and_expression_skips_rhs_overflow() {
+    let value: u8 = 255
+    let result = value != 255 && value + 1 > 0
+
+    assert(!result)
+}

--- a/crates/hir/src/analysis/semantic/lower/body.rs
+++ b/crates/hir/src/analysis/semantic/lower/body.rs
@@ -530,6 +530,9 @@ impl<'a, 'db> SmirLowerCtxt<'a, 'db> {
                 if self.typed_body.semantic_expr_lowering(expr).is_some() {
                     return self.lower_call_like_expr(expr, ty, Some(*lhs), &[*rhs]);
                 }
+                if matches!(op, BinOp::Logical(_)) {
+                    return self.lower_logical_expr(expr);
+                }
                 let lhs = self.lower_expr_operand(*lhs);
                 let rhs = self.lower_expr_operand(*rhs);
                 self.emit_expr_with_origin(origin, ty, SExpr::Binary { op: *op, lhs, rhs })
@@ -1275,6 +1278,93 @@ impl<'a, 'db> SmirLowerCtxt<'a, 'db> {
         }
         self.switch_to(join_bb);
         result
+    }
+
+    fn lower_logical_expr(&mut self, expr: ExprId) -> SValueId {
+        // This deliberately lowers expression-context `&&` and `||` through a
+        // simple true/false/join CFG, matching condition lowering and keeping
+        // RHS evaluation lazy. The pre-opt Sonatina IR has extra constant
+        // assignment blocks, but normal Sonatina optimization collapses this
+        // shape and can use the LHS branch fact to simplify checked RHS
+        // arithmetic. A cleaner Fe-side lowering could instead thread the
+        // destination temp through recursive logical lowering and assign
+        // directly on each short-circuit edge, e.g. `a || b` writes `true` from
+        // the LHS-true edge and only lowers/assigns `b` on the LHS-false edge.
+        let result = self.alloc_temp(TyId::bool(self.db));
+        let true_bb = self.new_block();
+        let false_bb = self.new_block();
+        let join_bb = self.new_block();
+        let mut join_reachable = false;
+
+        self.lower_expr_branch(expr, true_bb, false_bb);
+
+        self.switch_to(true_bb);
+        if !self.is_terminated(self.current) {
+            join_reachable = true;
+            let value = self.emit_expr_with_origin(
+                SemOrigin::Expr(expr),
+                TyId::bool(self.db),
+                SExpr::Const(SConst::Value(bool_const(self.db, true))),
+            );
+            self.push_synthetic_stmt(SStmtKind::Assign {
+                dst: result,
+                expr: SExpr::Forward(SOperand::synthetic(value)),
+            });
+            self.set_synthetic_terminator(self.current, STerminatorKind::Goto(join_bb));
+        }
+
+        self.switch_to(false_bb);
+        if !self.is_terminated(self.current) {
+            join_reachable = true;
+            let value = self.emit_expr_with_origin(
+                SemOrigin::Expr(expr),
+                TyId::bool(self.db),
+                SExpr::Const(SConst::Value(bool_const(self.db, false))),
+            );
+            self.push_synthetic_stmt(SStmtKind::Assign {
+                dst: result,
+                expr: SExpr::Forward(SOperand::synthetic(value)),
+            });
+            self.set_synthetic_terminator(self.current, STerminatorKind::Goto(join_bb));
+        }
+
+        if !join_reachable {
+            self.set_synthetic_terminator(join_bb, STerminatorKind::Goto(join_bb));
+        }
+        self.switch_to(join_bb);
+        result
+    }
+
+    fn lower_expr_branch(&mut self, expr: ExprId, then_bb: SBlockId, else_bb: SBlockId) {
+        let Partial::Present(expr_data) = expr.data(self.db, self.body) else {
+            panic!("cannot lower absent condition expression")
+        };
+
+        match expr_data {
+            Expr::Bin(lhs, rhs, BinOp::Logical(LogicalBinOp::And)) => {
+                let rhs_bb = self.new_block();
+                self.lower_expr_branch(*lhs, rhs_bb, else_bb);
+                self.switch_to(rhs_bb);
+                self.lower_expr_branch(*rhs, then_bb, else_bb);
+            }
+            Expr::Bin(lhs, rhs, BinOp::Logical(LogicalBinOp::Or)) => {
+                let rhs_bb = self.new_block();
+                self.lower_expr_branch(*lhs, then_bb, rhs_bb);
+                self.switch_to(rhs_bb);
+                self.lower_expr_branch(*rhs, then_bb, else_bb);
+            }
+            _ => {
+                let cond = self.lower_expr(expr);
+                self.set_synthetic_terminator(
+                    self.current,
+                    STerminatorKind::Branch {
+                        cond: SOperand::expr(cond, expr),
+                        then_bb,
+                        else_bb,
+                    },
+                );
+            }
+        }
     }
 
     fn lower_match_expr(

--- a/newsfragments/1447.bugfix.md
+++ b/newsfragments/1447.bugfix.md
@@ -1,0 +1,1 @@
+Fixed expression-context `&&` and `||` lowering so right-hand side expressions are only evaluated when short-circuiting requires them.


### PR DESCRIPTION
This would cause an overflow revert:
```
let value: u8 = 255
let ok = value != 255 && value + 1 > 0
```