### PR TITLE
mir: lower DynString literals to a single CODECOPY

### DIFF
--- a/crates/codegen/src/sonatina/lower_runtime.rs
+++ b/crates/codegen/src/sonatina/lower_runtime.rs
@@ -95,7 +95,7 @@ struct ModuleLowerer<'db, 'a> {
     layout_names: FxHashMap<LayoutId<'db>, String>,
     const_globals: FxHashMap<ConstRegionId<'db>, GlobalVariableRef>,
     const_names: FxHashMap<ConstRegionId<'db>, String>,
-    explicit_code_region_sections: FxHashSet<(mir::RuntimeObject<'db>, mir::RuntimeSectionName)>,
+    const_data_sections: FxHashSet<(mir::RuntimeObject<'db>, mir::RuntimeSectionName)>,
 }
 
 impl<'db, 'a> ModuleLowerer<'db, 'a> {
@@ -117,7 +117,7 @@ impl<'db, 'a> ModuleLowerer<'db, 'a> {
             layout_names: FxHashMap::default(),
             const_globals: FxHashMap::default(),
             const_names: FxHashMap::default(),
-            explicit_code_region_sections: FxHashSet::default(),
+            const_data_sections: FxHashSet::default(),
         }
     }
 
@@ -344,8 +344,16 @@ impl<'db, 'a> ModuleLowerer<'db, 'a> {
     ) -> bool {
         matches!(section, mir::RuntimeSectionName::CodeRegion(_))
             || self
-                .explicit_code_region_sections
+                .const_data_sections
                 .contains(&(object, section.clone()))
+    }
+
+    fn mark_section_for_const_data(&mut self, section_ref: &mir::RuntimeSectionRef<'db>) {
+        let (object, section) = match section_ref {
+            mir::RuntimeSectionRef::Local { object, section }
+            | mir::RuntimeSectionRef::External { object, section } => (*object, section),
+        };
+        self.const_data_sections.insert((object, section.clone()));
     }
 
     fn mark_explicit_code_region(&mut self, region: mir::RuntimeCodeRegion<'db>) {
@@ -360,8 +368,7 @@ impl<'db, 'a> ModuleLowerer<'db, 'a> {
         match resolved.source(self.db) {
             mir::RuntimeSectionRef::Local { object, section }
             | mir::RuntimeSectionRef::External { object, section } => {
-                self.explicit_code_region_sections
-                    .insert((object, section.clone()));
+                self.const_data_sections.insert((object, section.clone()));
             }
         }
     }
@@ -1570,6 +1577,16 @@ impl<'ctx, 'db, 'a> FunctionLowerer<'ctx, 'db, 'a> {
                 let symbol = self.code_region_symbol_ref(*region);
                 self.fb
                     .insert_inst(SymSize::new(self.module.inst_set(), symbol), Type::I256)
+            }
+            RuntimeBuiltin::ConstRegionAddr { region } => {
+                for section in self.current_sections.clone() {
+                    self.module.mark_section_for_const_data(&section);
+                }
+                let gv = self.module.lower_const_region(*region)?;
+                self.fb.insert_inst(
+                    SymAddr::new(self.module.inst_set(), SymbolRef::Global(gv)),
+                    Type::I256,
+                )
             }
             RuntimeBuiltin::Malloc { size } => {
                 let size = self.local_value(*size)?;

--- a/crates/codegen/tests/sonatina_ir.rs
+++ b/crates/codegen/tests/sonatina_ir.rs
@@ -72,6 +72,30 @@ pub fn new_empty() -> Empty {
 }
 
 #[test]
+fn dynamic_string_literal_marks_main_section_for_const_data() {
+    let ir = with_top_mod_for_source(
+        "dynamic_string_literal_marks_main_section_for_const_data.fe",
+        r#"
+use std::evm::assert_msg
+
+pub fn main() {
+    assert_msg(false, "boom")
+}
+"#,
+        |db, top_mod| emit_module_sonatina_ir(db, top_mod).expect("Sonatina IR should emit"),
+    );
+
+    let main_object = ir
+        .split("object @main")
+        .nth(1)
+        .expect("main object should be emitted");
+    assert!(
+        ir.contains("evm_code_copy") && main_object.contains("data $const_region_"),
+        "DynString literals lowered with CODECOPY must embed their const region in main:\n{ir}"
+    );
+}
+
+#[test]
 fn sonatina_function_names_disambiguate_module_conflicts() {
     let ir = with_top_mod_for_source(
         "sonatina_function_names_disambiguate_module_conflicts.fe",

--- a/crates/hir/src/analysis/ty/ty_def.rs
+++ b/crates/hir/src/analysis/ty/ty_def.rs
@@ -328,7 +328,7 @@ impl<'db> TyId<'db> {
         Self::app(db, array, elem)
     }
 
-    pub(super) fn array_with_len(db: &'db dyn HirAnalysisDb, elem: TyId<'db>, len: usize) -> Self {
+    pub fn array_with_len(db: &'db dyn HirAnalysisDb, elem: TyId<'db>, len: usize) -> Self {
         let array = Self::array(db, elem);
 
         let len = EvaluatedConstTy::LitInt(IntegerId::new(db, BigUint::from(len)));

--- a/crates/mir/src/runtime/ir.rs
+++ b/crates/mir/src/runtime/ir.rs
@@ -1174,6 +1174,12 @@ pub enum RuntimeBuiltin<'db> {
     CodeRegionLen {
         region: RuntimeCodeRegion<'db>,
     },
+    /// Byte offset (in the code section) of a const region's data, as `u256`.
+    /// Lowered to `SymAddr` of the synthesised data blob; usable as the `offset`
+    /// operand of CODECOPY without going through the `ConstRef` rewrite pass.
+    ConstRegionAddr {
+        region: ConstRegionId<'db>,
+    },
     Malloc {
         size: RValueId,
     },

--- a/crates/mir/src/runtime/lower/body.rs
+++ b/crates/mir/src/runtime/lower/body.rs
@@ -38,12 +38,12 @@ use crate::{
     instance::{RuntimeInstance, RuntimeInstanceKey, get_or_build_runtime_instance},
     resolve_runtime_place_address_class,
     runtime::{
-        AddressSpaceKind, ConstRegionId, ConstScalar, IntrinsicArithBinOp, LayoutId, PlaceElem,
-        PlaceRoot, RBlock, RBlockId, RExpr, RLocal, RLocalId, RStmt, RTerminator, RefKind, RefView,
-        RuntimeBody, RuntimeCarrier, RuntimeClass, RuntimeCodeRegion, RuntimeExitBehavior,
-        RuntimeInterfaceSignature, RuntimeLocalLowering, RuntimeLocalRoot, RuntimePlace,
-        RuntimeProviderBinding, RuntimeProviderBindingId, ScalarClass, ScalarRepr, ScalarRole,
-        VariantId,
+        AddressSpaceKind, ConstNode, ConstRegionId, ConstScalar, IntrinsicArithBinOp, LayoutId,
+        PlaceElem, PlaceRoot, RBlock, RBlockId, RExpr, RLocal, RLocalId, RStmt, RTerminator,
+        RefKind, RefView, RuntimeBody, RuntimeCarrier, RuntimeClass, RuntimeCodeRegion,
+        RuntimeExitBehavior, RuntimeInterfaceSignature, RuntimeLocalLowering, RuntimeLocalRoot,
+        RuntimePlace, RuntimeProviderBinding, RuntimeProviderBindingId, ScalarClass, ScalarRepr,
+        ScalarRole, VariantId,
         code_region::runtime_code_region_for_semantic_ref,
         package::{LowerError, runtime_instance_for_semantic},
     },
@@ -1278,9 +1278,53 @@ impl<'db> RmirEmitter<'db> {
     }
 
     fn lower_dyn_string_literal(&mut self, bb: RBlockId, ty: TyId<'db>, bytes: &[u8]) -> RLocalId {
-        let len = self.alloc_u256_const(bb, bytes.len());
         let payload_size = 32 + bytes.len().next_multiple_of(32);
+        let total_words = payload_size / 32;
+        let len = self.alloc_u256_const(bb, bytes.len());
         let size = self.alloc_u256_const(bb, payload_size);
+        let copy_len = self.alloc_u256_const(bb, payload_size);
+
+        // Build a `[u256; total_words]` blob whose word-packed layout matches the
+        // runtime `[len_word || padded_data]` payload exactly. The Sonatina
+        // backend emits this as code-section data so the copy below becomes a
+        // single CODECOPY instead of a per-word MSTORE loop.
+        let blob_elem_ty = TyId::u256(self.db);
+        let blob_ty = TyId::array_with_len(self.db, blob_elem_ty, total_words);
+        let blob_layout = self.layout_for_ty(blob_ty);
+
+        let mut fields: Vec<ConstNode<'db>> = Vec::with_capacity(total_words);
+        fields.push(ConstNode::Scalar(ConstScalar::Int {
+            bits: 256,
+            signed: false,
+            words: usize_word_bytes(bytes.len()),
+        }));
+        for chunk in bytes.chunks(32) {
+            fields.push(ConstNode::Scalar(ConstScalar::Int {
+                bits: 256,
+                signed: false,
+                words: padded_word_bytes(chunk),
+            }));
+        }
+        let blob_node = ConstNode::Aggregate {
+            layout: blob_layout,
+            fields: fields.into_boxed_slice(),
+        };
+        let blob_region = ConstRegionId::new(self.db, blob_layout, blob_node);
+
+        let blob_addr = self.alloc_runtime_temp(
+            TyId::u256(self.db),
+            RuntimeCarrier::Value(RuntimeClass::Scalar(word_scalar_class())),
+        );
+        self.push_stmt(
+            bb,
+            RStmt::Assign {
+                dst: blob_addr,
+                expr: RExpr::Builtin(crate::runtime::RuntimeBuiltin::ConstRegionAddr {
+                    region: blob_region,
+                }),
+            },
+        );
+
         let ptr = self.alloc_runtime_temp(
             TyId::u256(self.db),
             RuntimeCarrier::Value(RuntimeClass::Scalar(word_scalar_class())),
@@ -1294,48 +1338,12 @@ impl<'db> RmirEmitter<'db> {
         );
         self.push_ignored_builtin(
             bb,
-            crate::runtime::RuntimeBuiltin::Mstore {
-                addr: ptr,
-                value: len,
+            crate::runtime::RuntimeBuiltin::CodeCopy {
+                dst: ptr,
+                offset: blob_addr,
+                len: copy_len,
             },
         );
-        for (idx, chunk) in bytes.chunks(32).enumerate() {
-            let addr = self.alloc_runtime_temp(
-                TyId::u256(self.db),
-                RuntimeCarrier::Value(RuntimeClass::Scalar(word_scalar_class())),
-            );
-            let offset = self.alloc_u256_const(bb, 32 * (idx + 1));
-            self.push_stmt(
-                bb,
-                RStmt::Assign {
-                    dst: addr,
-                    expr: RExpr::Binary {
-                        op: BinOp::Arith(ArithBinOp::Add),
-                        lhs: ptr,
-                        rhs: offset,
-                    },
-                },
-            );
-            let word = self.alloc_runtime_temp(
-                TyId::u256(self.db),
-                RuntimeCarrier::Value(RuntimeClass::Scalar(word_scalar_class())),
-            );
-            self.push_stmt(
-                bb,
-                RStmt::Assign {
-                    dst: word,
-                    expr: RExpr::ConstScalar(ConstScalar::Int {
-                        bits: 256,
-                        signed: false,
-                        words: padded_word_bytes(chunk),
-                    }),
-                },
-            );
-            self.push_ignored_builtin(
-                bb,
-                crate::runtime::RuntimeBuiltin::Mstore { addr, value: word },
-            );
-        }
 
         let layout = self.layout_for_ty(ty);
         let dst = self.alloc_runtime_temp(

--- a/crates/mir/src/runtime/lower/call.rs
+++ b/crates/mir/src/runtime/lower/call.rs
@@ -35,10 +35,17 @@ pub fn collect_referenced_const_regions<'db>(body: &RuntimeBody<'db>) -> Vec<Con
             let RStmt::Assign { expr, .. } = stmt else {
                 continue;
             };
-            if let RExpr::ConstRef { region, .. } = expr
-                && seen.insert(*region)
+            let region = match expr {
+                RExpr::ConstRef { region, .. } => Some(*region),
+                RExpr::Builtin(crate::runtime::RuntimeBuiltin::ConstRegionAddr { region }) => {
+                    Some(*region)
+                }
+                _ => None,
+            };
+            if let Some(region) = region
+                && seen.insert(region)
             {
-                regions.push(*region);
+                regions.push(region);
             }
         }
     }

--- a/crates/mir/src/runtime/pretty.rs
+++ b/crates/mir/src/runtime/pretty.rs
@@ -740,6 +740,7 @@ fn format_builtin<'db>(db: &'db dyn MirDb, builtin: &RuntimeBuiltin<'db>) -> Str
         RuntimeBuiltin::CurrentCodeRegionLen => "current_code_region_len".to_string(),
         RuntimeBuiltin::CodeRegionOffset { region } => format!("code_region_offset {:?}", region),
         RuntimeBuiltin::CodeRegionLen { region } => format!("code_region_len {:?}", region),
+        RuntimeBuiltin::ConstRegionAddr { region } => format!("const_region_addr {:?}", region),
         RuntimeBuiltin::Malloc { size } => format!("malloc {}", format_local_id(*size)),
         RuntimeBuiltin::Call {
             gas,

--- a/crates/mir/src/verify/runtime.rs
+++ b/crates/mir/src/verify/runtime.rs
@@ -211,7 +211,7 @@ fn verify_assign<'db>(
             _ => Some(RuntimeClass::Scalar(scalar_class_from_const(value))),
         },
         RExpr::Placeholder { class } => Some(class.clone()),
-        RExpr::Builtin(builtin) => verify_builtin(program, body, builtin)?,
+        RExpr::Builtin(builtin) => verify_builtin(db, program, body, builtin)?,
         RExpr::Unary { value, .. } => {
             if !matches!(
                 (runtime_value_class(body, *value)?, &dst_class),
@@ -539,6 +539,7 @@ fn same_block_dominating_enum_assert<'db>(
 }
 
 fn verify_builtin<'db>(
+    db: &'db dyn MirDb,
     program: &impl RuntimeProgramView<'db>,
     body: &RuntimeBody<'db>,
     builtin: &RuntimeBuiltin<'db>,
@@ -659,6 +660,10 @@ fn verify_builtin<'db>(
         RuntimeBuiltin::CurrentCodeRegionLen => Ok(Some(RuntimeClass::Scalar(word_scalar_class()))),
         RuntimeBuiltin::CodeRegionOffset { region } | RuntimeBuiltin::CodeRegionLen { region } => {
             let _ = program.code_region(*region);
+            Ok(Some(RuntimeClass::Scalar(word_scalar_class())))
+        }
+        RuntimeBuiltin::ConstRegionAddr { region } => {
+            verify_const_region(db, program, program.const_region(*region))?;
             Ok(Some(RuntimeClass::Scalar(word_scalar_class())))
         }
         RuntimeBuiltin::Malloc { size } => {

--- a/newsfragments/1454.performance.md
+++ b/newsfragments/1454.performance.md
@@ -1,0 +1,1 @@
+Lower `DynString` literals to a single CODECOPY instead of an allocator-and-MSTORE-per-word sequence. The literal's `[len_word || padded_data]` payload is packed into a `[u256; N]` const region in the code segment and copied in one shot, removing the per-word `PUSH32`/`ADD`/`MSTORE` overhead. Saves ~530 gas per deposit call in the ETH deposit contract differential test.


### PR DESCRIPTION
The previous lowering allocated memory and then wrote the length word plus each 32-byte chunk with its own MSTORE (and ADD per chunk). Now the literal payload is packed into a `[u256; N]` const region whose word-packed layout exactly matches the runtime `[len_word || padded_data]` shape, and a single CODECOPY copies it from the code segment.

Adds a `RuntimeBuiltin::ConstRegionAddr { region }` that lowers to a `SymAddr` of the const region's data — accepted by EvmCodeCopy as the `code_offset` operand without going through the `ConstRef` rewrite pass.

For a 38-byte revert message the old path emitted ~3 MSTOREs + 2 PUSH32s + 2 ADDs per chunk; the new path emits one CODECOPY of 64 bytes plus the length-word + size-word constants needed for the DynString header. Larger messages benefit linearly: no per-word PUSH32/MSTORE/ADD overhead.