### PR TITLE
Allow local-bound blanket impls of foreign traits

### DIFF
--- a/crates/fe/tests/fixtures/fe_test/local_bound_blanket_foreign_trait_impl.fe
+++ b/crates/fe/tests/fixtures/fe_test/local_bound_blanket_foreign_trait_impl.fe
@@ -1,0 +1,25 @@
+use core::ops::WrappingAdd
+
+trait Marker {}
+
+struct W {
+    value: u256,
+}
+
+impl Copy for W {}
+impl Marker for W {}
+
+impl<T: Marker> WrappingAdd for T {
+    fn wrapping_add(self, _ other: T) -> Self {
+        self
+    }
+}
+
+#[test]
+fn local_bound_blanket_foreign_trait_impl() {
+    let a = W { value: 11 }
+    let b = W { value: 31 }
+    let c = a.wrapping_add(b)
+
+    assert(c.value == 11)
+}

--- a/crates/fe/tests/fixtures/fe_test/local_bound_blanket_foreign_trait_impl_private_marker.fe
+++ b/crates/fe/tests/fixtures/fe_test/local_bound_blanket_foreign_trait_impl_private_marker.fe
@@ -1,0 +1,25 @@
+use core::ops::WrappingSub
+
+trait Marker {}
+
+pub struct W {
+    value: u256,
+}
+
+impl Copy for W {}
+impl Marker for W {}
+
+impl<T: Marker> WrappingSub for T {
+    fn wrapping_sub(self, _ other: T) -> Self {
+        self
+    }
+}
+
+#[test]
+fn local_bound_blanket_foreign_trait_impl_private_marker() {
+    let a = W { value: 31 }
+    let b = W { value: 11 }
+    let c = a.wrapping_sub(b)
+
+    assert(c.value == 31)
+}

--- a/crates/hir/src/analysis/diagnostics.rs
+++ b/crates/hir/src/analysis/diagnostics.rs
@@ -4202,6 +4202,19 @@ impl DiagnosticVoucher for TraitLowerDiag<'_> {
                 error_code,
             },
 
+            Self::UnsafeLocalBoundBlanketImpl(impl_trait) => CompleteDiagnostic {
+                severity: Severity::Error,
+                message: "external trait blanket impl is not anchored by a sealed local marker"
+                    .to_string(),
+                sub_diagnostics: vec![SubDiagnostic {
+                    style: LabelStyle::Primary,
+                    message: "external trait blanket impl must be anchored by a sealed local marker trait implemented only for local types".to_string(),
+                    span: impl_trait.span().resolve(db),
+                }],
+                notes: vec![],
+                error_code,
+            },
+
             Self::ConflictTraitImpl {
                 primary,
                 conflict_with,

--- a/crates/hir/src/analysis/name_resolution/path_resolver.rs
+++ b/crates/hir/src/analysis/name_resolution/path_resolver.rs
@@ -816,7 +816,8 @@ where
                         },
                         path,
                     ),
-                    TraitRefLowerError::Ignored => PathResError::parse_err(trait_path),
+                    TraitRefLowerError::UnsafeLocalBoundBlanketImpl
+                    | TraitRefLowerError::Ignored => PathResError::parse_err(trait_path),
                 };
                 return Err(err);
             }

--- a/crates/hir/src/analysis/ty/diagnostics.rs
+++ b/crates/hir/src/analysis/ty/diagnostics.rs
@@ -836,6 +836,7 @@ pub enum TraitLowerDiag<'db> {
         conflict_with: ImplTrait<'db>,
     },
     ExternalTraitForExternalType(ImplTrait<'db>),
+    UnsafeLocalBoundBlanketImpl(ImplTrait<'db>),
     CyclicTraitRef(ImplTrait<'db>),
     CyclicSuperTraits(Vec<Trait<'db>>),
 }
@@ -847,6 +848,7 @@ impl TraitLowerDiag<'_> {
             Self::ConflictTraitImpl { .. } => 1,
             Self::CyclicSuperTraits { .. } => 2,
             Self::CyclicTraitRef(_) => 3,
+            Self::UnsafeLocalBoundBlanketImpl(_) => 4,
         }
     }
 }

--- a/crates/hir/src/analysis/ty/trait_def.rs
+++ b/crates/hir/src/analysis/ty/trait_def.rs
@@ -799,10 +799,6 @@ impl<'db> TraitInstId<'db> {
     pub fn self_ty(self, db: &'db dyn HirAnalysisDb) -> TyId<'db> {
         self.args(db)[0]
     }
-
-    pub(crate) fn ingot(self, db: &'db dyn HirAnalysisDb) -> Ingot<'db> {
-        self.def(db).ingot(db)
-    }
 }
 
 // Represents a trait definition.

--- a/crates/hir/src/analysis/ty/trait_lower.rs
+++ b/crates/hir/src/analysis/ty/trait_lower.rs
@@ -426,6 +426,7 @@ pub(crate) enum TraitRefLowerError<'db> {
     PathResError(PathResError<'db>),
     InvalidDomain(PathRes<'db>),
     Cycle,
+    UnsafeLocalBoundBlanketImpl,
     /// Error is expected to be reported elsewhere.
     Ignored,
 }

--- a/crates/hir/src/core/semantic/mod.rs
+++ b/crates/hir/src/core/semantic/mod.rs
@@ -3737,7 +3737,9 @@ impl<'db> SuperTraitRefView<'db> {
             Err(TraitRefLowerError::PathResError(_)) => Err(SuperTraitLowerError::PathResolution),
             Err(TraitRefLowerError::InvalidDomain(_)) => Err(SuperTraitLowerError::InvalidDomain),
             Err(TraitRefLowerError::Cycle) => Err(SuperTraitLowerError::Cycle),
-            Err(TraitRefLowerError::Ignored) => Err(SuperTraitLowerError::Ignored),
+            Err(TraitRefLowerError::UnsafeLocalBoundBlanketImpl | TraitRefLowerError::Ignored) => {
+                Err(SuperTraitLowerError::Ignored)
+            }
         }
     }
 
@@ -3757,6 +3759,7 @@ impl<'db> SuperTraitRefView<'db> {
                 TraitRefLowerError::PathResError(_)
                 | TraitRefLowerError::InvalidDomain(_)
                 | TraitRefLowerError::Cycle
+                | TraitRefLowerError::UnsafeLocalBoundBlanketImpl
                 | TraitRefLowerError::Ignored,
             ) => return None,
         };
@@ -3884,6 +3887,13 @@ pub(crate) enum ImplTraitLowerError<'db> {
     },
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TraitImplAdmissibility {
+    Admissible,
+    ExternalTraitForExternalType,
+    UnsafeLocalBoundBlanketImpl,
+}
+
 impl<'db> ImplTrait<'db> {
     /// Semantic self type of this impl-trait block.
     pub fn ty(self, db: &'db dyn HirAnalysisDb) -> TyId<'db> {
@@ -3940,7 +3950,7 @@ impl<'db> ImplTrait<'db> {
 
         // Conflict check
         let trait_ = implementor.skip_binder().trait_(db);
-        let env = ingot_trait_env(db, trait_.ingot(db));
+        let env = ingot_trait_env(db, self.top_mod(db).ingot(db));
         if let Some(impls) = env.impls.get(&trait_.def(db)) {
             for &cand_view in impls {
                 let cand_impl_trait = cand_view.skip_binder().hir_impl_trait(db);
@@ -4007,17 +4017,104 @@ impl<'db> ImplTrait<'db> {
 
         let trait_inst = lower_trait_ref(db, ty, trait_ref, self.scope(), assumptions, None)?;
 
-        // Preserve ingot check used when lowering impl traits: an impl is
-        // only valid if it lives in the same ingot as either its
-        // implementor type or the trait itself.
-        let impl_trait_ingot = self.top_mod(db).ingot(db);
-        if Some(impl_trait_ingot) != ty.ingot(db)
-            && impl_trait_ingot != trait_inst.def(db).ingot(db)
-        {
-            return Err(TraitRefLowerError::Ignored);
+        match self.trait_impl_admissibility(db, ty, trait_inst, assumptions) {
+            TraitImplAdmissibility::Admissible => {}
+            TraitImplAdmissibility::ExternalTraitForExternalType => {
+                return Err(TraitRefLowerError::Ignored);
+            }
+            TraitImplAdmissibility::UnsafeLocalBoundBlanketImpl => {
+                return Err(TraitRefLowerError::UnsafeLocalBoundBlanketImpl);
+            }
         }
 
         Ok(trait_inst)
+    }
+
+    fn trait_impl_admissibility(
+        self,
+        db: &'db dyn HirAnalysisDb,
+        ty: TyId<'db>,
+        trait_inst: TraitInstId<'db>,
+        assumptions: PredicateListId<'db>,
+    ) -> TraitImplAdmissibility {
+        let impl_trait_ingot = self.top_mod(db).ingot(db);
+        if Some(impl_trait_ingot) == ty.ingot(db)
+            || impl_trait_ingot == trait_inst.def(db).ingot(db)
+        {
+            return TraitImplAdmissibility::Admissible;
+        }
+
+        if !matches!(ty.data(db), TyData::TyParam(_)) {
+            return TraitImplAdmissibility::ExternalTraitForExternalType;
+        }
+
+        if assumptions.list(db).iter().any(|pred| {
+            pred.self_ty(db) == ty
+                && Self::is_sealed_local_marker_anchor(db, pred.def(db), impl_trait_ingot)
+        }) {
+            TraitImplAdmissibility::Admissible
+        } else {
+            TraitImplAdmissibility::UnsafeLocalBoundBlanketImpl
+        }
+    }
+
+    fn is_sealed_local_marker_anchor(
+        db: &'db dyn HirAnalysisDb,
+        marker: Trait<'db>,
+        impl_trait_ingot: common::ingot::Ingot<'db>,
+    ) -> bool {
+        if marker.ingot(db) != impl_trait_ingot
+            || marker.scope().data(db).vis.is_pub()
+            || !marker.original_params(db).is_empty()
+            || marker.methods(db).next().is_some()
+            || !marker.types(db).is_empty()
+            || !marker.consts(db).is_empty()
+            || marker.super_trait_bounds(db).next().is_some()
+        {
+            return false;
+        }
+
+        marker
+            .ingot(db)
+            .all_impl_traits(db)
+            .iter()
+            .copied()
+            .filter(|&impl_| Self::impl_trait_implements_marker(db, impl_, marker))
+            .all(|impl_| Self::impl_trait_targets_local_nominal_root(db, impl_, impl_trait_ingot))
+    }
+
+    fn impl_trait_implements_marker(
+        db: &'db dyn HirAnalysisDb,
+        impl_trait: ImplTrait<'db>,
+        marker: Trait<'db>,
+    ) -> bool {
+        let Some(trait_ref) = impl_trait.trait_ref(db).to_opt() else {
+            return false;
+        };
+        let assumptions = constraints_for(db, impl_trait.into());
+        lower_trait_ref(
+            db,
+            impl_trait.ty(db),
+            trait_ref,
+            impl_trait.scope(),
+            assumptions,
+            None,
+        )
+        .is_ok_and(|inst| inst.def(db) == marker)
+    }
+
+    fn impl_trait_targets_local_nominal_root(
+        db: &'db dyn HirAnalysisDb,
+        impl_trait: ImplTrait<'db>,
+        impl_trait_ingot: common::ingot::Ingot<'db>,
+    ) -> bool {
+        match impl_trait.ty(db).base_ty(db).data(db) {
+            TyData::TyBase(TyBase::Adt(adt)) => adt.ingot(db) == impl_trait_ingot,
+            TyData::TyBase(TyBase::Contract(contract)) => {
+                contract.top_mod(db).ingot(db) == impl_trait_ingot
+            }
+            _ => false,
+        }
     }
 
     /// Semantic generic parameter types for this `impl trait` block, in
@@ -4170,6 +4267,9 @@ impl<'db> ImplTrait<'db> {
                         }
                         TraitRefLowerError::Cycle => {
                             diags.push(TraitLowerDiag::CyclicTraitRef(self).into());
+                        }
+                        TraitRefLowerError::UnsafeLocalBoundBlanketImpl => {
+                            diags.push(TraitLowerDiag::UnsafeLocalBoundBlanketImpl(self).into());
                         }
                         TraitRefLowerError::Ignored => {
                             diags.push(TraitLowerDiag::ExternalTraitForExternalType(self).into());

--- a/crates/hir/src/diagnosable.rs
+++ b/crates/hir/src/diagnosable.rs
@@ -128,7 +128,9 @@ impl<'db> SuperTraitRefView<'db> {
                     "super-trait bound",
                 ));
             }
-            Err(TraitRefLowerError::Ignored) => return None,
+            Err(TraitRefLowerError::UnsafeLocalBoundBlanketImpl | TraitRefLowerError::Ignored) => {
+                return None;
+            }
         };
 
         // Do not emit when subject contains assoc types of params
@@ -305,7 +307,7 @@ impl<'db> WherePredicateBoundView<'db> {
             Err(TraitRefLowerError::Cycle) => {
                 out.push(cyclic_trait_ref_diag(span.path().into(), "trait bound"));
             }
-            Err(TraitRefLowerError::Ignored) => {}
+            Err(TraitRefLowerError::UnsafeLocalBoundBlanketImpl | TraitRefLowerError::Ignored) => {}
         }
 
         out
@@ -1309,7 +1311,10 @@ impl<'db> GenericParamOwner<'db> {
                     Err(TraitRefLowerError::Cycle) => {
                         out.push(cyclic_trait_ref_diag(span.path().into(), "trait bound"));
                     }
-                    Err(TraitRefLowerError::Ignored) => {}
+                    Err(
+                        TraitRefLowerError::UnsafeLocalBoundBlanketImpl
+                        | TraitRefLowerError::Ignored,
+                    ) => {}
                 }
             }
         }

--- a/crates/uitest/fixtures/ty/def/local_bound_blanket_foreign_trait_impl_diagnostics.fe
+++ b/crates/uitest/fixtures/ty/def/local_bound_blanket_foreign_trait_impl_diagnostics.fe
@@ -1,0 +1,27 @@
+use core::ops::{WrappingAdd, WrappingMul}
+
+trait Marker {}
+
+struct W {
+    value: u256,
+}
+
+impl Marker for W {}
+
+impl<T: Copy> WrappingMul for T {
+    fn wrapping_mul(self, _ other: T) -> Self {
+        self
+    }
+}
+
+impl<T: Marker> WrappingAdd for T {
+    fn wrapping_add(self, _ other: T) -> Self {
+        self
+    }
+}
+
+impl WrappingAdd for W {
+    fn wrapping_add(self, _ other: W) -> W {
+        self
+    }
+}

--- a/crates/uitest/fixtures/ty/def/local_bound_blanket_foreign_trait_impl_diagnostics.snap
+++ b/crates/uitest/fixtures/ty/def/local_bound_blanket_foreign_trait_impl_diagnostics.snap
@@ -1,0 +1,23 @@
+---
+source: crates/uitest/tests/ty.rs
+expression: diags
+input_file: fixtures/ty/def/local_bound_blanket_foreign_trait_impl_diagnostics.fe
+---
+error[5-0001]: conflicting trait implementations
+   ┌─ local_bound_blanket_foreign_trait_impl_diagnostics.fe:17:33
+   │
+17 │ impl<T: Marker> WrappingAdd for T {
+   │                                 ^ this trait implementation
+   ·
+23 │ impl WrappingAdd for W {
+   │                      - conflicts with this trait implementation
+
+error[5-0004]: external trait blanket impl is not anchored by a sealed local marker
+   ┌─ local_bound_blanket_foreign_trait_impl_diagnostics.fe:11:1
+   │
+11 │ ╭ impl<T: Copy> WrappingMul for T {
+12 │ │     fn wrapping_mul(self, _ other: T) -> Self {
+13 │ │         self
+14 │ │     }
+15 │ │ }
+   │ ╰─^ external trait blanket impl must be anchored by a sealed local marker trait implemented only for local types

--- a/crates/uitest/fixtures/ty/def/local_bound_blanket_foreign_trait_impl_sealed_marker_restrictions.fe
+++ b/crates/uitest/fixtures/ty/def/local_bound_blanket_foreign_trait_impl_sealed_marker_restrictions.fe
@@ -1,0 +1,62 @@
+use core::ops::{
+    SaturatingAdd, SaturatingMul, SaturatingSub, WrappingAdd, WrappingMul, WrappingSub,
+}
+
+pub trait PublicMarker {}
+
+struct PublicType {}
+
+impl PublicMarker for PublicType {}
+
+impl<T: PublicMarker> WrappingAdd for T {
+    fn wrapping_add(self, _ other: T) -> Self {
+        self
+    }
+}
+
+trait MethodMarker {
+    fn marker(self)
+}
+
+impl<T: MethodMarker> WrappingSub for T {
+    fn wrapping_sub(self, _ other: T) -> Self {
+        self
+    }
+}
+
+trait GenericMarker<U> {}
+
+impl<T: GenericMarker<u256>> WrappingMul for T {
+    fn wrapping_mul(self, _ other: T) -> Self {
+        self
+    }
+}
+
+trait SuperMarker {}
+trait SubMarker: SuperMarker {}
+
+impl<T: SubMarker> SaturatingAdd for T {
+    fn saturating_add(self, _ other: T) -> Self {
+        self
+    }
+}
+
+trait BlanketMarker {}
+
+impl<T> BlanketMarker for T {}
+
+impl<T: BlanketMarker> SaturatingSub for T {
+    fn saturating_sub(self, _ other: T) -> Self {
+        self
+    }
+}
+
+trait PrimitiveMarker {}
+
+impl PrimitiveMarker for u256 {}
+
+impl<T: PrimitiveMarker> SaturatingMul for T {
+    fn saturating_mul(self, _ other: T) -> Self {
+        self
+    }
+}

--- a/crates/uitest/fixtures/ty/def/local_bound_blanket_foreign_trait_impl_sealed_marker_restrictions.snap
+++ b/crates/uitest/fixtures/ty/def/local_bound_blanket_foreign_trait_impl_sealed_marker_restrictions.snap
@@ -1,0 +1,64 @@
+---
+source: crates/uitest/tests/ty.rs
+expression: diags
+input_file: fixtures/ty/def/local_bound_blanket_foreign_trait_impl_sealed_marker_restrictions.fe
+---
+error[5-0004]: external trait blanket impl is not anchored by a sealed local marker
+   ┌─ local_bound_blanket_foreign_trait_impl_sealed_marker_restrictions.fe:11:1
+   │
+11 │ ╭ impl<T: PublicMarker> WrappingAdd for T {
+12 │ │     fn wrapping_add(self, _ other: T) -> Self {
+13 │ │         self
+14 │ │     }
+15 │ │ }
+   │ ╰─^ external trait blanket impl must be anchored by a sealed local marker trait implemented only for local types
+
+error[5-0004]: external trait blanket impl is not anchored by a sealed local marker
+   ┌─ local_bound_blanket_foreign_trait_impl_sealed_marker_restrictions.fe:21:1
+   │
+21 │ ╭ impl<T: MethodMarker> WrappingSub for T {
+22 │ │     fn wrapping_sub(self, _ other: T) -> Self {
+23 │ │         self
+24 │ │     }
+25 │ │ }
+   │ ╰─^ external trait blanket impl must be anchored by a sealed local marker trait implemented only for local types
+
+error[5-0004]: external trait blanket impl is not anchored by a sealed local marker
+   ┌─ local_bound_blanket_foreign_trait_impl_sealed_marker_restrictions.fe:29:1
+   │
+29 │ ╭ impl<T: GenericMarker<u256>> WrappingMul for T {
+30 │ │     fn wrapping_mul(self, _ other: T) -> Self {
+31 │ │         self
+32 │ │     }
+33 │ │ }
+   │ ╰─^ external trait blanket impl must be anchored by a sealed local marker trait implemented only for local types
+
+error[5-0004]: external trait blanket impl is not anchored by a sealed local marker
+   ┌─ local_bound_blanket_foreign_trait_impl_sealed_marker_restrictions.fe:38:1
+   │
+38 │ ╭ impl<T: SubMarker> SaturatingAdd for T {
+39 │ │     fn saturating_add(self, _ other: T) -> Self {
+40 │ │         self
+41 │ │     }
+42 │ │ }
+   │ ╰─^ external trait blanket impl must be anchored by a sealed local marker trait implemented only for local types
+
+error[5-0004]: external trait blanket impl is not anchored by a sealed local marker
+   ┌─ local_bound_blanket_foreign_trait_impl_sealed_marker_restrictions.fe:48:1
+   │
+48 │ ╭ impl<T: BlanketMarker> SaturatingSub for T {
+49 │ │     fn saturating_sub(self, _ other: T) -> Self {
+50 │ │         self
+51 │ │     }
+52 │ │ }
+   │ ╰─^ external trait blanket impl must be anchored by a sealed local marker trait implemented only for local types
+
+error[5-0004]: external trait blanket impl is not anchored by a sealed local marker
+   ┌─ local_bound_blanket_foreign_trait_impl_sealed_marker_restrictions.fe:58:1
+   │
+58 │ ╭ impl<T: PrimitiveMarker> SaturatingMul for T {
+59 │ │     fn saturating_mul(self, _ other: T) -> Self {
+60 │ │         self
+61 │ │     }
+62 │ │ }
+   │ ╰─^ external trait blanket impl must be anchored by a sealed local marker trait implemented only for local types

--- a/newsfragments/1450.bugfix.md
+++ b/newsfragments/1450.bugfix.md
@@ -1,0 +1,1 @@
+Allowed blanket implementations of external traits when the implementor is a type parameter directly bounded by a local trait.


### PR DESCRIPTION
Allows defining blanket impls of foreign traits when the impl is bound by a local trait.

For example:
```rust
use core::ops::WrappingAdd

struct W {
    value: u256,
}
trait Marker {}
impl Marker for W {}

impl<T: Marker> WrappingAdd for T {
    fn wrapping_add(self, _ other: T) -> Self {
        self
    }
}
```