### PR TITLE
Fix projected effect provider specialization

### DIFF
--- a/crates/fe/tests/fixtures/fe_test/projected_storage_map_effect_forwarding.fe
+++ b/crates/fe/tests/fixtures/fe_test/projected_storage_map_effect_forwarding.fe
@@ -1,0 +1,105 @@
+use std::evm::{Evm, StorageMap}
+
+msg ProjectedMapMsg {
+    #[selector = 0x01]
+    SetPrimary { key: u256, value: u256 },
+    #[selector = 0x02]
+    SetSecondary { key: u256, value: u256 },
+    #[selector = 0x03]
+    GetPrimary { key: u256 } -> u256,
+    #[selector = 0x04]
+    GetSecondary { key: u256 } -> u256,
+}
+
+fn read_leaf(_ key: u256) -> u256
+    uses (map: StorageMap<u256, u256>)
+{
+    map.get(key: key)
+}
+
+fn read_nested(_ key: u256) -> u256
+    uses (map: StorageMap<u256, u256>)
+{
+    read_leaf(key)
+}
+
+fn write_leaf(_ key: u256, _ value: u256)
+    uses (map: mut StorageMap<u256, u256>)
+{
+    map.set(key: key, value: value)
+}
+
+fn write_nested(_ key: u256, _ value: u256)
+    uses (map: mut StorageMap<u256, u256>)
+{
+    write_leaf(key, value)
+}
+
+struct Store {
+    primary: StorageMap<u256, u256>,
+    secondary: StorageMap<u256, u256>,
+}
+
+pub contract ProjectedMapForwarding {
+    mut store: Store
+
+    recv ProjectedMapMsg {
+        SetPrimary { key, value } uses (mut store) {
+            with (mut store.primary) {
+                write_nested(key, value)
+            }
+        }
+
+        SetSecondary { key, value } uses (mut store) {
+            with (mut store.secondary) {
+                write_nested(key, value)
+            }
+        }
+
+        GetPrimary { key } -> u256 uses (store) {
+            with (store.primary) {
+                read_nested(key)
+            }
+        }
+
+        GetSecondary { key } -> u256 uses (store) {
+            with (store.secondary) {
+                read_nested(key)
+            }
+        }
+    }
+}
+
+#[test]
+fn test_projected_storage_map_effect_forwarding() uses (evm: mut Evm) {
+    let contract_addr = evm.create2<ProjectedMapForwarding>(value: 0, args: (), salt: 0)
+
+    evm.call(
+        addr: contract_addr,
+        gas: 100000,
+        value: 0,
+        message: ProjectedMapMsg::SetPrimary { key: 1, value: 11 },
+    )
+    evm.call(
+        addr: contract_addr,
+        gas: 100000,
+        value: 0,
+        message: ProjectedMapMsg::SetSecondary { key: 1, value: 99 },
+    )
+
+    let primary: u256 = evm.call(
+        addr: contract_addr,
+        gas: 100000,
+        value: 0,
+        message: ProjectedMapMsg::GetPrimary { key: 1 },
+    )
+    assert(primary == 11)
+
+    let secondary: u256 = evm.call(
+        addr: contract_addr,
+        gas: 100000,
+        value: 0,
+        message: ProjectedMapMsg::GetSecondary { key: 1 },
+    )
+    assert(secondary == 99)
+}

--- a/crates/hir/src/analysis/semantic/instance/const_ref.rs
+++ b/crates/hir/src/analysis/semantic/instance/const_ref.rs
@@ -1,7 +1,7 @@
 use super::{
     EffectProviderSubst, GenericSubst, ImplEnv, SemanticInstance, SemanticInstanceKey,
     provisional_provider_binding_for_instance_effect, provisional_provider_idx_for_requirement,
-    resolved_provider_binding_for_instance_effect,
+    resolved_effect_binding_ty_for_instance_effect, resolved_provider_binding_for_instance_effect,
 };
 use crate::{
     analysis::{
@@ -150,6 +150,10 @@ fn resolve_callable_effect_providers<'db>(
                     ..
                 } => provider_resolution_mode
                     .resolve_binding(db, caller, binding)
+                    .filter(|provider| {
+                        provider.effective_target_ty()
+                            == specialization.provider.effective_target_ty()
+                    })
                     .map(|provider| crate::semantic::ProviderBinding {
                         provider_idx,
                         ..provider
@@ -207,11 +211,7 @@ fn resolve_callable_effect_providers<'db>(
             if let Some(slot) = subst_args.get_mut(param_idx) {
                 *slot = provider.provider.provider_ty;
             }
-            let actual_key_ty = provider
-                .provider
-                .semantics
-                .target_ty
-                .unwrap_or(provider.provider.provider_ty);
+            let actual_key_ty = effect_provider_target_ty(db, caller, provider);
             instantiate_callable_effect_layout_args(
                 db,
                 func,
@@ -222,6 +222,20 @@ fn resolve_callable_effect_providers<'db>(
         }
     }
     providers
+}
+
+fn effect_provider_target_ty<'db>(
+    db: &'db dyn HirAnalysisDb,
+    caller: SemanticInstance<'db>,
+    provider: &EffectProviderSpecialization<'db>,
+) -> TyId<'db> {
+    let fallback = provider.provider.effective_target_ty();
+    let crate::analysis::ty::ty_check::EffectProviderProvenance::Binding { binding, .. } =
+        provider.provenance
+    else {
+        return fallback;
+    };
+    resolved_effect_binding_ty_for_instance_effect(db, caller, binding).unwrap_or(fallback)
 }
 
 impl ProviderResolutionMode {

--- a/crates/hir/src/analysis/semantic/instance/mod.rs
+++ b/crates/hir/src/analysis/semantic/instance/mod.rs
@@ -17,7 +17,7 @@ pub use semantic::{
 };
 pub(crate) use semantic::{
     provisional_provider_binding_for_instance_effect, provisional_provider_idx_for_requirement,
-    semantic_instance_base_assumptions_for_key,
+    resolved_effect_binding_ty_for_instance_effect, semantic_instance_base_assumptions_for_key,
 };
 pub use template::{
     EffectProviderSubst, GenericSubst, ImplEnv, TypedBodyTemplate, instantiate_typed_body,

--- a/crates/hir/src/analysis/semantic/instance/mod.rs
+++ b/crates/hir/src/analysis/semantic/instance/mod.rs
@@ -12,8 +12,7 @@ pub use semantic::{
     RootSemanticInstanceError, SemanticEffectEnvInstantiationError, SemanticInstance,
     SemanticInstanceKey, get_or_build_semantic_instance, identity_semantic_instance_key,
     instantiated_effect_env, resolved_provider_binding_for_instance_effect,
-    root_semantic_instance_key, validate_instantiated_effect_env,
-    validate_instantiated_effect_env_key,
+    root_semantic_instance_key, validate_instantiated_effect_env_key,
 };
 pub(crate) use semantic::{
     provisional_provider_binding_for_instance_effect, provisional_provider_idx_for_requirement,

--- a/crates/hir/src/analysis/semantic/instance/semantic.rs
+++ b/crates/hir/src/analysis/semantic/instance/semantic.rs
@@ -7,8 +7,7 @@ use crate::{
         semantic::{
             CallSiteId, PlaceProvenance, SBlockId, SExpr, SStmtKind, STerminatorKind, SemanticBody,
             SemanticCalleeRef, SemanticLocalRole, ValueProvenance, VariantIndex, effect_param_site,
-            lower::BindingRoleMode,
-            lower::{lower_to_smir, lower_to_smir_with_call_sites},
+            lower::{BindingRoleMode, lower_to_smir, lower_to_smir_with_call_sites},
             verify_semantic_body,
         },
         ty::{
@@ -28,7 +27,7 @@ use crate::{
             },
             ty_check::{
                 BodyOwner, EffectParamSite, EffectProviderProvenance, EffectProviderSpecialization,
-                LocalBinding, ResolvedEffectArg, SemanticExprLowering, TypedBody,
+                LocalBinding, ParamSite, ResolvedEffectArg, SemanticExprLowering, TypedBody,
             },
             ty_def::{BorrowKind, CapabilityKind, TyId, instantiate_adt_field_ty},
         },
@@ -79,7 +78,7 @@ pub struct SemanticInstance<'db> {
 pub struct SemanticEffectEnvInstantiationError<'db> {
     pub owner: BodyOwner<'db>,
     pub owner_scope: ScopeId<'db>,
-    pub offending_ty: crate::analysis::ty::ty_def::TyId<'db>,
+    pub offending_ty: TyId<'db>,
     pub param_idx: usize,
     pub args_len: usize,
 }
@@ -124,7 +123,7 @@ pub enum RootSemanticInstanceError<'db> {
     UnsupportedGenericParam {
         owner: BodyOwner<'db>,
         owner_scope: ScopeId<'db>,
-        offending_ty: crate::analysis::ty::ty_def::TyId<'db>,
+        offending_ty: TyId<'db>,
         param_idx: usize,
     },
     MissingRootProvider {
@@ -163,7 +162,7 @@ pub fn instantiated_effect_env<'db>(
     instance: SemanticInstance<'db>,
 ) -> Option<InstantiatedEffectEnv<'db>> {
     let (site, requirements, providers, resolutions, forwarded_witnesses, assumptions) =
-        instantiate_effect_env_data(db, instance).unwrap_or_else(|err| {
+        instantiate_effect_env_data_for_key(db, instance.key(db)).unwrap_or_else(|err| {
             panic!(
                 "failed to instantiate effect env for {:?}: owner_scope={:?} param_idx={} args_len={} offending_ty={}",
                 err.owner,
@@ -613,7 +612,13 @@ impl<'db> SemanticInstance<'db> {
         db: &'db dyn HirAnalysisDb,
         binding: LocalBinding<'db>,
     ) -> SemanticLocalRole<'db> {
-        classify_binding_role(db, self, binding)
+        classify_binding_role(
+            db,
+            self,
+            self.binding_ty(db, binding),
+            self.assumptions(db),
+            resolved_provider_binding_for_instance_effect(db, self, binding),
+        )
     }
 
     pub(crate) fn provisional_binding_role(
@@ -621,7 +626,7 @@ impl<'db> SemanticInstance<'db> {
         db: &'db dyn HirAnalysisDb,
         binding: LocalBinding<'db>,
     ) -> SemanticLocalRole<'db> {
-        classify_binding_role_from_ty(
+        classify_binding_role(
             db,
             self,
             self.provisional_binding_ty(db, binding),
@@ -663,7 +668,7 @@ impl<'db> SemanticInstance<'db> {
                 Some(provider_idx),
             ),
             LocalBinding::Param {
-                site: crate::analysis::ty::ty_check::ParamSite::EffectField(_),
+                site: ParamSite::EffectField(_),
                 idx,
                 ..
             } => effect_binding_ty_from_env(db, instantiated_effect_env(db, self), idx, None),
@@ -903,7 +908,7 @@ pub fn resolved_provider_binding_for_instance_effect<'db>(
             idx, provider_idx, ..
         } => (idx, Some(provider_idx)),
         LocalBinding::Param {
-            site: crate::analysis::ty::ty_check::ParamSite::EffectField(_),
+            site: ParamSite::EffectField(_),
             idx,
             ..
         } => (idx, None),
@@ -925,14 +930,14 @@ pub(crate) fn resolved_effect_binding_ty_for_instance_effect<'db>(
     db: &'db dyn HirAnalysisDb,
     instance: SemanticInstance<'db>,
     binding: LocalBinding<'db>,
-) -> Option<crate::analysis::ty::ty_def::TyId<'db>> {
+) -> Option<TyId<'db>> {
     let env = instantiated_effect_env(db, instance)?;
     let (binding_idx, provider_idx) = match binding {
         LocalBinding::EffectParam {
             idx, provider_idx, ..
         } => (idx, Some(provider_idx)),
         LocalBinding::Param {
-            site: crate::analysis::ty::ty_check::ParamSite::EffectField(_),
+            site: ParamSite::EffectField(_),
             idx,
             ..
         } => (idx, None),
@@ -970,7 +975,7 @@ pub(crate) fn provisional_provider_binding_for_instance_effect<'db>(
             provisional_provider_binding_for_effect(db, key, site, idx as u32, provider_idx, is_mut)
         }),
         LocalBinding::Param {
-            site: crate::analysis::ty::ty_check::ParamSite::EffectField(effect_site),
+            site: ParamSite::EffectField(effect_site),
             idx,
             ..
         } => {
@@ -1156,12 +1161,9 @@ fn effect_binding_ty_from_env<'db>(
     env: Option<InstantiatedEffectEnv<'db>>,
     idx: usize,
     provider_idx: Option<u32>,
-) -> crate::analysis::ty::ty_def::TyId<'db> {
+) -> TyId<'db> {
     let Some(env) = env else {
-        return crate::analysis::ty::ty_def::TyId::invalid(
-            db,
-            crate::analysis::ty::ty_def::InvalidCause::Other,
-        );
+        return TyId::invalid(db, crate::analysis::ty::ty_def::InvalidCause::Other);
     };
     let requirement = env
         .requirements(db)
@@ -1188,12 +1190,7 @@ fn effect_binding_ty_from_env<'db>(
             .or_else(|| provider.map(|binding| binding.provider_ty)),
         None => None,
     }
-    .unwrap_or_else(|| {
-        crate::analysis::ty::ty_def::TyId::invalid(
-            db,
-            crate::analysis::ty::ty_def::InvalidCause::Other,
-        )
-    })
+    .unwrap_or_else(|| TyId::invalid(db, crate::analysis::ty::ty_def::InvalidCause::Other))
 }
 
 fn instantiated_resolved_binding<'db>(
@@ -1227,7 +1224,7 @@ fn requirement_provider_target_ty<'db>(
     scope: ScopeId<'db>,
     assumptions: PredicateListId<'db>,
     requirement: &EffectRequirement<'db>,
-) -> Option<crate::analysis::ty::ty_def::TyId<'db>> {
+) -> Option<TyId<'db>> {
     let target_ty = requirement.key.binding_ty(db)?;
     Some(
         effect_handle_metadata(db, scope, assumptions, target_ty)
@@ -1241,7 +1238,7 @@ fn specialized_root_provider_target_ty<'db>(
     assumptions: PredicateListId<'db>,
     requirement: &EffectRequirement<'db>,
     root_provider: &ProviderBinding<'db>,
-) -> Option<crate::analysis::ty::ty_def::TyId<'db>> {
+) -> Option<TyId<'db>> {
     match requirement.key {
         EffectRequirementKey::Trait(_) => Some(root_provider.provider_ty),
         EffectRequirementKey::Type(_) | EffectRequirementKey::Other => {
@@ -1332,34 +1329,6 @@ fn collect_semantic_callees<'db>(
 fn classify_binding_role<'db>(
     db: &'db dyn HirAnalysisDb,
     instance: SemanticInstance<'db>,
-    binding: LocalBinding<'db>,
-) -> SemanticLocalRole<'db> {
-    classify_binding_role_with_provider(
-        db,
-        instance,
-        binding,
-        resolved_provider_binding_for_instance_effect(db, instance, binding),
-    )
-}
-
-fn classify_binding_role_with_provider<'db>(
-    db: &'db dyn HirAnalysisDb,
-    instance: SemanticInstance<'db>,
-    binding: LocalBinding<'db>,
-    provider: Option<ProviderBinding<'db>>,
-) -> SemanticLocalRole<'db> {
-    classify_binding_role_from_ty(
-        db,
-        instance,
-        instance.binding_ty(db, binding),
-        instance.assumptions(db),
-        provider,
-    )
-}
-
-fn classify_binding_role_from_ty<'db>(
-    db: &'db dyn HirAnalysisDb,
-    instance: SemanticInstance<'db>,
     ty: TyId<'db>,
     assumptions: PredicateListId<'db>,
     provider: Option<ProviderBinding<'db>>,
@@ -1373,7 +1342,7 @@ fn classify_binding_role_from_ty<'db>(
     }
     if let Some(metadata) = effect_handle_metadata(db, scope, assumptions, ty) {
         return SemanticLocalRole::DirectCarrier {
-            provider: provider.clone(),
+            provider,
             target_ty: metadata.target_ty,
         };
     }
@@ -1393,25 +1362,11 @@ fn classify_binding_role_from_ty<'db>(
     }
 }
 
-pub fn validate_instantiated_effect_env<'db>(
-    db: &'db dyn HirAnalysisDb,
-    instance: SemanticInstance<'db>,
-) -> Result<(), SemanticEffectEnvInstantiationError<'db>> {
-    instantiate_effect_env_data_for_key(db, instance.key(db)).map(|_| ())
-}
-
 pub fn validate_instantiated_effect_env_key<'db>(
     db: &'db dyn HirAnalysisDb,
     key: SemanticInstanceKey<'db>,
 ) -> Result<(), SemanticEffectEnvInstantiationError<'db>> {
     instantiate_effect_env_data_for_key(db, key).map(|_| ())
-}
-
-fn instantiate_effect_env_data<'db>(
-    db: &'db dyn HirAnalysisDb,
-    instance: SemanticInstance<'db>,
-) -> Result<Option<InstantiatedEffectEnvData<'db>>, SemanticEffectEnvInstantiationError<'db>> {
-    instantiate_effect_env_data_for_key(db, instance.key(db))
 }
 
 fn instantiate_effect_env_data_for_key<'db>(
@@ -1537,7 +1492,7 @@ fn instantiated_effect_env_forwarded_witnesses<'db>(
 fn root_owner_generic_args<'db>(
     db: &'db dyn HirAnalysisDb,
     owner: BodyOwner<'db>,
-) -> Result<Vec<crate::analysis::ty::ty_def::TyId<'db>>, RootSemanticInstanceError<'db>> {
+) -> Result<Vec<TyId<'db>>, RootSemanticInstanceError<'db>> {
     match owner {
         BodyOwner::Func(func) => root_func_generic_args(db, func),
         BodyOwner::Const(_)
@@ -1550,7 +1505,7 @@ fn root_owner_generic_args<'db>(
 fn owner_identity_generic_args<'db>(
     db: &'db dyn HirAnalysisDb,
     owner: BodyOwner<'db>,
-) -> Vec<crate::analysis::ty::ty_def::TyId<'db>> {
+) -> Vec<TyId<'db>> {
     match owner {
         BodyOwner::Func(func) => CallableDef::Func(func).params(db).to_vec(),
         BodyOwner::Const(_)
@@ -1696,7 +1651,7 @@ fn root_provider_satisfies_effect_requirement<'db>(
 fn root_func_generic_args<'db>(
     db: &'db dyn HirAnalysisDb,
     func: crate::hir_def::Func<'db>,
-) -> Result<Vec<crate::analysis::ty::ty_def::TyId<'db>>, RootSemanticInstanceError<'db>> {
+) -> Result<Vec<TyId<'db>>, RootSemanticInstanceError<'db>> {
     let owner = BodyOwner::Func(func);
     let owner_scope = func.scope();
     let provider_param_idxs = place_effect_provider_param_index_map(db, func)
@@ -1842,8 +1797,8 @@ fn instantiate_provider_binding<'db>(
 fn instantiate_normalized_ty<'db>(
     db: &'db dyn HirAnalysisDb,
     key: SemanticInstanceKey<'db>,
-    ty: crate::analysis::ty::ty_def::TyId<'db>,
-) -> Result<crate::analysis::ty::ty_def::TyId<'db>, SemanticEffectEnvInstantiationError<'db>> {
+    ty: TyId<'db>,
+) -> Result<TyId<'db>, SemanticEffectEnvInstantiationError<'db>> {
     let scope = key.owner(db).scope();
     let assumptions = semantic_instance_base_assumptions_for_key(db, key);
     let ty = instantiate_checked(db, key.owner(db), scope, ty, key.subst(db).generic_args(db))?;
@@ -1890,7 +1845,7 @@ fn instantiate_checked<'db, T>(
     owner: BodyOwner<'db>,
     owner_scope: ScopeId<'db>,
     value: T,
-    args: &[crate::analysis::ty::ty_def::TyId<'db>],
+    args: &[TyId<'db>],
 ) -> Result<T, SemanticEffectEnvInstantiationError<'db>>
 where
     T: crate::analysis::ty::fold::TyFoldable<'db>,
@@ -1908,16 +1863,12 @@ where
 struct CheckedInstantiateFolder<'db, 'a> {
     owner: BodyOwner<'db>,
     owner_scope: ScopeId<'db>,
-    args: &'a [crate::analysis::ty::ty_def::TyId<'db>],
+    args: &'a [TyId<'db>],
     error: Option<SemanticEffectEnvInstantiationError<'db>>,
 }
 
 impl<'db> crate::analysis::ty::fold::TyFolder<'db> for CheckedInstantiateFolder<'db, '_> {
-    fn fold_ty(
-        &mut self,
-        db: &'db dyn HirAnalysisDb,
-        ty: crate::analysis::ty::ty_def::TyId<'db>,
-    ) -> crate::analysis::ty::ty_def::TyId<'db> {
+    fn fold_ty(&mut self, db: &'db dyn HirAnalysisDb, ty: TyId<'db>) -> TyId<'db> {
         match ty.data(db) {
             crate::analysis::ty::ty_def::TyData::TyParam(param)
                 if param.owner == self.owner_scope && !param.is_effect() =>

--- a/crates/hir/src/analysis/semantic/instance/semantic.rs
+++ b/crates/hir/src/analysis/semantic/instance/semantic.rs
@@ -921,6 +921,31 @@ pub fn resolved_provider_binding_for_instance_effect<'db>(
         })
 }
 
+pub(crate) fn resolved_effect_binding_ty_for_instance_effect<'db>(
+    db: &'db dyn HirAnalysisDb,
+    instance: SemanticInstance<'db>,
+    binding: LocalBinding<'db>,
+) -> Option<crate::analysis::ty::ty_def::TyId<'db>> {
+    let env = instantiated_effect_env(db, instance)?;
+    let (binding_idx, provider_idx) = match binding {
+        LocalBinding::EffectParam {
+            idx, provider_idx, ..
+        } => (idx, Some(provider_idx)),
+        LocalBinding::Param {
+            site: crate::analysis::ty::ty_check::ParamSite::EffectField(_),
+            idx,
+            ..
+        } => (idx, None),
+        LocalBinding::Local { .. } | LocalBinding::Param { .. } => return None,
+    };
+    Some(effect_binding_ty_from_env(
+        db,
+        Some(env),
+        binding_idx,
+        provider_idx,
+    ))
+}
+
 pub(crate) fn provisional_provider_binding_for_instance_effect<'db>(
     db: &'db dyn HirAnalysisDb,
     instance: SemanticInstance<'db>,
@@ -1433,17 +1458,13 @@ fn instantiate_provider_bindings_for_key<'db>(
     canonical: Vec<ProviderBinding<'db>>,
     resolutions: &[ResolvedEffectBinding],
 ) -> Result<Vec<ProviderBinding<'db>>, SemanticEffectEnvInstantiationError<'db>> {
-    let specializations = key
-        .effect_providers(db)
-        .providers(db)
-        .iter()
-        .map(|specialization| {
-            (
-                specialization.provider.provider_idx,
-                specialization.provider.clone(),
-            )
-        })
-        .collect::<FxHashMap<_, _>>();
+    let mut specializations = FxHashMap::default();
+    for specialization in key.effect_providers(db).providers(db) {
+        specializations.insert(
+            specialization.provider.provider_idx,
+            instantiate_provider_binding(db, key, specialization.provider.clone())?,
+        );
+    }
     if matches!(
         site,
         crate::analysis::ty::ty_check::EffectParamSite::Func(_)
@@ -1796,19 +1817,19 @@ fn instantiate_provider_binding<'db>(
         },
         source => source,
     };
-    let semantics = match source {
-        ProviderSource::ContractField { .. } => crate::analysis::ty::provider::ProviderSemantics {
+    let target_ty = provider
+        .semantics
+        .target_ty
+        .map(|ty| instantiate_normalized_ty(db, key, ty))
+        .transpose()?;
+    let semantics = if target_ty.is_some() {
+        crate::analysis::ty::provider::ProviderSemantics {
             provider_ty,
-            target_ty: provider
-                .semantics
-                .target_ty
-                .map(|ty| instantiate_normalized_ty(db, key, ty))
-                .transpose()?,
+            target_ty,
             ..provider.semantics
-        },
-        ProviderSource::UsesParam { .. } | ProviderSource::RootProvider { .. } => {
-            provider_semantics(db, scope, assumptions, provider_ty)
         }
+    } else {
+        provider_semantics(db, scope, assumptions, provider_ty)
     };
     Ok(ProviderBinding {
         provider_ty,

--- a/crates/hir/src/analysis/semantic/mod.rs
+++ b/crates/hir/src/analysis/semantic/mod.rs
@@ -16,7 +16,7 @@ pub use instance::{
     get_or_build_semantic_instance, identity_semantic_instance_key, instantiate_typed_body,
     instantiate_with_generic_args, instantiated_effect_env,
     resolved_provider_binding_for_instance_effect, root_semantic_instance_key, typed_body_template,
-    validate_instantiated_effect_env, validate_instantiated_effect_env_key,
+    validate_instantiated_effect_env_key,
 };
 pub(crate) use instance::{
     provisional_provider_binding_for_instance_effect, provisional_provider_idx_for_requirement,

--- a/crates/hir/src/analysis/ty/ty_check/expr.rs
+++ b/crates/hir/src/analysis/ty/ty_check/expr.rs
@@ -2061,8 +2061,12 @@ impl<'db> TyChecker<'db> {
                     self.env.owner(),
                 )
             });
+        let target_ty = provider_target_ty.map(|ty| self.table.fold_ty(self.db, ty));
         let provider = self
             .existing_provider_binding_for_effect_arg(provided, arg)
+            .filter(|provider| {
+                target_ty.is_none_or(|target_ty| provider.effective_target_ty() == target_ty)
+            })
             .map(|provider| ProviderBinding {
                 provider_idx: slot.provider_idx,
                 ..provider
@@ -2076,7 +2080,6 @@ impl<'db> TyChecker<'db> {
                         provider_target_ty,
                     )
                     .unwrap_or_else(|| self.table.fold_ty(self.db, provided.ty));
-                let target_ty = provider_target_ty.map(|ty| self.table.fold_ty(self.db, ty));
                 let semantics = provider_semantics_for_specialized_call(
                     self.db,
                     self.env.scope(),
@@ -2113,6 +2116,9 @@ impl<'db> TyChecker<'db> {
     ) -> Option<ProviderBinding<'db>> {
         let binding = match arg {
             super::EffectArg::Place(place) => {
+                if !place.projections.is_empty() {
+                    return None;
+                }
                 let PlaceBase::Binding(binding) = place.base;
                 Some(binding)
             }
@@ -2140,6 +2146,14 @@ impl<'db> TyChecker<'db> {
         let owner = self.env.owner();
         let binding = match arg {
             super::EffectArg::Place(place) => {
+                if !place.projections.is_empty()
+                    && let EffectOrigin::With { value_expr } = provided.origin
+                {
+                    return Some(EffectProviderProvenance::Expr {
+                        owner,
+                        expr: value_expr,
+                    });
+                }
                 let PlaceBase::Binding(binding) = place.base;
                 Some(binding)
             }

--- a/crates/hir/src/core/semantic/mod.rs
+++ b/crates/hir/src/core/semantic/mod.rs
@@ -1664,6 +1664,12 @@ pub struct ProviderBinding<'db> {
     pub semantics: ProviderSemantics<'db>,
 }
 
+impl<'db> ProviderBinding<'db> {
+    pub fn effective_target_ty(&self) -> TyId<'db> {
+        self.semantics.target_ty.unwrap_or(self.provider_ty)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Update)]
 pub struct ResolvedEffectBinding {
     pub requirement_idx: u32,

--- a/newsfragments/1459.bugfix.md
+++ b/newsfragments/1459.bugfix.md
@@ -1,0 +1,1 @@
+Fixed calls through projected effect providers, such as `with (store.map)`, so nested calls preserve the projected provider's concrete target type.


### PR DESCRIPTION
Fixes effect-provider specialization for projected providers, eg `with (store.map) { do_something_with_map() }` Previously, this would match the type of the root, and would fail during lowering. Also minor refactoring of nearby code.

