### PR TITLE
Restore fe_test fixture execution

### DIFF
--- a/crates/fe/tests/cli_output.rs
+++ b/crates/fe/tests/cli_output.rs
@@ -871,6 +871,20 @@ fn test_tree_output(fixture: Fixture<&str>) {
     snap_test!(output, snapshot_path.to_str().unwrap());
 }
 
+#[dir_test(
+    dir: "$CARGO_MANIFEST_DIR/tests/fixtures/fe_test",
+    glob: "*.fe",
+)]
+fn test_fe_test(fixture: Fixture<&str>) {
+    let (output, exit_code) = run_fe_main(&["test", "--jobs", "1", fixture.path()]);
+    assert_eq!(
+        exit_code,
+        0,
+        "fe test failed for {path}:\n{output}\n\nTo reproduce:\n  cargo run --bin fe -- test --jobs 1 {path}",
+        path = fixture.path(),
+    );
+}
+
 #[test]
 fn test_fe_test_rejects_oversized_balance_literal() {
     let temp = tempdir().expect("tempdir");


### PR DESCRIPTION
Fixing unintentional fallout from #1438.

fe_test fixtures were `fe test`ed by the compare-both-backends test, which was removed along with yul.