### PR TITLE
Mir dedupe

### DIFF
--- a/crates/codegen/src/sonatina/lower_runtime.rs
+++ b/crates/codegen/src/sonatina/lower_runtime.rs
@@ -402,9 +402,10 @@ impl<'db, 'a> ModuleLowerer<'db, 'a> {
                 let variants = data
                     .variants
                     .iter()
-                    .map(|variant| {
+                    .enumerate()
+                    .map(|(idx, variant)| {
                         Ok(VariantData {
-                            name: variant.name.clone(),
+                            name: format!("variant_{idx}"),
                             explicit_discriminant: None,
                             fields: variant
                                 .fields

--- a/crates/codegen/tests/fixtures/sonatina_ir/borrow_storage_field_handle.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/borrow_storage_field_handle.snap
@@ -6,7 +6,6 @@ input_file: crates/codegen/tests/fixtures/borrow_storage_field_handle.fe
 target = "evm-ethereum-osaka"
 
 type @layout_0 = {i256};
-type @layout_1 = {i256};
 
 func private %borrow_storage_field_handle(v0.i256) -> i256 {
     block0:
@@ -25,7 +24,7 @@ func private %borrow_storage_field_handle(v0.i256) -> i256 {
     block3:
         evm_sstore v0 v4;
         v14.i256 = evm_sload v0;
-        v15.@layout_1 = insert_value undef.@layout_1 0.i256 v14;
+        v15.@layout_0 = insert_value undef.@layout_0 0.i256 v14;
         v16.i256 = extract_value v15 0.i256;
         return v16;
 }

--- a/crates/codegen/tests/fixtures/sonatina_ir/by_ref_trait_provider_storage_bug.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/by_ref_trait_provider_storage_bug.snap
@@ -44,7 +44,7 @@ func private %abi_field_size(v0.i256) -> i256 {
         jump block1;
 
     block1:
-        v2.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_83d5_0 v0;
+        v2.i256 = call %payload_size v0;
         br 0.i1 block2 block3;
 
     block2:
@@ -232,7 +232,7 @@ func private %encode(v0.i256, v1.objref<@layout_0>) {
         jump block1;
 
     block1:
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_8ba2 v1 v0;
+        call %write_word v1 v0;
         return;
 }
 
@@ -245,10 +245,10 @@ func private %encode_field(v0.i256, v1.objref<@layout_0>, v2.i256) {
 
     block2:
         v5.i256 = call %base v1;
-        v8.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_83d5 v0;
+        v8.i256 = call %payload_size v0;
         v9.i256 = mload v2 i256;
         v10.i256 = sub v9 v5;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_291a v1 v10;
+        call %write_word v1 v10;
         v12.i256 = call %pos v1;
         v13.i256 = mload v2 i256;
         call %set_base v1 v13;
@@ -379,18 +379,6 @@ func inline(always) private %len(v0.@layout_1) -> i256 {
         jump block4;
 }
 
-func inline(always) private %impl_CallData__new() -> @layout_1 {
-    block0:
-        jump block1;
-
-    block1:
-        v1.constref<@layout_1> = const.ref $const_region_1;
-        v2.objref<@layout_1> = obj.alloc @layout_1;
-        obj.init.const v2 v1;
-        v3.@layout_1 = obj.load v2;
-        return v3;
-}
-
 func private %impl_SolEncoder__new(v0.i256) -> @layout_0 {
     block0:
         jump block1;
@@ -413,15 +401,19 @@ func private %impl_SolEncoder__new(v0.i256) -> @layout_0 {
         return v8;
 }
 
-func private %core__lib__abi__trait_AbiSize__payload_size__ge513_83d5(v0.i256) -> i256 {
+func inline(always) private %impl_CallData__new() -> @layout_1 {
     block0:
         jump block1;
 
     block1:
-        return 32.i256;
+        v1.constref<@layout_1> = const.ref $const_region_1;
+        v2.objref<@layout_1> = obj.alloc @layout_1;
+        obj.init.const v2 v1;
+        v3.@layout_1 = obj.load v2;
+        return v3;
 }
 
-func private %core__lib__abi__trait_AbiSize__payload_size__ge513_83d5_0(v0.i256) -> i256 {
+func private %payload_size(v0.i256) -> i256 {
     block0:
         jump block1;
 
@@ -505,21 +497,7 @@ func private %use_ctx(v0.i256) -> i256 {
         return v2;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_291a(v0.objref<@layout_0>, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v4.objref<i256> = obj.proj v0 1.i256;
-        v5.i256 = obj.load v4;
-        mstore v5 v1 i256;
-        v9.i256 = add v5 32.i256;
-        v10.objref<i256> = obj.proj v0 1.i256;
-        obj.store v10 v9;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_8ba2(v0.objref<@layout_0>, v1.i256) {
+func private %write_word(v0.objref<@layout_0>, v1.i256) {
     block0:
         jump block1;
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/by_ref_trait_provider_storage_bug.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/by_ref_trait_provider_storage_bug.snap
@@ -9,10 +9,8 @@ type @layout_0 = {i256, i256};
 type @layout_1 = {i256};
 type @layout_2 = {};
 type @layout_3 = {@layout_2};
-type @layout_4 = {i256, i256};
-type @layout_5 = {i256, i256};
 
-global private const @layout_5 $const_region_0 = {40, 2};
+global private const @layout_0 $const_region_0 = {40, 2};
 global private const @layout_1 $const_region_1 = {0};
 
 func private %__ByRefTraitProviderStorageBug_init(v0.i256) {
@@ -20,10 +18,10 @@ func private %__ByRefTraitProviderStorageBug_init(v0.i256) {
         jump block1;
 
     block1:
-        v3.constref<@layout_5> = const.ref $const_region_0;
-        v4.objref<@layout_5> = obj.alloc @layout_5;
+        v3.constref<@layout_0> = const.ref $const_region_0;
+        v4.objref<@layout_0> = obj.alloc @layout_0;
         obj.init.const v4 v3;
-        v5.@layout_5 = obj.load v4;
+        v5.@layout_0 = obj.load v4;
         v8.i256 = extract_value v5 0.i256;
         evm_sstore v0 v8;
         v10.i256 = extract_value v5 1.i256;
@@ -153,7 +151,7 @@ func inline(always) private %contract_recv_abi_ByRefTraitProviderStorageBug_1() 
         v5.objref<@layout_3> = obj.alloc @layout_3;
         call %decode_runtime_args v5;
         v7.i256 = call %__ByRefTraitProviderStorageBug_recv_0_0 0.i256;
-        v8.@layout_4 = call %encode_single_root_alloc v7;
+        v8.@layout_0 = call %encode_single_root_alloc v7;
         v9.i256 = extract_value v8 0.i256;
         v11.i256 = extract_value v8 1.i256;
         evm_return v9 v11;
@@ -234,7 +232,7 @@ func private %encode(v0.i256, v1.objref<@layout_0>) {
         jump block1;
 
     block1:
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_e918 v1 v0;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_8ba2 v1 v0;
         return;
 }
 
@@ -250,7 +248,7 @@ func private %encode_field(v0.i256, v1.objref<@layout_0>, v2.i256) {
         v8.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_83d5 v0;
         v9.i256 = mload v2 i256;
         v10.i256 = sub v9 v5;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_7682 v1 v10;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_291a v1 v10;
         v12.i256 = call %pos v1;
         v13.i256 = mload v2 i256;
         call %set_base v1 v13;
@@ -299,7 +297,7 @@ func private %encode_single_root(v0.i256, v1.objref<@layout_0>) {
         return;
 }
 
-func private %encode_single_root_alloc(v0.i256) -> @layout_4 {
+func private %encode_single_root_alloc(v0.i256) -> @layout_0 {
     block0:
         jump block1;
 
@@ -315,8 +313,8 @@ func private %encode_single_root_alloc(v0.i256) -> @layout_4 {
         obj.store v9 v10;
         v11.i256 = call %base v4;
         call %encode_single_root v0 v4;
-        v14.@layout_4 = insert_value undef.@layout_4 0.i256 v11;
-        v15.@layout_4 = insert_value v14 1.i256 v2;
+        v14.@layout_0 = insert_value undef.@layout_0 0.i256 v11;
+        v15.@layout_0 = insert_value v14 1.i256 v2;
         return v15;
 }
 
@@ -507,7 +505,7 @@ func private %use_ctx(v0.i256) -> i256 {
         return v2;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_7682(v0.objref<@layout_0>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_291a(v0.objref<@layout_0>, v1.i256) {
     block0:
         jump block1;
 
@@ -521,7 +519,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_7682(v0
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_e918(v0.objref<@layout_0>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_8ba2(v0.objref<@layout_0>, v1.i256) {
     block0:
         jump block1;
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/caller.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/caller.snap
@@ -7,17 +7,7 @@ target = "evm-ethereum-osaka"
 
 type @layout_0 = {i256};
 
-func private %std__lib__evm__effects__impl_trait_Evm_a1e8__caller_efe3() -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v0.i256 = evm_caller;
-        v3.@layout_0 = insert_value undef.@layout_0 0.i256 v0;
-        return v3;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_a1e8__caller_efe3_0() -> @layout_0 {
+func private %caller() -> @layout_0 {
     block0:
         jump block1;
 
@@ -50,7 +40,7 @@ func private %standalone_caller__caller__who_called__gcd5c_4c8a() -> @layout_0 {
         jump block1;
 
     block1:
-        v0.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_a1e8__caller_efe3;
+        v0.@layout_0 = call %caller;
         return v0;
 }
 
@@ -59,7 +49,7 @@ func private %standalone_caller__caller__who_called__gcd5c_a9cd() -> @layout_0 {
         jump block1;
 
     block1:
-        v0.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_a1e8__caller_efe3_0;
+        v0.@layout_0 = call %caller;
         return v0;
 }
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/code_region.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/code_region.snap
@@ -12,7 +12,7 @@ func private %balance() {
         jump block1;
 
     block1:
-        call %std__lib__evm__effects__impl_trait_Evm_0098__return_data_e62a 0.i256 0.i256;
+        call %return_data 0.i256 0.i256;
         unreachable;
 }
 
@@ -43,8 +43,8 @@ func private %child_init() {
         v1.i256 = sym_addr &__Child_runtime;
         v2.*i8 = evm_malloc v0;
         v3.i256 = ptr_to_int v2 i256;
-        call %std__lib__evm__effects__impl_trait_Evm_0098__codecopy_7791_0 v3 v1 v0;
-        call %std__lib__evm__effects__impl_trait_Evm_0098__return_data_5f25_2 v3 v0;
+        call %codecopy v3 v1 v0;
+        call %return_data v3 v0;
         unreachable;
 }
 
@@ -54,20 +54,11 @@ func private %child_runtime() {
 
     block1:
         call %calldatacopy 0.i256 0.i256 4.i256;
-        call %std__lib__evm__effects__impl_trait_Evm_0098__return_data_5f25_1 0.i256 4.i256;
+        call %return_data 0.i256 4.i256;
         unreachable;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_0098__codecopy_7791(v0.i256, v1.i256, v2.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        evm_code_copy v0 v1 v2;
-        return;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_0098__codecopy_7791_0(v0.i256, v1.i256, v2.i256) {
+func private %codecopy(v0.i256, v1.i256, v2.i256) {
     block0:
         jump block1;
 
@@ -95,14 +86,14 @@ func private %init() {
         v1.i256 = sym_addr &__Child_init;
         v2.*i8 = evm_malloc v0;
         v3.i256 = ptr_to_int v2 i256;
-        call %std__lib__evm__effects__impl_trait_Evm_0098__codecopy_7791 v3 v1 v0;
+        call %codecopy v3 v1 v0;
         v7.@layout_0 = call %create2_raw 0.i256 v3 v0 4660.i256;
         v8.i256 = sym_size &__Foo_runtime;
         v9.i256 = sym_addr &__Foo_runtime;
         v10.*i8 = evm_malloc v8;
         v11.i256 = ptr_to_int v10 i256;
-        call %std__lib__evm__effects__impl_trait_Evm_0098__codecopy_7791 v11 v9 v8;
-        call %std__lib__evm__effects__impl_trait_Evm_0098__return_data_5f25_0 v11 v8;
+        call %codecopy v11 v9 v8;
+        call %return_data v11 v8;
         unreachable;
 }
 
@@ -152,39 +143,7 @@ func private %read_selector() -> i256 {
         return v3;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_0098__return_data_5f25(v0.i256, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        evm_return v0 v1;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_0098__return_data_5f25_0(v0.i256, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        evm_return v0 v1;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_0098__return_data_5f25_1(v0.i256, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        evm_return v0 v1;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_0098__return_data_5f25_2(v0.i256, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        evm_return v0 v1;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_0098__return_data_e62a(v0.i256, v1.i256) {
+func private %return_data(v0.i256, v1.i256) {
     block0:
         jump block1;
 
@@ -202,7 +161,7 @@ func private %runtime() {
         br v2 block3 block6;
 
     block2:
-        call %std__lib__evm__effects__impl_trait_Evm_0098__return_data_5f25 0.i256 0.i256;
+        call %return_data 0.i256 0.i256;
         unreachable;
 
     block3:
@@ -229,7 +188,7 @@ func private %transfer() {
         jump block1;
 
     block1:
-        call %std__lib__evm__effects__impl_trait_Evm_0098__return_data_e62a 0.i256 0.i256;
+        call %return_data 0.i256 0.i256;
         unreachable;
 }
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/code_region_qualified.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/code_region_qualified.snap
@@ -24,7 +24,7 @@ func private %init() {
         v2.*i8 = evm_malloc v0;
         v3.i256 = ptr_to_int v2 i256;
         call %codecopy v3 v1 v0;
-        call %std__lib__evm__effects__impl_trait_Evm_0098__return_data_cf61_0 v3 v0;
+        call %return_data v3 v0;
         unreachable;
 }
 
@@ -46,15 +46,7 @@ func private %manual_contract_runtime_root_Foo() {
         evm_stop;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_0098__return_data_cf61(v0.i256, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        evm_return v0 v1;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_0098__return_data_cf61_0(v0.i256, v1.i256) {
+func private %return_data(v0.i256, v1.i256) {
     block0:
         jump block1;
 
@@ -67,7 +59,7 @@ func private %runtime() {
         jump block1;
 
     block1:
-        call %std__lib__evm__effects__impl_trait_Evm_0098__return_data_cf61 0.i256 0.i256;
+        call %return_data 0.i256 0.i256;
         unreachable;
 }
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/create_contract.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/create_contract.snap
@@ -7,17 +7,13 @@ target = "evm-ethereum-osaka"
 
 type @layout_0 = {i256};
 type @layout_1 = {i256, i256};
-type @layout_2 = {i256, i256};
-type @layout_3 = {i256, i256};
-type @layout_4 = {@layout_3, i256};
-type @layout_5 = {@layout_4, i256};
-type @layout_6 = {i256};
-type @layout_7 = {i256, i256, i256};
-type @layout_8 = {i256, i256};
-type @layout_9 = {};
-type @layout_10 = {@layout_9};
+type @layout_2 = {@layout_1, i256};
+type @layout_3 = {@layout_2, i256};
+type @layout_4 = {i256, i256, i256};
+type @layout_5 = {};
+type @layout_6 = {@layout_5};
 
-global private const @layout_6 $const_region_0 = {0};
+global private const @layout_0 $const_region_0 = {0};
 
 func private %__Child_init(v0.i256, v1.i256, v2.i256) {
     block0:
@@ -57,7 +53,7 @@ func private %abi_field_size(v0.@layout_0) -> i256 {
         jump block1;
 
     block1:
-        v2.i256 = call %core__lib__abi__trait_AbiSize__payload_size__g67a8_7f10_0 v0;
+        v2.i256 = call %core__lib__abi__trait_AbiSize__payload_size__g67a8_f166_0 v0;
         br 0.i1 block2 block3;
 
     block2:
@@ -115,27 +111,27 @@ func private %std__lib__evm__effects__impl_trait_Evm_c913__abort_9c27() {
         unreachable;
 }
 
-func inline(always) private %std__lib__abi__sol__impl_SolEncoder_ce34__at_6558(v0.i256) -> @layout_2 {
+func inline(always) private %std__lib__abi__sol__impl_SolEncoder_ce34__at_6558(v0.i256) -> @layout_1 {
     block0:
         jump block1;
 
     block1:
-        v4.@layout_2 = insert_value undef.@layout_2 0.i256 v0;
-        v6.@layout_2 = insert_value v4 1.i256 v0;
+        v4.@layout_1 = insert_value undef.@layout_1 0.i256 v0;
+        v6.@layout_1 = insert_value v4 1.i256 v0;
         return v6;
 }
 
-func inline(always) private %std__lib__abi__sol__impl_SolEncoder_ce34__at_9565(v0.i256) -> @layout_2 {
+func inline(always) private %std__lib__abi__sol__impl_SolEncoder_ce34__at_9565(v0.i256) -> @layout_1 {
     block0:
         jump block1;
 
     block1:
-        v4.@layout_2 = insert_value undef.@layout_2 0.i256 v0;
-        v6.@layout_2 = insert_value v4 1.i256 v0;
+        v4.@layout_1 = insert_value undef.@layout_1 0.i256 v0;
+        v6.@layout_1 = insert_value v4 1.i256 v0;
         return v6;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_0284(v0.objref<@layout_2>) -> i256 {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_3d65(v0.objref<@layout_1>) -> i256 {
     block0:
         jump block1;
 
@@ -145,32 +141,32 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_0284(v0.objre
         return v4;
 }
 
-func private %base__g463e(v0.objref<@layout_5>) -> i256 {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_4571(v0.objref<@layout_1>) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v3.objref<i256> = obj.proj v0 0.i256;
+        v4.i256 = obj.load v3;
+        return v4;
+}
+
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_756a(v0.objref<@layout_1>) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v3.objref<i256> = obj.proj v0 0.i256;
+        v4.i256 = obj.load v3;
+        return v4;
+}
+
+func private %base__g463e(v0.objref<@layout_3>) -> i256 {
     block0:
         jump block1;
 
     block1:
         v3.objref<i256> = obj.proj v0 1.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_32b3(v0.objref<@layout_2>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 0.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_ae34(v0.objref<@layout_2>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 0.i256;
         v4.i256 = obj.load v3;
         return v4;
 }
@@ -297,8 +293,8 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_4919(v0.i256, v
 
 func inline(always) private %contract_init_abi_Child() {
     block0:
-        v0.objref<@layout_3> = obj.alloc @layout_3;
-        v1.objref<@layout_5> = obj.alloc @layout_5;
+        v0.objref<@layout_1> = obj.alloc @layout_1;
+        v1.objref<@layout_3> = obj.alloc @layout_3;
         jump block1;
 
     block1:
@@ -336,12 +332,12 @@ func inline(always) private %contract_init_abi_Child() {
         obj.store v23 v20;
         v25.objref<i256> = obj.proj v0 1.i256;
         obj.store v25 v13;
-        v26.@layout_3 = obj.load v0;
-        v27.@layout_5 = call %decoder_new v26;
-        v28.objref<@layout_4> = obj.proj v1 0.i256;
-        v29.@layout_4 = extract_value v27 0.i256;
-        v30.objref<@layout_3> = obj.proj v28 0.i256;
-        v31.@layout_3 = extract_value v29 0.i256;
+        v26.@layout_1 = obj.load v0;
+        v27.@layout_3 = call %decoder_new v26;
+        v28.objref<@layout_2> = obj.proj v1 0.i256;
+        v29.@layout_2 = extract_value v27 0.i256;
+        v30.objref<@layout_1> = obj.proj v28 0.i256;
+        v31.@layout_1 = extract_value v29 0.i256;
         v32.objref<i256> = obj.proj v30 0.i256;
         v33.i256 = extract_value v31 0.i256;
         obj.store v32 v33;
@@ -416,8 +412,8 @@ func inline(always) private %contract_recv_abi_Factory_1() {
         evm_revert 0.i256 0.i256;
 
     block3:
-        v5.objref<@layout_10> = obj.alloc @layout_10;
-        v6.@layout_8 = call %decode_runtime_args__gbdfb v5;
+        v5.objref<@layout_6> = obj.alloc @layout_6;
+        v6.@layout_1 = call %decode_runtime_args__gbdfb v5;
         v7.i256 = extract_value v6 0.i256;
         v9.i256 = extract_value v6 1.i256;
         v10.@layout_0 = call %__Factory_recv_0_0 v7 v9;
@@ -441,8 +437,8 @@ func inline(always) private %contract_recv_abi_Factory_2() {
         evm_revert 0.i256 0.i256;
 
     block3:
-        v5.objref<@layout_10> = obj.alloc @layout_10;
-        v6.@layout_7 = call %decode_runtime_args__gadcc v5;
+        v5.objref<@layout_6> = obj.alloc @layout_6;
+        v6.@layout_4 = call %decode_runtime_args__gadcc v5;
         v7.i256 = extract_value v6 0.i256;
         v9.i256 = extract_value v6 1.i256;
         v11.i256 = extract_value v6 2.i256;
@@ -734,7 +730,7 @@ func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_e3bb() {
         evm_revert 0.i256 0.i256;
 }
 
-func inline(always) private %decode_field(v0.objref<@layout_5>) -> i256 {
+func inline(always) private %decode_field(v0.objref<@layout_3>) -> i256 {
     block0:
         jump block1;
 
@@ -742,7 +738,7 @@ func inline(always) private %decode_field(v0.objref<@layout_5>) -> i256 {
         br 0.i1 block2 block3;
 
     block2:
-        v3.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_272f v0;
+        v3.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_a38b v0;
         v4.i256 = call %base__g463e v0;
         v5.i256 = call %pos__g463e v0;
         (v6.i256, v7.i1) = uaddo v4 v3;
@@ -770,7 +766,7 @@ func inline(always) private %decode_field(v0.objref<@layout_5>) -> i256 {
         return v17;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from__g5385_0636(v0.@layout_6, v1.i256, v2.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_field_from__g5385_a92f(v0.@layout_0, v1.i256, v2.i256) -> i256 {
     block0:
         jump block1;
 
@@ -778,7 +774,7 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_0636(v0.@l
         br 0.i1 block2 block3;
 
     block2:
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_32d2 v0 v2;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_bb63 v0 v2;
         (v8.i256, v9.i1) = uaddo v1 v6;
         br v9 block5 block6;
 
@@ -786,7 +782,7 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_0636(v0.@l
         jump block4;
 
     block4:
-        v19.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_3180_0 v0 v2;
+        v19.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_0674_0 v0 v2;
         return v19;
 
     block5:
@@ -795,11 +791,11 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_0636(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v16.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_3180_0 v0 v8;
+        v16.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_0674_0 v0 v8;
         return v16;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from__g5385_5caf(v0.@layout_6, v1.i256, v2.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_field_from__g5385_d499(v0.@layout_0, v1.i256, v2.i256) -> i256 {
     block0:
         jump block1;
 
@@ -807,7 +803,7 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_5caf(v0.@l
         br 0.i1 block2 block3;
 
     block2:
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3368 v0 v2;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_44ae v0 v2;
         (v8.i256, v9.i1) = uaddo v1 v6;
         br v9 block5 block6;
 
@@ -815,7 +811,7 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_5caf(v0.@l
         jump block4;
 
     block4:
-        v19.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8640_0 v0 v2;
+        v19.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8794_0 v0 v2;
         return v19;
 
     block5:
@@ -824,11 +820,11 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_5caf(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v16.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8640_0 v0 v8;
+        v16.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8794_0 v0 v8;
         return v16;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_0f32(v0.@layout_6, v1.i256, v2.i256, v3.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_48c1(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
         jump block1;
 
@@ -836,65 +832,83 @@ func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__
         br 0.i1 block2 block3;
 
     block2:
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3368 v0 v2;
-        v9.i256 = call %core__lib__abi__checked_tail__gf13e_4046 v1 v7;
-        v11.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_7fc6 v0 v9 v3;
-        return v11;
-
-    block3:
-        jump block4;
-
-    block4:
-        v14.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8640_0 v0 v2;
-        return v14;
-}
-
-func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_f107(v0.@layout_6, v1.i256, v2.i256, v3.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        br 0.i1 block2 block3;
-
-    block2:
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_32d2 v0 v2;
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_44ae v0 v2;
         v9.i256 = call %core__lib__abi__checked_tail__gf13e_4919 v1 v7;
-        v11.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_7780 v0 v9 v3;
+        v11.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_0108 v0 v9 v3;
         return v11;
 
     block3:
         jump block4;
 
     block4:
-        v14.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_3180_0 v0 v2;
+        v14.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8794_0 v0 v2;
         return v14;
 }
 
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_3180(v0.@layout_6, v1.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_af97(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_8c36 v0 v1;
+        br 0.i1 block2 block3;
+
+    block2:
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_bb63 v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_4046 v1 v7;
+        v11.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_bec2 v0 v9 v3;
+        return v11;
+
+    block3:
+        jump block4;
+
+    block4:
+        v14.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_0674_0 v0 v2;
+        return v14;
+}
+
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_0674(v0.@layout_0, v1.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b9e6 v0 v1;
         return v4;
 }
 
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_3180_0(v0.@layout_6, v1.i256) -> i256 {
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_0674_0(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_8c36_0 v0 v1;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b9e6_0 v0 v1;
         return v4;
 }
 
-func inline(always) private %impl_trait_Deploy2__decode_from__gd20d(v0.@layout_6, v1.i256) -> @layout_7 {
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8794(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_6f75 v0;
-        v5.i256 = call %core__lib__abi__decode_msg_field_from__g5385_f1db v0 v1 v1 v3;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_d88e v0 v1;
+        return v4;
+}
+
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8794_0(v0.@layout_0, v1.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_d88e_0 v0 v1;
+        return v4;
+}
+
+func inline(always) private %impl_trait_Deploy2__decode_from__gd20d(v0.@layout_0, v1.i256) -> @layout_4 {
+    block0:
+        jump block1;
+
+    block1:
+        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_a79f v0;
+        v5.i256 = call %core__lib__abi__decode_msg_field_from__g5385_819c v0 v1 v1 v3;
         (v7.i256, v8.i1) = uaddo v1 32.i256;
         br v8 block2 block3;
 
@@ -904,7 +918,7 @@ func inline(always) private %impl_trait_Deploy2__decode_from__gd20d(v0.@layout_6
         evm_revert 0.i256 36.i256;
 
     block3:
-        v17.i256 = call %core__lib__abi__decode_msg_field_from__g5385_f1db v0 v1 v7 v3;
+        v17.i256 = call %core__lib__abi__decode_msg_field_from__g5385_819c v0 v1 v7 v3;
         (v20.i256, v21.i1) = uaddo v1 32.i256;
         br v21 block2 block4;
 
@@ -913,58 +927,20 @@ func inline(always) private %impl_trait_Deploy2__decode_from__gd20d(v0.@layout_6
         br v23 block2 block5;
 
     block5:
-        v27.i256 = call %core__lib__abi__decode_msg_field_from__g5385_f1db v0 v1 v22 v3;
-        v30.@layout_7 = insert_value undef.@layout_7 0.i256 v5;
-        v33.@layout_7 = insert_value v30 1.i256 v17;
-        v35.@layout_7 = insert_value v33 2.i256 v27;
+        v27.i256 = call %core__lib__abi__decode_msg_field_from__g5385_819c v0 v1 v22 v3;
+        v30.@layout_4 = insert_value undef.@layout_4 0.i256 v5;
+        v33.@layout_4 = insert_value v30 1.i256 v17;
+        v35.@layout_4 = insert_value v33 2.i256 v27;
         return v35;
 }
 
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8640(v0.@layout_6, v1.i256) -> i256 {
+func inline(always) private %impl_trait_Deploy__decode_from__gd20d(v0.@layout_0, v1.i256) -> @layout_1 {
     block0:
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b2da v0 v1;
-        return v4;
-}
-
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8640_0(v0.@layout_6, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b2da_0 v0 v1;
-        return v4;
-}
-
-func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_7780(v0.@layout_6, v1.i256, v2.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_352b v1 32.i256 v2;
-        v8.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_3180 v0 v1;
-        return v8;
-}
-
-func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_7fc6(v0.@layout_6, v1.i256, v2.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_056e v1 32.i256 v2;
-        v8.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8640 v0 v1;
-        return v8;
-}
-
-func inline(always) private %impl_trait_Deploy__decode_from__gd20d(v0.@layout_6, v1.i256) -> @layout_8 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_2577 v0;
-        v5.i256 = call %core__lib__abi__decode_msg_field_from__g5385_790c v0 v1 v1 v3;
+        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_18d5 v0;
+        v5.i256 = call %core__lib__abi__decode_msg_field_from__g5385_02f4 v0 v1 v1 v3;
         (v7.i256, v8.i1) = uaddo v1 32.i256;
         br v8 block2 block3;
 
@@ -974,31 +950,51 @@ func inline(always) private %impl_trait_Deploy__decode_from__gd20d(v0.@layout_6,
         evm_revert 0.i256 36.i256;
 
     block3:
-        v17.i256 = call %core__lib__abi__decode_msg_field_from__g5385_790c v0 v1 v7 v3;
-        v20.@layout_8 = insert_value undef.@layout_8 0.i256 v5;
-        v22.@layout_8 = insert_value v20 1.i256 v17;
+        v17.i256 = call %core__lib__abi__decode_msg_field_from__g5385_02f4 v0 v1 v7 v3;
+        v20.@layout_1 = insert_value undef.@layout_1 0.i256 v5;
+        v22.@layout_1 = insert_value v20 1.i256 v17;
         return v22;
 }
 
-func inline(always) private %decode_from_prechecked_head__g4e6c(v0.@layout_6, v1.i256, v2.i256) -> @layout_7 {
+func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_0108(v0.@layout_0, v1.i256, v2.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v6.@layout_7 = call %impl_trait_Deploy2__decode_from__gd20d v0 v1;
-        return v6;
+        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_352b v1 32.i256 v2;
+        v8.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8794 v0 v1;
+        return v8;
 }
 
-func inline(always) private %decode_from_prechecked_head__gbecb(v0.@layout_6, v1.i256, v2.i256) -> @layout_8 {
+func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_bec2(v0.@layout_0, v1.i256, v2.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v6.@layout_8 = call %impl_trait_Deploy__decode_from__gd20d v0 v1;
+        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_056e v1 32.i256 v2;
+        v8.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_0674 v0 v1;
+        return v8;
+}
+
+func inline(always) private %decode_from_prechecked_head__gbecb(v0.@layout_0, v1.i256, v2.i256) -> @layout_1 {
+    block0:
+        jump block1;
+
+    block1:
+        v6.@layout_1 = call %impl_trait_Deploy__decode_from__gd20d v0 v1;
         return v6;
 }
 
-func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_790c(v0.@layout_6, v1.i256, v2.i256, v3.i256) -> i256 {
+func inline(always) private %decode_from_prechecked_head__g4e6c(v0.@layout_0, v1.i256, v2.i256) -> @layout_4 {
+    block0:
+        jump block1;
+
+    block1:
+        v6.@layout_4 = call %impl_trait_Deploy2__decode_from__gd20d v0 v1;
+        return v6;
+}
+
+func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_02f4(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
         jump block1;
 
@@ -1006,18 +1002,18 @@ func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_790c(v
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_f107 v0 v1 v2 v3;
+        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_48c1 v0 v1 v2 v3;
         return v9;
 
     block3:
         jump block4;
 
     block4:
-        v14.i256 = call %core__lib__abi__decode_field_from__g5385_0636 v0 v1 v2;
+        v14.i256 = call %core__lib__abi__decode_field_from__g5385_d499 v0 v1 v2;
         return v14;
 }
 
-func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_f1db(v0.@layout_6, v1.i256, v2.i256, v3.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_819c(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
         jump block1;
 
@@ -1025,27 +1021,18 @@ func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_f1db(v
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_0f32 v0 v1 v2 v3;
+        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_af97 v0 v1 v2 v3;
         return v9;
 
     block3:
         jump block4;
 
     block4:
-        v14.i256 = call %core__lib__abi__decode_field_from__g5385_5caf v0 v1 v2;
+        v14.i256 = call %core__lib__abi__decode_field_from__g5385_a92f v0 v1 v2;
         return v14;
 }
 
-func inline(always) private %decode_payload__g407e(v0.objref<@layout_5>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_7adc v0;
-        return v2;
-}
-
-func private %decode_payload__g4770(v0.objref<@layout_5>) -> @layout_1 {
+func private %decode_payload__g4770(v0.objref<@layout_3>) -> @layout_1 {
     block0:
         jump block1;
 
@@ -1057,45 +1044,24 @@ func private %decode_payload__g4770(v0.objref<@layout_5>) -> @layout_1 {
         return v8;
 }
 
-func inline(always) private %decode_runtime_args__gadcc(v0.objref<@layout_10>) -> @layout_7 {
+func inline(always) private %decode_payload__g407e(v0.objref<@layout_3>) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.@layout_6 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_b215;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_847d v3;
-        mstore v1 4.i256 i256;
-        br 0.i1 block2 block5;
-
-    block2:
-        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_9c27;
-        unreachable;
-
-    block3:
-        jump block4;
-
-    block4:
-        v12.@layout_7 = call %decode_from_prechecked_head__g4e6c v3 4.i256 v5;
-        return v12;
-
-    block5:
-        mstore v2 v5 i256;
-        v15.i256 = mload v2 i256;
-        v16.i1 = gt 100.i256 v15;
-        br v16 block2 block3;
+        v2.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_1d50 v0;
+        return v2;
 }
 
-func inline(always) private %decode_runtime_args__gbdfb(v0.objref<@layout_10>) -> @layout_8 {
+func inline(always) private %decode_runtime_args__gbdfb(v0.objref<@layout_6>) -> @layout_1 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.@layout_6 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_2b2c;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_8db5 v3;
+        v3.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_2b2c;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_3968 v3;
         mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
 
@@ -1107,7 +1073,7 @@ func inline(always) private %decode_runtime_args__gbdfb(v0.objref<@layout_10>) -
         jump block4;
 
     block4:
-        v12.@layout_8 = call %decode_from_prechecked_head__gbecb v3 4.i256 v5;
+        v12.@layout_1 = call %decode_from_prechecked_head__gbecb v3 4.i256 v5;
         return v12;
 
     block5:
@@ -1117,12 +1083,42 @@ func inline(always) private %decode_runtime_args__gbdfb(v0.objref<@layout_10>) -
         br v16 block2 block3;
 }
 
-func private %decoder_new(v0.@layout_3) -> @layout_5 {
+func inline(always) private %decode_runtime_args__gadcc(v0.objref<@layout_6>) -> @layout_4 {
+    block0:
+        v1.*i256 = alloca i256;
+        v2.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v3.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_b215;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_6dc1 v3;
+        mstore v1 4.i256 i256;
+        br 0.i1 block2 block5;
+
+    block2:
+        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_9c27;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        v12.@layout_4 = call %decode_from_prechecked_head__g4e6c v3 4.i256 v5;
+        return v12;
+
+    block5:
+        mstore v2 v5 i256;
+        v15.i256 = mload v2 i256;
+        v16.i1 = gt 100.i256 v15;
+        br v16 block2 block3;
+}
+
+func private %decoder_new(v0.@layout_1) -> @layout_3 {
     block0:
         jump block1;
 
     block1:
-        v2.@layout_5 = call %impl_SolDecoder__new__g463e v0;
+        v2.@layout_3 = call %impl_SolDecoder__new__g463e v0;
         return v2;
 }
 
@@ -1144,13 +1140,13 @@ func private %dynamic_payload_size(v0.i256) -> i256 {
         return 0.i256;
 }
 
-func inline(always) private %encode__g7769(v0.@layout_1, v1.objref<@layout_2>) {
+func inline(always) private %encode__g7769(v0.@layout_1, v1.objref<@layout_1>) {
     block0:
         v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_0284 v1;
+        v4.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_756a v1;
         v6.i256 = add v4 64.i256;
         mstore v2 v6 i256;
         v8.i256 = add v4 32.i256;
@@ -1161,26 +1157,7 @@ func inline(always) private %encode__g7769(v0.@layout_1, v1.objref<@layout_2>) {
         v16.i256 = ptr_to_int v2 i256;
         call %encode_field_at v15 v1 v4 v8 v16;
         v18.i256 = add v4 64.i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_4208 v1 v18;
-        return;
-}
-
-func private %impl_trait_u256__encode__g426c(v0.i256, v1.objref<@layout_2>) {
-    block0:
-        jump block1;
-
-    block1:
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_498a v1 v0;
-        return;
-}
-
-func private %impl_trait_Address__encode__g426c(v0.@layout_0, v1.objref<@layout_2>) {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_2c07 v1 v4;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_13bc v1 v18;
         return;
 }
 
@@ -1199,22 +1176,41 @@ func inline(always) private %encode_alloc(v0.@layout_1) -> @layout_1 {
 
     block1:
         v2.i256 = call %abi_payload_size v0;
-        v3.@layout_2 = call %std__lib__abi__sol__impl_trait_Sol_1f5f__encoder_new_58e9 v2;
-        v4.objref<@layout_2> = obj.alloc @layout_2;
+        v3.@layout_1 = call %std__lib__abi__sol__impl_trait_Sol_1f5f__encoder_new_58e9 v2;
+        v4.objref<@layout_1> = obj.alloc @layout_1;
         v6.objref<i256> = obj.proj v4 0.i256;
         v7.i256 = extract_value v3 0.i256;
         obj.store v6 v7;
         v9.objref<i256> = obj.proj v4 1.i256;
         v10.i256 = extract_value v3 1.i256;
         obj.store v9 v10;
-        v11.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_ae34 v4;
+        v11.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_4571 v4;
         call %encode__g7769 v0 v4;
         v14.@layout_1 = insert_value undef.@layout_1 0.i256 v11;
         v15.@layout_1 = insert_value v14 1.i256 v2;
         return v15;
 }
 
-func private %encode_field(v0.@layout_0, v1.objref<@layout_2>, v2.i256) {
+func private %impl_trait_u256__encode__g426c(v0.i256, v1.objref<@layout_1>) {
+    block0:
+        jump block1;
+
+    block1:
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_7a3d v1 v0;
+        return;
+}
+
+func private %impl_trait_Address__encode__g426c(v0.@layout_0, v1.objref<@layout_1>) {
+    block0:
+        jump block1;
+
+    block1:
+        v4.i256 = extract_value v0 0.i256;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_1938 v1 v4;
+        return;
+}
+
+func private %encode_field(v0.@layout_0, v1.objref<@layout_1>, v2.i256) {
     block0:
         jump block1;
 
@@ -1222,19 +1218,19 @@ func private %encode_field(v0.@layout_0, v1.objref<@layout_2>, v2.i256) {
         br 0.i1 block2 block3;
 
     block2:
-        v5.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_32b3 v1;
-        v8.i256 = call %core__lib__abi__trait_AbiSize__payload_size__g67a8_7f10 v0;
+        v5.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_3d65 v1;
+        v8.i256 = call %core__lib__abi__trait_AbiSize__payload_size__g67a8_f166 v0;
         v9.i256 = mload v2 i256;
         v10.i256 = sub v9 v5;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_528a v1 v10;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_ef72 v1 v10;
         v12.i256 = call %impl_trait_SolEncoder__pos v1;
         v13.i256 = mload v2 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_b006 v1 v13;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_effd v1 v13;
         v15.i256 = mload v2 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_d061 v1 v15;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_0bd5 v1 v15;
         call %impl_trait_Address__encode__g426c v0 v1;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_b006 v1 v5;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_d061 v1 v12;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_effd v1 v5;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_0bd5 v1 v12;
         v20.i256 = mload v2 i256;
         v21.i256 = add v20 v8;
         mstore v2 v21 i256;
@@ -1250,7 +1246,7 @@ func private %encode_field(v0.@layout_0, v1.objref<@layout_2>, v2.i256) {
         v24.i256 = call %impl_trait_SolEncoder__pos v1;
         call %impl_trait_Address__encode_to_ptr__gf13e v0 v24;
         v28.i256 = add v24 32.i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_d061 v1 v28;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_0bd5 v1 v28;
         return;
 
     block6:
@@ -1261,7 +1257,7 @@ func private %encode_field(v0.@layout_0, v1.objref<@layout_2>, v2.i256) {
         return;
 }
 
-func inline(always) private %encode_field_at(v0.i256, v1.objref<@layout_2>, v2.i256, v3.i256, v4.i256) {
+func inline(always) private %encode_field_at(v0.i256, v1.objref<@layout_1>, v2.i256, v3.i256, v4.i256) {
     block0:
         jump block1;
 
@@ -1274,11 +1270,11 @@ func inline(always) private %encode_field_at(v0.i256, v1.objref<@layout_2>, v2.i
         v12.i256 = sub v11 v2;
         call %write_word_at v1 v3 v12;
         v15.i256 = mload v4 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_5121 v1 v15;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_7fd9 v1 v15;
         v17.i256 = mload v4 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_4208 v1 v17;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_13bc v1 v17;
         call %impl_trait_u256__encode__g426c v0 v1;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_5121 v1 v2;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_7fd9 v1 v2;
         v21.i256 = mload v4 i256;
         v22.i256 = add v21 v8;
         mstore v4 v22 i256;
@@ -1298,18 +1294,18 @@ func inline(always) private %encode_field_at(v0.i256, v1.objref<@layout_2>, v2.i
         jump block7;
 
     block7:
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_4208 v1 v3;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_13bc v1 v3;
         call %impl_trait_u256__encode__g426c v0 v1;
         return;
 }
 
-func private %encode_single_root(v0.@layout_0, v1.objref<@layout_2>) {
+func private %encode_single_root(v0.@layout_0, v1.objref<@layout_1>) {
     block0:
         v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_32b3 v1;
+        v4.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_3d65 v1;
         v6.i256 = add v4 32.i256;
         mstore v2 v6 i256;
         v7.i256 = ptr_to_int v2 i256;
@@ -1323,28 +1319,19 @@ func private %encode_single_root_alloc(v0.@layout_0) -> @layout_1 {
 
     block1:
         v2.i256 = call %abi_single_root_size v0;
-        v3.@layout_2 = call %std__lib__abi__sol__impl_trait_Sol_1f5f__encoder_new_c533 v2;
-        v4.objref<@layout_2> = obj.alloc @layout_2;
+        v3.@layout_1 = call %std__lib__abi__sol__impl_trait_Sol_1f5f__encoder_new_c533 v2;
+        v4.objref<@layout_1> = obj.alloc @layout_1;
         v6.objref<i256> = obj.proj v4 0.i256;
         v7.i256 = extract_value v3 0.i256;
         obj.store v6 v7;
         v9.objref<i256> = obj.proj v4 1.i256;
         v10.i256 = extract_value v3 1.i256;
         obj.store v9 v10;
-        v11.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_32b3 v4;
+        v11.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_3d65 v4;
         call %encode_single_root v0 v4;
         v14.@layout_1 = insert_value undef.@layout_1 0.i256 v11;
         v15.@layout_1 = insert_value v14 1.i256 v2;
         return v15;
-}
-
-func private %impl_trait_u256__encode_to_ptr__gf13e(v0.i256, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__store_word_5d2b v1 v0;
-        return;
 }
 
 func private %impl_trait_Address__encode_to_ptr__gf13e(v0.@layout_0, v1.i256) {
@@ -1357,43 +1344,188 @@ func private %impl_trait_Address__encode_to_ptr__gf13e(v0.@layout_0, v1.i256) {
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__encoder_new_58e9(v0.i256) -> @layout_2 {
+func private %impl_trait_u256__encode_to_ptr__gf13e(v0.i256, v1.i256) {
     block0:
         jump block1;
 
     block1:
-        v2.@layout_2 = call %std__lib__abi__sol__impl_SolEncoder_ce34__new_e146 v0;
+        call %std__lib__abi__sol__impl_trait_Sol_1f5f__store_word_5d2b v1 v0;
+        return;
+}
+
+func private %std__lib__abi__sol__impl_trait_Sol_1f5f__encoder_new_58e9(v0.i256) -> @layout_1 {
+    block0:
+        jump block1;
+
+    block1:
+        v2.@layout_1 = call %std__lib__abi__sol__impl_SolEncoder_ce34__new_e146 v0;
         return v2;
 }
 
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__encoder_new_c533(v0.i256) -> @layout_2 {
+func private %std__lib__abi__sol__impl_trait_Sol_1f5f__encoder_new_c533(v0.i256) -> @layout_1 {
     block0:
         jump block1;
 
     block1:
-        v2.@layout_2 = call %std__lib__abi__sol__impl_SolEncoder_ce34__new_aa27 v0;
+        v2.@layout_1 = call %std__lib__abi__sol__impl_SolEncoder_ce34__new_aa27 v0;
         return v2;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_2b2c() -> @layout_6 {
+func private %std__lib__evm__effects__impl_trait_Evm_c913__input_2b2c() -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v0.@layout_6 = call %std__lib__evm__calldata__impl_CallData_8f43__new_b558;
+        v0.@layout_0 = call %std__lib__evm__calldata__impl_CallData_8f43__new_b558;
         return v0;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_b215() -> @layout_6 {
+func private %std__lib__evm__effects__impl_trait_Evm_c913__input_b215() -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v0.@layout_6 = call %std__lib__evm__calldata__impl_CallData_8f43__new_4d25;
+        v0.@layout_0 = call %std__lib__evm__calldata__impl_CallData_8f43__new_4d25;
         return v0;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_1fd5(v0.objref<@layout_3>) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_18d5(v0.@layout_0) -> i256 {
+    block0:
+        v1.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v2.i256 = evm_calldata_size;
+        v5.i256 = extract_value v0 0.i256;
+        mstore v1 v2 i256;
+        v6.i256 = mload v1 i256;
+        v7.i1 = gt v5 v6;
+        br v7 block2 block3;
+
+    block2:
+        jump block4;
+
+    block3:
+        v9.i256 = extract_value v0 0.i256;
+        (v11.i256, v12.i1) = usubo v2 v9;
+        br v12 block5 block6;
+
+    block4:
+        v17.i256 = phi (0.i256 block2) (v11 block6);
+        return v17;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        jump block4;
+}
+
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_3968(v0.@layout_0) -> i256 {
+    block0:
+        v1.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v2.i256 = evm_calldata_size;
+        v5.i256 = extract_value v0 0.i256;
+        mstore v1 v2 i256;
+        v6.i256 = mload v1 i256;
+        v7.i1 = gt v5 v6;
+        br v7 block2 block3;
+
+    block2:
+        jump block4;
+
+    block3:
+        v9.i256 = extract_value v0 0.i256;
+        (v11.i256, v12.i1) = usubo v2 v9;
+        br v12 block5 block6;
+
+    block4:
+        v17.i256 = phi (0.i256 block2) (v11 block6);
+        return v17;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        jump block4;
+}
+
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_6dc1(v0.@layout_0) -> i256 {
+    block0:
+        v1.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v2.i256 = evm_calldata_size;
+        v5.i256 = extract_value v0 0.i256;
+        mstore v1 v2 i256;
+        v6.i256 = mload v1 i256;
+        v7.i1 = gt v5 v6;
+        br v7 block2 block3;
+
+    block2:
+        jump block4;
+
+    block3:
+        v9.i256 = extract_value v0 0.i256;
+        (v11.i256, v12.i1) = usubo v2 v9;
+        br v12 block5 block6;
+
+    block4:
+        v17.i256 = phi (0.i256 block2) (v11 block6);
+        return v17;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        jump block4;
+}
+
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_a79f(v0.@layout_0) -> i256 {
+    block0:
+        v1.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v2.i256 = evm_calldata_size;
+        v5.i256 = extract_value v0 0.i256;
+        mstore v1 v2 i256;
+        v6.i256 = mload v1 i256;
+        v7.i1 = gt v5 v6;
+        br v7 block2 block3;
+
+    block2:
+        jump block4;
+
+    block3:
+        v9.i256 = extract_value v0 0.i256;
+        (v11.i256, v12.i1) = usubo v2 v9;
+        br v12 block5 block6;
+
+    block4:
+        v17.i256 = phi (0.i256 block2) (v11 block6);
+        return v17;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        jump block4;
+}
+
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_c8d8(v0.objref<@layout_1>) -> i256 {
     block0:
         jump block1;
 
@@ -1403,41 +1535,7 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_1fd5
         return v4;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_2577(v0.@layout_6) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v2.i256 = evm_calldata_size;
-        v5.i256 = extract_value v0 0.i256;
-        mstore v1 v2 i256;
-        v6.i256 = mload v1 i256;
-        v7.i1 = gt v5 v6;
-        br v7 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v9.i256 = extract_value v0 0.i256;
-        (v11.i256, v12.i1) = usubo v2 v9;
-        br v12 block5 block6;
-
-    block4:
-        v17.i256 = phi (0.i256 block2) (v11 block6);
-        return v17;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_3e84(v0.objref<@layout_3>) -> i256 {
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_fea9(v0.objref<@layout_1>) -> i256 {
     block0:
         jump block1;
 
@@ -1447,131 +1545,29 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_3e84
         return v4;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_6f75(v0.@layout_6) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_4d25() -> @layout_0 {
     block0:
-        v1.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v2.i256 = evm_calldata_size;
-        v5.i256 = extract_value v0 0.i256;
-        mstore v1 v2 i256;
-        v6.i256 = mload v1 i256;
-        v7.i1 = gt v5 v6;
-        br v7 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v9.i256 = extract_value v0 0.i256;
-        (v11.i256, v12.i1) = usubo v2 v9;
-        br v12 block5 block6;
-
-    block4:
-        v17.i256 = phi (0.i256 block2) (v11 block6);
-        return v17;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
+        v1.constref<@layout_0> = const.ref $const_region_0;
+        v2.objref<@layout_0> = obj.alloc @layout_0;
+        obj.init.const v2 v1;
+        v3.@layout_0 = obj.load v2;
+        return v3;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_847d(v0.@layout_6) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v2.i256 = evm_calldata_size;
-        v5.i256 = extract_value v0 0.i256;
-        mstore v1 v2 i256;
-        v6.i256 = mload v1 i256;
-        v7.i1 = gt v5 v6;
-        br v7 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v9.i256 = extract_value v0 0.i256;
-        (v11.i256, v12.i1) = usubo v2 v9;
-        br v12 block5 block6;
-
-    block4:
-        v17.i256 = phi (0.i256 block2) (v11 block6);
-        return v17;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_8db5(v0.@layout_6) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v2.i256 = evm_calldata_size;
-        v5.i256 = extract_value v0 0.i256;
-        mstore v1 v2 i256;
-        v6.i256 = mload v1 i256;
-        v7.i1 = gt v5 v6;
-        br v7 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v9.i256 = extract_value v0 0.i256;
-        (v11.i256, v12.i1) = usubo v2 v9;
-        br v12 block5 block6;
-
-    block4:
-        v17.i256 = phi (0.i256 block2) (v11 block6);
-        return v17;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func inline(always) private %impl_Cursor__new__g463e(v0.@layout_3) -> @layout_4 {
+func inline(always) private %impl_Cursor__new__g463e(v0.@layout_1) -> @layout_2 {
     block0:
         jump block1;
 
     block1:
-        v4.@layout_4 = insert_value undef.@layout_4 0.i256 v0;
-        v6.@layout_4 = insert_value v4 1.i256 0.i256;
+        v4.@layout_2 = insert_value undef.@layout_2 0.i256 v0;
+        v6.@layout_2 = insert_value v4 1.i256 0.i256;
         return v6;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_4d25() -> @layout_6 {
-    block0:
-        jump block1;
-
-    block1:
-        v1.constref<@layout_6> = const.ref $const_region_0;
-        v2.objref<@layout_6> = obj.alloc @layout_6;
-        obj.init.const v2 v1;
-        v3.@layout_6 = obj.load v2;
-        return v3;
-}
-
-func private %std__lib__abi__sol__impl_SolEncoder_ce34__new_aa27(v0.i256) -> @layout_2 {
+func private %std__lib__abi__sol__impl_SolEncoder_ce34__new_aa27(v0.i256) -> @layout_1 {
     block0:
         jump block1;
 
@@ -1589,69 +1585,53 @@ func private %std__lib__abi__sol__impl_SolEncoder_ce34__new_aa27(v0.i256) -> @la
 
     block4:
         v7.i256 = phi (0.i256 block2) (v6 block3);
-        v8.@layout_2 = call %std__lib__abi__sol__impl_SolEncoder_ce34__at_9565 v7;
+        v8.@layout_1 = call %std__lib__abi__sol__impl_SolEncoder_ce34__at_9565 v7;
         return v8;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_b558() -> @layout_6 {
+func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_b558() -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v1.constref<@layout_6> = const.ref $const_region_0;
-        v2.objref<@layout_6> = obj.alloc @layout_6;
+        v1.constref<@layout_0> = const.ref $const_region_0;
+        v2.objref<@layout_0> = obj.alloc @layout_0;
         obj.init.const v2 v1;
-        v3.@layout_6 = obj.load v2;
+        v3.@layout_0 = obj.load v2;
         return v3;
 }
 
-func private %std__lib__abi__sol__impl_SolEncoder_ce34__new_e146(v0.i256) -> @layout_2 {
+func inline(always) private %impl_SolDecoder__new__g463e(v0.@layout_1) -> @layout_3 {
     block0:
         jump block1;
 
     block1:
-        v3.i1 = eq v0 0.i256;
-        br v3 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v5.*i8 = evm_malloc v0;
-        v6.i256 = ptr_to_int v5 i256;
-        jump block4;
-
-    block4:
-        v7.i256 = phi (0.i256 block2) (v6 block3);
-        v8.@layout_2 = call %std__lib__abi__sol__impl_SolEncoder_ce34__at_6558 v7;
-        return v8;
-}
-
-func inline(always) private %impl_SolDecoder__new__g463e(v0.@layout_3) -> @layout_5 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.@layout_4 = call %impl_Cursor__new__g463e v0;
-        v5.@layout_5 = insert_value undef.@layout_5 0.i256 v2;
-        v7.@layout_5 = insert_value v5 1.i256 0.i256;
+        v2.@layout_2 = call %impl_Cursor__new__g463e v0;
+        v5.@layout_3 = insert_value undef.@layout_3 0.i256 v2;
+        v7.@layout_3 = insert_value v5 1.i256 0.i256;
         return v7;
 }
 
-func private %core__lib__abi__trait_AbiSize__payload_size__g67a8_7f10(v0.@layout_0) -> i256 {
+func private %std__lib__abi__sol__impl_SolEncoder_ce34__new_e146(v0.i256) -> @layout_1 {
     block0:
         jump block1;
 
     block1:
-        return 32.i256;
-}
+        v3.i1 = eq v0 0.i256;
+        br v3 block2 block3;
 
-func private %core__lib__abi__trait_AbiSize__payload_size__g67a8_7f10_0(v0.@layout_0) -> i256 {
-    block0:
-        jump block1;
+    block2:
+        jump block4;
 
-    block1:
-        return 32.i256;
+    block3:
+        v5.*i8 = evm_malloc v0;
+        v6.i256 = ptr_to_int v5 i256;
+        jump block4;
+
+    block4:
+        v7.i256 = phi (0.i256 block2) (v6 block3);
+        v8.@layout_1 = call %std__lib__abi__sol__impl_SolEncoder_ce34__at_6558 v7;
+        return v8;
 }
 
 func inline(always) private %payload_size__gbd8e(v0.@layout_1) -> i256 {
@@ -1684,18 +1664,23 @@ func private %core__lib__abi__trait_AbiSize__payload_size__ge513_e893(v0.i256) -
         return 32.i256;
 }
 
-func private %pos__g463e(v0.objref<@layout_5>) -> i256 {
+func private %core__lib__abi__trait_AbiSize__payload_size__g67a8_f166(v0.@layout_0) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v3.objref<@layout_4> = obj.proj v0 0.i256;
-        v5.objref<i256> = obj.proj v3 1.i256;
-        v6.i256 = obj.load v5;
-        return v6;
+        return 32.i256;
 }
 
-func private %impl_trait_SolEncoder__pos(v0.objref<@layout_2>) -> i256 {
+func private %core__lib__abi__trait_AbiSize__payload_size__g67a8_f166_0(v0.@layout_0) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        return 32.i256;
+}
+
+func private %impl_trait_SolEncoder__pos(v0.objref<@layout_1>) -> i256 {
     block0:
         jump block1;
 
@@ -1705,19 +1690,30 @@ func private %impl_trait_SolEncoder__pos(v0.objref<@layout_2>) -> i256 {
         return v4;
 }
 
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_272f(v0.objref<@layout_5>) -> i256 {
+func private %pos__g463e(v0.objref<@layout_3>) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v3.objref<@layout_2> = obj.proj v0 0.i256;
+        v5.objref<i256> = obj.proj v3 1.i256;
+        v6.i256 = obj.load v5;
+        return v6;
+}
+
+func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_1d50(v0.objref<@layout_3>) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v4.objref<@layout_4> = obj.proj v0 0.i256;
-        v5.objref<@layout_3> = obj.proj v4 0.i256;
-        v6.@layout_3 = obj.load v5;
-        v7.objref<@layout_4> = obj.proj v0 0.i256;
-        v8.objref<@layout_3> = obj.proj v7 0.i256;
-        v9.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_1fd5 v8;
-        v10.objref<@layout_4> = obj.proj v0 0.i256;
+        v4.objref<@layout_2> = obj.proj v0 0.i256;
+        v5.objref<@layout_1> = obj.proj v4 0.i256;
+        v6.@layout_1 = obj.load v5;
+        v7.objref<@layout_2> = obj.proj v0 0.i256;
+        v8.objref<@layout_1> = obj.proj v7 0.i256;
+        v9.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_c8d8 v8;
+        v10.objref<@layout_2> = obj.proj v0 0.i256;
         v12.objref<i256> = obj.proj v10 1.i256;
         v13.i256 = obj.load v12;
         (v15.i256, v16.i1) = uaddo v13 32.i256;
@@ -1730,16 +1726,16 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         jump block4;
 
     block4:
-        v27.objref<@layout_4> = obj.proj v0 0.i256;
-        v28.objref<@layout_3> = obj.proj v27 0.i256;
-        v29.@layout_3 = obj.load v28;
-        v30.objref<@layout_4> = obj.proj v0 0.i256;
+        v27.objref<@layout_2> = obj.proj v0 0.i256;
+        v28.objref<@layout_1> = obj.proj v27 0.i256;
+        v29.@layout_1 = obj.load v28;
+        v30.objref<@layout_2> = obj.proj v0 0.i256;
         v31.objref<i256> = obj.proj v30 1.i256;
         v32.i256 = obj.load v31;
-        v33.objref<@layout_4> = obj.proj v0 0.i256;
-        v34.objref<@layout_3> = obj.proj v33 0.i256;
-        v35.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_d5b9 v34 v32;
-        v37.objref<@layout_4> = obj.proj v0 0.i256;
+        v33.objref<@layout_2> = obj.proj v0 0.i256;
+        v34.objref<@layout_1> = obj.proj v33 0.i256;
+        v35.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_32a8 v34 v32;
+        v37.objref<@layout_2> = obj.proj v0 0.i256;
         v38.objref<i256> = obj.proj v37 1.i256;
         obj.store v38 v15;
         return v35;
@@ -1756,26 +1752,26 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         evm_revert 0.i256 36.i256;
 
     block7:
-        v22.objref<@layout_4> = obj.proj v0 0.i256;
+        v22.objref<@layout_2> = obj.proj v0 0.i256;
         v23.objref<i256> = obj.proj v22 1.i256;
         v24.i256 = obj.load v23;
         v25.i1 = lt v15 v24;
         br v25 block2 block5;
 }
 
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_7adc(v0.objref<@layout_5>) -> i256 {
+func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_a38b(v0.objref<@layout_3>) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v4.objref<@layout_4> = obj.proj v0 0.i256;
-        v5.objref<@layout_3> = obj.proj v4 0.i256;
-        v6.@layout_3 = obj.load v5;
-        v7.objref<@layout_4> = obj.proj v0 0.i256;
-        v8.objref<@layout_3> = obj.proj v7 0.i256;
-        v9.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_3e84 v8;
-        v10.objref<@layout_4> = obj.proj v0 0.i256;
+        v4.objref<@layout_2> = obj.proj v0 0.i256;
+        v5.objref<@layout_1> = obj.proj v4 0.i256;
+        v6.@layout_1 = obj.load v5;
+        v7.objref<@layout_2> = obj.proj v0 0.i256;
+        v8.objref<@layout_1> = obj.proj v7 0.i256;
+        v9.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_fea9 v8;
+        v10.objref<@layout_2> = obj.proj v0 0.i256;
         v12.objref<i256> = obj.proj v10 1.i256;
         v13.i256 = obj.load v12;
         (v15.i256, v16.i1) = uaddo v13 32.i256;
@@ -1788,16 +1784,16 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         jump block4;
 
     block4:
-        v27.objref<@layout_4> = obj.proj v0 0.i256;
-        v28.objref<@layout_3> = obj.proj v27 0.i256;
-        v29.@layout_3 = obj.load v28;
-        v30.objref<@layout_4> = obj.proj v0 0.i256;
+        v27.objref<@layout_2> = obj.proj v0 0.i256;
+        v28.objref<@layout_1> = obj.proj v27 0.i256;
+        v29.@layout_1 = obj.load v28;
+        v30.objref<@layout_2> = obj.proj v0 0.i256;
         v31.objref<i256> = obj.proj v30 1.i256;
         v32.i256 = obj.load v31;
-        v33.objref<@layout_4> = obj.proj v0 0.i256;
-        v34.objref<@layout_3> = obj.proj v33 0.i256;
-        v35.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_3db5 v34 v32;
-        v37.objref<@layout_4> = obj.proj v0 0.i256;
+        v33.objref<@layout_2> = obj.proj v0 0.i256;
+        v34.objref<@layout_1> = obj.proj v33 0.i256;
+        v35.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_cb1c v34 v32;
+        v37.objref<@layout_2> = obj.proj v0 0.i256;
         v38.objref<i256> = obj.proj v37 1.i256;
         obj.store v38 v15;
         return v35;
@@ -1814,7 +1810,7 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         evm_revert 0.i256 36.i256;
 
     block7:
-        v22.objref<@layout_4> = obj.proj v0 0.i256;
+        v22.objref<@layout_2> = obj.proj v0 0.i256;
         v23.objref<i256> = obj.proj v22 1.i256;
         v24.i256 = obj.load v23;
         v25.i1 = lt v15 v24;
@@ -1837,7 +1833,7 @@ func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_6bdb(v0.i256, 
         evm_revert v0 v1;
 }
 
-func private %set_base__g463e(v0.objref<@layout_5>, v1.i256) {
+func private %set_base__g463e(v0.objref<@layout_3>, v1.i256) {
     block0:
         jump block1;
 
@@ -1847,7 +1843,7 @@ func private %set_base__g463e(v0.objref<@layout_5>, v1.i256) {
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_5121(v0.objref<@layout_2>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_7fd9(v0.objref<@layout_1>, v1.i256) {
     block0:
         jump block1;
 
@@ -1857,7 +1853,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_5121(v0.o
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_b006(v0.objref<@layout_2>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_effd(v0.objref<@layout_1>, v1.i256) {
     block0:
         jump block1;
 
@@ -1867,7 +1863,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_b006(v0.o
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_4208(v0.objref<@layout_2>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_0bd5(v0.objref<@layout_1>, v1.i256) {
     block0:
         jump block1;
 
@@ -1877,7 +1873,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_4208(v0.ob
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_d061(v0.objref<@layout_2>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_13bc(v0.objref<@layout_1>, v1.i256) {
     block0:
         jump block1;
 
@@ -1887,12 +1883,12 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_d061(v0.ob
         return;
 }
 
-func private %set_pos__g463e(v0.objref<@layout_5>, v1.i256) {
+func private %set_pos__g463e(v0.objref<@layout_3>, v1.i256) {
     block0:
         jump block1;
 
     block1:
-        v5.objref<@layout_4> = obj.proj v0 0.i256;
+        v5.objref<@layout_2> = obj.proj v0 0.i256;
         v7.objref<i256> = obj.proj v5 1.i256;
         obj.store v7 v1;
         return;
@@ -1916,29 +1912,7 @@ func private %std__lib__abi__sol__impl_trait_Sol_1f5f__store_word_d9ea(v0.i256, 
         return;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_32d2(v0.@layout_6, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3368(v0.@layout_6, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_3db5(v0.objref<@layout_3>, v1.i256) -> i256 {
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_32a8(v0.objref<@layout_1>, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -1950,7 +1924,7 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_
         return v8;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_8c36(v0.@layout_6, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_44ae(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -1961,7 +1935,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v7;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_8c36_0(v0.@layout_6, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b9e6(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -1972,7 +1946,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v7;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b2da(v0.@layout_6, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b9e6_0(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -1983,7 +1957,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v7;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b2da_0(v0.@layout_6, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_bb63(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -1994,7 +1968,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v7;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_d5b9(v0.objref<@layout_3>, v1.i256) -> i256 {
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_cb1c(v0.objref<@layout_1>, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -2006,7 +1980,29 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_
         return v8;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_2c07(v0.objref<@layout_2>, v1.i256) {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_d88e(v0.@layout_0, v1.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
+}
+
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_d88e_0(v0.@layout_0, v1.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
+}
+
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_1938(v0.objref<@layout_1>, v1.i256) {
     block0:
         jump block1;
 
@@ -2020,7 +2016,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_2c07(v0
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_498a(v0.objref<@layout_2>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_7a3d(v0.objref<@layout_1>, v1.i256) {
     block0:
         jump block1;
 
@@ -2034,26 +2030,26 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_498a(v0
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_528a(v0.objref<@layout_2>, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v4.objref<i256> = obj.proj v0 1.i256;
-        v5.i256 = obj.load v4;
-        mstore v5 v1 i256;
-        v9.i256 = add v5 32.i256;
-        v10.objref<i256> = obj.proj v0 1.i256;
-        obj.store v10 v9;
-        return;
-}
-
-func private %write_word_at(v0.objref<@layout_2>, v1.i256, v2.i256) {
+func private %write_word_at(v0.objref<@layout_1>, v1.i256, v2.i256) {
     block0:
         jump block1;
 
     block1:
         mstore v1 v2 i256;
+        return;
+}
+
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_ef72(v0.objref<@layout_1>, v1.i256) {
+    block0:
+        jump block1;
+
+    block1:
+        v4.objref<i256> = obj.proj v0 1.i256;
+        v5.i256 = obj.load v4;
+        mstore v5 v1 i256;
+        v9.i256 = add v5 32.i256;
+        v10.objref<i256> = obj.proj v0 1.i256;
+        obj.store v10 v9;
         return;
 }
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/create_contract.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/create_contract.snap
@@ -53,7 +53,7 @@ func private %abi_field_size(v0.@layout_0) -> i256 {
         jump block1;
 
     block1:
-        v2.i256 = call %core__lib__abi__trait_AbiSize__payload_size__g67a8_f166_0 v0;
+        v2.i256 = call %payload_size__g67a8 v0;
         br 0.i1 block2 block3;
 
     block2:
@@ -75,7 +75,16 @@ func private %abi_field_size(v0.@layout_0) -> i256 {
         return v6;
 }
 
-func private %abi_payload_size(v0.@layout_1) -> i256 {
+func private %core__lib__abi__abi_payload_size__g68da_a749(v0.@layout_1) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v2.i256 = call %payload_size__gbd8e v0;
+        return v2;
+}
+
+func private %core__lib__abi__abi_payload_size__g68da_a749_0(v0.@layout_1) -> i256 {
     block0:
         jump block1;
 
@@ -93,25 +102,16 @@ func private %abi_single_root_size(v0.@layout_0) -> i256 {
         return v2;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_c913__abort_0b80() {
+func private %abort() {
     block0:
         jump block1;
 
     block1:
-        call %std__lib__evm__effects__impl_trait_Evm_0098__revert_286a 0.i256 0.i256;
+        call %revert 0.i256 0.i256;
         unreachable;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_c913__abort_9c27() {
-    block0:
-        jump block1;
-
-    block1:
-        call %std__lib__evm__effects__impl_trait_Evm_0098__revert_6bdb 0.i256 0.i256;
-        unreachable;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_SolEncoder_ce34__at_6558(v0.i256) -> @layout_1 {
+func inline(always) private %at(v0.i256) -> @layout_1 {
     block0:
         jump block1;
 
@@ -119,46 +119,6 @@ func inline(always) private %std__lib__abi__sol__impl_SolEncoder_ce34__at_6558(v
         v4.@layout_1 = insert_value undef.@layout_1 0.i256 v0;
         v6.@layout_1 = insert_value v4 1.i256 v0;
         return v6;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_SolEncoder_ce34__at_9565(v0.i256) -> @layout_1 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.@layout_1 = insert_value undef.@layout_1 0.i256 v0;
-        v6.@layout_1 = insert_value v4 1.i256 v0;
-        return v6;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_3d65(v0.objref<@layout_1>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 0.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_4571(v0.objref<@layout_1>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 0.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_756a(v0.objref<@layout_1>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 0.i256;
-        v4.i256 = obj.load v3;
-        return v4;
 }
 
 func private %base__g463e(v0.objref<@layout_3>) -> i256 {
@@ -171,7 +131,17 @@ func private %base__g463e(v0.objref<@layout_3>) -> i256 {
         return v4;
 }
 
-func inline(always) private %core__lib__abi__checked_frame_end__gf13e_056e(v0.i256, v1.i256, v2.i256) -> i256 {
+func private %impl_trait_SolEncoder__base(v0.objref<@layout_1>) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v3.objref<i256> = obj.proj v0 0.i256;
+        v4.i256 = obj.load v3;
+        return v4;
+}
+
+func inline(always) private %checked_frame_end(v0.i256, v1.i256, v2.i256) -> i256 {
     block0:
         jump block1;
 
@@ -180,7 +150,7 @@ func inline(always) private %core__lib__abi__checked_frame_end__gf13e_056e(v0.i2
         br v6 block6 block7;
 
     block2:
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_7064;
+        call %decode_error;
         unreachable;
 
     block3:
@@ -203,39 +173,7 @@ func inline(always) private %core__lib__abi__checked_frame_end__gf13e_056e(v0.i2
         br v13 block2 block5;
 }
 
-func inline(always) private %core__lib__abi__checked_frame_end__gf13e_352b(v0.i256, v1.i256, v2.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        (v5.i256, v6.i1) = uaddo v0 v1;
-        br v6 block6 block7;
-
-    block2:
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_e3bb;
-        unreachable;
-
-    block3:
-        jump block4;
-
-    block4:
-        return v5;
-
-    block5:
-        v17.i1 = gt v5 v2;
-        br v17 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v13.i1 = lt v5 v0;
-        br v13 block2 block5;
-}
-
-func inline(always) private %core__lib__abi__checked_tail__gf13e_4046(v0.i256, v1.i256) -> i256 {
+func inline(always) private %core__lib__abi__checked_tail__gf13e_de45(v0.i256, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -244,7 +182,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_4046(v0.i256, v
         br v5 block5 block6;
 
     block2:
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_43bf;
+        call %decode_error;
         unreachable;
 
     block3:
@@ -263,7 +201,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_4046(v0.i256, v
         br v12 block2 block3;
 }
 
-func inline(always) private %core__lib__abi__checked_tail__gf13e_4919(v0.i256, v1.i256) -> i256 {
+func inline(always) private %core__lib__abi__checked_tail__gf13e_e315(v0.i256, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -272,7 +210,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_4919(v0.i256, v
         br v5 block5 block6;
 
     block2:
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_8b22;
+        call %decode_error;
         unreachable;
 
     block3:
@@ -495,7 +433,52 @@ func private %contract_runtime_root_Factory() {
         unreachable;
 }
 
-func private %copy_words(v0.i256, v1.i256, v2.i256) {
+func private %std__lib__evm__effects__copy_words_80fe(v0.i256, v1.i256, v2.i256) {
+    block0:
+        v3.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        mstore v3 0.i256 i256;
+        jump block2;
+
+    block2:
+        v5.i256 = mload v3 i256;
+        v7.i1 = lt v5 v2;
+        br v7 block3 block4;
+
+    block3:
+        v9.i256 = mload v3 i256;
+        (v10.i256, v11.i1) = uaddo v0 v9;
+        br v11 block5 block6;
+
+    block4:
+        return;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        v17.i256 = mload v3 i256;
+        (v18.i256, v19.i1) = uaddo v1 v17;
+        br v19 block5 block7;
+
+    block7:
+        v20.i256 = mload v18 i256;
+        mstore v10 v20 i256;
+        v23.i256 = ptr_to_int v3 i256;
+        v25.i256 = mload v23 i256;
+        (v26.i256, v27.i1) = uaddo v25 32.i256;
+        br v27 block5 block8;
+
+    block8:
+        mstore v23 v26 i256;
+        jump block2;
+}
+
+func private %std__lib__evm__effects__copy_words_80fe_0(v0.i256, v1.i256, v2.i256) {
     block0:
         v3.*i256 = alloca i256;
         jump block1;
@@ -557,7 +540,7 @@ func private %create(v0.i256, v1.@layout_1) -> @layout_0 {
         jump block4;
 
     block3:
-        v14.@layout_1 = call %encode_abi_payload v1;
+        v14.@layout_1 = call %std__lib__evm__effects__encode_abi_payload__g68da_c0b5_0 v1;
         v16.i256 = extract_value v14 1.i256;
         (v18.i256, v19.i1) = uaddo v2 v16;
         br v19 block9 block10;
@@ -599,7 +582,7 @@ func private %create(v0.i256, v1.@layout_1) -> @layout_0 {
     block11:
         v33.i256 = extract_value v14 0.i256;
         v34.i256 = extract_value v14 1.i256;
-        call %copy_words v30 v33 v34;
+        call %std__lib__evm__effects__copy_words_80fe_0 v30 v33 v34;
         v36.i256 = extract_value v14 1.i256;
         (v38.i256, v39.i1) = uaddo v2 v36;
         br v39 block9 block12;
@@ -626,7 +609,7 @@ func private %create2(v0.i256, v1.@layout_1, v2.i256) -> @layout_0 {
         jump block4;
 
     block3:
-        v16.@layout_1 = call %encode_abi_payload v1;
+        v16.@layout_1 = call %std__lib__evm__effects__encode_abi_payload__g68da_c0b5 v1;
         v18.i256 = extract_value v16 1.i256;
         (v20.i256, v21.i1) = uaddo v3 v18;
         br v21 block9 block10;
@@ -668,7 +651,7 @@ func private %create2(v0.i256, v1.@layout_1, v2.i256) -> @layout_0 {
     block11:
         v35.i256 = extract_value v16 0.i256;
         v36.i256 = extract_value v16 1.i256;
-        call %copy_words v32 v35 v36;
+        call %std__lib__evm__effects__copy_words_80fe v32 v35 v36;
         v38.i256 = extract_value v16 1.i256;
         (v40.i256, v41.i1) = uaddo v3 v38;
         br v41 block9 block12;
@@ -698,31 +681,7 @@ func private %create_raw(v0.i256, v1.i256, v2.i256) -> @layout_0 {
         return v9;
 }
 
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_43bf() {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert 0.i256 0.i256;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_7064() {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert 0.i256 0.i256;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_8b22() {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert 0.i256 0.i256;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_e3bb() {
+func private %decode_error() {
     block0:
         jump block1;
 
@@ -738,7 +697,7 @@ func inline(always) private %decode_field(v0.objref<@layout_3>) -> i256 {
         br 0.i1 block2 block3;
 
     block2:
-        v3.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_a38b v0;
+        v3.i256 = call %read_word v0;
         v4.i256 = call %base__g463e v0;
         v5.i256 = call %pos__g463e v0;
         (v6.i256, v7.i1) = uaddo v4 v3;
@@ -766,7 +725,7 @@ func inline(always) private %decode_field(v0.objref<@layout_3>) -> i256 {
         return v17;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from__g5385_a92f(v0.@layout_0, v1.i256, v2.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_field_from__g5385_56f1(v0.@layout_0, v1.i256, v2.i256) -> i256 {
     block0:
         jump block1;
 
@@ -774,7 +733,7 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_a92f(v0.@l
         br 0.i1 block2 block3;
 
     block2:
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_bb63 v0 v2;
+        v6.i256 = call %impl_trait_CallData__word_at v0 v2;
         (v8.i256, v9.i1) = uaddo v1 v6;
         br v9 block5 block6;
 
@@ -782,7 +741,7 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_a92f(v0.@l
         jump block4;
 
     block4:
-        v19.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_0674_0 v0 v2;
+        v19.i256 = call %decode_from__g72ab v0 v2;
         return v19;
 
     block5:
@@ -791,11 +750,11 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_a92f(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v16.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_0674_0 v0 v8;
+        v16.i256 = call %decode_from__g72ab v0 v8;
         return v16;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from__g5385_d499(v0.@layout_0, v1.i256, v2.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_field_from__g5385_f8bd(v0.@layout_0, v1.i256, v2.i256) -> i256 {
     block0:
         jump block1;
 
@@ -803,7 +762,7 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_d499(v0.@l
         br 0.i1 block2 block3;
 
     block2:
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_44ae v0 v2;
+        v6.i256 = call %impl_trait_CallData__word_at v0 v2;
         (v8.i256, v9.i1) = uaddo v1 v6;
         br v9 block5 block6;
 
@@ -811,7 +770,7 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_d499(v0.@l
         jump block4;
 
     block4:
-        v19.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8794_0 v0 v2;
+        v19.i256 = call %decode_from__g72ab v0 v2;
         return v19;
 
     block5:
@@ -820,11 +779,11 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_d499(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v16.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8794_0 v0 v8;
+        v16.i256 = call %decode_from__g72ab v0 v8;
         return v16;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_48c1(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_17af(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
         jump block1;
 
@@ -832,20 +791,20 @@ func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__
         br 0.i1 block2 block3;
 
     block2:
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_44ae v0 v2;
-        v9.i256 = call %core__lib__abi__checked_tail__gf13e_4919 v1 v7;
-        v11.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_0108 v0 v9 v3;
+        v7.i256 = call %impl_trait_CallData__word_at v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_de45 v1 v7;
+        v11.i256 = call %decode_from_bounded v0 v9 v3;
         return v11;
 
     block3:
         jump block4;
 
     block4:
-        v14.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8794_0 v0 v2;
+        v14.i256 = call %decode_from__g72ab v0 v2;
         return v14;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_af97(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_e18d(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
         jump block1;
 
@@ -853,53 +812,17 @@ func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__
         br 0.i1 block2 block3;
 
     block2:
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_bb63 v0 v2;
-        v9.i256 = call %core__lib__abi__checked_tail__gf13e_4046 v1 v7;
-        v11.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_bec2 v0 v9 v3;
+        v7.i256 = call %impl_trait_CallData__word_at v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_e315 v1 v7;
+        v11.i256 = call %decode_from_bounded v0 v9 v3;
         return v11;
 
     block3:
         jump block4;
 
     block4:
-        v14.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_0674_0 v0 v2;
+        v14.i256 = call %decode_from__g72ab v0 v2;
         return v14;
-}
-
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_0674(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b9e6 v0 v1;
-        return v4;
-}
-
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_0674_0(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b9e6_0 v0 v1;
-        return v4;
-}
-
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8794(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_d88e v0 v1;
-        return v4;
-}
-
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8794_0(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_d88e_0 v0 v1;
-        return v4;
 }
 
 func inline(always) private %impl_trait_Deploy2__decode_from__gd20d(v0.@layout_0, v1.i256) -> @layout_4 {
@@ -907,8 +830,8 @@ func inline(always) private %impl_trait_Deploy2__decode_from__gd20d(v0.@layout_0
         jump block1;
 
     block1:
-        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_a79f v0;
-        v5.i256 = call %core__lib__abi__decode_msg_field_from__g5385_819c v0 v1 v1 v3;
+        v3.i256 = call %impl_trait_CallData__len v0;
+        v5.i256 = call %core__lib__abi__decode_msg_field_from__g5385_3ba6 v0 v1 v1 v3;
         (v7.i256, v8.i1) = uaddo v1 32.i256;
         br v8 block2 block3;
 
@@ -918,7 +841,7 @@ func inline(always) private %impl_trait_Deploy2__decode_from__gd20d(v0.@layout_0
         evm_revert 0.i256 36.i256;
 
     block3:
-        v17.i256 = call %core__lib__abi__decode_msg_field_from__g5385_819c v0 v1 v7 v3;
+        v17.i256 = call %core__lib__abi__decode_msg_field_from__g5385_3ba6 v0 v1 v7 v3;
         (v20.i256, v21.i1) = uaddo v1 32.i256;
         br v21 block2 block4;
 
@@ -927,7 +850,7 @@ func inline(always) private %impl_trait_Deploy2__decode_from__gd20d(v0.@layout_0
         br v23 block2 block5;
 
     block5:
-        v27.i256 = call %core__lib__abi__decode_msg_field_from__g5385_819c v0 v1 v22 v3;
+        v27.i256 = call %core__lib__abi__decode_msg_field_from__g5385_3ba6 v0 v1 v22 v3;
         v30.@layout_4 = insert_value undef.@layout_4 0.i256 v5;
         v33.@layout_4 = insert_value v30 1.i256 v17;
         v35.@layout_4 = insert_value v33 2.i256 v27;
@@ -939,8 +862,8 @@ func inline(always) private %impl_trait_Deploy__decode_from__gd20d(v0.@layout_0,
         jump block1;
 
     block1:
-        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_18d5 v0;
-        v5.i256 = call %core__lib__abi__decode_msg_field_from__g5385_02f4 v0 v1 v1 v3;
+        v3.i256 = call %impl_trait_CallData__len v0;
+        v5.i256 = call %core__lib__abi__decode_msg_field_from__g5385_92e2 v0 v1 v1 v3;
         (v7.i256, v8.i1) = uaddo v1 32.i256;
         br v8 block2 block3;
 
@@ -950,30 +873,29 @@ func inline(always) private %impl_trait_Deploy__decode_from__gd20d(v0.@layout_0,
         evm_revert 0.i256 36.i256;
 
     block3:
-        v17.i256 = call %core__lib__abi__decode_msg_field_from__g5385_02f4 v0 v1 v7 v3;
+        v17.i256 = call %core__lib__abi__decode_msg_field_from__g5385_92e2 v0 v1 v7 v3;
         v20.@layout_1 = insert_value undef.@layout_1 0.i256 v5;
         v22.@layout_1 = insert_value v20 1.i256 v17;
         return v22;
 }
 
-func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_0108(v0.@layout_0, v1.i256, v2.i256) -> i256 {
+func private %decode_from_bounded(v0.@layout_0, v1.i256, v2.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_352b v1 32.i256 v2;
-        v8.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8794 v0 v1;
+        v6.i256 = call %checked_frame_end v1 32.i256 v2;
+        v8.i256 = call %decode_from__g72ab v0 v1;
         return v8;
 }
 
-func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_bec2(v0.@layout_0, v1.i256, v2.i256) -> i256 {
+func inline(always) private %decode_from__g72ab(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_056e v1 32.i256 v2;
-        v8.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_0674 v0 v1;
-        return v8;
+        v4.i256 = call %impl_trait_CallData__word_at v0 v1;
+        return v4;
 }
 
 func inline(always) private %decode_from_prechecked_head__gbecb(v0.@layout_0, v1.i256, v2.i256) -> @layout_1 {
@@ -994,7 +916,7 @@ func inline(always) private %decode_from_prechecked_head__g4e6c(v0.@layout_0, v1
         return v6;
 }
 
-func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_02f4(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_3ba6(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
         jump block1;
 
@@ -1002,18 +924,18 @@ func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_02f4(v
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_48c1 v0 v1 v2 v3;
+        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_e18d v0 v1 v2 v3;
         return v9;
 
     block3:
         jump block4;
 
     block4:
-        v14.i256 = call %core__lib__abi__decode_field_from__g5385_d499 v0 v1 v2;
+        v14.i256 = call %core__lib__abi__decode_field_from__g5385_56f1 v0 v1 v2;
         return v14;
 }
 
-func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_819c(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_92e2(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
         jump block1;
 
@@ -1021,14 +943,14 @@ func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_819c(v
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_af97 v0 v1 v2 v3;
+        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_17af v0 v1 v2 v3;
         return v9;
 
     block3:
         jump block4;
 
     block4:
-        v14.i256 = call %core__lib__abi__decode_field_from__g5385_a92f v0 v1 v2;
+        v14.i256 = call %core__lib__abi__decode_field_from__g5385_f8bd v0 v1 v2;
         return v14;
 }
 
@@ -1049,7 +971,7 @@ func inline(always) private %decode_payload__g407e(v0.objref<@layout_3>) -> i256
         jump block1;
 
     block1:
-        v2.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_1d50 v0;
+        v2.i256 = call %read_word v0;
         return v2;
 }
 
@@ -1060,13 +982,13 @@ func inline(always) private %decode_runtime_args__gbdfb(v0.objref<@layout_6>) ->
         jump block1;
 
     block1:
-        v3.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_2b2c;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_3968 v3;
+        v3.@layout_0 = call %input;
+        v5.i256 = call %impl_trait_CallData__len v3;
         mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
 
     block2:
-        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_0b80;
+        call %abort;
         unreachable;
 
     block3:
@@ -1090,13 +1012,13 @@ func inline(always) private %decode_runtime_args__gadcc(v0.objref<@layout_6>) ->
         jump block1;
 
     block1:
-        v3.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_b215;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_6dc1 v3;
+        v3.@layout_0 = call %input;
+        v5.i256 = call %impl_trait_CallData__len v3;
         mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
 
     block2:
-        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_9c27;
+        call %abort;
         unreachable;
 
     block3:
@@ -1130,7 +1052,7 @@ func private %dynamic_payload_size(v0.i256) -> i256 {
         br 0.i1 block2 block3;
 
     block2:
-        v3.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_9d4e v0;
+        v3.i256 = call %payload_size__ge513 v0;
         return v3;
 
     block3:
@@ -1146,7 +1068,7 @@ func inline(always) private %encode__g7769(v0.@layout_1, v1.objref<@layout_1>) {
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_756a v1;
+        v4.i256 = call %impl_trait_SolEncoder__base v1;
         v6.i256 = add v4 64.i256;
         mstore v2 v6 i256;
         v8.i256 = add v4 32.i256;
@@ -1157,26 +1079,45 @@ func inline(always) private %encode__g7769(v0.@layout_1, v1.objref<@layout_1>) {
         v16.i256 = ptr_to_int v2 i256;
         call %encode_field_at v15 v1 v4 v8 v16;
         v18.i256 = add v4 64.i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_13bc v1 v18;
+        call %impl_trait_SolEncoder__set_pos v1 v18;
         return;
 }
 
-func private %encode_abi_payload(v0.@layout_1) -> @layout_1 {
+func private %impl_trait_Address__encode__g426c(v0.@layout_0, v1.objref<@layout_1>) {
     block0:
         jump block1;
 
     block1:
-        v2.@layout_1 = call %encode_alloc v0;
+        v4.i256 = extract_value v0 0.i256;
+        call %write_word v1 v4;
+        return;
+}
+
+func private %std__lib__evm__effects__encode_abi_payload__g68da_c0b5(v0.@layout_1) -> @layout_1 {
+    block0:
+        jump block1;
+
+    block1:
+        v2.@layout_1 = call %core__lib__abi__encode_alloc__gee1c_b5f6 v0;
         return v2;
 }
 
-func inline(always) private %encode_alloc(v0.@layout_1) -> @layout_1 {
+func private %std__lib__evm__effects__encode_abi_payload__g68da_c0b5_0(v0.@layout_1) -> @layout_1 {
     block0:
         jump block1;
 
     block1:
-        v2.i256 = call %abi_payload_size v0;
-        v3.@layout_1 = call %std__lib__abi__sol__impl_trait_Sol_1f5f__encoder_new_58e9 v2;
+        v2.@layout_1 = call %core__lib__abi__encode_alloc__gee1c_b5f6_0 v0;
+        return v2;
+}
+
+func inline(always) private %core__lib__abi__encode_alloc__gee1c_b5f6(v0.@layout_1) -> @layout_1 {
+    block0:
+        jump block1;
+
+    block1:
+        v2.i256 = call %core__lib__abi__abi_payload_size__g68da_a749 v0;
+        v3.@layout_1 = call %encoder_new v2;
         v4.objref<@layout_1> = obj.alloc @layout_1;
         v6.objref<i256> = obj.proj v4 0.i256;
         v7.i256 = extract_value v3 0.i256;
@@ -1184,7 +1125,28 @@ func inline(always) private %encode_alloc(v0.@layout_1) -> @layout_1 {
         v9.objref<i256> = obj.proj v4 1.i256;
         v10.i256 = extract_value v3 1.i256;
         obj.store v9 v10;
-        v11.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_4571 v4;
+        v11.i256 = call %impl_trait_SolEncoder__base v4;
+        call %encode__g7769 v0 v4;
+        v14.@layout_1 = insert_value undef.@layout_1 0.i256 v11;
+        v15.@layout_1 = insert_value v14 1.i256 v2;
+        return v15;
+}
+
+func inline(always) private %core__lib__abi__encode_alloc__gee1c_b5f6_0(v0.@layout_1) -> @layout_1 {
+    block0:
+        jump block1;
+
+    block1:
+        v2.i256 = call %core__lib__abi__abi_payload_size__g68da_a749_0 v0;
+        v3.@layout_1 = call %encoder_new v2;
+        v4.objref<@layout_1> = obj.alloc @layout_1;
+        v6.objref<i256> = obj.proj v4 0.i256;
+        v7.i256 = extract_value v3 0.i256;
+        obj.store v6 v7;
+        v9.objref<i256> = obj.proj v4 1.i256;
+        v10.i256 = extract_value v3 1.i256;
+        obj.store v9 v10;
+        v11.i256 = call %impl_trait_SolEncoder__base v4;
         call %encode__g7769 v0 v4;
         v14.@layout_1 = insert_value undef.@layout_1 0.i256 v11;
         v15.@layout_1 = insert_value v14 1.i256 v2;
@@ -1196,17 +1158,7 @@ func private %impl_trait_u256__encode__g426c(v0.i256, v1.objref<@layout_1>) {
         jump block1;
 
     block1:
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_7a3d v1 v0;
-        return;
-}
-
-func private %impl_trait_Address__encode__g426c(v0.@layout_0, v1.objref<@layout_1>) {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_1938 v1 v4;
+        call %write_word v1 v0;
         return;
 }
 
@@ -1218,19 +1170,19 @@ func private %encode_field(v0.@layout_0, v1.objref<@layout_1>, v2.i256) {
         br 0.i1 block2 block3;
 
     block2:
-        v5.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_3d65 v1;
-        v8.i256 = call %core__lib__abi__trait_AbiSize__payload_size__g67a8_f166 v0;
+        v5.i256 = call %impl_trait_SolEncoder__base v1;
+        v8.i256 = call %payload_size__g67a8 v0;
         v9.i256 = mload v2 i256;
         v10.i256 = sub v9 v5;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_ef72 v1 v10;
+        call %write_word v1 v10;
         v12.i256 = call %impl_trait_SolEncoder__pos v1;
         v13.i256 = mload v2 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_effd v1 v13;
+        call %impl_trait_SolEncoder__set_base v1 v13;
         v15.i256 = mload v2 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_0bd5 v1 v15;
+        call %impl_trait_SolEncoder__set_pos v1 v15;
         call %impl_trait_Address__encode__g426c v0 v1;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_effd v1 v5;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_0bd5 v1 v12;
+        call %impl_trait_SolEncoder__set_base v1 v5;
+        call %impl_trait_SolEncoder__set_pos v1 v12;
         v20.i256 = mload v2 i256;
         v21.i256 = add v20 v8;
         mstore v2 v21 i256;
@@ -1246,7 +1198,7 @@ func private %encode_field(v0.@layout_0, v1.objref<@layout_1>, v2.i256) {
         v24.i256 = call %impl_trait_SolEncoder__pos v1;
         call %impl_trait_Address__encode_to_ptr__gf13e v0 v24;
         v28.i256 = add v24 32.i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_0bd5 v1 v28;
+        call %impl_trait_SolEncoder__set_pos v1 v28;
         return;
 
     block6:
@@ -1265,16 +1217,16 @@ func inline(always) private %encode_field_at(v0.i256, v1.objref<@layout_1>, v2.i
         br 0.i1 block2 block3;
 
     block2:
-        v8.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_e893 v0;
+        v8.i256 = call %payload_size__ge513 v0;
         v11.i256 = mload v4 i256;
         v12.i256 = sub v11 v2;
         call %write_word_at v1 v3 v12;
         v15.i256 = mload v4 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_7fd9 v1 v15;
+        call %impl_trait_SolEncoder__set_base v1 v15;
         v17.i256 = mload v4 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_13bc v1 v17;
+        call %impl_trait_SolEncoder__set_pos v1 v17;
         call %impl_trait_u256__encode__g426c v0 v1;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_7fd9 v1 v2;
+        call %impl_trait_SolEncoder__set_base v1 v2;
         v21.i256 = mload v4 i256;
         v22.i256 = add v21 v8;
         mstore v4 v22 i256;
@@ -1294,7 +1246,7 @@ func inline(always) private %encode_field_at(v0.i256, v1.objref<@layout_1>, v2.i
         jump block7;
 
     block7:
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_13bc v1 v3;
+        call %impl_trait_SolEncoder__set_pos v1 v3;
         call %impl_trait_u256__encode__g426c v0 v1;
         return;
 }
@@ -1305,7 +1257,7 @@ func private %encode_single_root(v0.@layout_0, v1.objref<@layout_1>) {
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_3d65 v1;
+        v4.i256 = call %impl_trait_SolEncoder__base v1;
         v6.i256 = add v4 32.i256;
         mstore v2 v6 i256;
         v7.i256 = ptr_to_int v2 i256;
@@ -1319,7 +1271,7 @@ func private %encode_single_root_alloc(v0.@layout_0) -> @layout_1 {
 
     block1:
         v2.i256 = call %abi_single_root_size v0;
-        v3.@layout_1 = call %std__lib__abi__sol__impl_trait_Sol_1f5f__encoder_new_c533 v2;
+        v3.@layout_1 = call %encoder_new v2;
         v4.objref<@layout_1> = obj.alloc @layout_1;
         v6.objref<i256> = obj.proj v4 0.i256;
         v7.i256 = extract_value v3 0.i256;
@@ -1327,11 +1279,20 @@ func private %encode_single_root_alloc(v0.@layout_0) -> @layout_1 {
         v9.objref<i256> = obj.proj v4 1.i256;
         v10.i256 = extract_value v3 1.i256;
         obj.store v9 v10;
-        v11.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_3d65 v4;
+        v11.i256 = call %impl_trait_SolEncoder__base v4;
         call %encode_single_root v0 v4;
         v14.@layout_1 = insert_value undef.@layout_1 0.i256 v11;
         v15.@layout_1 = insert_value v14 1.i256 v2;
         return v15;
+}
+
+func private %impl_trait_u256__encode_to_ptr__gf13e(v0.i256, v1.i256) {
+    block0:
+        jump block1;
+
+    block1:
+        call %store_word v1 v0;
+        return;
 }
 
 func private %impl_trait_Address__encode_to_ptr__gf13e(v0.@layout_0, v1.i256) {
@@ -1340,192 +1301,29 @@ func private %impl_trait_Address__encode_to_ptr__gf13e(v0.@layout_0, v1.i256) {
 
     block1:
         v5.i256 = extract_value v0 0.i256;
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__store_word_d9ea v1 v5;
+        call %store_word v1 v5;
         return;
 }
 
-func private %impl_trait_u256__encode_to_ptr__gf13e(v0.i256, v1.i256) {
+func private %encoder_new(v0.i256) -> @layout_1 {
     block0:
         jump block1;
 
     block1:
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__store_word_5d2b v1 v0;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__encoder_new_58e9(v0.i256) -> @layout_1 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.@layout_1 = call %std__lib__abi__sol__impl_SolEncoder_ce34__new_e146 v0;
+        v2.@layout_1 = call %impl_SolEncoder__new v0;
         return v2;
 }
 
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__encoder_new_c533(v0.i256) -> @layout_1 {
+func private %input() -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v2.@layout_1 = call %std__lib__abi__sol__impl_SolEncoder_ce34__new_aa27 v0;
-        return v2;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_2b2c() -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v0.@layout_0 = call %std__lib__evm__calldata__impl_CallData_8f43__new_b558;
+        v0.@layout_0 = call %impl_CallData__new;
         return v0;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_b215() -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v0.@layout_0 = call %std__lib__evm__calldata__impl_CallData_8f43__new_4d25;
-        return v0;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_18d5(v0.@layout_0) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v2.i256 = evm_calldata_size;
-        v5.i256 = extract_value v0 0.i256;
-        mstore v1 v2 i256;
-        v6.i256 = mload v1 i256;
-        v7.i1 = gt v5 v6;
-        br v7 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v9.i256 = extract_value v0 0.i256;
-        (v11.i256, v12.i1) = usubo v2 v9;
-        br v12 block5 block6;
-
-    block4:
-        v17.i256 = phi (0.i256 block2) (v11 block6);
-        return v17;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_3968(v0.@layout_0) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v2.i256 = evm_calldata_size;
-        v5.i256 = extract_value v0 0.i256;
-        mstore v1 v2 i256;
-        v6.i256 = mload v1 i256;
-        v7.i1 = gt v5 v6;
-        br v7 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v9.i256 = extract_value v0 0.i256;
-        (v11.i256, v12.i1) = usubo v2 v9;
-        br v12 block5 block6;
-
-    block4:
-        v17.i256 = phi (0.i256 block2) (v11 block6);
-        return v17;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_6dc1(v0.@layout_0) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v2.i256 = evm_calldata_size;
-        v5.i256 = extract_value v0 0.i256;
-        mstore v1 v2 i256;
-        v6.i256 = mload v1 i256;
-        v7.i1 = gt v5 v6;
-        br v7 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v9.i256 = extract_value v0 0.i256;
-        (v11.i256, v12.i1) = usubo v2 v9;
-        br v12 block5 block6;
-
-    block4:
-        v17.i256 = phi (0.i256 block2) (v11 block6);
-        return v17;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_a79f(v0.@layout_0) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v2.i256 = evm_calldata_size;
-        v5.i256 = extract_value v0 0.i256;
-        mstore v1 v2 i256;
-        v6.i256 = mload v1 i256;
-        v7.i1 = gt v5 v6;
-        br v7 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v9.i256 = extract_value v0 0.i256;
-        (v11.i256, v12.i1) = usubo v2 v9;
-        br v12 block5 block6;
-
-    block4:
-        v17.i256 = phi (0.i256 block2) (v11 block6);
-        return v17;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_c8d8(v0.objref<@layout_1>) -> i256 {
+func private %impl_trait_MemoryBytes__len(v0.objref<@layout_1>) -> i256 {
     block0:
         jump block1;
 
@@ -1535,39 +1333,41 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_c8d8
         return v4;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_fea9(v0.objref<@layout_1>) -> i256 {
+func inline(always) private %impl_trait_CallData__len(v0.@layout_0) -> i256 {
     block0:
+        v1.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.objref<i256> = obj.proj v0 1.i256;
-        v4.i256 = obj.load v3;
-        return v4;
+        v2.i256 = evm_calldata_size;
+        v5.i256 = extract_value v0 0.i256;
+        mstore v1 v2 i256;
+        v6.i256 = mload v1 i256;
+        v7.i1 = gt v5 v6;
+        br v7 block2 block3;
+
+    block2:
+        jump block4;
+
+    block3:
+        v9.i256 = extract_value v0 0.i256;
+        (v11.i256, v12.i1) = usubo v2 v9;
+        br v12 block5 block6;
+
+    block4:
+        v17.i256 = phi (0.i256 block2) (v11 block6);
+        return v17;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        jump block4;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_4d25() -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v1.constref<@layout_0> = const.ref $const_region_0;
-        v2.objref<@layout_0> = obj.alloc @layout_0;
-        obj.init.const v2 v1;
-        v3.@layout_0 = obj.load v2;
-        return v3;
-}
-
-func inline(always) private %impl_Cursor__new__g463e(v0.@layout_1) -> @layout_2 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.@layout_2 = insert_value undef.@layout_2 0.i256 v0;
-        v6.@layout_2 = insert_value v4 1.i256 0.i256;
-        return v6;
-}
-
-func private %std__lib__abi__sol__impl_SolEncoder_ce34__new_aa27(v0.i256) -> @layout_1 {
+func private %impl_SolEncoder__new(v0.i256) -> @layout_1 {
     block0:
         jump block1;
 
@@ -1585,11 +1385,21 @@ func private %std__lib__abi__sol__impl_SolEncoder_ce34__new_aa27(v0.i256) -> @la
 
     block4:
         v7.i256 = phi (0.i256 block2) (v6 block3);
-        v8.@layout_1 = call %std__lib__abi__sol__impl_SolEncoder_ce34__at_9565 v7;
+        v8.@layout_1 = call %at v7;
         return v8;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_b558() -> @layout_0 {
+func inline(always) private %impl_Cursor__new__g463e(v0.@layout_1) -> @layout_2 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.@layout_2 = insert_value undef.@layout_2 0.i256 v0;
+        v6.@layout_2 = insert_value v4 1.i256 0.i256;
+        return v6;
+}
+
+func inline(always) private %impl_CallData__new() -> @layout_0 {
     block0:
         jump block1;
 
@@ -1612,26 +1422,12 @@ func inline(always) private %impl_SolDecoder__new__g463e(v0.@layout_1) -> @layou
         return v7;
 }
 
-func private %std__lib__abi__sol__impl_SolEncoder_ce34__new_e146(v0.i256) -> @layout_1 {
+func private %payload_size__ge513(v0.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v3.i1 = eq v0 0.i256;
-        br v3 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v5.*i8 = evm_malloc v0;
-        v6.i256 = ptr_to_int v5 i256;
-        jump block4;
-
-    block4:
-        v7.i256 = phi (0.i256 block2) (v6 block3);
-        v8.@layout_1 = call %std__lib__abi__sol__impl_SolEncoder_ce34__at_6558 v7;
-        return v8;
+        return 32.i256;
 }
 
 func inline(always) private %payload_size__gbd8e(v0.@layout_1) -> i256 {
@@ -1648,46 +1444,12 @@ func inline(always) private %payload_size__gbd8e(v0.@layout_1) -> i256 {
         return v10;
 }
 
-func private %core__lib__abi__trait_AbiSize__payload_size__ge513_9d4e(v0.i256) -> i256 {
+func private %payload_size__g67a8(v0.@layout_0) -> i256 {
     block0:
         jump block1;
 
     block1:
         return 32.i256;
-}
-
-func private %core__lib__abi__trait_AbiSize__payload_size__ge513_e893(v0.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        return 32.i256;
-}
-
-func private %core__lib__abi__trait_AbiSize__payload_size__g67a8_f166(v0.@layout_0) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        return 32.i256;
-}
-
-func private %core__lib__abi__trait_AbiSize__payload_size__g67a8_f166_0(v0.@layout_0) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        return 32.i256;
-}
-
-func private %impl_trait_SolEncoder__pos(v0.objref<@layout_1>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 1.i256;
-        v4.i256 = obj.load v3;
-        return v4;
 }
 
 func private %pos__g463e(v0.objref<@layout_3>) -> i256 {
@@ -1701,7 +1463,17 @@ func private %pos__g463e(v0.objref<@layout_3>) -> i256 {
         return v6;
 }
 
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_1d50(v0.objref<@layout_3>) -> i256 {
+func private %impl_trait_SolEncoder__pos(v0.objref<@layout_1>) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v3.objref<i256> = obj.proj v0 1.i256;
+        v4.i256 = obj.load v3;
+        return v4;
+}
+
+func inline(always) private %read_word(v0.objref<@layout_3>) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         jump block1;
@@ -1712,7 +1484,7 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         v6.@layout_1 = obj.load v5;
         v7.objref<@layout_2> = obj.proj v0 0.i256;
         v8.objref<@layout_1> = obj.proj v7 0.i256;
-        v9.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_c8d8 v8;
+        v9.i256 = call %impl_trait_MemoryBytes__len v8;
         v10.objref<@layout_2> = obj.proj v0 0.i256;
         v12.objref<i256> = obj.proj v10 1.i256;
         v13.i256 = obj.load v12;
@@ -1734,7 +1506,7 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         v32.i256 = obj.load v31;
         v33.objref<@layout_2> = obj.proj v0 0.i256;
         v34.objref<@layout_1> = obj.proj v33 0.i256;
-        v35.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_32a8 v34 v32;
+        v35.i256 = call %impl_trait_MemoryBytes__word_at v34 v32;
         v37.objref<@layout_2> = obj.proj v0 0.i256;
         v38.objref<i256> = obj.proj v37 1.i256;
         obj.store v38 v15;
@@ -1759,65 +1531,7 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         br v25 block2 block5;
 }
 
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_a38b(v0.objref<@layout_3>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v4.objref<@layout_2> = obj.proj v0 0.i256;
-        v5.objref<@layout_1> = obj.proj v4 0.i256;
-        v6.@layout_1 = obj.load v5;
-        v7.objref<@layout_2> = obj.proj v0 0.i256;
-        v8.objref<@layout_1> = obj.proj v7 0.i256;
-        v9.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_fea9 v8;
-        v10.objref<@layout_2> = obj.proj v0 0.i256;
-        v12.objref<i256> = obj.proj v10 1.i256;
-        v13.i256 = obj.load v12;
-        (v15.i256, v16.i1) = uaddo v13 32.i256;
-        br v16 block6 block7;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v27.objref<@layout_2> = obj.proj v0 0.i256;
-        v28.objref<@layout_1> = obj.proj v27 0.i256;
-        v29.@layout_1 = obj.load v28;
-        v30.objref<@layout_2> = obj.proj v0 0.i256;
-        v31.objref<i256> = obj.proj v30 1.i256;
-        v32.i256 = obj.load v31;
-        v33.objref<@layout_2> = obj.proj v0 0.i256;
-        v34.objref<@layout_1> = obj.proj v33 0.i256;
-        v35.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_cb1c v34 v32;
-        v37.objref<@layout_2> = obj.proj v0 0.i256;
-        v38.objref<i256> = obj.proj v37 1.i256;
-        obj.store v38 v15;
-        return v35;
-
-    block5:
-        mstore v1 v9 i256;
-        v41.i256 = mload v1 i256;
-        v42.i1 = gt v15 v41;
-        br v42 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v22.objref<@layout_2> = obj.proj v0 0.i256;
-        v23.objref<i256> = obj.proj v22 1.i256;
-        v24.i256 = obj.load v23;
-        v25.i1 = lt v15 v24;
-        br v25 block2 block5;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_286a(v0.i256, v1.i256) {
+func private %revert(v0.i256, v1.i256) {
     block0:
         jump block1;
 
@@ -1825,12 +1539,14 @@ func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_286a(v0.i256, 
         evm_revert v0 v1;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_6bdb(v0.i256, v1.i256) {
+func private %impl_trait_SolEncoder__set_base(v0.objref<@layout_1>, v1.i256) {
     block0:
         jump block1;
 
     block1:
-        evm_revert v0 v1;
+        v5.objref<i256> = obj.proj v0 0.i256;
+        obj.store v5 v1;
+        return;
 }
 
 func private %set_base__g463e(v0.objref<@layout_3>, v1.i256) {
@@ -1843,37 +1559,7 @@ func private %set_base__g463e(v0.objref<@layout_3>, v1.i256) {
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_7fd9(v0.objref<@layout_1>, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        obj.store v5 v1;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_effd(v0.objref<@layout_1>, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        obj.store v5 v1;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_0bd5(v0.objref<@layout_1>, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v5.objref<i256> = obj.proj v0 1.i256;
-        obj.store v5 v1;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_13bc(v0.objref<@layout_1>, v1.i256) {
+func private %impl_trait_SolEncoder__set_pos(v0.objref<@layout_1>, v1.i256) {
     block0:
         jump block1;
 
@@ -1894,7 +1580,7 @@ func private %set_pos__g463e(v0.objref<@layout_3>, v1.i256) {
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__store_word_5d2b(v0.i256, v1.i256) {
+func private %store_word(v0.i256, v1.i256) {
     block0:
         jump block1;
 
@@ -1903,16 +1589,18 @@ func private %std__lib__abi__sol__impl_trait_Sol_1f5f__store_word_5d2b(v0.i256, 
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__store_word_d9ea(v0.i256, v1.i256) {
+func inline(always) private %impl_trait_CallData__word_at(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        mstore v0 v1 i256;
-        return;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_32a8(v0.objref<@layout_1>, v1.i256) -> i256 {
+func private %impl_trait_MemoryBytes__word_at(v0.objref<@layout_1>, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -1924,99 +1612,7 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_
         return v8;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_44ae(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b9e6(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b9e6_0(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_bb63(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_cb1c(v0.objref<@layout_1>, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.objref<i256> = obj.proj v0 0.i256;
-        v5.i256 = obj.load v4;
-        v7.i256 = add v5 v1;
-        v8.i256 = mload v7 i256;
-        return v8;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_d88e(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_d88e_0(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_1938(v0.objref<@layout_1>, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v4.objref<i256> = obj.proj v0 1.i256;
-        v5.i256 = obj.load v4;
-        mstore v5 v1 i256;
-        v9.i256 = add v5 32.i256;
-        v10.objref<i256> = obj.proj v0 1.i256;
-        obj.store v10 v9;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_7a3d(v0.objref<@layout_1>, v1.i256) {
+func private %write_word(v0.objref<@layout_1>, v1.i256) {
     block0:
         jump block1;
 
@@ -2036,20 +1632,6 @@ func private %write_word_at(v0.objref<@layout_1>, v1.i256, v2.i256) {
 
     block1:
         mstore v1 v2 i256;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_ef72(v0.objref<@layout_1>, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v4.objref<i256> = obj.proj v0 1.i256;
-        v5.i256 = obj.load v4;
-        mstore v5 v1 i256;
-        v9.i256 = add v5 32.i256;
-        v10.objref<i256> = obj.proj v0 1.i256;
-        obj.store v10 v9;
         return;
 }
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/effect_handle_field_deref.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/effect_handle_field_deref.snap
@@ -67,7 +67,7 @@ func private %abi_field_size(v0.i256) -> i256 {
         jump block1;
 
     block1:
-        v2.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_a8bc_0 v0;
+        v2.i256 = call %payload_size v0;
         br 0.i1 block2 block3;
 
     block2:
@@ -98,30 +98,12 @@ func private %abi_single_root_size(v0.i256) -> i256 {
         return v2;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_c913__abort_4c56() {
+func private %abort() {
     block0:
         jump block1;
 
     block1:
-        call %std__lib__evm__effects__impl_trait_Evm_0098__revert_a881 0.i256 0.i256;
-        unreachable;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_c913__abort_9c1e() {
-    block0:
-        jump block1;
-
-    block1:
-        call %std__lib__evm__effects__impl_trait_Evm_0098__revert_ba8b 0.i256 0.i256;
-        unreachable;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_c913__abort_ffa6() {
-    block0:
-        jump block1;
-
-    block1:
-        call %std__lib__evm__effects__impl_trait_Evm_0098__revert_27e9 0.i256 0.i256;
+        call %revert 0.i256 0.i256;
         unreachable;
 }
 
@@ -169,7 +151,7 @@ func private %bump(v0.objref<@layout_1>, v1.i256) -> i256 {
         return v18;
 }
 
-func inline(always) private %core__lib__abi__checked_frame_end__gf13e_6c9f(v0.i256, v1.i256, v2.i256) -> i256 {
+func inline(always) private %checked_frame_end(v0.i256, v1.i256, v2.i256) -> i256 {
     block0:
         jump block1;
 
@@ -178,7 +160,7 @@ func inline(always) private %core__lib__abi__checked_frame_end__gf13e_6c9f(v0.i2
         br v6 block6 block7;
 
     block2:
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_5569;
+        call %decode_error;
         unreachable;
 
     block3:
@@ -201,71 +183,7 @@ func inline(always) private %core__lib__abi__checked_frame_end__gf13e_6c9f(v0.i2
         br v13 block2 block5;
 }
 
-func inline(always) private %core__lib__abi__checked_frame_end__gf13e_7613(v0.i256, v1.i256, v2.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        (v5.i256, v6.i1) = uaddo v0 v1;
-        br v6 block6 block7;
-
-    block2:
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_1efd;
-        unreachable;
-
-    block3:
-        jump block4;
-
-    block4:
-        return v5;
-
-    block5:
-        v17.i1 = gt v5 v2;
-        br v17 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v13.i1 = lt v5 v0;
-        br v13 block2 block5;
-}
-
-func inline(always) private %core__lib__abi__checked_frame_end__gf13e_d188(v0.i256, v1.i256, v2.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        (v5.i256, v6.i1) = uaddo v0 v1;
-        br v6 block6 block7;
-
-    block2:
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_928c;
-        unreachable;
-
-    block3:
-        jump block4;
-
-    block4:
-        return v5;
-
-    block5:
-        v17.i1 = gt v5 v2;
-        br v17 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v13.i1 = lt v5 v0;
-        br v13 block2 block5;
-}
-
-func inline(always) private %core__lib__abi__checked_tail__gf13e_3857(v0.i256, v1.i256) -> i256 {
+func inline(always) private %core__lib__abi__checked_tail__gf13e_43ad(v0.i256, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -274,7 +192,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_3857(v0.i256, v
         br v5 block5 block6;
 
     block2:
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_bd08;
+        call %decode_error;
         unreachable;
 
     block3:
@@ -293,7 +211,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_3857(v0.i256, v
         br v12 block2 block3;
 }
 
-func inline(always) private %core__lib__abi__checked_tail__gf13e_931a(v0.i256, v1.i256) -> i256 {
+func inline(always) private %core__lib__abi__checked_tail__gf13e_82d7(v0.i256, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -302,7 +220,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_931a(v0.i256, v
         br v5 block5 block6;
 
     block2:
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_9d46;
+        call %decode_error;
         unreachable;
 
     block3:
@@ -321,7 +239,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_931a(v0.i256, v
         br v12 block2 block3;
 }
 
-func inline(always) private %core__lib__abi__checked_tail__gf13e_c189(v0.i256, v1.i256) -> i256 {
+func inline(always) private %core__lib__abi__checked_tail__gf13e_ca04(v0.i256, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -330,7 +248,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_c189(v0.i256, v
         br v5 block5 block6;
 
     block2:
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_a064;
+        call %decode_error;
         unreachable;
 
     block3:
@@ -483,7 +401,7 @@ func private %contract_runtime_root_EffectHandleFieldDeref() {
         unreachable;
 }
 
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_1efd() {
+func private %decode_error() {
     block0:
         jump block1;
 
@@ -491,47 +409,7 @@ func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_1efd() {
         evm_revert 0.i256 0.i256;
 }
 
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_5569() {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert 0.i256 0.i256;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_928c() {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert 0.i256 0.i256;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_9d46() {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert 0.i256 0.i256;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_a064() {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert 0.i256 0.i256;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_bd08() {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert 0.i256 0.i256;
-}
-
-func inline(always) private %core__lib__abi__decode_field_from__g5385_8786(v0.@layout_2, v1.i256, v2.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_field_from__g5385_0849(v0.@layout_2, v1.i256, v2.i256) -> i256 {
     block0:
         jump block1;
 
@@ -539,7 +417,7 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_8786(v0.@l
         br 0.i1 block2 block3;
 
     block2:
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_ec19 v0 v2;
+        v6.i256 = call %word_at v0 v2;
         (v8.i256, v9.i1) = uaddo v1 v6;
         br v9 block5 block6;
 
@@ -547,7 +425,7 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_8786(v0.@l
         jump block4;
 
     block4:
-        v19.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_9017_0 v0 v2;
+        v19.i256 = call %decode_from__g72ab v0 v2;
         return v19;
 
     block5:
@@ -556,11 +434,11 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_8786(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v16.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_9017_0 v0 v8;
+        v16.i256 = call %decode_from__g72ab v0 v8;
         return v16;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from__g5385_bfe4(v0.@layout_2, v1.i256, v2.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_field_from__g5385_c2b1(v0.@layout_2, v1.i256, v2.i256) -> i256 {
     block0:
         jump block1;
 
@@ -568,7 +446,7 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_bfe4(v0.@l
         br 0.i1 block2 block3;
 
     block2:
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_43e7 v0 v2;
+        v6.i256 = call %word_at v0 v2;
         (v8.i256, v9.i1) = uaddo v1 v6;
         br v9 block5 block6;
 
@@ -576,7 +454,7 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_bfe4(v0.@l
         jump block4;
 
     block4:
-        v19.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_25cb_0 v0 v2;
+        v19.i256 = call %decode_from__g72ab v0 v2;
         return v19;
 
     block5:
@@ -585,11 +463,11 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_bfe4(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v16.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_25cb_0 v0 v8;
+        v16.i256 = call %decode_from__g72ab v0 v8;
         return v16;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from__g5385_e15e(v0.@layout_2, v1.i256, v2.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_field_from__g5385_fd77(v0.@layout_2, v1.i256, v2.i256) -> i256 {
     block0:
         jump block1;
 
@@ -597,7 +475,7 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_e15e(v0.@l
         br 0.i1 block2 block3;
 
     block2:
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_5afc v0 v2;
+        v6.i256 = call %word_at v0 v2;
         (v8.i256, v9.i1) = uaddo v1 v6;
         br v9 block5 block6;
 
@@ -605,7 +483,7 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_e15e(v0.@l
         jump block4;
 
     block4:
-        v19.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_a2bb_0 v0 v2;
+        v19.i256 = call %decode_from__g72ab v0 v2;
         return v19;
 
     block5:
@@ -614,11 +492,11 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_e15e(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v16.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_a2bb_0 v0 v8;
+        v16.i256 = call %decode_from__g72ab v0 v8;
         return v16;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_00a6(v0.@layout_2, v1.i256, v2.i256, v3.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_039f(v0.@layout_2, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
         jump block1;
 
@@ -626,20 +504,20 @@ func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__
         br 0.i1 block2 block3;
 
     block2:
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_5afc v0 v2;
-        v9.i256 = call %core__lib__abi__checked_tail__gf13e_c189 v1 v7;
-        v11.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_7fdb v0 v9 v3;
+        v7.i256 = call %word_at v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_43ad v1 v7;
+        v11.i256 = call %decode_from_bounded v0 v9 v3;
         return v11;
 
     block3:
         jump block4;
 
     block4:
-        v14.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_a2bb_0 v0 v2;
+        v14.i256 = call %decode_from__g72ab v0 v2;
         return v14;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_0d6b(v0.@layout_2, v1.i256, v2.i256, v3.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_1aa9(v0.@layout_2, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
         jump block1;
 
@@ -647,20 +525,20 @@ func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__
         br 0.i1 block2 block3;
 
     block2:
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_43e7 v0 v2;
-        v9.i256 = call %core__lib__abi__checked_tail__gf13e_931a v1 v7;
-        v11.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_f6e3 v0 v9 v3;
+        v7.i256 = call %word_at v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_ca04 v1 v7;
+        v11.i256 = call %decode_from_bounded v0 v9 v3;
         return v11;
 
     block3:
         jump block4;
 
     block4:
-        v14.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_25cb_0 v0 v2;
+        v14.i256 = call %decode_from__g72ab v0 v2;
         return v14;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_b8f1(v0.@layout_2, v1.i256, v2.i256, v3.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_fc77(v0.@layout_2, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
         jump block1;
 
@@ -668,111 +546,27 @@ func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__
         br 0.i1 block2 block3;
 
     block2:
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_ec19 v0 v2;
-        v9.i256 = call %core__lib__abi__checked_tail__gf13e_3857 v1 v7;
-        v11.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_db00 v0 v9 v3;
+        v7.i256 = call %word_at v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_82d7 v1 v7;
+        v11.i256 = call %decode_from_bounded v0 v9 v3;
         return v11;
 
     block3:
         jump block4;
 
     block4:
-        v14.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_9017_0 v0 v2;
+        v14.i256 = call %decode_from__g72ab v0 v2;
         return v14;
 }
 
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_25cb(v0.@layout_2, v1.i256) -> i256 {
+func inline(always) private %impl_trait_BumpMover__decode_from__gd20d(v0.@layout_2, v1.i256) -> @layout_2 {
     block0:
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_ae0d v0 v1;
-        return v4;
-}
-
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_25cb_0(v0.@layout_2, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_ae0d_0 v0 v1;
-        return v4;
-}
-
-func inline(always) private %impl_trait_ReadViaHolder__decode_from__gd20d(v0.@layout_2, v1.i256) -> @layout_2 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_6925 v0;
-        v5.i256 = call %core__lib__abi__decode_msg_field_from__g5385_a6e2 v0 v1 v1 v3;
+        v3.i256 = call %len v0;
+        v5.i256 = call %core__lib__abi__decode_msg_field_from__g5385_4029 v0 v1 v1 v3;
         v8.@layout_2 = insert_value undef.@layout_2 0.i256 v5;
-        return v8;
-}
-
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_9017(v0.@layout_2, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_4b0c v0 v1;
-        return v4;
-}
-
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_9017_0(v0.@layout_2, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_4b0c_0 v0 v1;
-        return v4;
-}
-
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_a2bb(v0.@layout_2, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_1321 v0 v1;
-        return v4;
-}
-
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_a2bb_0(v0.@layout_2, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_1321_0 v0 v1;
-        return v4;
-}
-
-func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_7fdb(v0.@layout_2, v1.i256, v2.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_6c9f v1 32.i256 v2;
-        v8.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_a2bb v0 v1;
-        return v8;
-}
-
-func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_db00(v0.@layout_2, v1.i256, v2.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_7613 v1 32.i256 v2;
-        v8.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_9017 v0 v1;
-        return v8;
-}
-
-func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_f6e3(v0.@layout_2, v1.i256, v2.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_d188 v1 32.i256 v2;
-        v8.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_25cb v0 v1;
         return v8;
 }
 
@@ -781,8 +575,8 @@ func inline(always) private %impl_trait_SeedSlot__decode_from__gd20d(v0.@layout_
         jump block1;
 
     block1:
-        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_07e1 v0;
-        v5.i256 = call %core__lib__abi__decode_msg_field_from__g5385_4599 v0 v1 v1 v3;
+        v3.i256 = call %len v0;
+        v5.i256 = call %core__lib__abi__decode_msg_field_from__g5385_c914 v0 v1 v1 v3;
         (v7.i256, v8.i1) = uaddo v1 32.i256;
         br v8 block2 block3;
 
@@ -792,29 +586,48 @@ func inline(always) private %impl_trait_SeedSlot__decode_from__gd20d(v0.@layout_
         evm_revert 0.i256 36.i256;
 
     block3:
-        v17.i256 = call %core__lib__abi__decode_msg_field_from__g5385_4599 v0 v1 v7 v3;
+        v17.i256 = call %core__lib__abi__decode_msg_field_from__g5385_c914 v0 v1 v7 v3;
         v20.@layout_0 = insert_value undef.@layout_0 0.i256 v5;
         v22.@layout_0 = insert_value v20 1.i256 v17;
         return v22;
 }
 
-func inline(always) private %impl_trait_BumpMover__decode_from__gd20d(v0.@layout_2, v1.i256) -> @layout_2 {
+func inline(always) private %impl_trait_ReadViaHolder__decode_from__gd20d(v0.@layout_2, v1.i256) -> @layout_2 {
     block0:
         jump block1;
 
     block1:
-        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_7bfd v0;
-        v5.i256 = call %core__lib__abi__decode_msg_field_from__g5385_38ba v0 v1 v1 v3;
+        v3.i256 = call %len v0;
+        v5.i256 = call %core__lib__abi__decode_msg_field_from__g5385_2dda v0 v1 v1 v3;
         v8.@layout_2 = insert_value undef.@layout_2 0.i256 v5;
         return v8;
 }
 
-func inline(always) private %decode_from_prechecked_head__gdaee(v0.@layout_2, v1.i256, v2.i256) -> @layout_2 {
+func private %decode_from_bounded(v0.@layout_2, v1.i256, v2.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v6.@layout_2 = call %impl_trait_BumpMover__decode_from__gd20d v0 v1;
+        v6.i256 = call %checked_frame_end v1 32.i256 v2;
+        v8.i256 = call %decode_from__g72ab v0 v1;
+        return v8;
+}
+
+func inline(always) private %decode_from__g72ab(v0.@layout_2, v1.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.i256 = call %word_at v0 v1;
+        return v4;
+}
+
+func inline(always) private %decode_from_prechecked_head__g1d15(v0.@layout_2, v1.i256, v2.i256) -> @layout_0 {
+    block0:
+        jump block1;
+
+    block1:
+        v6.@layout_0 = call %impl_trait_SeedSlot__decode_from__gd20d v0 v1;
         return v6;
 }
 
@@ -827,16 +640,16 @@ func inline(always) private %decode_from_prechecked_head__ge273(v0.@layout_2, v1
         return v6;
 }
 
-func inline(always) private %decode_from_prechecked_head__g1d15(v0.@layout_2, v1.i256, v2.i256) -> @layout_0 {
+func inline(always) private %decode_from_prechecked_head__gdaee(v0.@layout_2, v1.i256, v2.i256) -> @layout_2 {
     block0:
         jump block1;
 
     block1:
-        v6.@layout_0 = call %impl_trait_SeedSlot__decode_from__gd20d v0 v1;
+        v6.@layout_2 = call %impl_trait_BumpMover__decode_from__gd20d v0 v1;
         return v6;
 }
 
-func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_38ba(v0.@layout_2, v1.i256, v2.i256, v3.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_2dda(v0.@layout_2, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
         jump block1;
 
@@ -844,18 +657,18 @@ func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_38ba(v
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_0d6b v0 v1 v2 v3;
+        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_fc77 v0 v1 v2 v3;
         return v9;
 
     block3:
         jump block4;
 
     block4:
-        v14.i256 = call %core__lib__abi__decode_field_from__g5385_bfe4 v0 v1 v2;
+        v14.i256 = call %core__lib__abi__decode_field_from__g5385_fd77 v0 v1 v2;
         return v14;
 }
 
-func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_4599(v0.@layout_2, v1.i256, v2.i256, v3.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_4029(v0.@layout_2, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
         jump block1;
 
@@ -863,18 +676,18 @@ func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_4599(v
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_b8f1 v0 v1 v2 v3;
+        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_039f v0 v1 v2 v3;
         return v9;
 
     block3:
         jump block4;
 
     block4:
-        v14.i256 = call %core__lib__abi__decode_field_from__g5385_8786 v0 v1 v2;
+        v14.i256 = call %core__lib__abi__decode_field_from__g5385_0849 v0 v1 v2;
         return v14;
 }
 
-func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_a6e2(v0.@layout_2, v1.i256, v2.i256, v3.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_c914(v0.@layout_2, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
         jump block1;
 
@@ -882,14 +695,14 @@ func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_a6e2(v
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_00a6 v0 v1 v2 v3;
+        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_1aa9 v0 v1 v2 v3;
         return v9;
 
     block3:
         jump block4;
 
     block4:
-        v14.i256 = call %core__lib__abi__decode_field_from__g5385_e15e v0 v1 v2;
+        v14.i256 = call %core__lib__abi__decode_field_from__g5385_c2b1 v0 v1 v2;
         return v14;
 }
 
@@ -900,13 +713,13 @@ func inline(always) private %decode_runtime_args__g5aad(v0.objref<@layout_4>) ->
         jump block1;
 
     block1:
-        v3.@layout_2 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_dcd3;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_6f55 v3;
+        v3.@layout_2 = call %input;
+        v5.i256 = call %len v3;
         mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
 
     block2:
-        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_9c1e;
+        call %abort;
         unreachable;
 
     block3:
@@ -930,13 +743,13 @@ func inline(always) private %decode_runtime_args__g01e9(v0.objref<@layout_4>) ->
         jump block1;
 
     block1:
-        v3.@layout_2 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_c5c0;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_d203 v3;
+        v3.@layout_2 = call %input;
+        v5.i256 = call %len v3;
         mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
 
     block2:
-        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_ffa6;
+        call %abort;
         unreachable;
 
     block3:
@@ -960,13 +773,13 @@ func inline(always) private %decode_runtime_args__g0392(v0.objref<@layout_4>) ->
         jump block1;
 
     block1:
-        v3.@layout_2 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_0e8a;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_c2dc v3;
+        v3.@layout_2 = call %input;
+        v5.i256 = call %len v3;
         mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
 
     block2:
-        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_4c56;
+        call %abort;
         unreachable;
 
     block3:
@@ -988,7 +801,7 @@ func private %encode(v0.i256, v1.objref<@layout_0>) {
         jump block1;
 
     block1:
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_75ef v1 v0;
+        call %write_word v1 v0;
         return;
 }
 
@@ -1001,10 +814,10 @@ func private %encode_field(v0.i256, v1.objref<@layout_0>, v2.i256) {
 
     block2:
         v5.i256 = call %base v1;
-        v8.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_a8bc v0;
+        v8.i256 = call %payload_size v0;
         v9.i256 = mload v2 i256;
         v10.i256 = sub v9 v5;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_5f6e v1 v10;
+        call %write_word v1 v10;
         v12.i256 = call %pos v1;
         v13.i256 = mload v2 i256;
         call %set_base v1 v13;
@@ -1110,34 +923,16 @@ func private %from_raw(v0.i256) -> @layout_2 {
         return v4;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_0e8a() -> @layout_2 {
+func private %input() -> @layout_2 {
     block0:
         jump block1;
 
     block1:
-        v0.@layout_2 = call %std__lib__evm__calldata__impl_CallData_8f43__new_ac71;
+        v0.@layout_2 = call %impl_CallData__new;
         return v0;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_c5c0() -> @layout_2 {
-    block0:
-        jump block1;
-
-    block1:
-        v0.@layout_2 = call %std__lib__evm__calldata__impl_CallData_8f43__new_e145;
-        return v0;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_dcd3() -> @layout_2 {
-    block0:
-        jump block1;
-
-    block1:
-        v0.@layout_2 = call %std__lib__evm__calldata__impl_CallData_8f43__new_0a05;
-        return v0;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_07e1(v0.@layout_2) -> i256 {
+func inline(always) private %len(v0.@layout_2) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         jump block1;
@@ -1169,188 +964,6 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
 
     block6:
         jump block4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_6925(v0.@layout_2) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v2.i256 = evm_calldata_size;
-        v5.i256 = extract_value v0 0.i256;
-        mstore v1 v2 i256;
-        v6.i256 = mload v1 i256;
-        v7.i1 = gt v5 v6;
-        br v7 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v9.i256 = extract_value v0 0.i256;
-        (v11.i256, v12.i1) = usubo v2 v9;
-        br v12 block5 block6;
-
-    block4:
-        v17.i256 = phi (0.i256 block2) (v11 block6);
-        return v17;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_6f55(v0.@layout_2) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v2.i256 = evm_calldata_size;
-        v5.i256 = extract_value v0 0.i256;
-        mstore v1 v2 i256;
-        v6.i256 = mload v1 i256;
-        v7.i1 = gt v5 v6;
-        br v7 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v9.i256 = extract_value v0 0.i256;
-        (v11.i256, v12.i1) = usubo v2 v9;
-        br v12 block5 block6;
-
-    block4:
-        v17.i256 = phi (0.i256 block2) (v11 block6);
-        return v17;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_7bfd(v0.@layout_2) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v2.i256 = evm_calldata_size;
-        v5.i256 = extract_value v0 0.i256;
-        mstore v1 v2 i256;
-        v6.i256 = mload v1 i256;
-        v7.i1 = gt v5 v6;
-        br v7 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v9.i256 = extract_value v0 0.i256;
-        (v11.i256, v12.i1) = usubo v2 v9;
-        br v12 block5 block6;
-
-    block4:
-        v17.i256 = phi (0.i256 block2) (v11 block6);
-        return v17;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_c2dc(v0.@layout_2) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v2.i256 = evm_calldata_size;
-        v5.i256 = extract_value v0 0.i256;
-        mstore v1 v2 i256;
-        v6.i256 = mload v1 i256;
-        v7.i1 = gt v5 v6;
-        br v7 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v9.i256 = extract_value v0 0.i256;
-        (v11.i256, v12.i1) = usubo v2 v9;
-        br v12 block5 block6;
-
-    block4:
-        v17.i256 = phi (0.i256 block2) (v11 block6);
-        return v17;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_d203(v0.@layout_2) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v2.i256 = evm_calldata_size;
-        v5.i256 = extract_value v0 0.i256;
-        mstore v1 v2 i256;
-        v6.i256 = mload v1 i256;
-        v7.i1 = gt v5 v6;
-        br v7 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v9.i256 = extract_value v0 0.i256;
-        (v11.i256, v12.i1) = usubo v2 v9;
-        br v12 block5 block6;
-
-    block4:
-        v17.i256 = phi (0.i256 block2) (v11 block6);
-        return v17;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_0a05() -> @layout_2 {
-    block0:
-        jump block1;
-
-    block1:
-        v1.constref<@layout_2> = const.ref $const_region_0;
-        v2.objref<@layout_2> = obj.alloc @layout_2;
-        obj.init.const v2 v1;
-        v3.@layout_2 = obj.load v2;
-        return v3;
 }
 
 func private %impl_SolEncoder__new(v0.i256) -> @layout_0 {
@@ -1375,7 +988,7 @@ func private %impl_SolEncoder__new(v0.i256) -> @layout_0 {
         return v8;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_ac71() -> @layout_2 {
+func inline(always) private %impl_CallData__new() -> @layout_2 {
     block0:
         jump block1;
 
@@ -1387,27 +1000,7 @@ func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_ac
         return v3;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_e145() -> @layout_2 {
-    block0:
-        jump block1;
-
-    block1:
-        v1.constref<@layout_2> = const.ref $const_region_0;
-        v2.objref<@layout_2> = obj.alloc @layout_2;
-        obj.init.const v2 v1;
-        v3.@layout_2 = obj.load v2;
-        return v3;
-}
-
-func private %core__lib__abi__trait_AbiSize__payload_size__ge513_a8bc(v0.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        return 32.i256;
-}
-
-func private %core__lib__abi__trait_AbiSize__payload_size__ge513_a8bc_0(v0.i256) -> i256 {
+func private %payload_size(v0.i256) -> i256 {
     block0:
         jump block1;
 
@@ -1445,23 +1038,7 @@ func private %read_cell(v0.i256) -> i256 {
         return v6;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_27e9(v0.i256, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert v0 v1;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_a881(v0.i256, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert v0 v1;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_ba8b(v0.i256, v1.i256) {
+func private %revert(v0.i256, v1.i256) {
     block0:
         jump block1;
 
@@ -1507,95 +1084,7 @@ func private %store_word(v0.i256, v1.i256) {
         return;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_1321(v0.@layout_2, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_1321_0(v0.@layout_2, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_43e7(v0.@layout_2, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_4b0c(v0.@layout_2, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_4b0c_0(v0.@layout_2, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_5afc(v0.@layout_2, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_ae0d(v0.@layout_2, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_ae0d_0(v0.@layout_2, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_ec19(v0.@layout_2, v1.i256) -> i256 {
+func inline(always) private %word_at(v0.@layout_2, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -1618,21 +1107,7 @@ func private %write_cell(v0.i256, v1.i256) -> i256 {
         return v8;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_5f6e(v0.objref<@layout_0>, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v4.objref<i256> = obj.proj v0 1.i256;
-        v5.i256 = obj.load v4;
-        mstore v5 v1 i256;
-        v9.i256 = add v5 32.i256;
-        v10.objref<i256> = obj.proj v0 1.i256;
-        obj.store v10 v9;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_75ef(v0.objref<@layout_0>, v1.i256) {
+func private %write_word(v0.objref<@layout_0>, v1.i256) {
     block0:
         jump block1;
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/effect_handle_field_deref.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/effect_handle_field_deref.snap
@@ -8,15 +8,9 @@ target = "evm-ethereum-osaka"
 type @layout_0 = {i256, i256};
 type @layout_1 = {i256};
 type @layout_2 = {i256};
-type @layout_3 = {i256};
-type @layout_4 = {i256};
-type @layout_5 = {i256, i256};
-type @layout_6 = {};
-type @layout_7 = {@layout_6};
-type @layout_8 = {i256, i256};
-type @layout_9 = {i256};
-type @layout_10 = {@layout_9, i256};
-type @layout_11 = {i256};
+type @layout_3 = {};
+type @layout_4 = {@layout_3};
+type @layout_5 = {@layout_2, i256};
 
 global private const @layout_2 $const_region_0 = {0};
 
@@ -34,7 +28,7 @@ func private %__EffectHandleFieldDeref_recv_0_0(v0.i256, v1.i256) -> i256 {
         jump block1;
 
     block1:
-        v3.@layout_9 = call %stor_ptr v0;
+        v3.@layout_2 = call %stor_ptr v0;
         v4.i256 = call %raw v3;
         v6.i256 = call %write_cell v1 v4;
         return v6;
@@ -45,10 +39,10 @@ func private %__EffectHandleFieldDeref_recv_0_1(v0.i256) -> i256 {
         jump block1;
 
     block1:
-        v2.@layout_9 = call %stor_ptr v0;
-        v6.@layout_10 = insert_value undef.@layout_10 0.i256 v2;
-        v7.@layout_10 = insert_value v6 1.i256 1.i256;
-        v8.@layout_9 = call %extract_ptr v7;
+        v2.@layout_2 = call %stor_ptr v0;
+        v6.@layout_5 = insert_value undef.@layout_5 0.i256 v2;
+        v7.@layout_5 = insert_value v6 1.i256 1.i256;
+        v8.@layout_2 = call %extract_ptr v7;
         v9.i256 = call %raw v8;
         v10.i256 = call %read_cell v9;
         return v10;
@@ -399,12 +393,12 @@ func inline(always) private %contract_recv_abi_EffectHandleFieldDeref_1() {
         evm_revert 0.i256 0.i256;
 
     block3:
-        v5.objref<@layout_7> = obj.alloc @layout_7;
-        v6.@layout_5 = call %decode_runtime_args__g5aad v5;
+        v5.objref<@layout_4> = obj.alloc @layout_4;
+        v6.@layout_0 = call %decode_runtime_args__g5aad v5;
         v7.i256 = extract_value v6 0.i256;
         v9.i256 = extract_value v6 1.i256;
         v10.i256 = call %__EffectHandleFieldDeref_recv_0_0 v7 v9;
-        v11.@layout_8 = call %encode_single_root_alloc v10;
+        v11.@layout_0 = call %encode_single_root_alloc v10;
         v12.i256 = extract_value v11 0.i256;
         v13.i256 = extract_value v11 1.i256;
         evm_return v12 v13;
@@ -424,11 +418,11 @@ func inline(always) private %contract_recv_abi_EffectHandleFieldDeref_2() {
         evm_revert 0.i256 0.i256;
 
     block3:
-        v5.objref<@layout_7> = obj.alloc @layout_7;
-        v6.@layout_4 = call %decode_runtime_args__g01e9 v5;
+        v5.objref<@layout_4> = obj.alloc @layout_4;
+        v6.@layout_2 = call %decode_runtime_args__g01e9 v5;
         v7.i256 = extract_value v6 0.i256;
         v8.i256 = call %__EffectHandleFieldDeref_recv_0_1 v7;
-        v9.@layout_8 = call %encode_single_root_alloc v8;
+        v9.@layout_0 = call %encode_single_root_alloc v8;
         v10.i256 = extract_value v9 0.i256;
         v12.i256 = extract_value v9 1.i256;
         evm_return v10 v12;
@@ -448,11 +442,11 @@ func inline(always) private %contract_recv_abi_EffectHandleFieldDeref_3() {
         evm_revert 0.i256 0.i256;
 
     block3:
-        v5.objref<@layout_7> = obj.alloc @layout_7;
-        v6.@layout_3 = call %decode_runtime_args__g0392 v5;
+        v5.objref<@layout_4> = obj.alloc @layout_4;
+        v6.@layout_2 = call %decode_runtime_args__g0392 v5;
         v7.i256 = extract_value v6 0.i256;
         v8.i256 = call %__EffectHandleFieldDeref_recv_0_2 v7 0.i256;
-        v9.@layout_8 = call %encode_single_root_alloc v8;
+        v9.@layout_0 = call %encode_single_root_alloc v8;
         v10.i256 = extract_value v9 0.i256;
         v12.i256 = extract_value v9 1.i256;
         evm_return v10 v12;
@@ -537,7 +531,7 @@ func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_bd08() {
         evm_revert 0.i256 0.i256;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from__g5385_1cc8(v0.@layout_2, v1.i256, v2.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_field_from__g5385_8786(v0.@layout_2, v1.i256, v2.i256) -> i256 {
     block0:
         jump block1;
 
@@ -545,7 +539,7 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_1cc8(v0.@l
         br 0.i1 block2 block3;
 
     block2:
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_7303 v0 v2;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_ec19 v0 v2;
         (v8.i256, v9.i1) = uaddo v1 v6;
         br v9 block5 block6;
 
@@ -553,7 +547,7 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_1cc8(v0.@l
         jump block4;
 
     block4:
-        v19.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f4af_0 v0 v2;
+        v19.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_9017_0 v0 v2;
         return v19;
 
     block5:
@@ -562,11 +556,11 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_1cc8(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v16.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f4af_0 v0 v8;
+        v16.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_9017_0 v0 v8;
         return v16;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from__g5385_23bd(v0.@layout_2, v1.i256, v2.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_field_from__g5385_bfe4(v0.@layout_2, v1.i256, v2.i256) -> i256 {
     block0:
         jump block1;
 
@@ -574,7 +568,7 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_23bd(v0.@l
         br 0.i1 block2 block3;
 
     block2:
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_dee9 v0 v2;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_43e7 v0 v2;
         (v8.i256, v9.i1) = uaddo v1 v6;
         br v9 block5 block6;
 
@@ -582,7 +576,7 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_23bd(v0.@l
         jump block4;
 
     block4:
-        v19.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f0a9_0 v0 v2;
+        v19.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_25cb_0 v0 v2;
         return v19;
 
     block5:
@@ -591,11 +585,11 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_23bd(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v16.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f0a9_0 v0 v8;
+        v16.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_25cb_0 v0 v8;
         return v16;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from__g5385_48de(v0.@layout_2, v1.i256, v2.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_field_from__g5385_e15e(v0.@layout_2, v1.i256, v2.i256) -> i256 {
     block0:
         jump block1;
 
@@ -603,7 +597,7 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_48de(v0.@l
         br 0.i1 block2 block3;
 
     block2:
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_7c41 v0 v2;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_5afc v0 v2;
         (v8.i256, v9.i1) = uaddo v1 v6;
         br v9 block5 block6;
 
@@ -611,7 +605,7 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_48de(v0.@l
         jump block4;
 
     block4:
-        v19.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_a878_0 v0 v2;
+        v19.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_a2bb_0 v0 v2;
         return v19;
 
     block5:
@@ -620,11 +614,11 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_48de(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v16.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_a878_0 v0 v8;
+        v16.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_a2bb_0 v0 v8;
         return v16;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_61db(v0.@layout_2, v1.i256, v2.i256, v3.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_00a6(v0.@layout_2, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
         jump block1;
 
@@ -632,41 +626,20 @@ func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__
         br 0.i1 block2 block3;
 
     block2:
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_dee9 v0 v2;
-        v9.i256 = call %core__lib__abi__checked_tail__gf13e_3857 v1 v7;
-        v11.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_dae2 v0 v9 v3;
-        return v11;
-
-    block3:
-        jump block4;
-
-    block4:
-        v14.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f0a9_0 v0 v2;
-        return v14;
-}
-
-func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_d7e7(v0.@layout_2, v1.i256, v2.i256, v3.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        br 0.i1 block2 block3;
-
-    block2:
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_7c41 v0 v2;
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_5afc v0 v2;
         v9.i256 = call %core__lib__abi__checked_tail__gf13e_c189 v1 v7;
-        v11.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_2684 v0 v9 v3;
+        v11.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_7fdb v0 v9 v3;
         return v11;
 
     block3:
         jump block4;
 
     block4:
-        v14.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_a878_0 v0 v2;
+        v14.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_a2bb_0 v0 v2;
         return v14;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_f2f8(v0.@layout_2, v1.i256, v2.i256, v3.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_0d6b(v0.@layout_2, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
         jump block1;
 
@@ -674,132 +647,142 @@ func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__
         br 0.i1 block2 block3;
 
     block2:
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_7303 v0 v2;
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_43e7 v0 v2;
         v9.i256 = call %core__lib__abi__checked_tail__gf13e_931a v1 v7;
-        v11.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_89cb v0 v9 v3;
+        v11.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_f6e3 v0 v9 v3;
         return v11;
 
     block3:
         jump block4;
 
     block4:
-        v14.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f4af_0 v0 v2;
+        v14.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_25cb_0 v0 v2;
         return v14;
 }
 
-func inline(always) private %impl_trait_BumpMover__decode_from__gd20d(v0.@layout_2, v1.i256) -> @layout_3 {
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_b8f1(v0.@layout_2, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_9e81 v0;
-        v5.i256 = call %core__lib__abi__decode_msg_field_from__g5385_5108 v0 v1 v1 v3;
-        v8.@layout_3 = insert_value undef.@layout_3 0.i256 v5;
-        return v8;
+        br 0.i1 block2 block3;
+
+    block2:
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_ec19 v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_3857 v1 v7;
+        v11.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_db00 v0 v9 v3;
+        return v11;
+
+    block3:
+        jump block4;
+
+    block4:
+        v14.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_9017_0 v0 v2;
+        return v14;
 }
 
-func inline(always) private %impl_trait_ReadViaHolder__decode_from__gd20d(v0.@layout_2, v1.i256) -> @layout_4 {
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_25cb(v0.@layout_2, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_392e v0;
-        v5.i256 = call %core__lib__abi__decode_msg_field_from__g5385_7d42 v0 v1 v1 v3;
-        v8.@layout_4 = insert_value undef.@layout_4 0.i256 v5;
-        return v8;
-}
-
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_a878(v0.@layout_2, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_9c31 v0 v1;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_ae0d v0 v1;
         return v4;
 }
 
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_a878_0(v0.@layout_2, v1.i256) -> i256 {
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_25cb_0(v0.@layout_2, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_9c31_0 v0 v1;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_ae0d_0 v0 v1;
         return v4;
 }
 
-func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_2684(v0.@layout_2, v1.i256, v2.i256) -> i256 {
+func inline(always) private %impl_trait_ReadViaHolder__decode_from__gd20d(v0.@layout_2, v1.i256) -> @layout_2 {
+    block0:
+        jump block1;
+
+    block1:
+        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_6925 v0;
+        v5.i256 = call %core__lib__abi__decode_msg_field_from__g5385_a6e2 v0 v1 v1 v3;
+        v8.@layout_2 = insert_value undef.@layout_2 0.i256 v5;
+        return v8;
+}
+
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_9017(v0.@layout_2, v1.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_4b0c v0 v1;
+        return v4;
+}
+
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_9017_0(v0.@layout_2, v1.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_4b0c_0 v0 v1;
+        return v4;
+}
+
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_a2bb(v0.@layout_2, v1.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_1321 v0 v1;
+        return v4;
+}
+
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_a2bb_0(v0.@layout_2, v1.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_1321_0 v0 v1;
+        return v4;
+}
+
+func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_7fdb(v0.@layout_2, v1.i256, v2.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
         v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_6c9f v1 32.i256 v2;
-        v8.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_a878 v0 v1;
+        v8.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_a2bb v0 v1;
         return v8;
 }
 
-func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_89cb(v0.@layout_2, v1.i256, v2.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_d188 v1 32.i256 v2;
-        v8.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f4af v0 v1;
-        return v8;
-}
-
-func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_dae2(v0.@layout_2, v1.i256, v2.i256) -> i256 {
+func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_db00(v0.@layout_2, v1.i256, v2.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
         v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_7613 v1 32.i256 v2;
-        v8.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f0a9 v0 v1;
+        v8.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_9017 v0 v1;
         return v8;
 }
 
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f0a9(v0.@layout_2, v1.i256) -> i256 {
+func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_f6e3(v0.@layout_2, v1.i256, v2.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_950e v0 v1;
-        return v4;
+        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_d188 v1 32.i256 v2;
+        v8.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_25cb v0 v1;
+        return v8;
 }
 
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f0a9_0(v0.@layout_2, v1.i256) -> i256 {
+func inline(always) private %impl_trait_SeedSlot__decode_from__gd20d(v0.@layout_2, v1.i256) -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_950e_0 v0 v1;
-        return v4;
-}
-
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f4af(v0.@layout_2, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_4e15 v0 v1;
-        return v4;
-}
-
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f4af_0(v0.@layout_2, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_4e15_0 v0 v1;
-        return v4;
-}
-
-func inline(always) private %impl_trait_SeedSlot__decode_from__gd20d(v0.@layout_2, v1.i256) -> @layout_5 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_1933 v0;
-        v5.i256 = call %core__lib__abi__decode_msg_field_from__g5385_3605 v0 v1 v1 v3;
+        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_07e1 v0;
+        v5.i256 = call %core__lib__abi__decode_msg_field_from__g5385_4599 v0 v1 v1 v3;
         (v7.i256, v8.i1) = uaddo v1 32.i256;
         br v8 block2 block3;
 
@@ -809,40 +792,51 @@ func inline(always) private %impl_trait_SeedSlot__decode_from__gd20d(v0.@layout_
         evm_revert 0.i256 36.i256;
 
     block3:
-        v17.i256 = call %core__lib__abi__decode_msg_field_from__g5385_3605 v0 v1 v7 v3;
-        v20.@layout_5 = insert_value undef.@layout_5 0.i256 v5;
-        v22.@layout_5 = insert_value v20 1.i256 v17;
+        v17.i256 = call %core__lib__abi__decode_msg_field_from__g5385_4599 v0 v1 v7 v3;
+        v20.@layout_0 = insert_value undef.@layout_0 0.i256 v5;
+        v22.@layout_0 = insert_value v20 1.i256 v17;
         return v22;
 }
 
-func inline(always) private %decode_from_prechecked_head__gdaee(v0.@layout_2, v1.i256, v2.i256) -> @layout_3 {
+func inline(always) private %impl_trait_BumpMover__decode_from__gd20d(v0.@layout_2, v1.i256) -> @layout_2 {
     block0:
         jump block1;
 
     block1:
-        v6.@layout_3 = call %impl_trait_BumpMover__decode_from__gd20d v0 v1;
-        return v6;
+        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_7bfd v0;
+        v5.i256 = call %core__lib__abi__decode_msg_field_from__g5385_38ba v0 v1 v1 v3;
+        v8.@layout_2 = insert_value undef.@layout_2 0.i256 v5;
+        return v8;
 }
 
-func inline(always) private %decode_from_prechecked_head__ge273(v0.@layout_2, v1.i256, v2.i256) -> @layout_4 {
+func inline(always) private %decode_from_prechecked_head__gdaee(v0.@layout_2, v1.i256, v2.i256) -> @layout_2 {
     block0:
         jump block1;
 
     block1:
-        v6.@layout_4 = call %impl_trait_ReadViaHolder__decode_from__gd20d v0 v1;
+        v6.@layout_2 = call %impl_trait_BumpMover__decode_from__gd20d v0 v1;
         return v6;
 }
 
-func inline(always) private %decode_from_prechecked_head__g1d15(v0.@layout_2, v1.i256, v2.i256) -> @layout_5 {
+func inline(always) private %decode_from_prechecked_head__ge273(v0.@layout_2, v1.i256, v2.i256) -> @layout_2 {
     block0:
         jump block1;
 
     block1:
-        v6.@layout_5 = call %impl_trait_SeedSlot__decode_from__gd20d v0 v1;
+        v6.@layout_2 = call %impl_trait_ReadViaHolder__decode_from__gd20d v0 v1;
         return v6;
 }
 
-func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_3605(v0.@layout_2, v1.i256, v2.i256, v3.i256) -> i256 {
+func inline(always) private %decode_from_prechecked_head__g1d15(v0.@layout_2, v1.i256, v2.i256) -> @layout_0 {
+    block0:
+        jump block1;
+
+    block1:
+        v6.@layout_0 = call %impl_trait_SeedSlot__decode_from__gd20d v0 v1;
+        return v6;
+}
+
+func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_38ba(v0.@layout_2, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
         jump block1;
 
@@ -850,18 +844,18 @@ func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_3605(v
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_61db v0 v1 v2 v3;
+        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_0d6b v0 v1 v2 v3;
         return v9;
 
     block3:
         jump block4;
 
     block4:
-        v14.i256 = call %core__lib__abi__decode_field_from__g5385_23bd v0 v1 v2;
+        v14.i256 = call %core__lib__abi__decode_field_from__g5385_bfe4 v0 v1 v2;
         return v14;
 }
 
-func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_5108(v0.@layout_2, v1.i256, v2.i256, v3.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_4599(v0.@layout_2, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
         jump block1;
 
@@ -869,18 +863,18 @@ func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_5108(v
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_f2f8 v0 v1 v2 v3;
+        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_b8f1 v0 v1 v2 v3;
         return v9;
 
     block3:
         jump block4;
 
     block4:
-        v14.i256 = call %core__lib__abi__decode_field_from__g5385_1cc8 v0 v1 v2;
+        v14.i256 = call %core__lib__abi__decode_field_from__g5385_8786 v0 v1 v2;
         return v14;
 }
 
-func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_7d42(v0.@layout_2, v1.i256, v2.i256, v3.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_a6e2(v0.@layout_2, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
         jump block1;
 
@@ -888,18 +882,18 @@ func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_7d42(v
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_d7e7 v0 v1 v2 v3;
+        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_00a6 v0 v1 v2 v3;
         return v9;
 
     block3:
         jump block4;
 
     block4:
-        v14.i256 = call %core__lib__abi__decode_field_from__g5385_48de v0 v1 v2;
+        v14.i256 = call %core__lib__abi__decode_field_from__g5385_e15e v0 v1 v2;
         return v14;
 }
 
-func inline(always) private %decode_runtime_args__g5aad(v0.objref<@layout_7>) -> @layout_5 {
+func inline(always) private %decode_runtime_args__g5aad(v0.objref<@layout_4>) -> @layout_0 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
@@ -907,7 +901,7 @@ func inline(always) private %decode_runtime_args__g5aad(v0.objref<@layout_7>) ->
 
     block1:
         v3.@layout_2 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_dcd3;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_960d v3;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_6f55 v3;
         mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
 
@@ -919,7 +913,7 @@ func inline(always) private %decode_runtime_args__g5aad(v0.objref<@layout_7>) ->
         jump block4;
 
     block4:
-        v12.@layout_5 = call %decode_from_prechecked_head__g1d15 v3 4.i256 v5;
+        v12.@layout_0 = call %decode_from_prechecked_head__g1d15 v3 4.i256 v5;
         return v12;
 
     block5:
@@ -929,7 +923,7 @@ func inline(always) private %decode_runtime_args__g5aad(v0.objref<@layout_7>) ->
         br v16 block2 block3;
 }
 
-func inline(always) private %decode_runtime_args__g01e9(v0.objref<@layout_7>) -> @layout_4 {
+func inline(always) private %decode_runtime_args__g01e9(v0.objref<@layout_4>) -> @layout_2 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
@@ -937,7 +931,7 @@ func inline(always) private %decode_runtime_args__g01e9(v0.objref<@layout_7>) ->
 
     block1:
         v3.@layout_2 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_c5c0;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_f59a v3;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_d203 v3;
         mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
 
@@ -949,7 +943,7 @@ func inline(always) private %decode_runtime_args__g01e9(v0.objref<@layout_7>) ->
         jump block4;
 
     block4:
-        v12.@layout_4 = call %decode_from_prechecked_head__ge273 v3 4.i256 v5;
+        v12.@layout_2 = call %decode_from_prechecked_head__ge273 v3 4.i256 v5;
         return v12;
 
     block5:
@@ -959,7 +953,7 @@ func inline(always) private %decode_runtime_args__g01e9(v0.objref<@layout_7>) ->
         br v16 block2 block3;
 }
 
-func inline(always) private %decode_runtime_args__g0392(v0.objref<@layout_7>) -> @layout_3 {
+func inline(always) private %decode_runtime_args__g0392(v0.objref<@layout_4>) -> @layout_2 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
@@ -967,7 +961,7 @@ func inline(always) private %decode_runtime_args__g0392(v0.objref<@layout_7>) ->
 
     block1:
         v3.@layout_2 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_0e8a;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_4133 v3;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_c2dc v3;
         mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
 
@@ -979,7 +973,7 @@ func inline(always) private %decode_runtime_args__g0392(v0.objref<@layout_7>) ->
         jump block4;
 
     block4:
-        v12.@layout_3 = call %decode_from_prechecked_head__gdaee v3 4.i256 v5;
+        v12.@layout_2 = call %decode_from_prechecked_head__gdaee v3 4.i256 v5;
         return v12;
 
     block5:
@@ -994,7 +988,7 @@ func private %encode(v0.i256, v1.objref<@layout_0>) {
         jump block1;
 
     block1:
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_2aa5 v1 v0;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_75ef v1 v0;
         return;
 }
 
@@ -1010,7 +1004,7 @@ func private %encode_field(v0.i256, v1.objref<@layout_0>, v2.i256) {
         v8.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_a8bc v0;
         v9.i256 = mload v2 i256;
         v10.i256 = sub v9 v5;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_8a50 v1 v10;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_5f6e v1 v10;
         v12.i256 = call %pos v1;
         v13.i256 = mload v2 i256;
         call %set_base v1 v13;
@@ -1059,7 +1053,7 @@ func private %encode_single_root(v0.i256, v1.objref<@layout_0>) {
         return;
 }
 
-func private %encode_single_root_alloc(v0.i256) -> @layout_8 {
+func private %encode_single_root_alloc(v0.i256) -> @layout_0 {
     block0:
         jump block1;
 
@@ -1075,8 +1069,8 @@ func private %encode_single_root_alloc(v0.i256) -> @layout_8 {
         obj.store v9 v10;
         v11.i256 = call %base v4;
         call %encode_single_root v0 v4;
-        v14.@layout_8 = insert_value undef.@layout_8 0.i256 v11;
-        v15.@layout_8 = insert_value v14 1.i256 v2;
+        v14.@layout_0 = insert_value undef.@layout_0 0.i256 v11;
+        v15.@layout_0 = insert_value v14 1.i256 v2;
         return v15;
 }
 
@@ -1098,21 +1092,21 @@ func private %encoder_new(v0.i256) -> @layout_0 {
         return v2;
 }
 
-func private %extract_ptr(v0.@layout_10) -> @layout_9 {
+func private %extract_ptr(v0.@layout_5) -> @layout_2 {
     block0:
         jump block1;
 
     block1:
-        v3.@layout_9 = extract_value v0 0.i256;
+        v3.@layout_2 = extract_value v0 0.i256;
         return v3;
 }
 
-func private %from_raw(v0.i256) -> @layout_9 {
+func private %from_raw(v0.i256) -> @layout_2 {
     block0:
         jump block1;
 
     block1:
-        v4.@layout_9 = insert_value undef.@layout_9 0.i256 v0;
+        v4.@layout_2 = insert_value undef.@layout_2 0.i256 v0;
         return v4;
 }
 
@@ -1143,7 +1137,7 @@ func private %std__lib__evm__effects__impl_trait_Evm_c913__input_dcd3() -> @layo
         return v0;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_1933(v0.@layout_2) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_07e1(v0.@layout_2) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         jump block1;
@@ -1177,7 +1171,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         jump block4;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_392e(v0.@layout_2) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_6925(v0.@layout_2) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         jump block1;
@@ -1211,7 +1205,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         jump block4;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_4133(v0.@layout_2) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_6f55(v0.@layout_2) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         jump block1;
@@ -1245,7 +1239,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         jump block4;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_960d(v0.@layout_2) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_7bfd(v0.@layout_2) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         jump block1;
@@ -1279,7 +1273,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         jump block4;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_9e81(v0.@layout_2) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_c2dc(v0.@layout_2) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         jump block1;
@@ -1313,7 +1307,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         jump block4;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_f59a(v0.@layout_2) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_d203(v0.@layout_2) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         jump block1;
@@ -1431,7 +1425,7 @@ func private %pos(v0.objref<@layout_0>) -> i256 {
         return v4;
 }
 
-func private %raw(v0.@layout_9) -> i256 {
+func private %raw(v0.@layout_2) -> i256 {
     block0:
         jump block1;
 
@@ -1446,7 +1440,7 @@ func private %read_cell(v0.i256) -> i256 {
 
     block1:
         v3.i256 = evm_sload v0;
-        v5.@layout_11 = insert_value undef.@layout_11 0.i256 v3;
+        v5.@layout_2 = insert_value undef.@layout_2 0.i256 v3;
         v6.i256 = extract_value v5 0.i256;
         return v6;
 }
@@ -1495,12 +1489,12 @@ func private %set_pos(v0.objref<@layout_0>, v1.i256) {
         return;
 }
 
-func private %stor_ptr(v0.i256) -> @layout_9 {
+func private %stor_ptr(v0.i256) -> @layout_2 {
     block0:
         jump block1;
 
     block1:
-        v2.@layout_9 = call %from_raw v0;
+        v2.@layout_2 = call %from_raw v0;
         return v2;
 }
 
@@ -1513,7 +1507,7 @@ func private %store_word(v0.i256, v1.i256) {
         return;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_4e15(v0.@layout_2, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_1321(v0.@layout_2, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -1524,7 +1518,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v7;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_4e15_0(v0.@layout_2, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_1321_0(v0.@layout_2, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -1535,7 +1529,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v7;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_7303(v0.@layout_2, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_43e7(v0.@layout_2, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -1546,7 +1540,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v7;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_7c41(v0.@layout_2, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_4b0c(v0.@layout_2, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -1557,7 +1551,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v7;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_950e(v0.@layout_2, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_4b0c_0(v0.@layout_2, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -1568,7 +1562,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v7;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_950e_0(v0.@layout_2, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_5afc(v0.@layout_2, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -1579,7 +1573,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v7;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_9c31(v0.@layout_2, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_ae0d(v0.@layout_2, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -1590,7 +1584,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v7;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_9c31_0(v0.@layout_2, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_ae0d_0(v0.@layout_2, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -1601,7 +1595,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v7;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_dee9(v0.@layout_2, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_ec19(v0.@layout_2, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -1619,12 +1613,12 @@ func private %write_cell(v0.i256, v1.i256) -> i256 {
     block1:
         evm_sstore v1 v0;
         v5.i256 = evm_sload v1;
-        v7.@layout_11 = insert_value undef.@layout_11 0.i256 v5;
+        v7.@layout_2 = insert_value undef.@layout_2 0.i256 v5;
         v8.i256 = extract_value v7 0.i256;
         return v8;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_2aa5(v0.objref<@layout_0>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_5f6e(v0.objref<@layout_0>, v1.i256) {
     block0:
         jump block1;
 
@@ -1638,7 +1632,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_2aa5(v0
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_8a50(v0.objref<@layout_0>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_75ef(v0.objref<@layout_0>, v1.i256) {
     block0:
         jump block1;
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/effect_ptr_domains.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/effect_ptr_domains.snap
@@ -9,33 +9,6 @@ type @layout_0 = {i256, i256};
 
 global private const @layout_0 $const_region_0 = {10, 20};
 
-func private %bump__gaab0(v0.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v2.i256 = mload v0 i256;
-        (v4.i256, v5.i1) = uaddo v2 1.i256;
-        br v5 block2 block3;
-
-    block2:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block3:
-        mstore v0 v4 i256;
-        v13.i256 = add v0 32.i256;
-        v14.i256 = mload v13 i256;
-        (v16.i256, v17.i1) = uaddo v14 2.i256;
-        br v17 block2 block4;
-
-    block4:
-        v19.i256 = add v0 32.i256;
-        mstore v19 v16 i256;
-        return;
-}
-
 func private %bump__gc323(v0.i256) {
     block0:
         jump block1;
@@ -89,6 +62,33 @@ func private %bump__gb2d8(v0.objref<@layout_0>) {
     block4:
         v20.objref<i256> = obj.proj v0 1.i256;
         obj.store v20 v17;
+        return;
+}
+
+func private %bump__gaab0(v0.i256) {
+    block0:
+        jump block1;
+
+    block1:
+        v2.i256 = mload v0 i256;
+        (v4.i256, v5.i1) = uaddo v2 1.i256;
+        br v5 block2 block3;
+
+    block2:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block3:
+        mstore v0 v4 i256;
+        v13.i256 = add v0 32.i256;
+        v14.i256 = mload v13 i256;
+        (v16.i256, v17.i1) = uaddo v14 2.i256;
+        br v17 block2 block4;
+
+    block4:
+        v19.i256 = add v0 32.i256;
+        mstore v19 v16 i256;
         return;
 }
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/enum_variant_contract.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/enum_variant_contract.snap
@@ -16,7 +16,7 @@ func private %abi_encode_u256(v0.i256) {
 
     block1:
         call %mstore 0.i256 v0;
-        call %std__lib__evm__effects__impl_trait_Evm_0098__return_data_06c7 0.i256 32.i256;
+        call %return_data 0.i256 32.i256;
         unreachable;
 }
 
@@ -48,7 +48,7 @@ func private %init() {
         v2.*i8 = evm_malloc v0;
         v3.i256 = ptr_to_int v2 i256;
         call %codecopy v3 v1 v0;
-        call %std__lib__evm__effects__impl_trait_Evm_0098__return_data_1461_0 v3 v0;
+        call %return_data v3 v0;
         unreachable;
 }
 
@@ -79,23 +79,7 @@ func private %mstore(v0.i256, v1.i256) {
         return;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_0098__return_data_06c7(v0.i256, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        evm_return v0 v1;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_0098__return_data_1461(v0.i256, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        evm_return v0 v1;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_0098__return_data_1461_0(v0.i256, v1.i256) {
+func private %return_data(v0.i256, v1.i256) {
     block0:
         jump block1;
 
@@ -175,7 +159,7 @@ func private %runtime() {
         jump block16;
 
     block16:
-        call %std__lib__evm__effects__impl_trait_Evm_0098__return_data_1461 0.i256 0.i256;
+        call %return_data 0.i256 0.i256;
         unreachable;
 
     block17:

--- a/crates/codegen/tests/fixtures/sonatina_ir/enum_variant_contract.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/enum_variant_contract.snap
@@ -6,8 +6,8 @@ input_file: crates/codegen/tests/fixtures/enum_variant_contract.fe
 target = "evm-ethereum-osaka"
 
 type @layout_0 = enum {
-    #None,
-    #Some(i256),
+    #variant_0,
+    #variant_1(i256),
 };
 
 func private %abi_encode_u256(v0.i256) {
@@ -115,7 +115,7 @@ func private %runtime() {
 
     block2:
         v7.i256 = call %calldataload 4.i256;
-        v8.@layout_0 = enum.make @layout_0 #Some v7;
+        v8.@layout_0 = enum.make @layout_0 #variant_1 v7;
         v9.enumtag(@layout_0) = enum.tag v8;
         br_table v9 (1.enumtag(@layout_0) block6) (0.enumtag(@layout_0) block7);
 
@@ -132,16 +132,16 @@ func private %runtime() {
         unreachable;
 
     block6:
-        enum.assert_variant v8 #Some;
-        v17.i256 = enum.extract v8 #Some 0.i256;
+        enum.assert_variant v8 #variant_1;
+        v17.i256 = enum.extract v8 #variant_1 0.i256;
         jump block5;
 
     block7:
         jump block5;
 
     block8:
-        v18.@layout_0 = enum.make @layout_0 #None;
-        v19.@layout_0 = enum.make @layout_0 #None;
+        v18.@layout_0 = enum.make @layout_0 #variant_0;
+        v19.@layout_0 = enum.make @layout_0 #variant_0;
         v20.enumtag(@layout_0) = enum.tag v19;
         br_table v20 (1.enumtag(@layout_0) block12) (0.enumtag(@layout_0) block13);
 
@@ -158,8 +158,8 @@ func private %runtime() {
         unreachable;
 
     block12:
-        enum.assert_variant v19 #Some;
-        v26.i256 = enum.extract v19 #Some 0.i256;
+        enum.assert_variant v19 #variant_1;
+        v26.i256 = enum.extract v19 #variant_1 0.i256;
         jump block11;
 
     block13:
@@ -167,7 +167,7 @@ func private %runtime() {
 
     block14:
         v27.i256 = call %calldataload 4.i256;
-        v28.@layout_0 = enum.make @layout_0 #Some v27;
+        v28.@layout_0 = enum.make @layout_0 #variant_1 v27;
         v29.enumtag(@layout_0) = enum.tag v28;
         br_table v29 (1.enumtag(@layout_0) block18) (0.enumtag(@layout_0) block19);
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/erc20.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/erc20.snap
@@ -7,30 +7,17 @@ target = "evm-ethereum-osaka"
 
 type @layout_0 = {i256};
 type @layout_1 = {i256, i256};
-type @layout_2 = {i256, i256};
+type @layout_2 = {@layout_1, i256};
 type @layout_3 = {@layout_2, i256};
-type @layout_4 = {@layout_3, i256};
-type @layout_5 = {i256};
-type @layout_6 = {@layout_0, @layout_0};
-type @layout_7 = {@layout_0, i256};
-type @layout_8 = {@layout_0, i256};
-type @layout_9 = {i256};
-type @layout_10 = {@layout_0, i256};
-type @layout_11 = {@layout_0};
-type @layout_12 = {@layout_0, i256};
-type @layout_13 = {@layout_0, @layout_0, i256};
-type @layout_14 = {@layout_0, i256};
-type @layout_15 = {@layout_0, i256};
-type @layout_16 = {i256, @layout_0};
-type @layout_17 = {};
-type @layout_18 = {@layout_17};
-type @layout_19 = {@layout_0, @layout_0, i256};
-type @layout_20 = {@layout_0, @layout_0, i256};
-type @layout_21 = {i256, i256};
-type @layout_22 = {@layout_0, @layout_0};
+type @layout_4 = {@layout_0, @layout_0};
+type @layout_5 = {@layout_0, i256};
+type @layout_6 = {@layout_0, @layout_0, i256};
+type @layout_7 = {@layout_0};
+type @layout_8 = {i256, @layout_0};
+type @layout_9 = {};
+type @layout_10 = {@layout_9};
 
-global private const @layout_5 $const_region_0 = {0};
-global private const @layout_0 $const_region_1 = {0};
+global private const @layout_0 $const_region_0 = {0};
 
 func private %__CoolCoin_init(v0.i256, v1.@layout_0, v2.i256, v3.i256, v4.i256, v5.i256, v6.i256) {
     block0:
@@ -43,7 +30,7 @@ func private %__CoolCoin_init(v0.i256, v1.@layout_0, v2.i256, v3.i256, v4.i256, 
         br v16 block2 block3;
 
     block2:
-        call %standalone_erc20__erc20__mint__ga9cb_110c v1 v0 v2 1.i256 2.i256;
+        call %standalone_erc20__erc20__mint__ga9cb_527c v1 v0 v2 1.i256 2.i256;
         jump block4;
 
     block3:
@@ -59,7 +46,7 @@ func private %__CoolCoin_recv_0_0(v0.@layout_0, v1.i256, v2.i256, v3.i256, v4.i2
 
     block1:
         v5.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_a1e8__caller_aa40_0;
-        call %standalone_erc20__erc20__transfer__ga9cb_4eee v5 v0 v1 v2 1.i256 2.i256;
+        call %standalone_erc20__erc20__transfer__ga9cb_db9b v5 v0 v1 v2 1.i256 2.i256;
         return 1.i1;
 }
 
@@ -69,7 +56,7 @@ func private %__CoolCoin_recv_0_1(v0.@layout_0, v1.i256, v2.i256, v3.i256, v4.i2
 
     block1:
         v5.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_a1e8__caller_aa40_0;
-        call %standalone_erc20__erc20__approve__ga9cb_5597 v5 v0 v1 v2 1.i256 2.i256;
+        call %standalone_erc20__erc20__approve__ga9cb_7b1c v5 v0 v1 v2 1.i256 2.i256;
         return 1.i1;
 }
 
@@ -79,8 +66,8 @@ func private %__CoolCoin_recv_0_2(v0.@layout_0, v1.@layout_0, v2.i256, v3.i256, 
 
     block1:
         v6.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_a1e8__caller_aa40_0;
-        call %standalone_erc20__erc20__spend_allowance__g13d4_17f7 v0 v6 v2 v3 1.i256 2.i256;
-        call %standalone_erc20__erc20__transfer__ga9cb_5037 v0 v1 v2 v3 1.i256 2.i256;
+        call %standalone_erc20__erc20__spend_allowance__g13d4_a04b v0 v6 v2 v3 1.i256 2.i256;
+        call %standalone_erc20__erc20__transfer__ga9cb_8101 v0 v1 v2 v3 1.i256 2.i256;
         return 1.i1;
 }
 
@@ -98,9 +85,9 @@ func private %__CoolCoin_recv_0_4(v0.@layout_0, v1.@layout_0, v2.i256, v3.i256, 
         jump block1;
 
     block1:
-        v9.@layout_22 = insert_value undef.@layout_22 0.i256 v0;
-        v12.@layout_22 = insert_value v9 1.i256 v1;
-        v13.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get__g94db_c935 v12 2.i256;
+        v9.@layout_4 = insert_value undef.@layout_4 0.i256 v0;
+        v12.@layout_4 = insert_value v9 1.i256 v1;
+        v13.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get__g94db_61a4 v12 2.i256;
         return v13;
 }
 
@@ -143,7 +130,7 @@ func private %__CoolCoin_recv_1_0(v0.@layout_0, v1.i256, v2.i256, v3.i256, v4.i2
 
     block1:
         call %require 1.i256 v6;
-        call %standalone_erc20__erc20__mint__ga9cb_03ab v0 v1 v2 1.i256 2.i256;
+        call %standalone_erc20__erc20__mint__ga9cb_2b3b v0 v1 v2 1.i256 2.i256;
         return 1.i1;
 }
 
@@ -153,7 +140,7 @@ func private %__CoolCoin_recv_1_1(v0.i256, v1.i256, v2.i256, v3.i256) -> i1 {
 
     block1:
         v4.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_a1e8__caller_aa40_0;
-        call %standalone_erc20__erc20__burn__ga9cb_733e v4 v0 v1 1.i256 2.i256;
+        call %standalone_erc20__erc20__burn__ga9cb_d32b v4 v0 v1 1.i256 2.i256;
         return 1.i1;
 }
 
@@ -163,8 +150,8 @@ func private %__CoolCoin_recv_1_2(v0.@layout_0, v1.i256, v2.i256, v3.i256, v4.i2
 
     block1:
         v5.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_a1e8__caller_aa40_0;
-        call %standalone_erc20__erc20__spend_allowance__g13d4_17f7_0 v0 v5 v1 v2 1.i256 2.i256;
-        call %standalone_erc20__erc20__burn__ga9cb_5a19 v0 v1 v2 1.i256 2.i256;
+        call %standalone_erc20__erc20__spend_allowance__g13d4_a04b_0 v0 v5 v1 v2 1.i256 2.i256;
+        call %standalone_erc20__erc20__burn__ga9cb_d0fb v0 v1 v2 1.i256 2.i256;
         return 1.i1;
 }
 
@@ -174,9 +161,9 @@ func private %__CoolCoin_recv_1_3(v0.@layout_0, v1.i256, v2.i256, v3.i256, v4.i2
 
     block1:
         v5.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_a1e8__caller_aa40_0;
-        v9.@layout_22 = insert_value undef.@layout_22 0.i256 v5;
-        v12.@layout_22 = insert_value v9 1.i256 v0;
-        v13.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get__g94db_552a v12 2.i256;
+        v9.@layout_4 = insert_value undef.@layout_4 0.i256 v5;
+        v12.@layout_4 = insert_value v9 1.i256 v0;
+        v13.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get__g94db_6651 v12 2.i256;
         (v15.i256, v16.i1) = uaddo v13 v1;
         br v16 block2 block3;
 
@@ -186,7 +173,7 @@ func private %__CoolCoin_recv_1_3(v0.@layout_0, v1.i256, v2.i256, v3.i256, v4.i2
         evm_revert 0.i256 36.i256;
 
     block3:
-        call %standalone_erc20__erc20__approve__ga9cb_2b40 v5 v0 v15 v2 1.i256 2.i256;
+        call %standalone_erc20__erc20__approve__ga9cb_d6ba v5 v0 v15 v2 1.i256 2.i256;
         return 1.i1;
 }
 
@@ -197,9 +184,9 @@ func private %__CoolCoin_recv_1_4(v0.@layout_0, v1.i256, v2.i256, v3.i256, v4.i2
 
     block1:
         v6.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_a1e8__caller_aa40_0;
-        v10.@layout_22 = insert_value undef.@layout_22 0.i256 v6;
-        v13.@layout_22 = insert_value v10 1.i256 v0;
-        v14.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get__g94db_552a v13 2.i256;
+        v10.@layout_4 = insert_value undef.@layout_4 0.i256 v6;
+        v13.@layout_4 = insert_value v10 1.i256 v0;
+        v14.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get__g94db_6651 v13 2.i256;
         mstore v5 v1 i256;
         v16.i256 = mload v5 i256;
         v17.i1 = lt v14 v16;
@@ -230,7 +217,7 @@ func private %__CoolCoin_recv_1_4(v0.@layout_0, v1.i256, v2.i256, v3.i256, v4.i2
         evm_revert v22 36.i256;
 
     block7:
-        call %standalone_erc20__erc20__approve__ga9cb_e036 v6 v0 v36 v2 1.i256 2.i256;
+        call %standalone_erc20__erc20__approve__ga9cb_da09 v6 v0 v36 v2 1.i256 2.i256;
         return 1.i1;
 }
 
@@ -558,7 +545,7 @@ func private %std__lib__evm__effects__impl_trait_Evm_c913__abort_cf57() {
         unreachable;
 }
 
-func private %standalone_erc20__erc20__approve__ga9cb_2b40(v0.@layout_0, v1.@layout_0, v2.i256, v3.i256, v4.i256, v5.i256) {
+func private %standalone_erc20__erc20__approve__ga9cb_7b1c(v0.@layout_0, v1.@layout_0, v2.i256, v3.i256, v4.i256, v5.i256) {
     block0:
         v6.objref<@layout_0> = obj.alloc @layout_0;
         v7.objref<@layout_0> = obj.alloc @layout_0;
@@ -604,12 +591,12 @@ func private %standalone_erc20__erc20__approve__ga9cb_2b40(v0.@layout_0, v1.@lay
 
     block7:
         v46.i256 = add v3 1.i256;
-        v51.@layout_22 = insert_value undef.@layout_22 0.i256 v0;
-        v52.@layout_22 = insert_value v51 1.i256 v1;
-        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set__ge2d3_c199_0 v52 v2 2.i256;
-        v56.@layout_19 = insert_value undef.@layout_19 0.i256 v0;
-        v57.@layout_19 = insert_value v56 1.i256 v1;
-        v58.@layout_19 = insert_value v57 2.i256 v2;
+        v51.@layout_4 = insert_value undef.@layout_4 0.i256 v0;
+        v52.@layout_4 = insert_value v51 1.i256 v1;
+        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set__ge2d3_ddb6_0 v52 v2 2.i256;
+        v56.@layout_6 = insert_value undef.@layout_6 0.i256 v0;
+        v57.@layout_6 = insert_value v56 1.i256 v1;
+        v58.@layout_6 = insert_value v57 2.i256 v2;
         call %emit__g9cd0 v58;
         return;
 
@@ -627,7 +614,7 @@ func private %standalone_erc20__erc20__approve__ga9cb_2b40(v0.@layout_0, v1.@lay
         evm_revert v37 36.i256;
 }
 
-func private %standalone_erc20__erc20__approve__ga9cb_5597(v0.@layout_0, v1.@layout_0, v2.i256, v3.i256, v4.i256, v5.i256) {
+func private %standalone_erc20__erc20__approve__ga9cb_d6ba(v0.@layout_0, v1.@layout_0, v2.i256, v3.i256, v4.i256, v5.i256) {
     block0:
         v6.objref<@layout_0> = obj.alloc @layout_0;
         v7.objref<@layout_0> = obj.alloc @layout_0;
@@ -673,12 +660,12 @@ func private %standalone_erc20__erc20__approve__ga9cb_5597(v0.@layout_0, v1.@lay
 
     block7:
         v46.i256 = add v3 1.i256;
-        v51.@layout_22 = insert_value undef.@layout_22 0.i256 v0;
-        v52.@layout_22 = insert_value v51 1.i256 v1;
-        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set__ge2d3_c199_0 v52 v2 2.i256;
-        v56.@layout_19 = insert_value undef.@layout_19 0.i256 v0;
-        v57.@layout_19 = insert_value v56 1.i256 v1;
-        v58.@layout_19 = insert_value v57 2.i256 v2;
+        v51.@layout_4 = insert_value undef.@layout_4 0.i256 v0;
+        v52.@layout_4 = insert_value v51 1.i256 v1;
+        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set__ge2d3_ddb6_0 v52 v2 2.i256;
+        v56.@layout_6 = insert_value undef.@layout_6 0.i256 v0;
+        v57.@layout_6 = insert_value v56 1.i256 v1;
+        v58.@layout_6 = insert_value v57 2.i256 v2;
         call %emit__g9cd0 v58;
         return;
 
@@ -696,7 +683,7 @@ func private %standalone_erc20__erc20__approve__ga9cb_5597(v0.@layout_0, v1.@lay
         evm_revert v37 36.i256;
 }
 
-func private %standalone_erc20__erc20__approve__ga9cb_e036(v0.@layout_0, v1.@layout_0, v2.i256, v3.i256, v4.i256, v5.i256) {
+func private %standalone_erc20__erc20__approve__ga9cb_da09(v0.@layout_0, v1.@layout_0, v2.i256, v3.i256, v4.i256, v5.i256) {
     block0:
         v6.objref<@layout_0> = obj.alloc @layout_0;
         v7.objref<@layout_0> = obj.alloc @layout_0;
@@ -742,12 +729,12 @@ func private %standalone_erc20__erc20__approve__ga9cb_e036(v0.@layout_0, v1.@lay
 
     block7:
         v46.i256 = add v3 1.i256;
-        v51.@layout_22 = insert_value undef.@layout_22 0.i256 v0;
-        v52.@layout_22 = insert_value v51 1.i256 v1;
-        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set__ge2d3_c199_0 v52 v2 2.i256;
-        v56.@layout_19 = insert_value undef.@layout_19 0.i256 v0;
-        v57.@layout_19 = insert_value v56 1.i256 v1;
-        v58.@layout_19 = insert_value v57 2.i256 v2;
+        v51.@layout_4 = insert_value undef.@layout_4 0.i256 v0;
+        v52.@layout_4 = insert_value v51 1.i256 v1;
+        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set__ge2d3_ddb6_0 v52 v2 2.i256;
+        v56.@layout_6 = insert_value undef.@layout_6 0.i256 v0;
+        v57.@layout_6 = insert_value v56 1.i256 v1;
+        v58.@layout_6 = insert_value v57 2.i256 v2;
         call %emit__g9cd0 v58;
         return;
 
@@ -765,7 +752,7 @@ func private %standalone_erc20__erc20__approve__ga9cb_e036(v0.@layout_0, v1.@lay
         evm_revert v37 36.i256;
 }
 
-func private %std__lib__abi__sol__types__impl_trait_Address_0a07__as_topic_4475(v0.@layout_0) -> i256 {
+func private %std__lib__abi__sol__types__impl_trait_Address_0a07__as_topic_102e(v0.@layout_0) -> i256 {
     block0:
         jump block1;
 
@@ -774,7 +761,7 @@ func private %std__lib__abi__sol__types__impl_trait_Address_0a07__as_topic_4475(
         return v3;
 }
 
-func private %std__lib__abi__sol__types__impl_trait_Address_0a07__as_topic_d053(v0.@layout_0) -> i256 {
+func private %std__lib__abi__sol__types__impl_trait_Address_0a07__as_topic_d26a(v0.@layout_0) -> i256 {
     block0:
         jump block1;
 
@@ -853,7 +840,7 @@ func inline(always) private %std__lib__abi__sol__impl_SolEncoder_ce34__at_fb00(v
         return v6;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_1fbd(v0.objref<@layout_1>) -> i256 {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_117c(v0.objref<@layout_1>) -> i256 {
     block0:
         jump block1;
 
@@ -863,7 +850,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_1fbd(v0.objre
         return v4;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_25d4(v0.objref<@layout_1>) -> i256 {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_1580(v0.objref<@layout_1>) -> i256 {
     block0:
         jump block1;
 
@@ -873,7 +860,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_25d4(v0.objre
         return v4;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_6030(v0.objref<@layout_1>) -> i256 {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_4803(v0.objref<@layout_1>) -> i256 {
     block0:
         jump block1;
 
@@ -883,17 +870,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_6030(v0.objre
         return v4;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_8751(v0.objref<@layout_1>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 0.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_91bf(v0.objref<@layout_4>) -> i256 {
+func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_5297(v0.objref<@layout_3>) -> i256 {
     block0:
         jump block1;
 
@@ -903,7 +880,7 @@ func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_91bf(v
         return v4;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_91bf_0(v0.objref<@layout_4>) -> i256 {
+func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_5297_0(v0.objref<@layout_3>) -> i256 {
     block0:
         jump block1;
 
@@ -913,7 +890,7 @@ func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_91bf_0
         return v4;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_9c4a(v0.objref<@layout_1>) -> i256 {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_57cd(v0.objref<@layout_1>) -> i256 {
     block0:
         jump block1;
 
@@ -923,7 +900,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_9c4a(v0.objre
         return v4;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_a9a0(v0.objref<@layout_1>) -> i256 {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_61c3(v0.objref<@layout_1>) -> i256 {
     block0:
         jump block1;
 
@@ -933,7 +910,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_a9a0(v0.objre
         return v4;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_bb09(v0.objref<@layout_1>) -> i256 {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_7bd0(v0.objref<@layout_1>) -> i256 {
     block0:
         jump block1;
 
@@ -943,7 +920,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_bb09(v0.objre
         return v4;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_c13e(v0.objref<@layout_1>) -> i256 {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_b8b6(v0.objref<@layout_1>) -> i256 {
     block0:
         jump block1;
 
@@ -953,7 +930,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_c13e(v0.objre
         return v4;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_fd6f(v0.objref<@layout_1>) -> i256 {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_e214(v0.objref<@layout_1>) -> i256 {
     block0:
         jump block1;
 
@@ -963,7 +940,17 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_fd6f(v0.objre
         return v4;
 }
 
-func private %standalone_erc20__erc20__burn__ga9cb_5a19(v0.@layout_0, v1.i256, v2.i256, v3.i256, v4.i256) {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_eb78(v0.objref<@layout_1>) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v3.objref<i256> = obj.proj v0 0.i256;
+        v4.i256 = obj.load v3;
+        return v4;
+}
+
+func private %standalone_erc20__erc20__burn__ga9cb_d0fb(v0.@layout_0, v1.i256, v2.i256, v3.i256, v4.i256) {
     block0:
         v5.objref<@layout_0> = obj.alloc @layout_0;
         jump block1;
@@ -1030,14 +1017,14 @@ func private %standalone_erc20__erc20__burn__ga9cb_5a19(v0.@layout_0, v1.i256, v
     block12:
         evm_sstore v2 v55;
         v59.@layout_0 = call %zero;
-        v62.@layout_20 = insert_value undef.@layout_20 0.i256 v0;
-        v63.@layout_20 = insert_value v62 1.i256 v59;
-        v65.@layout_20 = insert_value v63 2.i256 v1;
+        v62.@layout_6 = insert_value undef.@layout_6 0.i256 v0;
+        v63.@layout_6 = insert_value v62 1.i256 v59;
+        v65.@layout_6 = insert_value v63 2.i256 v1;
         call %emit__g4c3d v65;
         return;
 }
 
-func private %standalone_erc20__erc20__burn__ga9cb_733e(v0.@layout_0, v1.i256, v2.i256, v3.i256, v4.i256) {
+func private %standalone_erc20__erc20__burn__ga9cb_d32b(v0.@layout_0, v1.i256, v2.i256, v3.i256, v4.i256) {
     block0:
         v5.objref<@layout_0> = obj.alloc @layout_0;
         jump block1;
@@ -1104,9 +1091,9 @@ func private %standalone_erc20__erc20__burn__ga9cb_733e(v0.@layout_0, v1.i256, v
     block12:
         evm_sstore v2 v55;
         v59.@layout_0 = call %zero;
-        v62.@layout_20 = insert_value undef.@layout_20 0.i256 v0;
-        v63.@layout_20 = insert_value v62 1.i256 v59;
-        v65.@layout_20 = insert_value v63 2.i256 v1;
+        v62.@layout_6 = insert_value undef.@layout_6 0.i256 v0;
+        v63.@layout_6 = insert_value v62 1.i256 v59;
+        v65.@layout_6 = insert_value v63 2.i256 v1;
         call %emit__g4c3d v65;
         return;
 }
@@ -2153,8 +2140,8 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_c89e(v0.i256, v
 
 func inline(always) private %contract_init_abi_CoolCoin() {
     block0:
-        v0.objref<@layout_2> = obj.alloc @layout_2;
-        v1.objref<@layout_4> = obj.alloc @layout_4;
+        v0.objref<@layout_1> = obj.alloc @layout_1;
+        v1.objref<@layout_3> = obj.alloc @layout_3;
         jump block1;
 
     block1:
@@ -2192,12 +2179,12 @@ func inline(always) private %contract_init_abi_CoolCoin() {
         obj.store v23 v20;
         v25.objref<i256> = obj.proj v0 1.i256;
         obj.store v25 v13;
-        v26.@layout_2 = obj.load v0;
-        v27.@layout_4 = call %decoder_new v26;
-        v28.objref<@layout_3> = obj.proj v1 0.i256;
-        v29.@layout_3 = extract_value v27 0.i256;
-        v30.objref<@layout_2> = obj.proj v28 0.i256;
-        v31.@layout_2 = extract_value v29 0.i256;
+        v26.@layout_1 = obj.load v0;
+        v27.@layout_3 = call %decoder_new v26;
+        v28.objref<@layout_2> = obj.proj v1 0.i256;
+        v29.@layout_2 = extract_value v27 0.i256;
+        v30.objref<@layout_1> = obj.proj v28 0.i256;
+        v31.@layout_1 = extract_value v29 0.i256;
         v32.objref<i256> = obj.proj v30 0.i256;
         v33.i256 = extract_value v31 0.i256;
         obj.store v32 v33;
@@ -2210,7 +2197,7 @@ func inline(always) private %contract_init_abi_CoolCoin() {
         v38.objref<i256> = obj.proj v1 1.i256;
         v39.i256 = extract_value v27 1.i256;
         obj.store v38 v39;
-        v40.@layout_16 = call %decode_payload__gf566 v1;
+        v40.@layout_8 = call %decode_payload__gf566 v1;
         v41.i256 = extract_value v40 0.i256;
         v42.@layout_0 = extract_value v40 1.i256;
         call %__CoolCoin_init v41 v42 0.i256 3.i256 1.i256 2.i256 3.i256;
@@ -2243,12 +2230,12 @@ func inline(always) private %contract_recv_abi_CoolCoin_1086394137() {
         evm_revert 0.i256 0.i256;
 
     block3:
-        v5.objref<@layout_18> = obj.alloc @layout_18;
-        v6.@layout_8 = call %decode_runtime_args__g2273 v5;
+        v5.objref<@layout_10> = obj.alloc @layout_10;
+        v6.@layout_5 = call %decode_runtime_args__g2273 v5;
         v7.@layout_0 = extract_value v6 0.i256;
         v9.i256 = extract_value v6 1.i256;
         v12.i1 = call %__CoolCoin_recv_1_0 v7 v9 0.i256 3.i256 1.i256 2.i256 3.i256;
-        v13.@layout_21 = call %encode_single_root_alloc__g09ca v12;
+        v13.@layout_1 = call %encode_single_root_alloc__g09ca v12;
         v14.i256 = extract_value v13 0.i256;
         v15.i256 = extract_value v13 1.i256;
         evm_return v14 v15;
@@ -2268,11 +2255,11 @@ func inline(always) private %contract_recv_abi_CoolCoin_1117154408() {
         evm_revert 0.i256 0.i256;
 
     block3:
-        v5.objref<@layout_18> = obj.alloc @layout_18;
-        v6.@layout_9 = call %decode_runtime_args__gf629 v5;
+        v5.objref<@layout_10> = obj.alloc @layout_10;
+        v6.@layout_0 = call %decode_runtime_args__gf629 v5;
         v7.i256 = extract_value v6 0.i256;
         v10.i1 = call %__CoolCoin_recv_1_1 v7 0.i256 1.i256 2.i256;
-        v11.@layout_21 = call %encode_single_root_alloc__g09ca v10;
+        v11.@layout_1 = call %encode_single_root_alloc__g09ca v10;
         v12.i256 = extract_value v11 0.i256;
         v13.i256 = extract_value v11 1.i256;
         evm_return v12 v13;
@@ -2292,10 +2279,10 @@ func inline(always) private %contract_recv_abi_CoolCoin_117300739() {
         evm_revert 0.i256 0.i256;
 
     block3:
-        v5.objref<@layout_18> = obj.alloc @layout_18;
+        v5.objref<@layout_10> = obj.alloc @layout_10;
         call %decode_runtime_args__gce2e v5;
         v7.i256 = call %__CoolCoin_recv_0_6;
-        v8.@layout_21 = call %encode_single_root_alloc__g472d v7;
+        v8.@layout_1 = call %encode_single_root_alloc__g472d v7;
         v9.i256 = extract_value v8 0.i256;
         v11.i256 = extract_value v8 1.i256;
         evm_return v9 v11;
@@ -2315,12 +2302,12 @@ func inline(always) private %contract_recv_abi_CoolCoin_157198259() {
         evm_revert 0.i256 0.i256;
 
     block3:
-        v5.objref<@layout_18> = obj.alloc @layout_18;
-        v6.@layout_7 = call %decode_runtime_args__g7a2c v5;
+        v5.objref<@layout_10> = obj.alloc @layout_10;
+        v6.@layout_5 = call %decode_runtime_args__g7a2c v5;
         v7.@layout_0 = extract_value v6 0.i256;
         v9.i256 = extract_value v6 1.i256;
         v11.i1 = call %__CoolCoin_recv_0_1 v7 v9 0.i256 1.i256 2.i256;
-        v12.@layout_21 = call %encode_single_root_alloc__g09ca v11;
+        v12.@layout_1 = call %encode_single_root_alloc__g09ca v11;
         v13.i256 = extract_value v12 0.i256;
         v14.i256 = extract_value v12 1.i256;
         evm_return v13 v14;
@@ -2340,11 +2327,11 @@ func inline(always) private %contract_recv_abi_CoolCoin_1889567281() {
         evm_revert 0.i256 0.i256;
 
     block3:
-        v5.objref<@layout_18> = obj.alloc @layout_18;
-        v6.@layout_11 = call %decode_runtime_args__g953d v5;
+        v5.objref<@layout_10> = obj.alloc @layout_10;
+        v6.@layout_7 = call %decode_runtime_args__g953d v5;
         v7.@layout_0 = extract_value v6 0.i256;
         v10.i256 = call %__CoolCoin_recv_0_3 v7 0.i256 1.i256 2.i256;
-        v11.@layout_21 = call %encode_single_root_alloc__gac80 v10;
+        v11.@layout_1 = call %encode_single_root_alloc__gac80 v10;
         v12.i256 = extract_value v11 0.i256;
         v13.i256 = extract_value v11 1.i256;
         evm_return v12 v13;
@@ -2364,12 +2351,12 @@ func inline(always) private %contract_recv_abi_CoolCoin_2043438992() {
         evm_revert 0.i256 0.i256;
 
     block3:
-        v5.objref<@layout_18> = obj.alloc @layout_18;
-        v6.@layout_10 = call %decode_runtime_args__g216b v5;
+        v5.objref<@layout_10> = obj.alloc @layout_10;
+        v6.@layout_5 = call %decode_runtime_args__g216b v5;
         v7.@layout_0 = extract_value v6 0.i256;
         v9.i256 = extract_value v6 1.i256;
         v11.i1 = call %__CoolCoin_recv_1_2 v7 v9 0.i256 1.i256 2.i256;
-        v12.@layout_21 = call %encode_single_root_alloc__g09ca v11;
+        v12.@layout_1 = call %encode_single_root_alloc__g09ca v11;
         v13.i256 = extract_value v12 0.i256;
         v14.i256 = extract_value v12 1.i256;
         evm_return v13 v14;
@@ -2389,10 +2376,10 @@ func inline(always) private %contract_recv_abi_CoolCoin_2514000705() {
         evm_revert 0.i256 0.i256;
 
     block3:
-        v5.objref<@layout_18> = obj.alloc @layout_18;
+        v5.objref<@layout_10> = obj.alloc @layout_10;
         call %decode_runtime_args__g295c v5;
         v7.i256 = call %__CoolCoin_recv_0_7;
-        v8.@layout_21 = call %encode_single_root_alloc__g0c18 v7;
+        v8.@layout_1 = call %encode_single_root_alloc__g0c18 v7;
         v9.i256 = extract_value v8 0.i256;
         v11.i256 = extract_value v8 1.i256;
         evm_return v9 v11;
@@ -2412,12 +2399,12 @@ func inline(always) private %contract_recv_abi_CoolCoin_2757214935() {
         evm_revert 0.i256 0.i256;
 
     block3:
-        v5.objref<@layout_18> = obj.alloc @layout_18;
-        v6.@layout_15 = call %decode_runtime_args__g6a7c v5;
+        v5.objref<@layout_10> = obj.alloc @layout_10;
+        v6.@layout_5 = call %decode_runtime_args__g6a7c v5;
         v7.@layout_0 = extract_value v6 0.i256;
         v9.i256 = extract_value v6 1.i256;
         v11.i1 = call %__CoolCoin_recv_1_4 v7 v9 0.i256 1.i256 2.i256;
-        v12.@layout_21 = call %encode_single_root_alloc__g09ca v11;
+        v12.@layout_1 = call %encode_single_root_alloc__g09ca v11;
         v13.i256 = extract_value v12 0.i256;
         v14.i256 = extract_value v12 1.i256;
         evm_return v13 v14;
@@ -2437,12 +2424,12 @@ func inline(always) private %contract_recv_abi_CoolCoin_2835717307() {
         evm_revert 0.i256 0.i256;
 
     block3:
-        v5.objref<@layout_18> = obj.alloc @layout_18;
-        v6.@layout_14 = call %decode_runtime_args__ge035 v5;
+        v5.objref<@layout_10> = obj.alloc @layout_10;
+        v6.@layout_5 = call %decode_runtime_args__ge035 v5;
         v7.@layout_0 = extract_value v6 0.i256;
         v9.i256 = extract_value v6 1.i256;
         v11.i1 = call %__CoolCoin_recv_0_0 v7 v9 0.i256 1.i256 2.i256;
-        v12.@layout_21 = call %encode_single_root_alloc__g09ca v11;
+        v12.@layout_1 = call %encode_single_root_alloc__g09ca v11;
         v13.i256 = extract_value v12 0.i256;
         v14.i256 = extract_value v12 1.i256;
         evm_return v13 v14;
@@ -2462,12 +2449,12 @@ func inline(always) private %contract_recv_abi_CoolCoin_3714247998() {
         evm_revert 0.i256 0.i256;
 
     block3:
-        v5.objref<@layout_18> = obj.alloc @layout_18;
-        v6.@layout_6 = call %decode_runtime_args__gc772 v5;
+        v5.objref<@layout_10> = obj.alloc @layout_10;
+        v6.@layout_4 = call %decode_runtime_args__gc772 v5;
         v7.@layout_0 = extract_value v6 0.i256;
         v9.@layout_0 = extract_value v6 1.i256;
         v11.i256 = call %__CoolCoin_recv_0_4 v7 v9 0.i256 1.i256 2.i256;
-        v12.@layout_21 = call %encode_single_root_alloc__gac80 v11;
+        v12.@layout_1 = call %encode_single_root_alloc__gac80 v11;
         v13.i256 = extract_value v12 0.i256;
         v14.i256 = extract_value v12 1.i256;
         evm_return v13 v14;
@@ -2487,10 +2474,10 @@ func inline(always) private %contract_recv_abi_CoolCoin_404098525() {
         evm_revert 0.i256 0.i256;
 
     block3:
-        v5.objref<@layout_18> = obj.alloc @layout_18;
+        v5.objref<@layout_10> = obj.alloc @layout_10;
         call %decode_runtime_args__gce7d v5;
         v9.i256 = call %__CoolCoin_recv_0_5 0.i256 1.i256 2.i256;
-        v10.@layout_21 = call %encode_single_root_alloc__gac80 v9;
+        v10.@layout_1 = call %encode_single_root_alloc__gac80 v9;
         v11.i256 = extract_value v10 0.i256;
         v12.i256 = extract_value v10 1.i256;
         evm_return v11 v12;
@@ -2510,13 +2497,13 @@ func inline(always) private %contract_recv_abi_CoolCoin_599290589() {
         evm_revert 0.i256 0.i256;
 
     block3:
-        v5.objref<@layout_18> = obj.alloc @layout_18;
-        v6.@layout_13 = call %decode_runtime_args__g4e54 v5;
+        v5.objref<@layout_10> = obj.alloc @layout_10;
+        v6.@layout_6 = call %decode_runtime_args__g4e54 v5;
         v7.@layout_0 = extract_value v6 0.i256;
         v9.@layout_0 = extract_value v6 1.i256;
         v11.i256 = extract_value v6 2.i256;
         v12.i1 = call %__CoolCoin_recv_0_2 v7 v9 v11 0.i256 1.i256 2.i256;
-        v13.@layout_21 = call %encode_single_root_alloc__g09ca v12;
+        v13.@layout_1 = call %encode_single_root_alloc__g09ca v12;
         v14.i256 = extract_value v13 0.i256;
         v15.i256 = extract_value v13 1.i256;
         evm_return v14 v15;
@@ -2536,10 +2523,10 @@ func inline(always) private %contract_recv_abi_CoolCoin_826074471() {
         evm_revert 0.i256 0.i256;
 
     block3:
-        v5.objref<@layout_18> = obj.alloc @layout_18;
+        v5.objref<@layout_10> = obj.alloc @layout_10;
         call %decode_runtime_args__g5a0b v5;
         v7.i8 = call %__CoolCoin_recv_0_8;
-        v8.@layout_21 = call %encode_single_root_alloc__gcb0a v7;
+        v8.@layout_1 = call %encode_single_root_alloc__gcb0a v7;
         v9.i256 = extract_value v8 0.i256;
         v11.i256 = extract_value v8 1.i256;
         evm_return v9 v11;
@@ -2559,12 +2546,12 @@ func inline(always) private %contract_recv_abi_CoolCoin_961581905() {
         evm_revert 0.i256 0.i256;
 
     block3:
-        v5.objref<@layout_18> = obj.alloc @layout_18;
-        v6.@layout_12 = call %decode_runtime_args__g698d v5;
+        v5.objref<@layout_10> = obj.alloc @layout_10;
+        v6.@layout_5 = call %decode_runtime_args__g698d v5;
         v7.@layout_0 = extract_value v6 0.i256;
         v9.i256 = extract_value v6 1.i256;
         v11.i1 = call %__CoolCoin_recv_1_3 v7 v9 0.i256 1.i256 2.i256;
-        v12.@layout_21 = call %encode_single_root_alloc__g09ca v11;
+        v12.@layout_1 = call %encode_single_root_alloc__g09ca v11;
         v13.i256 = extract_value v12 0.i256;
         v14.i256 = extract_value v12 1.i256;
         evm_return v13 v14;
@@ -2917,7 +2904,7 @@ func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_fe05() {
         evm_revert 0.i256 0.i256;
 }
 
-func inline(always) private %decode_field__g3854(v0.objref<@layout_4>) -> i256 {
+func inline(always) private %decode_field__g3854(v0.objref<@layout_3>) -> i256 {
     block0:
         jump block1;
 
@@ -2925,9 +2912,9 @@ func inline(always) private %decode_field__g3854(v0.objref<@layout_4>) -> i256 {
         br 0.i1 block2 block3;
 
     block2:
-        v3.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_0a1c_0 v0;
-        v4.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_91bf_0 v0;
-        v5.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g463e_3f42_0 v0;
+        v3.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_715d_0 v0;
+        v4.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_5297_0 v0;
+        v5.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g463e_9627_0 v0;
         (v6.i256, v7.i1) = uaddo v4 v3;
         br v7 block5 block6;
 
@@ -2944,16 +2931,16 @@ func inline(always) private %decode_field__g3854(v0.objref<@layout_4>) -> i256 {
         evm_revert 0.i256 36.i256;
 
     block6:
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_4735_0 v0 v6;
-        v15.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_91bf_0 v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_ae9c_0 v0 v15;
+        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_6134_0 v0 v6;
+        v15.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_5297_0 v0;
+        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_9c2d_0 v0 v15;
         v17.i256 = call %impl_trait_u256__decode_payload__g407e v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_4735_0 v0 v4;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_ae9c_0 v0 v5;
+        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_6134_0 v0 v4;
+        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_9c2d_0 v0 v5;
         return v17;
 }
 
-func inline(always) private %decode_field__g8463(v0.objref<@layout_4>) -> @layout_0 {
+func inline(always) private %decode_field__g8463(v0.objref<@layout_3>) -> @layout_0 {
     block0:
         jump block1;
 
@@ -2961,9 +2948,9 @@ func inline(always) private %decode_field__g8463(v0.objref<@layout_4>) -> @layou
         br 0.i1 block2 block3;
 
     block2:
-        v3.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_0a1c v0;
-        v4.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_91bf v0;
-        v5.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g463e_3f42 v0;
+        v3.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_715d v0;
+        v4.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_5297 v0;
+        v5.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g463e_9627 v0;
         (v6.i256, v7.i1) = uaddo v4 v3;
         br v7 block5 block6;
 
@@ -2980,16 +2967,16 @@ func inline(always) private %decode_field__g8463(v0.objref<@layout_4>) -> @layou
         evm_revert 0.i256 36.i256;
 
     block6:
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_4735 v0 v6;
-        v15.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_91bf v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_ae9c v0 v15;
+        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_6134 v0 v6;
+        v15.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_5297 v0;
+        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_9c2d v0 v15;
         v17.@layout_0 = call %impl_trait_Address__decode_payload__g407e v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_4735 v0 v4;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_ae9c v0 v5;
+        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_6134 v0 v4;
+        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_9c2d v0 v5;
         return v17;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from__g5385_03a7(v0.@layout_5, v1.i256, v2.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_field_from__g5385_005b(v0.@layout_0, v1.i256, v2.i256) -> i256 {
     block0:
         jump block1;
 
@@ -2997,7 +2984,7 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_03a7(v0.@l
         br 0.i1 block2 block3;
 
     block2:
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_9725 v0 v2;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_d855 v0 v2;
         (v8.i256, v9.i1) = uaddo v1 v6;
         br v9 block5 block6;
 
@@ -3005,7 +2992,7 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_03a7(v0.@l
         jump block4;
 
     block4:
-        v19.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_3a7c_0 v0 v2;
+        v19.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_cab7_0 v0 v2;
         return v19;
 
     block5:
@@ -3014,11 +3001,11 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_03a7(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v16.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_3a7c_0 v0 v8;
+        v16.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_cab7_0 v0 v8;
         return v16;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from__gcfb5_2692(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
+func inline(always) private %core__lib__abi__decode_field_from__g5385_071f(v0.@layout_0, v1.i256, v2.i256) -> i256 {
     block0:
         jump block1;
 
@@ -3026,7 +3013,7 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_2692(v0.@l
         br 0.i1 block2 block3;
 
     block2:
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_69bf v0 v2;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_f73a v0 v2;
         (v8.i256, v9.i1) = uaddo v1 v6;
         br v9 block5 block6;
 
@@ -3034,7 +3021,7 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_2692(v0.@l
         jump block4;
 
     block4:
-        v19.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_3716_0 v0 v2;
+        v19.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f835_0 v0 v2;
         return v19;
 
     block5:
@@ -3043,11 +3030,11 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_2692(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v16.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_3716_0 v0 v8;
+        v16.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f835_0 v0 v8;
         return v16;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from__gcfb5_2eef(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
+func inline(always) private %core__lib__abi__decode_field_from__g5385_0b34(v0.@layout_0, v1.i256, v2.i256) -> i256 {
     block0:
         jump block1;
 
@@ -3055,7 +3042,7 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_2eef(v0.@l
         br 0.i1 block2 block3;
 
     block2:
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_ce64 v0 v2;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_e8c5 v0 v2;
         (v8.i256, v9.i1) = uaddo v1 v6;
         br v9 block5 block6;
 
@@ -3063,7 +3050,7 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_2eef(v0.@l
         jump block4;
 
     block4:
-        v19.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_2519_0 v0 v2;
+        v19.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_ab67_0 v0 v2;
         return v19;
 
     block5:
@@ -3072,11 +3059,11 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_2eef(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v16.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_2519_0 v0 v8;
+        v16.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_ab67_0 v0 v8;
         return v16;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from__g5385_4796(v0.@layout_5, v1.i256, v2.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_field_from__g5385_3cbb(v0.@layout_0, v1.i256, v2.i256) -> i256 {
     block0:
         jump block1;
 
@@ -3084,7 +3071,7 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_4796(v0.@l
         br 0.i1 block2 block3;
 
     block2:
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_27ad v0 v2;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_9c0e v0 v2;
         (v8.i256, v9.i1) = uaddo v1 v6;
         br v9 block5 block6;
 
@@ -3092,7 +3079,7 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_4796(v0.@l
         jump block4;
 
     block4:
-        v19.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8d9f_0 v0 v2;
+        v19.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_337f_0 v0 v2;
         return v19;
 
     block5:
@@ -3101,11 +3088,11 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_4796(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v16.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8d9f_0 v0 v8;
+        v16.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_337f_0 v0 v8;
         return v16;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from__g5385_5cc4(v0.@layout_5, v1.i256, v2.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_field_from__gcfb5_4621(v0.@layout_0, v1.i256, v2.i256) -> @layout_0 {
     block0:
         jump block1;
 
@@ -3113,7 +3100,7 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_5cc4(v0.@l
         br 0.i1 block2 block3;
 
     block2:
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_5ce9 v0 v2;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_6f45 v0 v2;
         (v8.i256, v9.i1) = uaddo v1 v6;
         br v9 block5 block6;
 
@@ -3121,7 +3108,7 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_5cc4(v0.@l
         jump block4;
 
     block4:
-        v19.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_b39f_0 v0 v2;
+        v19.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_42a1_0 v0 v2;
         return v19;
 
     block5:
@@ -3130,11 +3117,11 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_5cc4(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v16.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_b39f_0 v0 v8;
+        v16.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_42a1_0 v0 v8;
         return v16;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from__gcfb5_7143(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
+func inline(always) private %core__lib__abi__decode_field_from__gcfb5_57f7(v0.@layout_0, v1.i256, v2.i256) -> @layout_0 {
     block0:
         jump block1;
 
@@ -3142,7 +3129,7 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_7143(v0.@l
         br 0.i1 block2 block3;
 
     block2:
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_faf2 v0 v2;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_6ca3 v0 v2;
         (v8.i256, v9.i1) = uaddo v1 v6;
         br v9 block5 block6;
 
@@ -3150,7 +3137,7 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_7143(v0.@l
         jump block4;
 
     block4:
-        v19.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_5535_0 v0 v2;
+        v19.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_a8a8_0 v0 v2;
         return v19;
 
     block5:
@@ -3159,11 +3146,11 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_7143(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v16.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_5535_0 v0 v8;
+        v16.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_a8a8_0 v0 v8;
         return v16;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from__g5385_7366(v0.@layout_5, v1.i256, v2.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_field_from__gcfb5_5b19(v0.@layout_0, v1.i256, v2.i256) -> @layout_0 {
     block0:
         jump block1;
 
@@ -3171,7 +3158,7 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_7366(v0.@l
         br 0.i1 block2 block3;
 
     block2:
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c32c v0 v2;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_191d v0 v2;
         (v8.i256, v9.i1) = uaddo v1 v6;
         br v9 block5 block6;
 
@@ -3179,7 +3166,7 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_7366(v0.@l
         jump block4;
 
     block4:
-        v19.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_5c31_0 v0 v2;
+        v19.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_9696_0 v0 v2;
         return v19;
 
     block5:
@@ -3188,11 +3175,11 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_7366(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v16.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_5c31_0 v0 v8;
+        v16.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_9696_0 v0 v8;
         return v16;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from__gcfb5_786c(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
+func inline(always) private %core__lib__abi__decode_field_from__gcfb5_6b0d(v0.@layout_0, v1.i256, v2.i256) -> @layout_0 {
     block0:
         jump block1;
 
@@ -3200,7 +3187,7 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_786c(v0.@l
         br 0.i1 block2 block3;
 
     block2:
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c2d4 v0 v2;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_9869 v0 v2;
         (v8.i256, v9.i1) = uaddo v1 v6;
         br v9 block5 block6;
 
@@ -3208,7 +3195,7 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_786c(v0.@l
         jump block4;
 
     block4:
-        v19.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_4e5e_0 v0 v2;
+        v19.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_37dd_0 v0 v2;
         return v19;
 
     block5:
@@ -3217,11 +3204,11 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_786c(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v16.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_4e5e_0 v0 v8;
+        v16.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_37dd_0 v0 v8;
         return v16;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from__g5385_79b2(v0.@layout_5, v1.i256, v2.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_field_from__gcfb5_7dae(v0.@layout_0, v1.i256, v2.i256) -> @layout_0 {
     block0:
         jump block1;
 
@@ -3229,7 +3216,7 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_79b2(v0.@l
         br 0.i1 block2 block3;
 
     block2:
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b870 v0 v2;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_9914 v0 v2;
         (v8.i256, v9.i1) = uaddo v1 v6;
         br v9 block5 block6;
 
@@ -3237,7 +3224,7 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_79b2(v0.@l
         jump block4;
 
     block4:
-        v19.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_251a_0 v0 v2;
+        v19.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_6461_0 v0 v2;
         return v19;
 
     block5:
@@ -3246,11 +3233,11 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_79b2(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v16.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_251a_0 v0 v8;
+        v16.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_6461_0 v0 v8;
         return v16;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from__gcfb5_7fa7(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
+func inline(always) private %core__lib__abi__decode_field_from__g5385_8d0e(v0.@layout_0, v1.i256, v2.i256) -> i256 {
     block0:
         jump block1;
 
@@ -3258,7 +3245,7 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_7fa7(v0.@l
         br 0.i1 block2 block3;
 
     block2:
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_fdcb v0 v2;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_4c6a v0 v2;
         (v8.i256, v9.i1) = uaddo v1 v6;
         br v9 block5 block6;
 
@@ -3266,7 +3253,7 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_7fa7(v0.@l
         jump block4;
 
     block4:
-        v19.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_db93_0 v0 v2;
+        v19.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f48c_0 v0 v2;
         return v19;
 
     block5:
@@ -3275,11 +3262,11 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_7fa7(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v16.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_db93_0 v0 v8;
+        v16.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f48c_0 v0 v8;
         return v16;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from__g5385_9270(v0.@layout_5, v1.i256, v2.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_field_from__gcfb5_bcba(v0.@layout_0, v1.i256, v2.i256) -> @layout_0 {
     block0:
         jump block1;
 
@@ -3287,7 +3274,7 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_9270(v0.@l
         br 0.i1 block2 block3;
 
     block2:
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_780b v0 v2;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_5c44 v0 v2;
         (v8.i256, v9.i1) = uaddo v1 v6;
         br v9 block5 block6;
 
@@ -3295,7 +3282,7 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_9270(v0.@l
         jump block4;
 
     block4:
-        v19.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_0a95_0 v0 v2;
+        v19.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_62af_0 v0 v2;
         return v19;
 
     block5:
@@ -3304,11 +3291,11 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_9270(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v16.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_0a95_0 v0 v8;
+        v16.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_62af_0 v0 v8;
         return v16;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from__gcfb5_b564(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
+func inline(always) private %core__lib__abi__decode_field_from__g5385_cce7(v0.@layout_0, v1.i256, v2.i256) -> i256 {
     block0:
         jump block1;
 
@@ -3316,7 +3303,7 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_b564(v0.@l
         br 0.i1 block2 block3;
 
     block2:
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_88a1 v0 v2;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_cde4 v0 v2;
         (v8.i256, v9.i1) = uaddo v1 v6;
         br v9 block5 block6;
 
@@ -3324,7 +3311,7 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_b564(v0.@l
         jump block4;
 
     block4:
-        v19.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_9286_0 v0 v2;
+        v19.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_96fc_0 v0 v2;
         return v19;
 
     block5:
@@ -3333,11 +3320,11 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_b564(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v16.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_9286_0 v0 v8;
+        v16.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_96fc_0 v0 v8;
         return v16;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from__g5385_cb05(v0.@layout_5, v1.i256, v2.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_field_from__g5385_e2bc(v0.@layout_0, v1.i256, v2.i256) -> i256 {
     block0:
         jump block1;
 
@@ -3345,7 +3332,7 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_cb05(v0.@l
         br 0.i1 block2 block3;
 
     block2:
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_49c5 v0 v2;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_1397 v0 v2;
         (v8.i256, v9.i1) = uaddo v1 v6;
         br v9 block5 block6;
 
@@ -3353,7 +3340,7 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_cb05(v0.@l
         jump block4;
 
     block4:
-        v19.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_18e6_0 v0 v2;
+        v19.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f68c_0 v0 v2;
         return v19;
 
     block5:
@@ -3362,11 +3349,11 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_cb05(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v16.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_18e6_0 v0 v8;
+        v16.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f68c_0 v0 v8;
         return v16;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from__gcfb5_d5a0(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
+func inline(always) private %core__lib__abi__decode_field_from__gcfb5_e707(v0.@layout_0, v1.i256, v2.i256) -> @layout_0 {
     block0:
         jump block1;
 
@@ -3374,7 +3361,7 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_d5a0(v0.@l
         br 0.i1 block2 block3;
 
     block2:
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_0f5c v0 v2;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_e3fc v0 v2;
         (v8.i256, v9.i1) = uaddo v1 v6;
         br v9 block5 block6;
 
@@ -3382,7 +3369,7 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_d5a0(v0.@l
         jump block4;
 
     block4:
-        v19.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_f4e0_0 v0 v2;
+        v19.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_b7c4_0 v0 v2;
         return v19;
 
     block5:
@@ -3391,11 +3378,11 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_d5a0(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v16.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_f4e0_0 v0 v8;
+        v16.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_b7c4_0 v0 v8;
         return v16;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from__gcfb5_d5c8(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
+func inline(always) private %core__lib__abi__decode_field_from__gcfb5_eb7d(v0.@layout_0, v1.i256, v2.i256) -> @layout_0 {
     block0:
         jump block1;
 
@@ -3403,7 +3390,7 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_d5c8(v0.@l
         br 0.i1 block2 block3;
 
     block2:
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_6dae v0 v2;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_4de3 v0 v2;
         (v8.i256, v9.i1) = uaddo v1 v6;
         br v9 block5 block6;
 
@@ -3411,7 +3398,7 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_d5c8(v0.@l
         jump block4;
 
     block4:
-        v19.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_3641_0 v0 v2;
+        v19.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_0837_0 v0 v2;
         return v19;
 
     block5:
@@ -3420,11 +3407,11 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_d5c8(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v16.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_3641_0 v0 v8;
+        v16.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_0837_0 v0 v8;
         return v16;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from__g5385_d887(v0.@layout_5, v1.i256, v2.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_field_from__gcfb5_fe88(v0.@layout_0, v1.i256, v2.i256) -> @layout_0 {
     block0:
         jump block1;
 
@@ -3432,7 +3419,7 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_d887(v0.@l
         br 0.i1 block2 block3;
 
     block2:
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c259 v0 v2;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_2a43 v0 v2;
         (v8.i256, v9.i1) = uaddo v1 v6;
         br v9 block5 block6;
 
@@ -3440,7 +3427,7 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_d887(v0.@l
         jump block4;
 
     block4:
-        v19.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_4e52_0 v0 v2;
+        v19.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_6f9a_0 v0 v2;
         return v19;
 
     block5:
@@ -3449,11 +3436,11 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_d887(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v16.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_4e52_0 v0 v8;
+        v16.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_6f9a_0 v0 v8;
         return v16;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from__gcfb5_e784(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
+func inline(always) private %core__lib__abi__decode_field_from__g5385_ffe6(v0.@layout_0, v1.i256, v2.i256) -> i256 {
     block0:
         jump block1;
 
@@ -3461,7 +3448,7 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_e784(v0.@l
         br 0.i1 block2 block3;
 
     block2:
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_7946 v0 v2;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_e336 v0 v2;
         (v8.i256, v9.i1) = uaddo v1 v6;
         br v9 block5 block6;
 
@@ -3469,7 +3456,7 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_e784(v0.@l
         jump block4;
 
     block4:
-        v19.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_b822_0 v0 v2;
+        v19.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_d1bc_0 v0 v2;
         return v19;
 
     block5:
@@ -3478,11 +3465,11 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_e784(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v16.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_b822_0 v0 v8;
+        v16.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_d1bc_0 v0 v8;
         return v16;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__gcfb5_07a0(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> @layout_0 {
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__gcfb5_0d46(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> @layout_0 {
     block0:
         jump block1;
 
@@ -3490,397 +3477,361 @@ func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__
         br 0.i1 block2 block3;
 
     block2:
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_88a1 v0 v2;
-        v9.i256 = call %core__lib__abi__checked_tail__gf13e_9794 v1 v7;
-        v11.@layout_0 = call %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_3fea v0 v9 v3;
-        return v11;
-
-    block3:
-        jump block4;
-
-    block4:
-        v14.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_9286_0 v0 v2;
-        return v14;
-}
-
-func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__gcfb5_18ef(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        br 0.i1 block2 block3;
-
-    block2:
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_69bf v0 v2;
-        v9.i256 = call %core__lib__abi__checked_tail__gf13e_46df v1 v7;
-        v11.@layout_0 = call %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_978c v0 v9 v3;
-        return v11;
-
-    block3:
-        jump block4;
-
-    block4:
-        v14.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_3716_0 v0 v2;
-        return v14;
-}
-
-func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__gcfb5_2207(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        br 0.i1 block2 block3;
-
-    block2:
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_fdcb v0 v2;
-        v9.i256 = call %core__lib__abi__checked_tail__gf13e_45b0 v1 v7;
-        v11.@layout_0 = call %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_d676 v0 v9 v3;
-        return v11;
-
-    block3:
-        jump block4;
-
-    block4:
-        v14.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_db93_0 v0 v2;
-        return v14;
-}
-
-func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__gcfb5_2724(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        br 0.i1 block2 block3;
-
-    block2:
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c2d4 v0 v2;
-        v9.i256 = call %core__lib__abi__checked_tail__gf13e_ad42 v1 v7;
-        v11.@layout_0 = call %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_64e6 v0 v9 v3;
-        return v11;
-
-    block3:
-        jump block4;
-
-    block4:
-        v14.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_4e5e_0 v0 v2;
-        return v14;
-}
-
-func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_34fc(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        br 0.i1 block2 block3;
-
-    block2:
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c32c v0 v2;
-        v9.i256 = call %core__lib__abi__checked_tail__gf13e_b743 v1 v7;
-        v11.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_d01b v0 v9 v3;
-        return v11;
-
-    block3:
-        jump block4;
-
-    block4:
-        v14.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_5c31_0 v0 v2;
-        return v14;
-}
-
-func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_5db0(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        br 0.i1 block2 block3;
-
-    block2:
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_27ad v0 v2;
-        v9.i256 = call %core__lib__abi__checked_tail__gf13e_9611 v1 v7;
-        v11.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_2374 v0 v9 v3;
-        return v11;
-
-    block3:
-        jump block4;
-
-    block4:
-        v14.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8d9f_0 v0 v2;
-        return v14;
-}
-
-func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__gcfb5_764c(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        br 0.i1 block2 block3;
-
-    block2:
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_ce64 v0 v2;
-        v9.i256 = call %core__lib__abi__checked_tail__gf13e_3749 v1 v7;
-        v11.@layout_0 = call %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_3639 v0 v9 v3;
-        return v11;
-
-    block3:
-        jump block4;
-
-    block4:
-        v14.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_2519_0 v0 v2;
-        return v14;
-}
-
-func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_7760(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        br 0.i1 block2 block3;
-
-    block2:
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_780b v0 v2;
-        v9.i256 = call %core__lib__abi__checked_tail__gf13e_8bdb v1 v7;
-        v11.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_1972 v0 v9 v3;
-        return v11;
-
-    block3:
-        jump block4;
-
-    block4:
-        v14.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_0a95_0 v0 v2;
-        return v14;
-}
-
-func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_839e(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        br 0.i1 block2 block3;
-
-    block2:
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_9725 v0 v2;
-        v9.i256 = call %core__lib__abi__checked_tail__gf13e_2af0 v1 v7;
-        v11.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_43c7 v0 v9 v3;
-        return v11;
-
-    block3:
-        jump block4;
-
-    block4:
-        v14.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_3a7c_0 v0 v2;
-        return v14;
-}
-
-func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_847c(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        br 0.i1 block2 block3;
-
-    block2:
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b870 v0 v2;
-        v9.i256 = call %core__lib__abi__checked_tail__gf13e_9c13 v1 v7;
-        v11.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_8823 v0 v9 v3;
-        return v11;
-
-    block3:
-        jump block4;
-
-    block4:
-        v14.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_251a_0 v0 v2;
-        return v14;
-}
-
-func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__gcfb5_a4f7(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        br 0.i1 block2 block3;
-
-    block2:
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_faf2 v0 v2;
-        v9.i256 = call %core__lib__abi__checked_tail__gf13e_2d1a v1 v7;
-        v11.@layout_0 = call %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_2c09 v0 v9 v3;
-        return v11;
-
-    block3:
-        jump block4;
-
-    block4:
-        v14.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_5535_0 v0 v2;
-        return v14;
-}
-
-func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_b51a(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        br 0.i1 block2 block3;
-
-    block2:
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_5ce9 v0 v2;
-        v9.i256 = call %core__lib__abi__checked_tail__gf13e_134e v1 v7;
-        v11.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_2360 v0 v9 v3;
-        return v11;
-
-    block3:
-        jump block4;
-
-    block4:
-        v14.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_b39f_0 v0 v2;
-        return v14;
-}
-
-func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_c7d5(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        br 0.i1 block2 block3;
-
-    block2:
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_49c5 v0 v2;
-        v9.i256 = call %core__lib__abi__checked_tail__gf13e_15b4 v1 v7;
-        v11.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_38c3 v0 v9 v3;
-        return v11;
-
-    block3:
-        jump block4;
-
-    block4:
-        v14.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_18e6_0 v0 v2;
-        return v14;
-}
-
-func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_d4dc(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        br 0.i1 block2 block3;
-
-    block2:
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c259 v0 v2;
-        v9.i256 = call %core__lib__abi__checked_tail__gf13e_50a2 v1 v7;
-        v11.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_6ea9 v0 v9 v3;
-        return v11;
-
-    block3:
-        jump block4;
-
-    block4:
-        v14.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_4e52_0 v0 v2;
-        return v14;
-}
-
-func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__gcfb5_ed91(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        br 0.i1 block2 block3;
-
-    block2:
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_7946 v0 v2;
-        v9.i256 = call %core__lib__abi__checked_tail__gf13e_c3ce v1 v7;
-        v11.@layout_0 = call %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_8e68 v0 v9 v3;
-        return v11;
-
-    block3:
-        jump block4;
-
-    block4:
-        v14.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_b822_0 v0 v2;
-        return v14;
-}
-
-func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__gcfb5_ef75(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        br 0.i1 block2 block3;
-
-    block2:
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_0f5c v0 v2;
-        v9.i256 = call %core__lib__abi__checked_tail__gf13e_7a36 v1 v7;
-        v11.@layout_0 = call %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_29bc v0 v9 v3;
-        return v11;
-
-    block3:
-        jump block4;
-
-    block4:
-        v14.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_f4e0_0 v0 v2;
-        return v14;
-}
-
-func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__gcfb5_faf8(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        br 0.i1 block2 block3;
-
-    block2:
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_6dae v0 v2;
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_191d v0 v2;
         v9.i256 = call %core__lib__abi__checked_tail__gf13e_c89e v1 v7;
-        v11.@layout_0 = call %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_a883 v0 v9 v3;
+        v11.@layout_0 = call %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_a671 v0 v9 v3;
         return v11;
 
     block3:
         jump block4;
 
     block4:
-        v14.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_3641_0 v0 v2;
+        v14.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_9696_0 v0 v2;
         return v14;
 }
 
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_0a95(v0.@layout_5, v1.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__gcfb5_1116(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c700 v0 v1;
-        return v4;
+        br 0.i1 block2 block3;
+
+    block2:
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_e3fc v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_7a36 v1 v7;
+        v11.@layout_0 = call %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_2732 v0 v9 v3;
+        return v11;
+
+    block3:
+        jump block4;
+
+    block4:
+        v14.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_b7c4_0 v0 v2;
+        return v14;
 }
 
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_0a95_0(v0.@layout_5, v1.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__gcfb5_2034(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c700_0 v0 v1;
-        return v4;
+        br 0.i1 block2 block3;
+
+    block2:
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_2a43 v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_ad42 v1 v7;
+        v11.@layout_0 = call %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_d913 v0 v9 v3;
+        return v11;
+
+    block3:
+        jump block4;
+
+    block4:
+        v14.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_6f9a_0 v0 v2;
+        return v14;
 }
 
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_18e6(v0.@layout_5, v1.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_2d17(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b705 v0 v1;
-        return v4;
+        br 0.i1 block2 block3;
+
+    block2:
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_1397 v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_b743 v1 v7;
+        v11.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_4417 v0 v9 v3;
+        return v11;
+
+    block3:
+        jump block4;
+
+    block4:
+        v14.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f68c_0 v0 v2;
+        return v14;
 }
 
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_18e6_0(v0.@layout_5, v1.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__gcfb5_322a(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b705_0 v0 v1;
-        return v4;
+        br 0.i1 block2 block3;
+
+    block2:
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_5c44 v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_3749 v1 v7;
+        v11.@layout_0 = call %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_71be v0 v9 v3;
+        return v11;
+
+    block3:
+        jump block4;
+
+    block4:
+        v14.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_62af_0 v0 v2;
+        return v14;
 }
 
-func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_2519(v0.@layout_5, v1.i256) -> @layout_0 {
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_3651(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_8736 v0 v1;
+        br 0.i1 block2 block3;
+
+    block2:
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_e8c5 v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_2af0 v1 v7;
+        v11.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_45cc v0 v9 v3;
+        return v11;
+
+    block3:
+        jump block4;
+
+    block4:
+        v14.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_ab67_0 v0 v2;
+        return v14;
+}
+
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__gcfb5_4a33(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> @layout_0 {
+    block0:
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_9869 v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_46df v1 v7;
+        v11.@layout_0 = call %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_63cb v0 v9 v3;
+        return v11;
+
+    block3:
+        jump block4;
+
+    block4:
+        v14.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_37dd_0 v0 v2;
+        return v14;
+}
+
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__gcfb5_5304(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> @layout_0 {
+    block0:
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_6f45 v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_9794 v1 v7;
+        v11.@layout_0 = call %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_5c48 v0 v9 v3;
+        return v11;
+
+    block3:
+        jump block4;
+
+    block4:
+        v14.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_42a1_0 v0 v2;
+        return v14;
+}
+
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__gcfb5_56e5(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> @layout_0 {
+    block0:
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_9914 v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_45b0 v1 v7;
+        v11.@layout_0 = call %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_b8b8 v0 v9 v3;
+        return v11;
+
+    block3:
+        jump block4;
+
+    block4:
+        v14.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_6461_0 v0 v2;
+        return v14;
+}
+
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_6632(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_cde4 v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_8bdb v1 v7;
+        v11.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_8124 v0 v9 v3;
+        return v11;
+
+    block3:
+        jump block4;
+
+    block4:
+        v14.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_96fc_0 v0 v2;
+        return v14;
+}
+
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_75e6(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_4c6a v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_9611 v1 v7;
+        v11.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_54e2 v0 v9 v3;
+        return v11;
+
+    block3:
+        jump block4;
+
+    block4:
+        v14.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f48c_0 v0 v2;
+        return v14;
+}
+
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_76b2(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_e336 v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_50a2 v1 v7;
+        v11.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_e4c0 v0 v9 v3;
+        return v11;
+
+    block3:
+        jump block4;
+
+    block4:
+        v14.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_d1bc_0 v0 v2;
+        return v14;
+}
+
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_7b37(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_f73a v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_15b4 v1 v7;
+        v11.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_81b3 v0 v9 v3;
+        return v11;
+
+    block3:
+        jump block4;
+
+    block4:
+        v14.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f835_0 v0 v2;
+        return v14;
+}
+
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_88e0(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_d855 v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_9c13 v1 v7;
+        v11.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_9915 v0 v9 v3;
+        return v11;
+
+    block3:
+        jump block4;
+
+    block4:
+        v14.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_cab7_0 v0 v2;
+        return v14;
+}
+
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_8d67(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_9c0e v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_134e v1 v7;
+        v11.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_9d3c v0 v9 v3;
+        return v11;
+
+    block3:
+        jump block4;
+
+    block4:
+        v14.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_337f_0 v0 v2;
+        return v14;
+}
+
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__gcfb5_c901(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> @layout_0 {
+    block0:
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_6ca3 v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_2d1a v1 v7;
+        v11.@layout_0 = call %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_00f8 v0 v9 v3;
+        return v11;
+
+    block3:
+        jump block4;
+
+    block4:
+        v14.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_a8a8_0 v0 v2;
+        return v14;
+}
+
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__gcfb5_fee7(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> @layout_0 {
+    block0:
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_4de3 v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_c3ce v1 v7;
+        v11.@layout_0 = call %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_1d36 v0 v9 v3;
+        return v11;
+
+    block3:
+        jump block4;
+
+    block4:
+        v14.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_0837_0 v0 v2;
+        return v14;
+}
+
+func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_0837(v0.@layout_0, v1.i256) -> @layout_0 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c0ea v0 v1;
         v6.i256 = shr 160.i256 v4;
         v8.i1 = eq v6 0.i256;
         v9.i1 = is_zero v8;
@@ -3897,12 +3848,12 @@ func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__de
         return v12;
 }
 
-func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_2519_0(v0.@layout_5, v1.i256) -> @layout_0 {
+func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_0837_0(v0.@layout_0, v1.i256) -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_8736_0 v0 v1;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c0ea_0 v0 v1;
         v6.i256 = shr 160.i256 v4;
         v8.i1 = eq v6 0.i256;
         v9.i1 = is_zero v8;
@@ -3919,25 +3870,29 @@ func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__de
         return v12;
 }
 
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_251a(v0.@layout_5, v1.i256) -> i256 {
+func inline(always) private %impl_trait_Allowance__decode_from__gd20d(v0.@layout_0, v1.i256) -> @layout_4 {
     block0:
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3bad v0 v1;
-        return v4;
+        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_ade7 v0;
+        v5.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_eb2d v0 v1 v1 v3;
+        (v7.i256, v8.i1) = uaddo v1 32.i256;
+        br v8 block2 block3;
+
+    block2:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block3:
+        v17.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_eb2d v0 v1 v7 v3;
+        v20.@layout_4 = insert_value undef.@layout_4 0.i256 v5;
+        v22.@layout_4 = insert_value v20 1.i256 v17;
+        return v22;
 }
 
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_251a_0(v0.@layout_5, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3bad_0 v0 v1;
-        return v4;
-}
-
-func inline(always) private %impl_trait_Symbol__decode_from__gd20d(v0.@layout_5, v1.i256) {
+func inline(always) private %impl_trait_Symbol__decode_from__gd20d(v0.@layout_0, v1.i256) {
     block0:
         jump block1;
 
@@ -3945,136 +3900,30 @@ func inline(always) private %impl_trait_Symbol__decode_from__gd20d(v0.@layout_5,
         return;
 }
 
-func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_3641(v0.@layout_5, v1.i256) -> @layout_0 {
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_337f(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b9ca v0 v1;
-        v6.i256 = shr 160.i256 v4;
-        v8.i1 = eq v6 0.i256;
-        v9.i1 = is_zero v8;
-        br v9 block2 block3;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v12.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
-        return v12;
-}
-
-func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_3641_0(v0.@layout_5, v1.i256) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b9ca_0 v0 v1;
-        v6.i256 = shr 160.i256 v4;
-        v8.i1 = eq v6 0.i256;
-        v9.i1 = is_zero v8;
-        br v9 block2 block3;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v12.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
-        return v12;
-}
-
-func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_3716(v0.@layout_5, v1.i256) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_d831 v0 v1;
-        v6.i256 = shr 160.i256 v4;
-        v8.i1 = eq v6 0.i256;
-        v9.i1 = is_zero v8;
-        br v9 block2 block3;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v12.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
-        return v12;
-}
-
-func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_3716_0(v0.@layout_5, v1.i256) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_d831_0 v0 v1;
-        v6.i256 = shr 160.i256 v4;
-        v8.i1 = eq v6 0.i256;
-        v9.i1 = is_zero v8;
-        br v9 block2 block3;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v12.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
-        return v12;
-}
-
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_3a7c(v0.@layout_5, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_9757 v0 v1;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_bfaf v0 v1;
         return v4;
 }
 
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_3a7c_0(v0.@layout_5, v1.i256) -> i256 {
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_337f_0(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_9757_0 v0 v1;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_bfaf_0 v0 v1;
         return v4;
 }
 
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_4e52(v0.@layout_5, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_37dd(v0.@layout_0, v1.i256) -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_790f v0 v1;
-        return v4;
-}
-
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_4e52_0(v0.@layout_5, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_790f_0 v0 v1;
-        return v4;
-}
-
-func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_4e5e(v0.@layout_5, v1.i256) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_fec2 v0 v1;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_31f2 v0 v1;
         v6.i256 = shr 160.i256 v4;
         v8.i1 = eq v6 0.i256;
         v9.i1 = is_zero v8;
@@ -4091,12 +3940,12 @@ func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__de
         return v12;
 }
 
-func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_4e5e_0(v0.@layout_5, v1.i256) -> @layout_0 {
+func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_37dd_0(v0.@layout_0, v1.i256) -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_fec2_0 v0 v1;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_31f2_0 v0 v1;
         v6.i256 = shr 160.i256 v4;
         v8.i1 = eq v6 0.i256;
         v9.i1 = is_zero v8;
@@ -4113,12 +3962,12 @@ func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__de
         return v12;
 }
 
-func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_5535(v0.@layout_5, v1.i256) -> @layout_0 {
+func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_42a1(v0.@layout_0, v1.i256) -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_a6b2 v0 v1;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_78a1 v0 v1;
         v6.i256 = shr 160.i256 v4;
         v8.i1 = eq v6 0.i256;
         v9.i1 = is_zero v8;
@@ -4135,12 +3984,12 @@ func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__de
         return v12;
 }
 
-func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_5535_0(v0.@layout_5, v1.i256) -> @layout_0 {
+func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_42a1_0(v0.@layout_0, v1.i256) -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_a6b2_0 v0 v1;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_78a1_0 v0 v1;
         v6.i256 = shr 160.i256 v4;
         v8.i1 = eq v6 0.i256;
         v9.i1 = is_zero v8;
@@ -4157,418 +4006,7 @@ func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__de
         return v12;
 }
 
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_5c31(v0.@layout_5, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3a1f v0 v1;
-        return v4;
-}
-
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_5c31_0(v0.@layout_5, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3a1f_0 v0 v1;
-        return v4;
-}
-
-func inline(always) private %impl_trait_Allowance__decode_from__gd20d(v0.@layout_5, v1.i256) -> @layout_6 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_e949 v0;
-        v5.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_6698 v0 v1 v1 v3;
-        (v7.i256, v8.i1) = uaddo v1 32.i256;
-        br v8 block2 block3;
-
-    block2:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block3:
-        v17.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_6698 v0 v1 v7 v3;
-        v20.@layout_6 = insert_value undef.@layout_6 0.i256 v5;
-        v22.@layout_6 = insert_value v20 1.i256 v17;
-        return v22;
-}
-
-func inline(always) private %impl_trait_Approve__decode_from__gd20d(v0.@layout_5, v1.i256) -> @layout_7 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_aa47 v0;
-        v5.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_329a v0 v1 v1 v3;
-        (v7.i256, v8.i1) = uaddo v1 32.i256;
-        br v8 block2 block3;
-
-    block2:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block3:
-        v17.i256 = call %core__lib__abi__decode_msg_field_from__g5385_0219 v0 v1 v7 v3;
-        v20.@layout_7 = insert_value undef.@layout_7 0.i256 v5;
-        v22.@layout_7 = insert_value v20 1.i256 v17;
-        return v22;
-}
-
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8d9f(v0.@layout_5, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b461 v0 v1;
-        return v4;
-}
-
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8d9f_0(v0.@layout_5, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b461_0 v0 v1;
-        return v4;
-}
-
-func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_9286(v0.@layout_5, v1.i256) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_a8d6 v0 v1;
-        v6.i256 = shr 160.i256 v4;
-        v8.i1 = eq v6 0.i256;
-        v9.i1 = is_zero v8;
-        br v9 block2 block3;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v12.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
-        return v12;
-}
-
-func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_9286_0(v0.@layout_5, v1.i256) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_a8d6_0 v0 v1;
-        v6.i256 = shr 160.i256 v4;
-        v8.i1 = eq v6 0.i256;
-        v9.i1 = is_zero v8;
-        br v9 block2 block3;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v12.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
-        return v12;
-}
-
-func inline(always) private %impl_trait_Mint__decode_from__gd20d(v0.@layout_5, v1.i256) -> @layout_8 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_779e v0;
-        v5.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_0358 v0 v1 v1 v3;
-        (v7.i256, v8.i1) = uaddo v1 32.i256;
-        br v8 block2 block3;
-
-    block2:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block3:
-        v17.i256 = call %core__lib__abi__decode_msg_field_from__g5385_9796 v0 v1 v7 v3;
-        v20.@layout_8 = insert_value undef.@layout_8 0.i256 v5;
-        v22.@layout_8 = insert_value v20 1.i256 v17;
-        return v22;
-}
-
-func inline(always) private %impl_trait_Burn__decode_from__gd20d(v0.@layout_5, v1.i256) -> @layout_9 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_6f43 v0;
-        v5.i256 = call %core__lib__abi__decode_msg_field_from__g5385_ce42 v0 v1 v1 v3;
-        v8.@layout_9 = insert_value undef.@layout_9 0.i256 v5;
-        return v8;
-}
-
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_b39f(v0.@layout_5, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_e134 v0 v1;
-        return v4;
-}
-
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_b39f_0(v0.@layout_5, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_e134_0 v0 v1;
-        return v4;
-}
-
-func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_b822(v0.@layout_5, v1.i256) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_40a0 v0 v1;
-        v6.i256 = shr 160.i256 v4;
-        v8.i1 = eq v6 0.i256;
-        v9.i1 = is_zero v8;
-        br v9 block2 block3;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v12.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
-        return v12;
-}
-
-func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_b822_0(v0.@layout_5, v1.i256) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_40a0_0 v0 v1;
-        v6.i256 = shr 160.i256 v4;
-        v8.i1 = eq v6 0.i256;
-        v9.i1 = is_zero v8;
-        br v9 block2 block3;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v12.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
-        return v12;
-}
-
-func inline(always) private %impl_trait_BurnFrom__decode_from__gd20d(v0.@layout_5, v1.i256) -> @layout_10 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_e065 v0;
-        v5.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_059c v0 v1 v1 v3;
-        (v7.i256, v8.i1) = uaddo v1 32.i256;
-        br v8 block2 block3;
-
-    block2:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block3:
-        v17.i256 = call %core__lib__abi__decode_msg_field_from__g5385_745e v0 v1 v7 v3;
-        v20.@layout_10 = insert_value undef.@layout_10 0.i256 v5;
-        v22.@layout_10 = insert_value v20 1.i256 v17;
-        return v22;
-}
-
-func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_1972(v0.@layout_5, v1.i256, v2.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_aaf5 v1 32.i256 v2;
-        v8.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_0a95 v0 v1;
-        return v8;
-}
-
-func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_2360(v0.@layout_5, v1.i256, v2.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_01a8 v1 32.i256 v2;
-        v8.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_b39f v0 v1;
-        return v8;
-}
-
-func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_2374(v0.@layout_5, v1.i256, v2.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_a584 v1 32.i256 v2;
-        v8.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8d9f v0 v1;
-        return v8;
-}
-
-func private %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_29bc(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_e706 v1 32.i256 v2;
-        v8.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_f4e0 v0 v1;
-        return v8;
-}
-
-func private %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_2c09(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_cc78 v1 32.i256 v2;
-        v8.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_5535 v0 v1;
-        return v8;
-}
-
-func private %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_3639(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_4689 v1 32.i256 v2;
-        v8.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_2519 v0 v1;
-        return v8;
-}
-
-func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_38c3(v0.@layout_5, v1.i256, v2.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_c0b4 v1 32.i256 v2;
-        v8.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_18e6 v0 v1;
-        return v8;
-}
-
-func private %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_3fea(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_de97 v1 32.i256 v2;
-        v8.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_9286 v0 v1;
-        return v8;
-}
-
-func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_43c7(v0.@layout_5, v1.i256, v2.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_f40a v1 32.i256 v2;
-        v8.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_3a7c v0 v1;
-        return v8;
-}
-
-func private %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_64e6(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_6403 v1 32.i256 v2;
-        v8.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_4e5e v0 v1;
-        return v8;
-}
-
-func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_6ea9(v0.@layout_5, v1.i256, v2.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_9888 v1 32.i256 v2;
-        v8.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_4e52 v0 v1;
-        return v8;
-}
-
-func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_8823(v0.@layout_5, v1.i256, v2.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_9284 v1 32.i256 v2;
-        v8.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_251a v0 v1;
-        return v8;
-}
-
-func private %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_8e68(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_c3cb v1 32.i256 v2;
-        v8.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_b822 v0 v1;
-        return v8;
-}
-
-func private %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_978c(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_60b4 v1 32.i256 v2;
-        v8.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_3716 v0 v1;
-        return v8;
-}
-
-func private %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_a883(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_9b12 v1 32.i256 v2;
-        v8.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_3641 v0 v1;
-        return v8;
-}
-
-func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_d01b(v0.@layout_5, v1.i256, v2.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_d1eb v1 32.i256 v2;
-        v8.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_5c31 v0 v1;
-        return v8;
-}
-
-func private %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_d676(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_b8aa v1 32.i256 v2;
-        v8.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_db93 v0 v1;
-        return v8;
-}
-
-func inline(always) private %impl_trait_Decimals__decode_from__gd20d(v0.@layout_5, v1.i256) {
+func inline(always) private %impl_trait_TotalSupply__decode_from__gd20d(v0.@layout_0, v1.i256) {
     block0:
         jump block1;
 
@@ -4576,18 +4014,7 @@ func inline(always) private %impl_trait_Decimals__decode_from__gd20d(v0.@layout_
         return;
 }
 
-func inline(always) private %impl_trait_BalanceOf__decode_from__gd20d(v0.@layout_5, v1.i256) -> @layout_11 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_e9e0 v0;
-        v5.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_6f66 v0 v1 v1 v3;
-        v8.@layout_11 = insert_value undef.@layout_11 0.i256 v5;
-        return v8;
-}
-
-func inline(always) private %impl_trait_Name__decode_from__gd20d(v0.@layout_5, v1.i256) {
+func inline(always) private %impl_trait_Name__decode_from__gd20d(v0.@layout_0, v1.i256) {
     block0:
         jump block1;
 
@@ -4595,13 +4022,109 @@ func inline(always) private %impl_trait_Name__decode_from__gd20d(v0.@layout_5, v
         return;
 }
 
-func inline(always) private %impl_trait_IncreaseAllowance__decode_from__gd20d(v0.@layout_5, v1.i256) -> @layout_12 {
+func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_62af(v0.@layout_0, v1.i256) -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_de6d v0;
-        v5.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_f58a v0 v1 v1 v3;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_fef2 v0 v1;
+        v6.i256 = shr 160.i256 v4;
+        v8.i1 = eq v6 0.i256;
+        v9.i1 = is_zero v8;
+        br v9 block2 block3;
+
+    block2:
+        evm_revert 0.i256 0.i256;
+
+    block3:
+        jump block4;
+
+    block4:
+        v12.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
+        return v12;
+}
+
+func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_62af_0(v0.@layout_0, v1.i256) -> @layout_0 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_fef2_0 v0 v1;
+        v6.i256 = shr 160.i256 v4;
+        v8.i1 = eq v6 0.i256;
+        v9.i1 = is_zero v8;
+        br v9 block2 block3;
+
+    block2:
+        evm_revert 0.i256 0.i256;
+
+    block3:
+        jump block4;
+
+    block4:
+        v12.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
+        return v12;
+}
+
+func inline(always) private %impl_trait_Decimals__decode_from__gd20d(v0.@layout_0, v1.i256) {
+    block0:
+        jump block1;
+
+    block1:
+        return;
+}
+
+func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_6461(v0.@layout_0, v1.i256) -> @layout_0 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_7e53 v0 v1;
+        v6.i256 = shr 160.i256 v4;
+        v8.i1 = eq v6 0.i256;
+        v9.i1 = is_zero v8;
+        br v9 block2 block3;
+
+    block2:
+        evm_revert 0.i256 0.i256;
+
+    block3:
+        jump block4;
+
+    block4:
+        v12.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
+        return v12;
+}
+
+func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_6461_0(v0.@layout_0, v1.i256) -> @layout_0 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_7e53_0 v0 v1;
+        v6.i256 = shr 160.i256 v4;
+        v8.i1 = eq v6 0.i256;
+        v9.i1 = is_zero v8;
+        br v9 block2 block3;
+
+    block2:
+        evm_revert 0.i256 0.i256;
+
+    block3:
+        jump block4;
+
+    block4:
+        v12.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
+        return v12;
+}
+
+func inline(always) private %impl_trait_BurnFrom__decode_from__gd20d(v0.@layout_0, v1.i256) -> @layout_5 {
+    block0:
+        jump block1;
+
+    block1:
+        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_566f v0;
+        v5.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_1421 v0 v1 v1 v3;
         (v7.i256, v8.i1) = uaddo v1 32.i256;
         br v8 block2 block3;
 
@@ -4611,19 +4134,63 @@ func inline(always) private %impl_trait_IncreaseAllowance__decode_from__gd20d(v0
         evm_revert 0.i256 36.i256;
 
     block3:
-        v17.i256 = call %core__lib__abi__decode_msg_field_from__g5385_0929 v0 v1 v7 v3;
-        v20.@layout_12 = insert_value undef.@layout_12 0.i256 v5;
-        v22.@layout_12 = insert_value v20 1.i256 v17;
+        v17.i256 = call %core__lib__abi__decode_msg_field_from__g5385_0581 v0 v1 v7 v3;
+        v20.@layout_5 = insert_value undef.@layout_5 0.i256 v5;
+        v22.@layout_5 = insert_value v20 1.i256 v17;
         return v22;
 }
 
-func inline(always) private %impl_trait_TransferFrom__decode_from__gd20d(v0.@layout_5, v1.i256) -> @layout_13 {
+func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_6f9a(v0.@layout_0, v1.i256) -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_36c4 v0;
-        v5.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_3b80 v0 v1 v1 v3;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3903 v0 v1;
+        v6.i256 = shr 160.i256 v4;
+        v8.i1 = eq v6 0.i256;
+        v9.i1 = is_zero v8;
+        br v9 block2 block3;
+
+    block2:
+        evm_revert 0.i256 0.i256;
+
+    block3:
+        jump block4;
+
+    block4:
+        v12.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
+        return v12;
+}
+
+func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_6f9a_0(v0.@layout_0, v1.i256) -> @layout_0 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3903_0 v0 v1;
+        v6.i256 = shr 160.i256 v4;
+        v8.i1 = eq v6 0.i256;
+        v9.i1 = is_zero v8;
+        br v9 block2 block3;
+
+    block2:
+        evm_revert 0.i256 0.i256;
+
+    block3:
+        jump block4;
+
+    block4:
+        v12.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
+        return v12;
+}
+
+func inline(always) private %impl_trait_TransferFrom__decode_from__gd20d(v0.@layout_0, v1.i256) -> @layout_6 {
+    block0:
+        jump block1;
+
+    block1:
+        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_5dba v0;
+        v5.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_1e96 v0 v1 v1 v3;
         (v7.i256, v8.i1) = uaddo v1 32.i256;
         br v8 block2 block3;
 
@@ -4633,7 +4200,7 @@ func inline(always) private %impl_trait_TransferFrom__decode_from__gd20d(v0.@lay
         evm_revert 0.i256 36.i256;
 
     block3:
-        v17.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_3b80 v0 v1 v7 v3;
+        v17.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_1e96 v0 v1 v7 v3;
         (v20.i256, v21.i1) = uaddo v1 32.i256;
         br v21 block2 block4;
 
@@ -4642,20 +4209,104 @@ func inline(always) private %impl_trait_TransferFrom__decode_from__gd20d(v0.@lay
         br v23 block2 block5;
 
     block5:
-        v27.i256 = call %core__lib__abi__decode_msg_field_from__g5385_2a48 v0 v1 v22 v3;
-        v30.@layout_13 = insert_value undef.@layout_13 0.i256 v5;
-        v33.@layout_13 = insert_value v30 1.i256 v17;
-        v35.@layout_13 = insert_value v33 2.i256 v27;
+        v27.i256 = call %core__lib__abi__decode_msg_field_from__g5385_8188 v0 v1 v22 v3;
+        v30.@layout_6 = insert_value undef.@layout_6 0.i256 v5;
+        v33.@layout_6 = insert_value v30 1.i256 v17;
+        v35.@layout_6 = insert_value v33 2.i256 v27;
         return v35;
 }
 
-func inline(always) private %impl_trait_Transfer__decode_from__gd20d(v0.@layout_5, v1.i256) -> @layout_14 {
+func inline(always) private %impl_trait_Burn__decode_from__gd20d(v0.@layout_0, v1.i256) -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_0eff v0;
-        v5.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_bede v0 v1 v1 v3;
+        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_4aee v0;
+        v5.i256 = call %core__lib__abi__decode_msg_field_from__g5385_5e40 v0 v1 v1 v3;
+        v8.@layout_0 = insert_value undef.@layout_0 0.i256 v5;
+        return v8;
+}
+
+func inline(always) private %impl_trait_BalanceOf__decode_from__gd20d(v0.@layout_0, v1.i256) -> @layout_7 {
+    block0:
+        jump block1;
+
+    block1:
+        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_c2ce v0;
+        v5.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_4d2f v0 v1 v1 v3;
+        v8.@layout_7 = insert_value undef.@layout_7 0.i256 v5;
+        return v8;
+}
+
+func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_9696(v0.@layout_0, v1.i256) -> @layout_0 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_86b9 v0 v1;
+        v6.i256 = shr 160.i256 v4;
+        v8.i1 = eq v6 0.i256;
+        v9.i1 = is_zero v8;
+        br v9 block2 block3;
+
+    block2:
+        evm_revert 0.i256 0.i256;
+
+    block3:
+        jump block4;
+
+    block4:
+        v12.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
+        return v12;
+}
+
+func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_9696_0(v0.@layout_0, v1.i256) -> @layout_0 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_86b9_0 v0 v1;
+        v6.i256 = shr 160.i256 v4;
+        v8.i1 = eq v6 0.i256;
+        v9.i1 = is_zero v8;
+        br v9 block2 block3;
+
+    block2:
+        evm_revert 0.i256 0.i256;
+
+    block3:
+        jump block4;
+
+    block4:
+        v12.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
+        return v12;
+}
+
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_96fc(v0.@layout_0, v1.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_fa4a v0 v1;
+        return v4;
+}
+
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_96fc_0(v0.@layout_0, v1.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_fa4a_0 v0 v1;
+        return v4;
+}
+
+func inline(always) private %impl_trait_IncreaseAllowance__decode_from__gd20d(v0.@layout_0, v1.i256) -> @layout_5 {
+    block0:
+        jump block1;
+
+    block1:
+        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_e2e1 v0;
+        v5.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_7613 v0 v1 v1 v3;
         (v7.i256, v8.i1) = uaddo v1 32.i256;
         br v8 block2 block3;
 
@@ -4665,63 +4316,19 @@ func inline(always) private %impl_trait_Transfer__decode_from__gd20d(v0.@layout_
         evm_revert 0.i256 36.i256;
 
     block3:
-        v17.i256 = call %core__lib__abi__decode_msg_field_from__g5385_252f v0 v1 v7 v3;
-        v20.@layout_14 = insert_value undef.@layout_14 0.i256 v5;
-        v22.@layout_14 = insert_value v20 1.i256 v17;
+        v17.i256 = call %core__lib__abi__decode_msg_field_from__g5385_711b v0 v1 v7 v3;
+        v20.@layout_5 = insert_value undef.@layout_5 0.i256 v5;
+        v22.@layout_5 = insert_value v20 1.i256 v17;
         return v22;
 }
 
-func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_db93(v0.@layout_5, v1.i256) -> @layout_0 {
+func inline(always) private %impl_trait_Mint__decode_from__gd20d(v0.@layout_0, v1.i256) -> @layout_5 {
     block0:
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3ba3 v0 v1;
-        v6.i256 = shr 160.i256 v4;
-        v8.i1 = eq v6 0.i256;
-        v9.i1 = is_zero v8;
-        br v9 block2 block3;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v12.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
-        return v12;
-}
-
-func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_db93_0(v0.@layout_5, v1.i256) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3ba3_0 v0 v1;
-        v6.i256 = shr 160.i256 v4;
-        v8.i1 = eq v6 0.i256;
-        v9.i1 = is_zero v8;
-        br v9 block2 block3;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v12.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
-        return v12;
-}
-
-func inline(always) private %impl_trait_DecreaseAllowance__decode_from__gd20d(v0.@layout_5, v1.i256) -> @layout_15 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_e83e v0;
-        v5.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_7904 v0 v1 v1 v3;
+        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_3418 v0;
+        v5.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_9a55 v0 v1 v1 v3;
         (v7.i256, v8.i1) = uaddo v1 32.i256;
         br v8 block2 block3;
 
@@ -4731,26 +4338,40 @@ func inline(always) private %impl_trait_DecreaseAllowance__decode_from__gd20d(v0
         evm_revert 0.i256 36.i256;
 
     block3:
-        v17.i256 = call %core__lib__abi__decode_msg_field_from__g5385_9aa8 v0 v1 v7 v3;
-        v20.@layout_15 = insert_value undef.@layout_15 0.i256 v5;
-        v22.@layout_15 = insert_value v20 1.i256 v17;
+        v17.i256 = call %core__lib__abi__decode_msg_field_from__g5385_e784 v0 v1 v7 v3;
+        v20.@layout_5 = insert_value undef.@layout_5 0.i256 v5;
+        v22.@layout_5 = insert_value v20 1.i256 v17;
         return v22;
 }
 
-func inline(always) private %impl_trait_TotalSupply__decode_from__gd20d(v0.@layout_5, v1.i256) {
+func inline(always) private %impl_trait_DecreaseAllowance__decode_from__gd20d(v0.@layout_0, v1.i256) -> @layout_5 {
     block0:
         jump block1;
 
     block1:
-        return;
+        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_f8fd v0;
+        v5.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_db81 v0 v1 v1 v3;
+        (v7.i256, v8.i1) = uaddo v1 32.i256;
+        br v8 block2 block3;
+
+    block2:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block3:
+        v17.i256 = call %core__lib__abi__decode_msg_field_from__g5385_9297 v0 v1 v7 v3;
+        v20.@layout_5 = insert_value undef.@layout_5 0.i256 v5;
+        v22.@layout_5 = insert_value v20 1.i256 v17;
+        return v22;
 }
 
-func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_f4e0(v0.@layout_5, v1.i256) -> @layout_0 {
+func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_a8a8(v0.@layout_0, v1.i256) -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_bae8 v0 v1;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_8e74 v0 v1;
         v6.i256 = shr 160.i256 v4;
         v8.i1 = eq v6 0.i256;
         v9.i1 = is_zero v8;
@@ -4767,12 +4388,12 @@ func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__de
         return v12;
 }
 
-func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_f4e0_0(v0.@layout_5, v1.i256) -> @layout_0 {
+func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_a8a8_0(v0.@layout_0, v1.i256) -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_bae8_0 v0 v1;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_8e74_0 v0 v1;
         v6.i256 = shr 160.i256 v4;
         v8.i1 = eq v6 0.i256;
         v9.i1 = is_zero v8;
@@ -4789,97 +4410,373 @@ func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__de
         return v12;
 }
 
-func inline(always) private %decode_from_prechecked_head__gbd88(v0.@layout_5, v1.i256, v2.i256) {
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_ab67(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        call %impl_trait_Name__decode_from__gd20d v0 v1;
-        return;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c443 v0 v1;
+        return v4;
 }
 
-func inline(always) private %decode_from_prechecked_head__g76d6(v0.@layout_5, v1.i256, v2.i256) -> @layout_8 {
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_ab67_0(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v6.@layout_8 = call %impl_trait_Mint__decode_from__gd20d v0 v1;
-        return v6;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c443_0 v0 v1;
+        return v4;
 }
 
-func inline(always) private %decode_from_prechecked_head__g41f8(v0.@layout_5, v1.i256, v2.i256) -> @layout_9 {
+func inline(always) private %impl_trait_Transfer__decode_from__gd20d(v0.@layout_0, v1.i256) -> @layout_5 {
     block0:
         jump block1;
 
     block1:
-        v6.@layout_9 = call %impl_trait_Burn__decode_from__gd20d v0 v1;
-        return v6;
+        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_13b9 v0;
+        v5.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_db42 v0 v1 v1 v3;
+        (v7.i256, v8.i1) = uaddo v1 32.i256;
+        br v8 block2 block3;
+
+    block2:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block3:
+        v17.i256 = call %core__lib__abi__decode_msg_field_from__g5385_f7b3 v0 v1 v7 v3;
+        v20.@layout_5 = insert_value undef.@layout_5 0.i256 v5;
+        v22.@layout_5 = insert_value v20 1.i256 v17;
+        return v22;
 }
 
-func inline(always) private %decode_from_prechecked_head__g205f(v0.@layout_5, v1.i256, v2.i256) -> @layout_14 {
+func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_b7c4(v0.@layout_0, v1.i256) -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v6.@layout_14 = call %impl_trait_Transfer__decode_from__gd20d v0 v1;
-        return v6;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_0df5 v0 v1;
+        v6.i256 = shr 160.i256 v4;
+        v8.i1 = eq v6 0.i256;
+        v9.i1 = is_zero v8;
+        br v9 block2 block3;
+
+    block2:
+        evm_revert 0.i256 0.i256;
+
+    block3:
+        jump block4;
+
+    block4:
+        v12.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
+        return v12;
 }
 
-func inline(always) private %decode_from_prechecked_head__g5470(v0.@layout_5, v1.i256, v2.i256) -> @layout_6 {
+func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_b7c4_0(v0.@layout_0, v1.i256) -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v6.@layout_6 = call %impl_trait_Allowance__decode_from__gd20d v0 v1;
-        return v6;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_0df5_0 v0 v1;
+        v6.i256 = shr 160.i256 v4;
+        v8.i1 = eq v6 0.i256;
+        v9.i1 = is_zero v8;
+        br v9 block2 block3;
+
+    block2:
+        evm_revert 0.i256 0.i256;
+
+    block3:
+        jump block4;
+
+    block4:
+        v12.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
+        return v12;
 }
 
-func inline(always) private %decode_from_prechecked_head__g6690(v0.@layout_5, v1.i256, v2.i256) -> @layout_13 {
+func private %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_00f8(v0.@layout_0, v1.i256, v2.i256) -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v6.@layout_13 = call %impl_trait_TransferFrom__decode_from__gd20d v0 v1;
-        return v6;
+        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_cc78 v1 32.i256 v2;
+        v8.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_a8a8 v0 v1;
+        return v8;
 }
 
-func inline(always) private %decode_from_prechecked_head__g7ea0(v0.@layout_5, v1.i256, v2.i256) -> @layout_11 {
+func private %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_1d36(v0.@layout_0, v1.i256, v2.i256) -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v6.@layout_11 = call %impl_trait_BalanceOf__decode_from__gd20d v0 v1;
-        return v6;
+        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_c3cb v1 32.i256 v2;
+        v8.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_0837 v0 v1;
+        return v8;
 }
 
-func inline(always) private %decode_from_prechecked_head__g691a(v0.@layout_5, v1.i256, v2.i256) {
+func private %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_2732(v0.@layout_0, v1.i256, v2.i256) -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        call %impl_trait_Symbol__decode_from__gd20d v0 v1;
-        return;
+        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_e706 v1 32.i256 v2;
+        v8.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_b7c4 v0 v1;
+        return v8;
 }
 
-func inline(always) private %decode_from_prechecked_head__g7d8c(v0.@layout_5, v1.i256, v2.i256) -> @layout_12 {
+func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_4417(v0.@layout_0, v1.i256, v2.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v6.@layout_12 = call %impl_trait_IncreaseAllowance__decode_from__gd20d v0 v1;
-        return v6;
+        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_d1eb v1 32.i256 v2;
+        v8.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f68c v0 v1;
+        return v8;
 }
 
-func inline(always) private %decode_from_prechecked_head__gab8c(v0.@layout_5, v1.i256, v2.i256) -> @layout_7 {
+func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_45cc(v0.@layout_0, v1.i256, v2.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v6.@layout_7 = call %impl_trait_Approve__decode_from__gd20d v0 v1;
-        return v6;
+        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_f40a v1 32.i256 v2;
+        v8.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_ab67 v0 v1;
+        return v8;
 }
 
-func inline(always) private %decode_from_prechecked_head__g4997(v0.@layout_5, v1.i256, v2.i256) {
+func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_54e2(v0.@layout_0, v1.i256, v2.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_a584 v1 32.i256 v2;
+        v8.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f48c v0 v1;
+        return v8;
+}
+
+func private %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_5c48(v0.@layout_0, v1.i256, v2.i256) -> @layout_0 {
+    block0:
+        jump block1;
+
+    block1:
+        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_de97 v1 32.i256 v2;
+        v8.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_42a1 v0 v1;
+        return v8;
+}
+
+func private %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_63cb(v0.@layout_0, v1.i256, v2.i256) -> @layout_0 {
+    block0:
+        jump block1;
+
+    block1:
+        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_60b4 v1 32.i256 v2;
+        v8.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_37dd v0 v1;
+        return v8;
+}
+
+func private %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_71be(v0.@layout_0, v1.i256, v2.i256) -> @layout_0 {
+    block0:
+        jump block1;
+
+    block1:
+        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_4689 v1 32.i256 v2;
+        v8.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_62af v0 v1;
+        return v8;
+}
+
+func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_8124(v0.@layout_0, v1.i256, v2.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_aaf5 v1 32.i256 v2;
+        v8.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_96fc v0 v1;
+        return v8;
+}
+
+func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_81b3(v0.@layout_0, v1.i256, v2.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_c0b4 v1 32.i256 v2;
+        v8.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f835 v0 v1;
+        return v8;
+}
+
+func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_9915(v0.@layout_0, v1.i256, v2.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_9284 v1 32.i256 v2;
+        v8.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_cab7 v0 v1;
+        return v8;
+}
+
+func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_9d3c(v0.@layout_0, v1.i256, v2.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_01a8 v1 32.i256 v2;
+        v8.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_337f v0 v1;
+        return v8;
+}
+
+func private %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_a671(v0.@layout_0, v1.i256, v2.i256) -> @layout_0 {
+    block0:
+        jump block1;
+
+    block1:
+        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_9b12 v1 32.i256 v2;
+        v8.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_9696 v0 v1;
+        return v8;
+}
+
+func private %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_b8b8(v0.@layout_0, v1.i256, v2.i256) -> @layout_0 {
+    block0:
+        jump block1;
+
+    block1:
+        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_b8aa v1 32.i256 v2;
+        v8.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_6461 v0 v1;
+        return v8;
+}
+
+func private %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_d913(v0.@layout_0, v1.i256, v2.i256) -> @layout_0 {
+    block0:
+        jump block1;
+
+    block1:
+        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_6403 v1 32.i256 v2;
+        v8.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_6f9a v0 v1;
+        return v8;
+}
+
+func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_e4c0(v0.@layout_0, v1.i256, v2.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_9888 v1 32.i256 v2;
+        v8.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_d1bc v0 v1;
+        return v8;
+}
+
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_cab7(v0.@layout_0, v1.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_67b2 v0 v1;
+        return v4;
+}
+
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_cab7_0(v0.@layout_0, v1.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_67b2_0 v0 v1;
+        return v4;
+}
+
+func inline(always) private %impl_trait_Approve__decode_from__gd20d(v0.@layout_0, v1.i256) -> @layout_5 {
+    block0:
+        jump block1;
+
+    block1:
+        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_9f1e v0;
+        v5.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_faa5 v0 v1 v1 v3;
+        (v7.i256, v8.i1) = uaddo v1 32.i256;
+        br v8 block2 block3;
+
+    block2:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block3:
+        v17.i256 = call %core__lib__abi__decode_msg_field_from__g5385_d336 v0 v1 v7 v3;
+        v20.@layout_5 = insert_value undef.@layout_5 0.i256 v5;
+        v22.@layout_5 = insert_value v20 1.i256 v17;
+        return v22;
+}
+
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_d1bc(v0.@layout_0, v1.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3723 v0 v1;
+        return v4;
+}
+
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_d1bc_0(v0.@layout_0, v1.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3723_0 v0 v1;
+        return v4;
+}
+
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f48c(v0.@layout_0, v1.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_8b76 v0 v1;
+        return v4;
+}
+
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f48c_0(v0.@layout_0, v1.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_8b76_0 v0 v1;
+        return v4;
+}
+
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f68c(v0.@layout_0, v1.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_6669 v0 v1;
+        return v4;
+}
+
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f68c_0(v0.@layout_0, v1.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_6669_0 v0 v1;
+        return v4;
+}
+
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f835(v0.@layout_0, v1.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_7d6a v0 v1;
+        return v4;
+}
+
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f835_0(v0.@layout_0, v1.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_7d6a_0 v0 v1;
+        return v4;
+}
+
+func inline(always) private %decode_from_prechecked_head__g4997(v0.@layout_0, v1.i256, v2.i256) {
     block0:
         jump block1;
 
@@ -4888,16 +4785,43 @@ func inline(always) private %decode_from_prechecked_head__g4997(v0.@layout_5, v1
         return;
 }
 
-func inline(always) private %decode_from_prechecked_head__gad59(v0.@layout_5, v1.i256, v2.i256) -> @layout_10 {
+func inline(always) private %decode_from_prechecked_head__gad59(v0.@layout_0, v1.i256, v2.i256) -> @layout_5 {
     block0:
         jump block1;
 
     block1:
-        v6.@layout_10 = call %impl_trait_BurnFrom__decode_from__gd20d v0 v1;
+        v6.@layout_5 = call %impl_trait_BurnFrom__decode_from__gd20d v0 v1;
         return v6;
 }
 
-func inline(always) private %decode_from_prechecked_head__g051e(v0.@layout_5, v1.i256, v2.i256) {
+func inline(always) private %decode_from_prechecked_head__g383e(v0.@layout_0, v1.i256, v2.i256) -> @layout_5 {
+    block0:
+        jump block1;
+
+    block1:
+        v6.@layout_5 = call %impl_trait_DecreaseAllowance__decode_from__gd20d v0 v1;
+        return v6;
+}
+
+func inline(always) private %decode_from_prechecked_head__g7ea0(v0.@layout_0, v1.i256, v2.i256) -> @layout_7 {
+    block0:
+        jump block1;
+
+    block1:
+        v6.@layout_7 = call %impl_trait_BalanceOf__decode_from__gd20d v0 v1;
+        return v6;
+}
+
+func inline(always) private %decode_from_prechecked_head__g6690(v0.@layout_0, v1.i256, v2.i256) -> @layout_6 {
+    block0:
+        jump block1;
+
+    block1:
+        v6.@layout_6 = call %impl_trait_TransferFrom__decode_from__gd20d v0 v1;
+        return v6;
+}
+
+func inline(always) private %decode_from_prechecked_head__g051e(v0.@layout_0, v1.i256, v2.i256) {
     block0:
         jump block1;
 
@@ -4906,16 +4830,79 @@ func inline(always) private %decode_from_prechecked_head__g051e(v0.@layout_5, v1
         return;
 }
 
-func inline(always) private %decode_from_prechecked_head__g383e(v0.@layout_5, v1.i256, v2.i256) -> @layout_15 {
+func inline(always) private %decode_from_prechecked_head__g205f(v0.@layout_0, v1.i256, v2.i256) -> @layout_5 {
     block0:
         jump block1;
 
     block1:
-        v6.@layout_15 = call %impl_trait_DecreaseAllowance__decode_from__gd20d v0 v1;
+        v6.@layout_5 = call %impl_trait_Transfer__decode_from__gd20d v0 v1;
         return v6;
 }
 
-func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_0219(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> i256 {
+func inline(always) private %decode_from_prechecked_head__g7d8c(v0.@layout_0, v1.i256, v2.i256) -> @layout_5 {
+    block0:
+        jump block1;
+
+    block1:
+        v6.@layout_5 = call %impl_trait_IncreaseAllowance__decode_from__gd20d v0 v1;
+        return v6;
+}
+
+func inline(always) private %decode_from_prechecked_head__gab8c(v0.@layout_0, v1.i256, v2.i256) -> @layout_5 {
+    block0:
+        jump block1;
+
+    block1:
+        v6.@layout_5 = call %impl_trait_Approve__decode_from__gd20d v0 v1;
+        return v6;
+}
+
+func inline(always) private %decode_from_prechecked_head__g76d6(v0.@layout_0, v1.i256, v2.i256) -> @layout_5 {
+    block0:
+        jump block1;
+
+    block1:
+        v6.@layout_5 = call %impl_trait_Mint__decode_from__gd20d v0 v1;
+        return v6;
+}
+
+func inline(always) private %decode_from_prechecked_head__g5470(v0.@layout_0, v1.i256, v2.i256) -> @layout_4 {
+    block0:
+        jump block1;
+
+    block1:
+        v6.@layout_4 = call %impl_trait_Allowance__decode_from__gd20d v0 v1;
+        return v6;
+}
+
+func inline(always) private %decode_from_prechecked_head__g41f8(v0.@layout_0, v1.i256, v2.i256) -> @layout_0 {
+    block0:
+        jump block1;
+
+    block1:
+        v6.@layout_0 = call %impl_trait_Burn__decode_from__gd20d v0 v1;
+        return v6;
+}
+
+func inline(always) private %decode_from_prechecked_head__gbd88(v0.@layout_0, v1.i256, v2.i256) {
+    block0:
+        jump block1;
+
+    block1:
+        call %impl_trait_Name__decode_from__gd20d v0 v1;
+        return;
+}
+
+func inline(always) private %decode_from_prechecked_head__g691a(v0.@layout_0, v1.i256, v2.i256) {
+    block0:
+        jump block1;
+
+    block1:
+        call %impl_trait_Symbol__decode_from__gd20d v0 v1;
+        return;
+}
+
+func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_0581(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
         jump block1;
 
@@ -4923,18 +4910,18 @@ func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_0219(v
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_5db0 v0 v1 v2 v3;
+        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_7b37 v0 v1 v2 v3;
         return v9;
 
     block3:
         jump block4;
 
     block4:
-        v14.i256 = call %core__lib__abi__decode_field_from__g5385_4796 v0 v1 v2;
+        v14.i256 = call %core__lib__abi__decode_field_from__g5385_071f v0 v1 v2;
         return v14;
 }
 
-func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_0358(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> @layout_0 {
+func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_1421(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> @layout_0 {
     block0:
         jump block1;
 
@@ -4942,18 +4929,18 @@ func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_0358(v
         br 0.i1 block2 block3;
 
     block2:
-        v9.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_18ef v0 v1 v2 v3;
+        v9.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_2034 v0 v1 v2 v3;
         return v9;
 
     block3:
         jump block4;
 
     block4:
-        v14.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_2692 v0 v1 v2;
+        v14.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_fe88 v0 v1 v2;
         return v14;
 }
 
-func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_059c(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> @layout_0 {
+func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_1e96(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> @layout_0 {
     block0:
         jump block1;
 
@@ -4961,18 +4948,18 @@ func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_059c(v
         br 0.i1 block2 block3;
 
     block2:
-        v9.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_2724 v0 v1 v2 v3;
+        v9.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_c901 v0 v1 v2 v3;
         return v9;
 
     block3:
         jump block4;
 
     block4:
-        v14.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_786c v0 v1 v2;
+        v14.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_57f7 v0 v1 v2;
         return v14;
 }
 
-func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_0929(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_4d2f(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> @layout_0 {
     block0:
         jump block1;
 
@@ -4980,18 +4967,18 @@ func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_0929(v
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_7760 v0 v1 v2 v3;
+        v9.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_0d46 v0 v1 v2 v3;
         return v9;
 
     block3:
         jump block4;
 
     block4:
-        v14.i256 = call %core__lib__abi__decode_field_from__g5385_9270 v0 v1 v2;
+        v14.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_5b19 v0 v1 v2;
         return v14;
 }
 
-func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_252f(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_5e40(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
         jump block1;
 
@@ -4999,18 +4986,18 @@ func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_252f(v
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_847c v0 v1 v2 v3;
+        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_76b2 v0 v1 v2 v3;
         return v9;
 
     block3:
         jump block4;
 
     block4:
-        v14.i256 = call %core__lib__abi__decode_field_from__g5385_79b2 v0 v1 v2;
+        v14.i256 = call %core__lib__abi__decode_field_from__g5385_ffe6 v0 v1 v2;
         return v14;
 }
 
-func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_2a48(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_711b(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
         jump block1;
 
@@ -5018,18 +5005,18 @@ func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_2a48(v
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_839e v0 v1 v2 v3;
+        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_6632 v0 v1 v2 v3;
         return v9;
 
     block3:
         jump block4;
 
     block4:
-        v14.i256 = call %core__lib__abi__decode_field_from__g5385_03a7 v0 v1 v2;
+        v14.i256 = call %core__lib__abi__decode_field_from__g5385_cce7 v0 v1 v2;
         return v14;
 }
 
-func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_329a(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> @layout_0 {
+func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_7613(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> @layout_0 {
     block0:
         jump block1;
 
@@ -5037,18 +5024,18 @@ func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_329a(v
         br 0.i1 block2 block3;
 
     block2:
-        v9.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_2207 v0 v1 v2 v3;
+        v9.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_322a v0 v1 v2 v3;
         return v9;
 
     block3:
         jump block4;
 
     block4:
-        v14.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_7fa7 v0 v1 v2;
+        v14.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_bcba v0 v1 v2;
         return v14;
 }
 
-func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_3b80(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> @layout_0 {
+func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_8188(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
         jump block1;
 
@@ -5056,18 +5043,18 @@ func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_3b80(v
         br 0.i1 block2 block3;
 
     block2:
-        v9.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_a4f7 v0 v1 v2 v3;
+        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_3651 v0 v1 v2 v3;
         return v9;
 
     block3:
         jump block4;
 
     block4:
-        v14.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_7143 v0 v1 v2;
+        v14.i256 = call %core__lib__abi__decode_field_from__g5385_0b34 v0 v1 v2;
         return v14;
 }
 
-func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_6698(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> @layout_0 {
+func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_9297(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
         jump block1;
 
@@ -5075,18 +5062,18 @@ func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_6698(v
         br 0.i1 block2 block3;
 
     block2:
-        v9.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_07a0 v0 v1 v2 v3;
+        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_8d67 v0 v1 v2 v3;
         return v9;
 
     block3:
         jump block4;
 
     block4:
-        v14.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_b564 v0 v1 v2;
+        v14.i256 = call %core__lib__abi__decode_field_from__g5385_3cbb v0 v1 v2;
         return v14;
 }
 
-func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_6f66(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> @layout_0 {
+func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_9a55(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> @layout_0 {
     block0:
         jump block1;
 
@@ -5094,18 +5081,18 @@ func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_6f66(v
         br 0.i1 block2 block3;
 
     block2:
-        v9.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_faf8 v0 v1 v2 v3;
+        v9.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_4a33 v0 v1 v2 v3;
         return v9;
 
     block3:
         jump block4;
 
     block4:
-        v14.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_d5c8 v0 v1 v2;
+        v14.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_6b0d v0 v1 v2;
         return v14;
 }
 
-func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_745e(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_d336(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
         jump block1;
 
@@ -5113,18 +5100,18 @@ func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_745e(v
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_c7d5 v0 v1 v2 v3;
+        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_75e6 v0 v1 v2 v3;
         return v9;
 
     block3:
         jump block4;
 
     block4:
-        v14.i256 = call %core__lib__abi__decode_field_from__g5385_cb05 v0 v1 v2;
+        v14.i256 = call %core__lib__abi__decode_field_from__g5385_8d0e v0 v1 v2;
         return v14;
 }
 
-func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_7904(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> @layout_0 {
+func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_db42(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> @layout_0 {
     block0:
         jump block1;
 
@@ -5132,18 +5119,18 @@ func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_7904(v
         br 0.i1 block2 block3;
 
     block2:
-        v9.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_ef75 v0 v1 v2 v3;
+        v9.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_fee7 v0 v1 v2 v3;
         return v9;
 
     block3:
         jump block4;
 
     block4:
-        v14.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_d5a0 v0 v1 v2;
+        v14.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_eb7d v0 v1 v2;
         return v14;
 }
 
-func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_9796(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_db81(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> @layout_0 {
     block0:
         jump block1;
 
@@ -5151,18 +5138,18 @@ func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_9796(v
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_34fc v0 v1 v2 v3;
+        v9.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_1116 v0 v1 v2 v3;
         return v9;
 
     block3:
         jump block4;
 
     block4:
-        v14.i256 = call %core__lib__abi__decode_field_from__g5385_7366 v0 v1 v2;
+        v14.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_e707 v0 v1 v2;
         return v14;
 }
 
-func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_9aa8(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_e784(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
         jump block1;
 
@@ -5170,18 +5157,18 @@ func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_9aa8(v
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_b51a v0 v1 v2 v3;
+        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_2d17 v0 v1 v2 v3;
         return v9;
 
     block3:
         jump block4;
 
     block4:
-        v14.i256 = call %core__lib__abi__decode_field_from__g5385_5cc4 v0 v1 v2;
+        v14.i256 = call %core__lib__abi__decode_field_from__g5385_e2bc v0 v1 v2;
         return v14;
 }
 
-func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_bede(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> @layout_0 {
+func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_eb2d(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> @layout_0 {
     block0:
         jump block1;
 
@@ -5189,18 +5176,18 @@ func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_bede(v
         br 0.i1 block2 block3;
 
     block2:
-        v9.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_ed91 v0 v1 v2 v3;
+        v9.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_5304 v0 v1 v2 v3;
         return v9;
 
     block3:
         jump block4;
 
     block4:
-        v14.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_e784 v0 v1 v2;
+        v14.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_4621 v0 v1 v2;
         return v14;
 }
 
-func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_ce42(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_f7b3(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
         jump block1;
 
@@ -5208,18 +5195,18 @@ func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_ce42(v
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_d4dc v0 v1 v2 v3;
+        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_88e0 v0 v1 v2 v3;
         return v9;
 
     block3:
         jump block4;
 
     block4:
-        v14.i256 = call %core__lib__abi__decode_field_from__g5385_d887 v0 v1 v2;
+        v14.i256 = call %core__lib__abi__decode_field_from__g5385_005b v0 v1 v2;
         return v14;
 }
 
-func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_f58a(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> @layout_0 {
+func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_faa5(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> @layout_0 {
     block0:
         jump block1;
 
@@ -5227,32 +5214,32 @@ func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_f58a(v
         br 0.i1 block2 block3;
 
     block2:
-        v9.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_764c v0 v1 v2 v3;
+        v9.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_56e5 v0 v1 v2 v3;
         return v9;
 
     block3:
         jump block4;
 
     block4:
-        v14.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_2eef v0 v1 v2;
+        v14.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_7dae v0 v1 v2;
         return v14;
 }
 
-func inline(always) private %impl_trait_u256__decode_payload__g407e(v0.objref<@layout_4>) -> i256 {
+func inline(always) private %impl_trait_u256__decode_payload__g407e(v0.objref<@layout_3>) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v2.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_85d9 v0;
+        v2.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_d6d9 v0;
         return v2;
 }
 
-func inline(always) private %impl_trait_Address__decode_payload__g407e(v0.objref<@layout_4>) -> @layout_0 {
+func inline(always) private %impl_trait_Address__decode_payload__g407e(v0.objref<@layout_3>) -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v2.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_87b3 v0;
+        v2.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_99f7 v0;
         v4.i256 = shr 160.i256 v2;
         v6.i1 = eq v4 0.i256;
         v7.i1 = is_zero v6;
@@ -5269,69 +5256,39 @@ func inline(always) private %impl_trait_Address__decode_payload__g407e(v0.objref
         return v10;
 }
 
-func private %decode_payload__gf566(v0.objref<@layout_4>) -> @layout_16 {
+func private %decode_payload__gf566(v0.objref<@layout_3>) -> @layout_8 {
     block0:
         jump block1;
 
     block1:
         v2.i256 = call %decode_field__g3854 v0;
         v3.@layout_0 = call %decode_field__g8463 v0;
-        v6.@layout_16 = insert_value undef.@layout_16 0.i256 v2;
-        v8.@layout_16 = insert_value v6 1.i256 v3;
+        v6.@layout_8 = insert_value undef.@layout_8 0.i256 v2;
+        v8.@layout_8 = insert_value v6 1.i256 v3;
         return v8;
 }
 
-func inline(always) private %decode_runtime_args__g5a0b(v0.objref<@layout_18>) {
+func inline(always) private %decode_runtime_args__g698d(v0.objref<@layout_10>) -> @layout_5 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_cd56;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_fc14 v3;
+        v3.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_d673;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_25ce v3;
         mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
 
     block2:
-        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_57a6;
+        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_cb5c;
         unreachable;
 
     block3:
         jump block4;
 
     block4:
-        call %decode_from_prechecked_head__g4997 v3 4.i256 v5;
-        return;
-
-    block5:
-        mstore v2 v5 i256;
-        v14.i256 = mload v2 i256;
-        v15.i1 = gt 4.i256 v14;
-        br v15 block2 block3;
-}
-
-func inline(always) private %decode_runtime_args__g6a7c(v0.objref<@layout_18>) -> @layout_15 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v3.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_663b;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_5dcb v3;
-        mstore v1 4.i256 i256;
-        br 0.i1 block2 block5;
-
-    block2:
-        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_20f2;
-        unreachable;
-
-    block3:
-        jump block4;
-
-    block4:
-        v12.@layout_15 = call %decode_from_prechecked_head__g383e v3 4.i256 v5;
+        v12.@layout_5 = call %decode_from_prechecked_head__g7d8c v3 4.i256 v5;
         return v12;
 
     block5:
@@ -5341,27 +5298,27 @@ func inline(always) private %decode_runtime_args__g6a7c(v0.objref<@layout_18>) -
         br v16 block2 block3;
 }
 
-func inline(always) private %decode_runtime_args__g7a2c(v0.objref<@layout_18>) -> @layout_7 {
+func inline(always) private %decode_runtime_args__g216b(v0.objref<@layout_10>) -> @layout_5 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_a580;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_22ff v3;
+        v3.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_6a54;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_a72b v3;
         mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
 
     block2:
-        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_ce6e;
+        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_cf57;
         unreachable;
 
     block3:
         jump block4;
 
     block4:
-        v12.@layout_7 = call %decode_from_prechecked_head__gab8c v3 4.i256 v5;
+        v12.@layout_5 = call %decode_from_prechecked_head__gad59 v3 4.i256 v5;
         return v12;
 
     block5:
@@ -5371,15 +5328,15 @@ func inline(always) private %decode_runtime_args__g7a2c(v0.objref<@layout_18>) -
         br v16 block2 block3;
 }
 
-func inline(always) private %decode_runtime_args__g295c(v0.objref<@layout_18>) {
+func inline(always) private %decode_runtime_args__g295c(v0.objref<@layout_10>) {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_5bd8;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_ae2f v3;
+        v3.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_5bd8;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_0a2a v3;
         mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
 
@@ -5401,45 +5358,15 @@ func inline(always) private %decode_runtime_args__g295c(v0.objref<@layout_18>) {
         br v15 block2 block3;
 }
 
-func inline(always) private %decode_runtime_args__gce7d(v0.objref<@layout_18>) {
+func inline(always) private %decode_runtime_args__g2273(v0.objref<@layout_10>) -> @layout_5 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_88e5;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_9efd v3;
-        mstore v1 4.i256 i256;
-        br 0.i1 block2 block5;
-
-    block2:
-        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_b229;
-        unreachable;
-
-    block3:
-        jump block4;
-
-    block4:
-        call %decode_from_prechecked_head__g051e v3 4.i256 v5;
-        return;
-
-    block5:
-        mstore v2 v5 i256;
-        v14.i256 = mload v2 i256;
-        v15.i1 = gt 4.i256 v14;
-        br v15 block2 block3;
-}
-
-func inline(always) private %decode_runtime_args__g2273(v0.objref<@layout_18>) -> @layout_8 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v3.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_f89e;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_5742 v3;
+        v3.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_f89e;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_f197 v3;
         mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
 
@@ -5451,7 +5378,7 @@ func inline(always) private %decode_runtime_args__g2273(v0.objref<@layout_18>) -
         jump block4;
 
     block4:
-        v12.@layout_8 = call %decode_from_prechecked_head__g76d6 v3 4.i256 v5;
+        v12.@layout_5 = call %decode_from_prechecked_head__g76d6 v3 4.i256 v5;
         return v12;
 
     block5:
@@ -5461,195 +5388,15 @@ func inline(always) private %decode_runtime_args__g2273(v0.objref<@layout_18>) -
         br v16 block2 block3;
 }
 
-func inline(always) private %decode_runtime_args__g4e54(v0.objref<@layout_18>) -> @layout_13 {
+func inline(always) private %decode_runtime_args__gce2e(v0.objref<@layout_10>) {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_3dc9;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_ce93 v3;
-        mstore v1 4.i256 i256;
-        br 0.i1 block2 block5;
-
-    block2:
-        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_2f36;
-        unreachable;
-
-    block3:
-        jump block4;
-
-    block4:
-        v12.@layout_13 = call %decode_from_prechecked_head__g6690 v3 4.i256 v5;
-        return v12;
-
-    block5:
-        mstore v2 v5 i256;
-        v15.i256 = mload v2 i256;
-        v16.i1 = gt 100.i256 v15;
-        br v16 block2 block3;
-}
-
-func inline(always) private %decode_runtime_args__g698d(v0.objref<@layout_18>) -> @layout_12 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v3.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_d673;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_f03b v3;
-        mstore v1 4.i256 i256;
-        br 0.i1 block2 block5;
-
-    block2:
-        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_cb5c;
-        unreachable;
-
-    block3:
-        jump block4;
-
-    block4:
-        v12.@layout_12 = call %decode_from_prechecked_head__g7d8c v3 4.i256 v5;
-        return v12;
-
-    block5:
-        mstore v2 v5 i256;
-        v15.i256 = mload v2 i256;
-        v16.i1 = gt 68.i256 v15;
-        br v16 block2 block3;
-}
-
-func inline(always) private %decode_runtime_args__gc772(v0.objref<@layout_18>) -> @layout_6 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v3.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_3347;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_4a91 v3;
-        mstore v1 4.i256 i256;
-        br 0.i1 block2 block5;
-
-    block2:
-        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_12ed;
-        unreachable;
-
-    block3:
-        jump block4;
-
-    block4:
-        v12.@layout_6 = call %decode_from_prechecked_head__g5470 v3 4.i256 v5;
-        return v12;
-
-    block5:
-        mstore v2 v5 i256;
-        v15.i256 = mload v2 i256;
-        v16.i1 = gt 68.i256 v15;
-        br v16 block2 block3;
-}
-
-func inline(always) private %decode_runtime_args__g953d(v0.objref<@layout_18>) -> @layout_11 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v3.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_b73f;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_6107 v3;
-        mstore v1 4.i256 i256;
-        br 0.i1 block2 block5;
-
-    block2:
-        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_6993;
-        unreachable;
-
-    block3:
-        jump block4;
-
-    block4:
-        v12.@layout_11 = call %decode_from_prechecked_head__g7ea0 v3 4.i256 v5;
-        return v12;
-
-    block5:
-        mstore v2 v5 i256;
-        v15.i256 = mload v2 i256;
-        v16.i1 = gt 36.i256 v15;
-        br v16 block2 block3;
-}
-
-func inline(always) private %decode_runtime_args__g216b(v0.objref<@layout_18>) -> @layout_10 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v3.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_6a54;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_7388 v3;
-        mstore v1 4.i256 i256;
-        br 0.i1 block2 block5;
-
-    block2:
-        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_cf57;
-        unreachable;
-
-    block3:
-        jump block4;
-
-    block4:
-        v12.@layout_10 = call %decode_from_prechecked_head__gad59 v3 4.i256 v5;
-        return v12;
-
-    block5:
-        mstore v2 v5 i256;
-        v15.i256 = mload v2 i256;
-        v16.i1 = gt 68.i256 v15;
-        br v16 block2 block3;
-}
-
-func inline(always) private %decode_runtime_args__gf629(v0.objref<@layout_18>) -> @layout_9 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v3.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_e029;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_c018 v3;
-        mstore v1 4.i256 i256;
-        br 0.i1 block2 block5;
-
-    block2:
-        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_98a8;
-        unreachable;
-
-    block3:
-        jump block4;
-
-    block4:
-        v12.@layout_9 = call %decode_from_prechecked_head__g41f8 v3 4.i256 v5;
-        return v12;
-
-    block5:
-        mstore v2 v5 i256;
-        v15.i256 = mload v2 i256;
-        v16.i1 = gt 36.i256 v15;
-        br v16 block2 block3;
-}
-
-func inline(always) private %decode_runtime_args__gce2e(v0.objref<@layout_18>) {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v3.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_844a;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_b318 v3;
+        v3.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_844a;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_b402 v3;
         mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
 
@@ -5671,15 +5418,225 @@ func inline(always) private %decode_runtime_args__gce2e(v0.objref<@layout_18>) {
         br v15 block2 block3;
 }
 
-func inline(always) private %decode_runtime_args__ge035(v0.objref<@layout_18>) -> @layout_14 {
+func inline(always) private %decode_runtime_args__g7a2c(v0.objref<@layout_10>) -> @layout_5 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_dac7;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_1a14 v3;
+        v3.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_a580;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_d7d7 v3;
+        mstore v1 4.i256 i256;
+        br 0.i1 block2 block5;
+
+    block2:
+        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_ce6e;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        v12.@layout_5 = call %decode_from_prechecked_head__gab8c v3 4.i256 v5;
+        return v12;
+
+    block5:
+        mstore v2 v5 i256;
+        v15.i256 = mload v2 i256;
+        v16.i1 = gt 68.i256 v15;
+        br v16 block2 block3;
+}
+
+func inline(always) private %decode_runtime_args__g953d(v0.objref<@layout_10>) -> @layout_7 {
+    block0:
+        v1.*i256 = alloca i256;
+        v2.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v3.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_b73f;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_f6a9 v3;
+        mstore v1 4.i256 i256;
+        br 0.i1 block2 block5;
+
+    block2:
+        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_6993;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        v12.@layout_7 = call %decode_from_prechecked_head__g7ea0 v3 4.i256 v5;
+        return v12;
+
+    block5:
+        mstore v2 v5 i256;
+        v15.i256 = mload v2 i256;
+        v16.i1 = gt 36.i256 v15;
+        br v16 block2 block3;
+}
+
+func inline(always) private %decode_runtime_args__gc772(v0.objref<@layout_10>) -> @layout_4 {
+    block0:
+        v1.*i256 = alloca i256;
+        v2.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v3.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_3347;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_2c20 v3;
+        mstore v1 4.i256 i256;
+        br 0.i1 block2 block5;
+
+    block2:
+        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_12ed;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        v12.@layout_4 = call %decode_from_prechecked_head__g5470 v3 4.i256 v5;
+        return v12;
+
+    block5:
+        mstore v2 v5 i256;
+        v15.i256 = mload v2 i256;
+        v16.i1 = gt 68.i256 v15;
+        br v16 block2 block3;
+}
+
+func inline(always) private %decode_runtime_args__g6a7c(v0.objref<@layout_10>) -> @layout_5 {
+    block0:
+        v1.*i256 = alloca i256;
+        v2.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v3.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_663b;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_a0e3 v3;
+        mstore v1 4.i256 i256;
+        br 0.i1 block2 block5;
+
+    block2:
+        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_20f2;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        v12.@layout_5 = call %decode_from_prechecked_head__g383e v3 4.i256 v5;
+        return v12;
+
+    block5:
+        mstore v2 v5 i256;
+        v15.i256 = mload v2 i256;
+        v16.i1 = gt 68.i256 v15;
+        br v16 block2 block3;
+}
+
+func inline(always) private %decode_runtime_args__g5a0b(v0.objref<@layout_10>) {
+    block0:
+        v1.*i256 = alloca i256;
+        v2.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v3.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_cd56;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_d815 v3;
+        mstore v1 4.i256 i256;
+        br 0.i1 block2 block5;
+
+    block2:
+        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_57a6;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        call %decode_from_prechecked_head__g4997 v3 4.i256 v5;
+        return;
+
+    block5:
+        mstore v2 v5 i256;
+        v14.i256 = mload v2 i256;
+        v15.i1 = gt 4.i256 v14;
+        br v15 block2 block3;
+}
+
+func inline(always) private %decode_runtime_args__gce7d(v0.objref<@layout_10>) {
+    block0:
+        v1.*i256 = alloca i256;
+        v2.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v3.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_88e5;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_c091 v3;
+        mstore v1 4.i256 i256;
+        br 0.i1 block2 block5;
+
+    block2:
+        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_b229;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        call %decode_from_prechecked_head__g051e v3 4.i256 v5;
+        return;
+
+    block5:
+        mstore v2 v5 i256;
+        v14.i256 = mload v2 i256;
+        v15.i1 = gt 4.i256 v14;
+        br v15 block2 block3;
+}
+
+func inline(always) private %decode_runtime_args__g4e54(v0.objref<@layout_10>) -> @layout_6 {
+    block0:
+        v1.*i256 = alloca i256;
+        v2.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v3.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_3dc9;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_bbea v3;
+        mstore v1 4.i256 i256;
+        br 0.i1 block2 block5;
+
+    block2:
+        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_2f36;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        v12.@layout_6 = call %decode_from_prechecked_head__g6690 v3 4.i256 v5;
+        return v12;
+
+    block5:
+        mstore v2 v5 i256;
+        v15.i256 = mload v2 i256;
+        v16.i1 = gt 100.i256 v15;
+        br v16 block2 block3;
+}
+
+func inline(always) private %decode_runtime_args__ge035(v0.objref<@layout_10>) -> @layout_5 {
+    block0:
+        v1.*i256 = alloca i256;
+        v2.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v3.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_dac7;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_cea7 v3;
         mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
 
@@ -5691,7 +5648,7 @@ func inline(always) private %decode_runtime_args__ge035(v0.objref<@layout_18>) -
         jump block4;
 
     block4:
-        v12.@layout_14 = call %decode_from_prechecked_head__g205f v3 4.i256 v5;
+        v12.@layout_5 = call %decode_from_prechecked_head__g205f v3 4.i256 v5;
         return v12;
 
     block5:
@@ -5701,16 +5658,80 @@ func inline(always) private %decode_runtime_args__ge035(v0.objref<@layout_18>) -
         br v16 block2 block3;
 }
 
-func private %decoder_new(v0.@layout_2) -> @layout_4 {
+func inline(always) private %decode_runtime_args__gf629(v0.objref<@layout_10>) -> @layout_0 {
+    block0:
+        v1.*i256 = alloca i256;
+        v2.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v3.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_e029;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_8c59 v3;
+        mstore v1 4.i256 i256;
+        br 0.i1 block2 block5;
+
+    block2:
+        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_98a8;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        v12.@layout_0 = call %decode_from_prechecked_head__g41f8 v3 4.i256 v5;
+        return v12;
+
+    block5:
+        mstore v2 v5 i256;
+        v15.i256 = mload v2 i256;
+        v16.i1 = gt 36.i256 v15;
+        br v16 block2 block3;
+}
+
+func private %decoder_new(v0.@layout_1) -> @layout_3 {
     block0:
         jump block1;
 
     block1:
-        v2.@layout_4 = call %impl_SolDecoder__new__g463e v0;
+        v2.@layout_3 = call %impl_SolDecoder__new__g463e v0;
         return v2;
 }
 
-func private %emit__g9cd0(v0.@layout_19) {
+func inline(always) private %impl_trait_ApprovalEvent__emit__gcd5c(v0.@layout_6) {
+    block0:
+        jump block1;
+
+    block1:
+        v3.i256 = extract_value v0 2.i256;
+        v4.@layout_1 = call %std__lib__evm__effects__encode_abi_payload__ge513_a2dc v3;
+        v6.i256 = extract_value v4 0.i256;
+        v8.i256 = extract_value v4 1.i256;
+        v10.@layout_0 = extract_value v0 0.i256;
+        v11.i256 = call %std__lib__abi__sol__types__impl_trait_Address_0a07__as_topic_d26a v10;
+        v12.@layout_0 = extract_value v0 1.i256;
+        v13.i256 = call %std__lib__abi__sol__types__impl_trait_Address_0a07__as_topic_d26a v12;
+        call %std__lib__evm__effects__impl_trait_Evm_476c__log3_ebb3 v6 v8 3682740849240848158437977969522068712009226744993583420104789809440898259342.i256 v11 v13;
+        return;
+}
+
+func inline(always) private %impl_trait_TransferEvent__emit__gcd5c(v0.@layout_6) {
+    block0:
+        jump block1;
+
+    block1:
+        v3.i256 = extract_value v0 2.i256;
+        v4.@layout_1 = call %std__lib__evm__effects__encode_abi_payload__ge513_3306 v3;
+        v6.i256 = extract_value v4 0.i256;
+        v8.i256 = extract_value v4 1.i256;
+        v10.@layout_0 = extract_value v0 0.i256;
+        v11.i256 = call %std__lib__abi__sol__types__impl_trait_Address_0a07__as_topic_102e v10;
+        v12.@layout_0 = extract_value v0 1.i256;
+        v13.i256 = call %std__lib__abi__sol__types__impl_trait_Address_0a07__as_topic_102e v12;
+        call %std__lib__evm__effects__impl_trait_Evm_476c__log3_89cc v6 v8 -9523714936405215257252364384647749786687397661936385964149718923739779436176.i256 v11 v13;
+        return;
+}
+
+func private %emit__g9cd0(v0.@layout_6) {
     block0:
         jump block1;
 
@@ -5719,41 +5740,7 @@ func private %emit__g9cd0(v0.@layout_19) {
         return;
 }
 
-func inline(always) private %impl_trait_ApprovalEvent__emit__gcd5c(v0.@layout_19) {
-    block0:
-        jump block1;
-
-    block1:
-        v3.i256 = extract_value v0 2.i256;
-        v4.@layout_21 = call %std__lib__evm__effects__encode_abi_payload__ge513_a2dc v3;
-        v6.i256 = extract_value v4 0.i256;
-        v8.i256 = extract_value v4 1.i256;
-        v10.@layout_0 = extract_value v0 0.i256;
-        v11.i256 = call %std__lib__abi__sol__types__impl_trait_Address_0a07__as_topic_d053 v10;
-        v12.@layout_0 = extract_value v0 1.i256;
-        v13.i256 = call %std__lib__abi__sol__types__impl_trait_Address_0a07__as_topic_d053 v12;
-        call %std__lib__evm__effects__impl_trait_Evm_476c__log3_ebb3 v6 v8 3682740849240848158437977969522068712009226744993583420104789809440898259342.i256 v11 v13;
-        return;
-}
-
-func inline(always) private %impl_trait_TransferEvent__emit__gcd5c(v0.@layout_20) {
-    block0:
-        jump block1;
-
-    block1:
-        v3.i256 = extract_value v0 2.i256;
-        v4.@layout_21 = call %std__lib__evm__effects__encode_abi_payload__ge513_3306 v3;
-        v6.i256 = extract_value v4 0.i256;
-        v8.i256 = extract_value v4 1.i256;
-        v10.@layout_0 = extract_value v0 0.i256;
-        v11.i256 = call %std__lib__abi__sol__types__impl_trait_Address_0a07__as_topic_4475 v10;
-        v12.@layout_0 = extract_value v0 1.i256;
-        v13.i256 = call %std__lib__abi__sol__types__impl_trait_Address_0a07__as_topic_4475 v12;
-        call %std__lib__evm__effects__impl_trait_Evm_476c__log3_89cc v6 v8 -9523714936405215257252364384647749786687397661936385964149718923739779436176.i256 v11 v13;
-        return;
-}
-
-func private %emit__g4c3d(v0.@layout_20) {
+func private %emit__g4c3d(v0.@layout_6) {
     block0:
         jump block1;
 
@@ -5762,105 +5749,13 @@ func private %emit__g4c3d(v0.@layout_20) {
         return;
 }
 
-func private %core__lib__abi__impl_trait_u256_d99e__encode__g426c_116b(v0.i256, v1.objref<@layout_1>) {
+func private %core__lib__abi__impl_trait_u256_d99e__encode__g426c_18aa(v0.i256, v1.objref<@layout_1>) {
     block0:
         jump block1;
 
     block1:
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_eba3 v1 v0;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_d1f3 v1 v0;
         return;
-}
-
-func private %core__lib__abi__impl_trait_u256_d99e__encode__g426c_270a(v0.i256, v1.objref<@layout_1>) {
-    block0:
-        jump block1;
-
-    block1:
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_798d v1 v0;
-        return;
-}
-
-func private %encode__g3cd9(v0.i256, v1.objref<@layout_1>) {
-    block0:
-        jump block1;
-
-    block1:
-        v3.i256 = call %core__lib__num__impl_trait_String_8f88__to_word__g3eb7_4283 v0;
-        v4.i256 = call %core__lib__abi__packed_string_len_c13a v3;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_0617 v1 v4;
-        v8.i1 = eq v4 0.i256;
-        v9.i1 = is_zero v8;
-        br v9 block2 block3;
-
-    block2:
-        v11.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_8751 v1;
-        v13.i256 = add v11 32.i256;
-        v15.i256 = sub 32.i256 v4;
-        v17.i256 = mul v15 8.i256;
-        v19.i256 = shl v17 v3;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_at_e460 v1 v13 v19;
-        jump block4;
-
-    block3:
-        jump block4;
-
-    block4:
-        return;
-}
-
-func private %core__lib__abi__impl_trait_u256_d99e__encode__g426c_2910(v0.i256, v1.objref<@layout_1>) {
-    block0:
-        jump block1;
-
-    block1:
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_8eda v1 v0;
-        return;
-}
-
-func private %encode__gbe21(v0.i256, v1.objref<@layout_1>) {
-    block0:
-        jump block1;
-
-    block1:
-        v3.i256 = call %core__lib__num__impl_trait_String_8f88__to_word__gc7cf_de49 v0;
-        v4.i256 = call %core__lib__abi__packed_string_len_29ef v3;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_7a95 v1 v4;
-        v8.i1 = eq v4 0.i256;
-        v9.i1 = is_zero v8;
-        br v9 block2 block3;
-
-    block2:
-        v11.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_bb09 v1;
-        v13.i256 = add v11 32.i256;
-        v15.i256 = sub 32.i256 v4;
-        v17.i256 = mul v15 8.i256;
-        v19.i256 = shl v17 v3;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_at_7ecd v1 v13 v19;
-        jump block4;
-
-    block3:
-        jump block4;
-
-    block4:
-        return;
-}
-
-func private %std__lib__evm__effects__encode_abi_payload__ge513_3306(v0.i256) -> @layout_21 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.@layout_21 = call %core__lib__abi__encode_alloc__gac80_5c94 v0;
-        return v2;
-}
-
-func private %std__lib__evm__effects__encode_abi_payload__ge513_a2dc(v0.i256) -> @layout_21 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.@layout_21 = call %core__lib__abi__encode_alloc__gac80_4157 v0;
-        return v2;
 }
 
 func private %impl_trait_u8__encode__g426c(v0.i8, v1.objref<@layout_1>) {
@@ -5869,11 +5764,38 @@ func private %impl_trait_u8__encode__g426c(v0.i8, v1.objref<@layout_1>) {
 
     block1:
         v3.i256 = zext v0 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_124f v1 v3;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_bbc2 v1 v3;
         return;
 }
 
-func inline(always) private %core__lib__abi__encode_alloc__gac80_4157(v0.i256) -> @layout_21 {
+func private %core__lib__abi__impl_trait_u256_d99e__encode__g426c_7413(v0.i256, v1.objref<@layout_1>) {
+    block0:
+        jump block1;
+
+    block1:
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_9351 v1 v0;
+        return;
+}
+
+func private %std__lib__evm__effects__encode_abi_payload__ge513_3306(v0.i256) -> @layout_1 {
+    block0:
+        jump block1;
+
+    block1:
+        v2.@layout_1 = call %core__lib__abi__encode_alloc__gac80_5c94 v0;
+        return v2;
+}
+
+func private %std__lib__evm__effects__encode_abi_payload__ge513_a2dc(v0.i256) -> @layout_1 {
+    block0:
+        jump block1;
+
+    block1:
+        v2.@layout_1 = call %core__lib__abi__encode_alloc__gac80_4157 v0;
+        return v2;
+}
+
+func inline(always) private %core__lib__abi__encode_alloc__gac80_4157(v0.i256) -> @layout_1 {
     block0:
         jump block1;
 
@@ -5887,14 +5809,14 @@ func inline(always) private %core__lib__abi__encode_alloc__gac80_4157(v0.i256) -
         v9.objref<i256> = obj.proj v4 1.i256;
         v10.i256 = extract_value v3 1.i256;
         obj.store v9 v10;
-        v11.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_9c4a v4;
-        call %core__lib__abi__impl_trait_u256_d99e__encode__g426c_116b v0 v4;
-        v14.@layout_21 = insert_value undef.@layout_21 0.i256 v11;
-        v15.@layout_21 = insert_value v14 1.i256 v2;
+        v11.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_57cd v4;
+        call %core__lib__abi__impl_trait_u256_d99e__encode__g426c_bc5c v0 v4;
+        v14.@layout_1 = insert_value undef.@layout_1 0.i256 v11;
+        v15.@layout_1 = insert_value v14 1.i256 v2;
         return v15;
 }
 
-func inline(always) private %core__lib__abi__encode_alloc__gac80_5c94(v0.i256) -> @layout_21 {
+func inline(always) private %core__lib__abi__encode_alloc__gac80_5c94(v0.i256) -> @layout_1 {
     block0:
         jump block1;
 
@@ -5908,11 +5830,76 @@ func inline(always) private %core__lib__abi__encode_alloc__gac80_5c94(v0.i256) -
         v9.objref<i256> = obj.proj v4 1.i256;
         v10.i256 = extract_value v3 1.i256;
         obj.store v9 v10;
-        v11.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_1fbd v4;
-        call %core__lib__abi__impl_trait_u256_d99e__encode__g426c_270a v0 v4;
-        v14.@layout_21 = insert_value undef.@layout_21 0.i256 v11;
-        v15.@layout_21 = insert_value v14 1.i256 v2;
+        v11.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_4803 v4;
+        call %core__lib__abi__impl_trait_u256_d99e__encode__g426c_7413 v0 v4;
+        v14.@layout_1 = insert_value undef.@layout_1 0.i256 v11;
+        v15.@layout_1 = insert_value v14 1.i256 v2;
         return v15;
+}
+
+func private %encode__g3cd9(v0.i256, v1.objref<@layout_1>) {
+    block0:
+        jump block1;
+
+    block1:
+        v3.i256 = call %core__lib__num__impl_trait_String_8f88__to_word__g3eb7_4283 v0;
+        v4.i256 = call %core__lib__abi__packed_string_len_c13a v3;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_19ab v1 v4;
+        v8.i1 = eq v4 0.i256;
+        v9.i1 = is_zero v8;
+        br v9 block2 block3;
+
+    block2:
+        v11.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_7bd0 v1;
+        v13.i256 = add v11 32.i256;
+        v15.i256 = sub 32.i256 v4;
+        v17.i256 = mul v15 8.i256;
+        v19.i256 = shl v17 v3;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_at_7077 v1 v13 v19;
+        jump block4;
+
+    block3:
+        jump block4;
+
+    block4:
+        return;
+}
+
+func private %core__lib__abi__impl_trait_u256_d99e__encode__g426c_bc5c(v0.i256, v1.objref<@layout_1>) {
+    block0:
+        jump block1;
+
+    block1:
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_d00a v1 v0;
+        return;
+}
+
+func private %encode__gbe21(v0.i256, v1.objref<@layout_1>) {
+    block0:
+        jump block1;
+
+    block1:
+        v3.i256 = call %core__lib__num__impl_trait_String_8f88__to_word__gc7cf_de49 v0;
+        v4.i256 = call %core__lib__abi__packed_string_len_29ef v3;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_d10d v1 v4;
+        v8.i1 = eq v4 0.i256;
+        v9.i1 = is_zero v8;
+        br v9 block2 block3;
+
+    block2:
+        v11.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_eb78 v1;
+        v13.i256 = add v11 32.i256;
+        v15.i256 = sub 32.i256 v4;
+        v17.i256 = mul v15 8.i256;
+        v19.i256 = shl v17 v3;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_at_1360 v1 v13 v19;
+        jump block4;
+
+    block3:
+        jump block4;
+
+    block4:
+        return;
 }
 
 func private %impl_trait_bool__encode__g426c(v0.i1, v1.objref<@layout_1>) {
@@ -5923,61 +5910,14 @@ func private %impl_trait_bool__encode__g426c(v0.i1, v1.objref<@layout_1>) {
         br v0 block2 block3;
 
     block2:
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_d813 v1 1.i256;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_4130 v1 1.i256;
         jump block4;
 
     block3:
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_d813 v1 0.i256;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_4130 v1 0.i256;
         jump block4;
 
     block4:
-        return;
-}
-
-func private %encode_field__g0a88(v0.i8, v1.objref<@layout_1>, v2.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        br 0.i1 block2 block3;
-
-    block2:
-        v5.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_a9a0 v1;
-        v8.i256 = call %core__lib__abi__trait_AbiSize__payload_size__g79ff_f3e8 v0;
-        v9.i256 = mload v2 i256;
-        v10.i256 = sub v9 v5;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_7b53 v1 v10;
-        v12.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_7b90 v1;
-        v13.i256 = mload v2 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_844b v1 v13;
-        v15.i256 = mload v2 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_0f4a v1 v15;
-        call %impl_trait_u8__encode__g426c v0 v1;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_844b v1 v5;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_0f4a v1 v12;
-        v20.i256 = mload v2 i256;
-        v21.i256 = add v20 v8;
-        mstore v2 v21 i256;
-        return;
-
-    block3:
-        jump block4;
-
-    block4:
-        br 1.i1 block5 block6;
-
-    block5:
-        v24.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_7b90 v1;
-        call %impl_trait_u8__encode_to_ptr__gf13e v0 v24;
-        v28.i256 = add v24 32.i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_0f4a v1 v28;
-        return;
-
-    block6:
-        jump block7;
-
-    block7:
-        call %impl_trait_u8__encode__g426c v0 v1;
         return;
 }
 
@@ -5989,19 +5929,19 @@ func private %encode_field__ge927(v0.i1, v1.objref<@layout_1>, v2.i256) {
         br 0.i1 block2 block3;
 
     block2:
-        v5.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_c13e v1;
+        v5.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_1580 v1;
         v8.i256 = call %core__lib__abi__trait_AbiSize__payload_size__gda9b_b33d v0;
         v9.i256 = mload v2 i256;
         v10.i256 = sub v9 v5;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_aa60 v1 v10;
-        v12.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_6cac v1;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_2812 v1 v10;
+        v12.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_4526 v1;
         v13.i256 = mload v2 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_cc2c v1 v13;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_22b1 v1 v13;
         v15.i256 = mload v2 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_b6ef v1 v15;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_73c1 v1 v15;
         call %impl_trait_bool__encode__g426c v0 v1;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_cc2c v1 v5;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_b6ef v1 v12;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_22b1 v1 v5;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_73c1 v1 v12;
         v20.i256 = mload v2 i256;
         v21.i256 = add v20 v8;
         mstore v2 v21 i256;
@@ -6014,10 +5954,10 @@ func private %encode_field__ge927(v0.i1, v1.objref<@layout_1>, v2.i256) {
         br 1.i1 block5 block6;
 
     block5:
-        v24.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_6cac v1;
+        v24.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_4526 v1;
         call %impl_trait_bool__encode_to_ptr__gf13e v0 v24;
         v28.i256 = add v24 32.i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_b6ef v1 v28;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_73c1 v1 v28;
         return;
 
     block6:
@@ -6025,98 +5965,6 @@ func private %encode_field__ge927(v0.i1, v1.objref<@layout_1>, v2.i256) {
 
     block7:
         call %impl_trait_bool__encode__g426c v0 v1;
-        return;
-}
-
-func private %encode_field__g2e64(v0.i256, v1.objref<@layout_1>, v2.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        br 0.i1 block2 block3;
-
-    block2:
-        v5.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_fd6f v1;
-        v8.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_77e5 v0;
-        v9.i256 = mload v2 i256;
-        v10.i256 = sub v9 v5;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_8f67 v1 v10;
-        v12.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_0de4 v1;
-        v13.i256 = mload v2 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_fa20 v1 v13;
-        v15.i256 = mload v2 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_3857 v1 v15;
-        call %core__lib__abi__impl_trait_u256_d99e__encode__g426c_2910 v0 v1;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_fa20 v1 v5;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_3857 v1 v12;
-        v20.i256 = mload v2 i256;
-        v21.i256 = add v20 v8;
-        mstore v2 v21 i256;
-        return;
-
-    block3:
-        jump block4;
-
-    block4:
-        br 1.i1 block5 block6;
-
-    block5:
-        v24.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_0de4 v1;
-        call %impl_trait_u256__encode_to_ptr__gf13e v0 v24;
-        v28.i256 = add v24 32.i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_3857 v1 v28;
-        return;
-
-    block6:
-        jump block7;
-
-    block7:
-        call %core__lib__abi__impl_trait_u256_d99e__encode__g426c_2910 v0 v1;
-        return;
-}
-
-func private %encode_field__g6d7e(v0.i256, v1.objref<@layout_1>, v2.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        br 1.i1 block2 block3;
-
-    block2:
-        v5.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_6030 v1;
-        v8.i256 = call %core__lib__abi__impl_trait_String_c06e__payload_size__gc7cf_4aab v0;
-        v9.i256 = mload v2 i256;
-        v10.i256 = sub v9 v5;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_406d v1 v10;
-        v12.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_324d v1;
-        v13.i256 = mload v2 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_750c v1 v13;
-        v15.i256 = mload v2 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_597d v1 v15;
-        call %encode__gbe21 v0 v1;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_750c v1 v5;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_597d v1 v12;
-        v20.i256 = mload v2 i256;
-        v21.i256 = add v20 v8;
-        mstore v2 v21 i256;
-        return;
-
-    block3:
-        jump block4;
-
-    block4:
-        br 0.i1 block5 block6;
-
-    block5:
-        v24.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_324d v1;
-        call %encode_to_ptr__g30cc v0 v24;
-        unreachable;
-
-    block6:
-        jump block7;
-
-    block7:
-        call %encode__gbe21 v0 v1;
         return;
 }
 
@@ -6128,19 +5976,19 @@ func private %encode_field__g859f(v0.i256, v1.objref<@layout_1>, v2.i256) {
         br 1.i1 block2 block3;
 
     block2:
-        v5.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_25d4 v1;
+        v5.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_61c3 v1;
         v8.i256 = call %core__lib__abi__impl_trait_String_c06e__payload_size__g3eb7_f656 v0;
         v9.i256 = mload v2 i256;
         v10.i256 = sub v9 v5;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_1ad1 v1 v10;
-        v12.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_d8ed v1;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_0ae5 v1 v10;
+        v12.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_6701 v1;
         v13.i256 = mload v2 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_c5ff v1 v13;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_1e89 v1 v13;
         v15.i256 = mload v2 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_7410 v1 v15;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_3e1f v1 v15;
         call %encode__g3cd9 v0 v1;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_c5ff v1 v5;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_7410 v1 v12;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_1e89 v1 v5;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_3e1f v1 v12;
         v20.i256 = mload v2 i256;
         v21.i256 = add v20 v8;
         mstore v2 v21 i256;
@@ -6153,7 +6001,7 @@ func private %encode_field__g859f(v0.i256, v1.objref<@layout_1>, v2.i256) {
         br 0.i1 block5 block6;
 
     block5:
-        v24.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_d8ed v1;
+        v24.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_6701 v1;
         call %encode_to_ptr__g4320 v0 v24;
         unreachable;
 
@@ -6165,59 +6013,142 @@ func private %encode_field__g859f(v0.i256, v1.objref<@layout_1>, v2.i256) {
         return;
 }
 
-func private %encode_single_root__ge927(v0.i1, v1.objref<@layout_1>) {
+func private %encode_field__g6d7e(v0.i256, v1.objref<@layout_1>, v2.i256) {
     block0:
-        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_c13e v1;
-        v6.i256 = add v4 32.i256;
-        mstore v2 v6 i256;
-        v7.i256 = ptr_to_int v2 i256;
-        call %encode_field__ge927 v0 v1 v7;
+        br 1.i1 block2 block3;
+
+    block2:
+        v5.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_e214 v1;
+        v8.i256 = call %core__lib__abi__impl_trait_String_c06e__payload_size__gc7cf_4aab v0;
+        v9.i256 = mload v2 i256;
+        v10.i256 = sub v9 v5;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_90db v1 v10;
+        v12.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_8ab3 v1;
+        v13.i256 = mload v2 i256;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_24e6 v1 v13;
+        v15.i256 = mload v2 i256;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_347a v1 v15;
+        call %encode__gbe21 v0 v1;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_24e6 v1 v5;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_347a v1 v12;
+        v20.i256 = mload v2 i256;
+        v21.i256 = add v20 v8;
+        mstore v2 v21 i256;
+        return;
+
+    block3:
+        jump block4;
+
+    block4:
+        br 0.i1 block5 block6;
+
+    block5:
+        v24.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_8ab3 v1;
+        call %encode_to_ptr__g30cc v0 v24;
+        unreachable;
+
+    block6:
+        jump block7;
+
+    block7:
+        call %encode__gbe21 v0 v1;
         return;
 }
 
-func private %encode_single_root__g0a88(v0.i8, v1.objref<@layout_1>) {
+func private %encode_field__g2e64(v0.i256, v1.objref<@layout_1>, v2.i256) {
     block0:
-        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_a9a0 v1;
-        v6.i256 = add v4 32.i256;
-        mstore v2 v6 i256;
-        v7.i256 = ptr_to_int v2 i256;
-        call %encode_field__g0a88 v0 v1 v7;
+        br 0.i1 block2 block3;
+
+    block2:
+        v5.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_117c v1;
+        v8.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_77e5 v0;
+        v9.i256 = mload v2 i256;
+        v10.i256 = sub v9 v5;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_586c v1 v10;
+        v12.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_a94d v1;
+        v13.i256 = mload v2 i256;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_2121 v1 v13;
+        v15.i256 = mload v2 i256;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_75cf v1 v15;
+        call %core__lib__abi__impl_trait_u256_d99e__encode__g426c_18aa v0 v1;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_2121 v1 v5;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_75cf v1 v12;
+        v20.i256 = mload v2 i256;
+        v21.i256 = add v20 v8;
+        mstore v2 v21 i256;
+        return;
+
+    block3:
+        jump block4;
+
+    block4:
+        br 1.i1 block5 block6;
+
+    block5:
+        v24.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_a94d v1;
+        call %impl_trait_u256__encode_to_ptr__gf13e v0 v24;
+        v28.i256 = add v24 32.i256;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_75cf v1 v28;
+        return;
+
+    block6:
+        jump block7;
+
+    block7:
+        call %core__lib__abi__impl_trait_u256_d99e__encode__g426c_18aa v0 v1;
         return;
 }
 
-func private %encode_single_root__g859f(v0.i256, v1.objref<@layout_1>) {
+func private %encode_field__g0a88(v0.i8, v1.objref<@layout_1>, v2.i256) {
     block0:
-        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_25d4 v1;
-        v6.i256 = add v4 32.i256;
-        mstore v2 v6 i256;
-        v7.i256 = ptr_to_int v2 i256;
-        call %encode_field__g859f v0 v1 v7;
+        br 0.i1 block2 block3;
+
+    block2:
+        v5.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_b8b6 v1;
+        v8.i256 = call %core__lib__abi__trait_AbiSize__payload_size__g79ff_f3e8 v0;
+        v9.i256 = mload v2 i256;
+        v10.i256 = sub v9 v5;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_50ef v1 v10;
+        v12.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_06d1 v1;
+        v13.i256 = mload v2 i256;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_065d v1 v13;
+        v15.i256 = mload v2 i256;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_9125 v1 v15;
+        call %impl_trait_u8__encode__g426c v0 v1;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_065d v1 v5;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_9125 v1 v12;
+        v20.i256 = mload v2 i256;
+        v21.i256 = add v20 v8;
+        mstore v2 v21 i256;
         return;
-}
 
-func private %encode_single_root__g6d7e(v0.i256, v1.objref<@layout_1>) {
-    block0:
-        v2.*i256 = alloca i256;
-        jump block1;
+    block3:
+        jump block4;
 
-    block1:
-        v4.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_6030 v1;
-        v6.i256 = add v4 32.i256;
-        mstore v2 v6 i256;
-        v7.i256 = ptr_to_int v2 i256;
-        call %encode_field__g6d7e v0 v1 v7;
+    block4:
+        br 1.i1 block5 block6;
+
+    block5:
+        v24.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_06d1 v1;
+        call %impl_trait_u8__encode_to_ptr__gf13e v0 v24;
+        v28.i256 = add v24 32.i256;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_9125 v1 v28;
+        return;
+
+    block6:
+        jump block7;
+
+    block7:
+        call %impl_trait_u8__encode__g426c v0 v1;
         return;
 }
 
@@ -6227,7 +6158,7 @@ func private %encode_single_root__g2e64(v0.i256, v1.objref<@layout_1>) {
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_fd6f v1;
+        v4.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_117c v1;
         v6.i256 = add v4 32.i256;
         mstore v2 v6 i256;
         v7.i256 = ptr_to_int v2 i256;
@@ -6235,7 +6166,35 @@ func private %encode_single_root__g2e64(v0.i256, v1.objref<@layout_1>) {
         return;
 }
 
-func private %encode_single_root_alloc__gcb0a(v0.i8) -> @layout_21 {
+func private %encode_single_root__ge927(v0.i1, v1.objref<@layout_1>) {
+    block0:
+        v2.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v4.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_1580 v1;
+        v6.i256 = add v4 32.i256;
+        mstore v2 v6 i256;
+        v7.i256 = ptr_to_int v2 i256;
+        call %encode_field__ge927 v0 v1 v7;
+        return;
+}
+
+func private %encode_single_root__g6d7e(v0.i256, v1.objref<@layout_1>) {
+    block0:
+        v2.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v4.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_e214 v1;
+        v6.i256 = add v4 32.i256;
+        mstore v2 v6 i256;
+        v7.i256 = ptr_to_int v2 i256;
+        call %encode_field__g6d7e v0 v1 v7;
+        return;
+}
+
+func private %encode_single_root_alloc__gcb0a(v0.i8) -> @layout_1 {
     block0:
         jump block1;
 
@@ -6249,14 +6208,14 @@ func private %encode_single_root_alloc__gcb0a(v0.i8) -> @layout_21 {
         v9.objref<i256> = obj.proj v4 1.i256;
         v10.i256 = extract_value v3 1.i256;
         obj.store v9 v10;
-        v11.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_a9a0 v4;
+        v11.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_b8b6 v4;
         call %encode_single_root__g0a88 v0 v4;
-        v14.@layout_21 = insert_value undef.@layout_21 0.i256 v11;
-        v15.@layout_21 = insert_value v14 1.i256 v2;
+        v14.@layout_1 = insert_value undef.@layout_1 0.i256 v11;
+        v15.@layout_1 = insert_value v14 1.i256 v2;
         return v15;
 }
 
-func private %encode_single_root_alloc__gac80(v0.i256) -> @layout_21 {
+func private %encode_single_root_alloc__gac80(v0.i256) -> @layout_1 {
     block0:
         jump block1;
 
@@ -6270,14 +6229,14 @@ func private %encode_single_root_alloc__gac80(v0.i256) -> @layout_21 {
         v9.objref<i256> = obj.proj v4 1.i256;
         v10.i256 = extract_value v3 1.i256;
         obj.store v9 v10;
-        v11.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_fd6f v4;
+        v11.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_117c v4;
         call %encode_single_root__g2e64 v0 v4;
-        v14.@layout_21 = insert_value undef.@layout_21 0.i256 v11;
-        v15.@layout_21 = insert_value v14 1.i256 v2;
+        v14.@layout_1 = insert_value undef.@layout_1 0.i256 v11;
+        v15.@layout_1 = insert_value v14 1.i256 v2;
         return v15;
 }
 
-func private %encode_single_root_alloc__g0c18(v0.i256) -> @layout_21 {
+func private %encode_single_root_alloc__g0c18(v0.i256) -> @layout_1 {
     block0:
         jump block1;
 
@@ -6291,14 +6250,14 @@ func private %encode_single_root_alloc__g0c18(v0.i256) -> @layout_21 {
         v9.objref<i256> = obj.proj v4 1.i256;
         v10.i256 = extract_value v3 1.i256;
         obj.store v9 v10;
-        v11.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_6030 v4;
+        v11.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_e214 v4;
         call %encode_single_root__g6d7e v0 v4;
-        v14.@layout_21 = insert_value undef.@layout_21 0.i256 v11;
-        v15.@layout_21 = insert_value v14 1.i256 v2;
+        v14.@layout_1 = insert_value undef.@layout_1 0.i256 v11;
+        v15.@layout_1 = insert_value v14 1.i256 v2;
         return v15;
 }
 
-func private %encode_single_root_alloc__g09ca(v0.i1) -> @layout_21 {
+func private %encode_single_root_alloc__g09ca(v0.i1) -> @layout_1 {
     block0:
         jump block1;
 
@@ -6312,14 +6271,14 @@ func private %encode_single_root_alloc__g09ca(v0.i1) -> @layout_21 {
         v9.objref<i256> = obj.proj v4 1.i256;
         v10.i256 = extract_value v3 1.i256;
         obj.store v9 v10;
-        v11.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_c13e v4;
+        v11.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_1580 v4;
         call %encode_single_root__ge927 v0 v4;
-        v14.@layout_21 = insert_value undef.@layout_21 0.i256 v11;
-        v15.@layout_21 = insert_value v14 1.i256 v2;
+        v14.@layout_1 = insert_value undef.@layout_1 0.i256 v11;
+        v15.@layout_1 = insert_value v14 1.i256 v2;
         return v15;
 }
 
-func private %encode_single_root_alloc__g472d(v0.i256) -> @layout_21 {
+func private %encode_single_root_alloc__g472d(v0.i256) -> @layout_1 {
     block0:
         jump block1;
 
@@ -6333,11 +6292,39 @@ func private %encode_single_root_alloc__g472d(v0.i256) -> @layout_21 {
         v9.objref<i256> = obj.proj v4 1.i256;
         v10.i256 = extract_value v3 1.i256;
         obj.store v9 v10;
-        v11.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_25d4 v4;
+        v11.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_61c3 v4;
         call %encode_single_root__g859f v0 v4;
-        v14.@layout_21 = insert_value undef.@layout_21 0.i256 v11;
-        v15.@layout_21 = insert_value v14 1.i256 v2;
+        v14.@layout_1 = insert_value undef.@layout_1 0.i256 v11;
+        v15.@layout_1 = insert_value v14 1.i256 v2;
         return v15;
+}
+
+func private %encode_single_root__g0a88(v0.i8, v1.objref<@layout_1>) {
+    block0:
+        v2.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v4.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_b8b6 v1;
+        v6.i256 = add v4 32.i256;
+        mstore v2 v6 i256;
+        v7.i256 = ptr_to_int v2 i256;
+        call %encode_field__g0a88 v0 v1 v7;
+        return;
+}
+
+func private %encode_single_root__g859f(v0.i256, v1.objref<@layout_1>) {
+    block0:
+        v2.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v4.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_61c3 v1;
+        v6.i256 = add v4 32.i256;
+        mstore v2 v6 i256;
+        v7.i256 = ptr_to_int v2 i256;
+        call %encode_field__g859f v0 v1 v7;
+        return;
 }
 
 func private %impl_trait_u256__encode_to_ptr__gf13e(v0.i256, v1.i256) {
@@ -6518,6 +6505,15 @@ func private %impl_trait_bool__from_word(v0.i256) -> i1 {
         return v4;
 }
 
+func inline(always) private %get__gc9ba(v0.@layout_8, v1.i256) -> i1 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.i1 = call %get_unchecked__gc9ba v0 v1;
+        return v4;
+}
+
 func inline(always) private %get__g636d(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
@@ -6527,25 +6523,25 @@ func inline(always) private %get__g636d(v0.@layout_0, v1.i256) -> i256 {
         return v4;
 }
 
-func inline(always) private %get__gc9ba(v0.@layout_16, v1.i256) -> i1 {
+func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__get__g94db_61a4(v0.@layout_4, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v4.i1 = call %get_unchecked__gc9ba v0 v1;
+        v4.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get_unchecked__g94db_c7cc v0 v1;
         return v4;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__get__g94db_552a(v0.@layout_22, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__get__g94db_6651(v0.@layout_4, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get_unchecked__g94db_6563 v0 v1;
+        v4.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get_unchecked__g94db_fd0a v0 v1;
         return v4;
 }
 
-func inline(always) private %get__ge2d3(v0.@layout_22, v1.i256) -> i256 {
+func inline(always) private %get__ge2d3(v0.@layout_4, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -6563,66 +6559,17 @@ func inline(always) private %get__gbae5(v0.@layout_0, v1.i256) -> i256 {
         return v4;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__get__g94db_c935(v0.@layout_22, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get_unchecked__g94db_43a6 v0 v1;
-        return v4;
-}
-
-func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__get_unchecked__g94db_43a6(v0.@layout_22, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__storage_map__storagemap_get_word_with_salt__g7bf4_af75 v0 2.i256;
-        v5.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__from_word_83e7 v4;
-        return v5;
-}
-
-func inline(always) private %get_unchecked__gbae5(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__storage_map__storagemap_get_word_with_salt__g67a8_cb7c v0 v1;
-        v5.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__from_word_db05 v4;
-        return v5;
-}
-
-func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__get_unchecked__g94db_6563(v0.@layout_22, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__storage_map__storagemap_get_word_with_salt__g7bf4_d4e7_0 v0 2.i256;
-        v5.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__from_word_896a_0 v4;
-        return v5;
-}
-
 func inline(always) private %get_unchecked__g636d(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__storage_map__storagemap_get_word_with_salt__g67a8_4599 v0 1.i256;
+        v4.i256 = call %std__lib__evm__storage_map__storagemap_get_word_with_salt__g67a8_bb80 v0 1.i256;
         v5.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__from_word_c764 v4;
         return v5;
 }
 
-func inline(always) private %get_unchecked__ge2d3(v0.@layout_22, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__storage_map__storagemap_get_word_with_salt__g7bf4_d4e7 v0 v1;
-        v5.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__from_word_896a v4;
-        return v5;
-}
-
-func inline(always) private %get_unchecked__gc9ba(v0.@layout_16, v1.i256) -> i1 {
+func inline(always) private %get_unchecked__gc9ba(v0.@layout_8, v1.i256) -> i1 {
     block0:
         jump block1;
 
@@ -6632,144 +6579,184 @@ func inline(always) private %get_unchecked__gc9ba(v0.@layout_16, v1.i256) -> i1 
         return v5;
 }
 
+func inline(always) private %get_unchecked__gbae5(v0.@layout_0, v1.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.i256 = call %std__lib__evm__storage_map__storagemap_get_word_with_salt__g67a8_bc66 v0 v1;
+        v5.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__from_word_db05 v4;
+        return v5;
+}
+
+func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__get_unchecked__g94db_c7cc(v0.@layout_4, v1.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.i256 = call %std__lib__evm__storage_map__storagemap_get_word_with_salt__g7bf4_b354 v0 2.i256;
+        v5.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__from_word_83e7 v4;
+        return v5;
+}
+
+func inline(always) private %get_unchecked__ge2d3(v0.@layout_4, v1.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.i256 = call %std__lib__evm__storage_map__storagemap_get_word_with_salt__g7bf4_16a4 v0 v1;
+        v5.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__from_word_896a v4;
+        return v5;
+}
+
+func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__get_unchecked__g94db_fd0a(v0.@layout_4, v1.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.i256 = call %std__lib__evm__storage_map__storagemap_get_word_with_salt__g7bf4_16a4_0 v0 2.i256;
+        v5.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__from_word_896a_0 v4;
+        return v5;
+}
+
 func private %grant(v0.i256, v1.@layout_0, v2.i256) {
     block0:
         jump block1;
 
     block1:
-        v8.@layout_16 = insert_value undef.@layout_16 0.i256 v0;
-        v10.@layout_16 = insert_value v8 1.i256 v1;
+        v8.@layout_8 = insert_value undef.@layout_8 0.i256 v0;
+        v10.@layout_8 = insert_value v8 1.i256 v1;
         call %set__gc9ba v10 1.i1 v2;
         return;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_3347() -> @layout_5 {
+func private %std__lib__evm__effects__impl_trait_Evm_c913__input_3347() -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v0.@layout_5 = call %std__lib__evm__calldata__impl_CallData_8f43__new_f11a;
+        v0.@layout_0 = call %std__lib__evm__calldata__impl_CallData_8f43__new_f11a;
         return v0;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_3dc9() -> @layout_5 {
+func private %std__lib__evm__effects__impl_trait_Evm_c913__input_3dc9() -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v0.@layout_5 = call %std__lib__evm__calldata__impl_CallData_8f43__new_0d2c;
+        v0.@layout_0 = call %std__lib__evm__calldata__impl_CallData_8f43__new_0d2c;
         return v0;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_5bd8() -> @layout_5 {
+func private %std__lib__evm__effects__impl_trait_Evm_c913__input_5bd8() -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v0.@layout_5 = call %std__lib__evm__calldata__impl_CallData_8f43__new_b0b8;
+        v0.@layout_0 = call %std__lib__evm__calldata__impl_CallData_8f43__new_b0b8;
         return v0;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_663b() -> @layout_5 {
+func private %std__lib__evm__effects__impl_trait_Evm_c913__input_663b() -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v0.@layout_5 = call %std__lib__evm__calldata__impl_CallData_8f43__new_0fa9;
+        v0.@layout_0 = call %std__lib__evm__calldata__impl_CallData_8f43__new_0fa9;
         return v0;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_6a54() -> @layout_5 {
+func private %std__lib__evm__effects__impl_trait_Evm_c913__input_6a54() -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v0.@layout_5 = call %std__lib__evm__calldata__impl_CallData_8f43__new_147c;
+        v0.@layout_0 = call %std__lib__evm__calldata__impl_CallData_8f43__new_147c;
         return v0;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_844a() -> @layout_5 {
+func private %std__lib__evm__effects__impl_trait_Evm_c913__input_844a() -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v0.@layout_5 = call %std__lib__evm__calldata__impl_CallData_8f43__new_923b;
+        v0.@layout_0 = call %std__lib__evm__calldata__impl_CallData_8f43__new_923b;
         return v0;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_88e5() -> @layout_5 {
+func private %std__lib__evm__effects__impl_trait_Evm_c913__input_88e5() -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v0.@layout_5 = call %std__lib__evm__calldata__impl_CallData_8f43__new_53e2;
+        v0.@layout_0 = call %std__lib__evm__calldata__impl_CallData_8f43__new_53e2;
         return v0;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_a580() -> @layout_5 {
+func private %std__lib__evm__effects__impl_trait_Evm_c913__input_a580() -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v0.@layout_5 = call %std__lib__evm__calldata__impl_CallData_8f43__new_8102;
+        v0.@layout_0 = call %std__lib__evm__calldata__impl_CallData_8f43__new_8102;
         return v0;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_b73f() -> @layout_5 {
+func private %std__lib__evm__effects__impl_trait_Evm_c913__input_b73f() -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v0.@layout_5 = call %std__lib__evm__calldata__impl_CallData_8f43__new_bc34;
+        v0.@layout_0 = call %std__lib__evm__calldata__impl_CallData_8f43__new_bc34;
         return v0;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_cd56() -> @layout_5 {
+func private %std__lib__evm__effects__impl_trait_Evm_c913__input_cd56() -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v0.@layout_5 = call %std__lib__evm__calldata__impl_CallData_8f43__new_5438;
+        v0.@layout_0 = call %std__lib__evm__calldata__impl_CallData_8f43__new_5438;
         return v0;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_d673() -> @layout_5 {
+func private %std__lib__evm__effects__impl_trait_Evm_c913__input_d673() -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v0.@layout_5 = call %std__lib__evm__calldata__impl_CallData_8f43__new_d306;
+        v0.@layout_0 = call %std__lib__evm__calldata__impl_CallData_8f43__new_d306;
         return v0;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_dac7() -> @layout_5 {
+func private %std__lib__evm__effects__impl_trait_Evm_c913__input_dac7() -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v0.@layout_5 = call %std__lib__evm__calldata__impl_CallData_8f43__new_0199;
+        v0.@layout_0 = call %std__lib__evm__calldata__impl_CallData_8f43__new_0199;
         return v0;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_e029() -> @layout_5 {
+func private %std__lib__evm__effects__impl_trait_Evm_c913__input_e029() -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v0.@layout_5 = call %std__lib__evm__calldata__impl_CallData_8f43__new_f379;
+        v0.@layout_0 = call %std__lib__evm__calldata__impl_CallData_8f43__new_f379;
         return v0;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_f89e() -> @layout_5 {
+func private %std__lib__evm__effects__impl_trait_Evm_c913__input_f89e() -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v0.@layout_5 = call %std__lib__evm__calldata__impl_CallData_8f43__new_b671;
+        v0.@layout_0 = call %std__lib__evm__calldata__impl_CallData_8f43__new_b671;
         return v0;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_0eff(v0.@layout_5) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_0a2a(v0.@layout_0) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         jump block1;
@@ -6803,7 +6790,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         jump block4;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_1a14(v0.@layout_5) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_13b9(v0.@layout_0) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         jump block1;
@@ -6837,7 +6824,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         jump block4;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_22ff(v0.@layout_5) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_25ce(v0.@layout_0) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         jump block1;
@@ -6871,7 +6858,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         jump block4;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_36c4(v0.@layout_5) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_2c20(v0.@layout_0) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         jump block1;
@@ -6905,7 +6892,75 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         jump block4;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_48ab(v0.objref<@layout_2>) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_3418(v0.@layout_0) -> i256 {
+    block0:
+        v1.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v2.i256 = evm_calldata_size;
+        v5.i256 = extract_value v0 0.i256;
+        mstore v1 v2 i256;
+        v6.i256 = mload v1 i256;
+        v7.i1 = gt v5 v6;
+        br v7 block2 block3;
+
+    block2:
+        jump block4;
+
+    block3:
+        v9.i256 = extract_value v0 0.i256;
+        (v11.i256, v12.i1) = usubo v2 v9;
+        br v12 block5 block6;
+
+    block4:
+        v17.i256 = phi (0.i256 block2) (v11 block6);
+        return v17;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        jump block4;
+}
+
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_4aee(v0.@layout_0) -> i256 {
+    block0:
+        v1.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v2.i256 = evm_calldata_size;
+        v5.i256 = extract_value v0 0.i256;
+        mstore v1 v2 i256;
+        v6.i256 = mload v1 i256;
+        v7.i1 = gt v5 v6;
+        br v7 block2 block3;
+
+    block2:
+        jump block4;
+
+    block3:
+        v9.i256 = extract_value v0 0.i256;
+        (v11.i256, v12.i1) = usubo v2 v9;
+        br v12 block5 block6;
+
+    block4:
+        v17.i256 = phi (0.i256 block2) (v11 block6);
+        return v17;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        jump block4;
+}
+
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_4f7f(v0.objref<@layout_1>) -> i256 {
     block0:
         jump block1;
 
@@ -6915,245 +6970,7 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_48ab
         return v4;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_4a91(v0.@layout_5) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v2.i256 = evm_calldata_size;
-        v5.i256 = extract_value v0 0.i256;
-        mstore v1 v2 i256;
-        v6.i256 = mload v1 i256;
-        v7.i1 = gt v5 v6;
-        br v7 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v9.i256 = extract_value v0 0.i256;
-        (v11.i256, v12.i1) = usubo v2 v9;
-        br v12 block5 block6;
-
-    block4:
-        v17.i256 = phi (0.i256 block2) (v11 block6);
-        return v17;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_5742(v0.@layout_5) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v2.i256 = evm_calldata_size;
-        v5.i256 = extract_value v0 0.i256;
-        mstore v1 v2 i256;
-        v6.i256 = mload v1 i256;
-        v7.i1 = gt v5 v6;
-        br v7 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v9.i256 = extract_value v0 0.i256;
-        (v11.i256, v12.i1) = usubo v2 v9;
-        br v12 block5 block6;
-
-    block4:
-        v17.i256 = phi (0.i256 block2) (v11 block6);
-        return v17;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_5dcb(v0.@layout_5) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v2.i256 = evm_calldata_size;
-        v5.i256 = extract_value v0 0.i256;
-        mstore v1 v2 i256;
-        v6.i256 = mload v1 i256;
-        v7.i1 = gt v5 v6;
-        br v7 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v9.i256 = extract_value v0 0.i256;
-        (v11.i256, v12.i1) = usubo v2 v9;
-        br v12 block5 block6;
-
-    block4:
-        v17.i256 = phi (0.i256 block2) (v11 block6);
-        return v17;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_6107(v0.@layout_5) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v2.i256 = evm_calldata_size;
-        v5.i256 = extract_value v0 0.i256;
-        mstore v1 v2 i256;
-        v6.i256 = mload v1 i256;
-        v7.i1 = gt v5 v6;
-        br v7 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v9.i256 = extract_value v0 0.i256;
-        (v11.i256, v12.i1) = usubo v2 v9;
-        br v12 block5 block6;
-
-    block4:
-        v17.i256 = phi (0.i256 block2) (v11 block6);
-        return v17;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_6f43(v0.@layout_5) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v2.i256 = evm_calldata_size;
-        v5.i256 = extract_value v0 0.i256;
-        mstore v1 v2 i256;
-        v6.i256 = mload v1 i256;
-        v7.i1 = gt v5 v6;
-        br v7 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v9.i256 = extract_value v0 0.i256;
-        (v11.i256, v12.i1) = usubo v2 v9;
-        br v12 block5 block6;
-
-    block4:
-        v17.i256 = phi (0.i256 block2) (v11 block6);
-        return v17;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_7388(v0.@layout_5) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v2.i256 = evm_calldata_size;
-        v5.i256 = extract_value v0 0.i256;
-        mstore v1 v2 i256;
-        v6.i256 = mload v1 i256;
-        v7.i1 = gt v5 v6;
-        br v7 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v9.i256 = extract_value v0 0.i256;
-        (v11.i256, v12.i1) = usubo v2 v9;
-        br v12 block5 block6;
-
-    block4:
-        v17.i256 = phi (0.i256 block2) (v11 block6);
-        return v17;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_779e(v0.@layout_5) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v2.i256 = evm_calldata_size;
-        v5.i256 = extract_value v0 0.i256;
-        mstore v1 v2 i256;
-        v6.i256 = mload v1 i256;
-        v7.i1 = gt v5 v6;
-        br v7 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v9.i256 = extract_value v0 0.i256;
-        (v11.i256, v12.i1) = usubo v2 v9;
-        br v12 block5 block6;
-
-    block4:
-        v17.i256 = phi (0.i256 block2) (v11 block6);
-        return v17;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_7b50(v0.objref<@layout_2>) -> i256 {
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_55d6(v0.objref<@layout_1>) -> i256 {
     block0:
         jump block1;
 
@@ -7163,7 +6980,75 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_7b50
         return v4;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_7b50_0(v0.objref<@layout_2>) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_566f(v0.@layout_0) -> i256 {
+    block0:
+        v1.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v2.i256 = evm_calldata_size;
+        v5.i256 = extract_value v0 0.i256;
+        mstore v1 v2 i256;
+        v6.i256 = mload v1 i256;
+        v7.i1 = gt v5 v6;
+        br v7 block2 block3;
+
+    block2:
+        jump block4;
+
+    block3:
+        v9.i256 = extract_value v0 0.i256;
+        (v11.i256, v12.i1) = usubo v2 v9;
+        br v12 block5 block6;
+
+    block4:
+        v17.i256 = phi (0.i256 block2) (v11 block6);
+        return v17;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        jump block4;
+}
+
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_5dba(v0.@layout_0) -> i256 {
+    block0:
+        v1.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v2.i256 = evm_calldata_size;
+        v5.i256 = extract_value v0 0.i256;
+        mstore v1 v2 i256;
+        v6.i256 = mload v1 i256;
+        v7.i1 = gt v5 v6;
+        br v7 block2 block3;
+
+    block2:
+        jump block4;
+
+    block3:
+        v9.i256 = extract_value v0 0.i256;
+        (v11.i256, v12.i1) = usubo v2 v9;
+        br v12 block5 block6;
+
+    block4:
+        v17.i256 = phi (0.i256 block2) (v11 block6);
+        return v17;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        jump block4;
+}
+
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_6e3e(v0.objref<@layout_1>) -> i256 {
     block0:
         jump block1;
 
@@ -7173,41 +7058,7 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_7b50
         return v4;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_9efd(v0.@layout_5) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v2.i256 = evm_calldata_size;
-        v5.i256 = extract_value v0 0.i256;
-        mstore v1 v2 i256;
-        v6.i256 = mload v1 i256;
-        v7.i1 = gt v5 v6;
-        br v7 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v9.i256 = extract_value v0 0.i256;
-        (v11.i256, v12.i1) = usubo v2 v9;
-        br v12 block5 block6;
-
-    block4:
-        v17.i256 = phi (0.i256 block2) (v11 block6);
-        return v17;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_a4fa(v0.objref<@layout_2>) -> i256 {
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_6e3e_0(v0.objref<@layout_1>) -> i256 {
     block0:
         jump block1;
 
@@ -7217,7 +7068,7 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_a4fa
         return v4;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_aa47(v0.@layout_5) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_8c59(v0.@layout_0) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         jump block1;
@@ -7251,7 +7102,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         jump block4;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_ae2f(v0.@layout_5) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_9f1e(v0.@layout_0) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         jump block1;
@@ -7285,7 +7136,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         jump block4;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_b318(v0.@layout_5) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_a0e3(v0.@layout_0) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         jump block1;
@@ -7319,7 +7170,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         jump block4;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_c018(v0.@layout_5) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_a72b(v0.@layout_0) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         jump block1;
@@ -7353,7 +7204,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         jump block4;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_ce93(v0.@layout_5) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_ade7(v0.@layout_0) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         jump block1;
@@ -7387,7 +7238,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         jump block4;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_de6d(v0.@layout_5) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_b402(v0.@layout_0) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         jump block1;
@@ -7421,7 +7272,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         jump block4;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_e065(v0.@layout_5) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_bbea(v0.@layout_0) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         jump block1;
@@ -7455,7 +7306,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         jump block4;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_e83e(v0.@layout_5) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_c091(v0.@layout_0) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         jump block1;
@@ -7489,7 +7340,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         jump block4;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_e949(v0.@layout_5) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_c2ce(v0.@layout_0) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         jump block1;
@@ -7523,7 +7374,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         jump block4;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_e9e0(v0.@layout_5) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_cea7(v0.@layout_0) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         jump block1;
@@ -7557,7 +7408,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         jump block4;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_f03b(v0.@layout_5) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_d7d7(v0.@layout_0) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         jump block1;
@@ -7591,7 +7442,143 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         jump block4;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_fc14(v0.@layout_5) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_d815(v0.@layout_0) -> i256 {
+    block0:
+        v1.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v2.i256 = evm_calldata_size;
+        v5.i256 = extract_value v0 0.i256;
+        mstore v1 v2 i256;
+        v6.i256 = mload v1 i256;
+        v7.i1 = gt v5 v6;
+        br v7 block2 block3;
+
+    block2:
+        jump block4;
+
+    block3:
+        v9.i256 = extract_value v0 0.i256;
+        (v11.i256, v12.i1) = usubo v2 v9;
+        br v12 block5 block6;
+
+    block4:
+        v17.i256 = phi (0.i256 block2) (v11 block6);
+        return v17;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        jump block4;
+}
+
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_e2e1(v0.@layout_0) -> i256 {
+    block0:
+        v1.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v2.i256 = evm_calldata_size;
+        v5.i256 = extract_value v0 0.i256;
+        mstore v1 v2 i256;
+        v6.i256 = mload v1 i256;
+        v7.i1 = gt v5 v6;
+        br v7 block2 block3;
+
+    block2:
+        jump block4;
+
+    block3:
+        v9.i256 = extract_value v0 0.i256;
+        (v11.i256, v12.i1) = usubo v2 v9;
+        br v12 block5 block6;
+
+    block4:
+        v17.i256 = phi (0.i256 block2) (v11 block6);
+        return v17;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        jump block4;
+}
+
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_f197(v0.@layout_0) -> i256 {
+    block0:
+        v1.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v2.i256 = evm_calldata_size;
+        v5.i256 = extract_value v0 0.i256;
+        mstore v1 v2 i256;
+        v6.i256 = mload v1 i256;
+        v7.i1 = gt v5 v6;
+        br v7 block2 block3;
+
+    block2:
+        jump block4;
+
+    block3:
+        v9.i256 = extract_value v0 0.i256;
+        (v11.i256, v12.i1) = usubo v2 v9;
+        br v12 block5 block6;
+
+    block4:
+        v17.i256 = phi (0.i256 block2) (v11 block6);
+        return v17;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        jump block4;
+}
+
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_f6a9(v0.@layout_0) -> i256 {
+    block0:
+        v1.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v2.i256 = evm_calldata_size;
+        v5.i256 = extract_value v0 0.i256;
+        mstore v1 v2 i256;
+        v6.i256 = mload v1 i256;
+        v7.i1 = gt v5 v6;
+        br v7 block2 block3;
+
+    block2:
+        jump block4;
+
+    block3:
+        v9.i256 = extract_value v0 0.i256;
+        (v11.i256, v12.i1) = usubo v2 v9;
+        br v12 block5 block6;
+
+    block4:
+        v17.i256 = phi (0.i256 block2) (v11 block6);
+        return v17;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        jump block4;
+}
+
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_f8fd(v0.@layout_0) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         jump block1;
@@ -7643,7 +7630,7 @@ func private %std__lib__evm__effects__impl_trait_Evm_476c__log3_ebb3(v0.i256, v1
         return;
 }
 
-func private %standalone_erc20__erc20__mint__ga9cb_03ab(v0.@layout_0, v1.i256, v2.i256, v3.i256, v4.i256) {
+func private %standalone_erc20__erc20__mint__ga9cb_2b3b(v0.@layout_0, v1.i256, v2.i256, v3.i256, v4.i256) {
     block0:
         v5.objref<@layout_0> = obj.alloc @layout_0;
         jump block1;
@@ -7691,14 +7678,14 @@ func private %standalone_erc20__erc20__mint__ga9cb_03ab(v0.@layout_0, v1.i256, v
     block8:
         call %set__gbae5 v0 v40 1.i256;
         v45.@layout_0 = call %zero;
-        v49.@layout_20 = insert_value undef.@layout_20 0.i256 v45;
-        v50.@layout_20 = insert_value v49 1.i256 v0;
-        v52.@layout_20 = insert_value v50 2.i256 v1;
+        v49.@layout_6 = insert_value undef.@layout_6 0.i256 v45;
+        v50.@layout_6 = insert_value v49 1.i256 v0;
+        v52.@layout_6 = insert_value v50 2.i256 v1;
         call %emit__g4c3d v52;
         return;
 }
 
-func private %standalone_erc20__erc20__mint__ga9cb_110c(v0.@layout_0, v1.i256, v2.i256, v3.i256, v4.i256) {
+func private %standalone_erc20__erc20__mint__ga9cb_527c(v0.@layout_0, v1.i256, v2.i256, v3.i256, v4.i256) {
     block0:
         v5.objref<@layout_0> = obj.alloc @layout_0;
         jump block1;
@@ -7746,9 +7733,9 @@ func private %standalone_erc20__erc20__mint__ga9cb_110c(v0.@layout_0, v1.i256, v
     block8:
         call %set__gbae5 v0 v40 1.i256;
         v45.@layout_0 = call %zero;
-        v49.@layout_20 = insert_value undef.@layout_20 0.i256 v45;
-        v50.@layout_20 = insert_value v49 1.i256 v0;
-        v52.@layout_20 = insert_value v50 2.i256 v1;
+        v49.@layout_6 = insert_value undef.@layout_6 0.i256 v45;
+        v50.@layout_6 = insert_value v49 1.i256 v0;
+        v52.@layout_6 = insert_value v50 2.i256 v1;
         call %emit__g4c3d v52;
         return;
 }
@@ -7763,63 +7750,52 @@ func private %ne(v0.@layout_0, v1.@layout_0) -> i1 {
         return v5;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_0199() -> @layout_5 {
+func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_0199() -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v1.constref<@layout_5> = const.ref $const_region_0;
-        v2.objref<@layout_5> = obj.alloc @layout_5;
+        v1.constref<@layout_0> = const.ref $const_region_0;
+        v2.objref<@layout_0> = obj.alloc @layout_0;
         obj.init.const v2 v1;
-        v3.@layout_5 = obj.load v2;
+        v3.@layout_0 = obj.load v2;
         return v3;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_0d2c() -> @layout_5 {
+func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_0d2c() -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v1.constref<@layout_5> = const.ref $const_region_0;
-        v2.objref<@layout_5> = obj.alloc @layout_5;
+        v1.constref<@layout_0> = const.ref $const_region_0;
+        v2.objref<@layout_0> = obj.alloc @layout_0;
         obj.init.const v2 v1;
-        v3.@layout_5 = obj.load v2;
+        v3.@layout_0 = obj.load v2;
         return v3;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_0fa9() -> @layout_5 {
+func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_0fa9() -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v1.constref<@layout_5> = const.ref $const_region_0;
-        v2.objref<@layout_5> = obj.alloc @layout_5;
+        v1.constref<@layout_0> = const.ref $const_region_0;
+        v2.objref<@layout_0> = obj.alloc @layout_0;
         obj.init.const v2 v1;
-        v3.@layout_5 = obj.load v2;
+        v3.@layout_0 = obj.load v2;
         return v3;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_147c() -> @layout_5 {
+func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_147c() -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v1.constref<@layout_5> = const.ref $const_region_0;
-        v2.objref<@layout_5> = obj.alloc @layout_5;
+        v1.constref<@layout_0> = const.ref $const_region_0;
+        v2.objref<@layout_0> = obj.alloc @layout_0;
         obj.init.const v2 v1;
-        v3.@layout_5 = obj.load v2;
+        v3.@layout_0 = obj.load v2;
         return v3;
-}
-
-func inline(always) private %impl_SolDecoder__new__g463e(v0.@layout_2) -> @layout_4 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.@layout_3 = call %impl_Cursor__new__g463e v0;
-        v5.@layout_4 = insert_value undef.@layout_4 0.i256 v2;
-        v7.@layout_4 = insert_value v5 1.i256 0.i256;
-        return v7;
 }
 
 func private %std__lib__abi__sol__impl_SolEncoder_ce34__new_36b0(v0.i256) -> @layout_1 {
@@ -7844,39 +7820,49 @@ func private %std__lib__abi__sol__impl_SolEncoder_ce34__new_36b0(v0.i256) -> @la
         return v8;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_53e2() -> @layout_5 {
+func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_53e2() -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v1.constref<@layout_5> = const.ref $const_region_0;
-        v2.objref<@layout_5> = obj.alloc @layout_5;
+        v1.constref<@layout_0> = const.ref $const_region_0;
+        v2.objref<@layout_0> = obj.alloc @layout_0;
         obj.init.const v2 v1;
-        v3.@layout_5 = obj.load v2;
+        v3.@layout_0 = obj.load v2;
         return v3;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_5438() -> @layout_5 {
+func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_5438() -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v1.constref<@layout_5> = const.ref $const_region_0;
-        v2.objref<@layout_5> = obj.alloc @layout_5;
+        v1.constref<@layout_0> = const.ref $const_region_0;
+        v2.objref<@layout_0> = obj.alloc @layout_0;
         obj.init.const v2 v1;
-        v3.@layout_5 = obj.load v2;
+        v3.@layout_0 = obj.load v2;
         return v3;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_8102() -> @layout_5 {
+func inline(always) private %impl_Cursor__new__g463e(v0.@layout_1) -> @layout_2 {
     block0:
         jump block1;
 
     block1:
-        v1.constref<@layout_5> = const.ref $const_region_0;
-        v2.objref<@layout_5> = obj.alloc @layout_5;
+        v4.@layout_2 = insert_value undef.@layout_2 0.i256 v0;
+        v6.@layout_2 = insert_value v4 1.i256 0.i256;
+        return v6;
+}
+
+func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_8102() -> @layout_0 {
+    block0:
+        jump block1;
+
+    block1:
+        v1.constref<@layout_0> = const.ref $const_region_0;
+        v2.objref<@layout_0> = obj.alloc @layout_0;
         obj.init.const v2 v1;
-        v3.@layout_5 = obj.load v2;
+        v3.@layout_0 = obj.load v2;
         return v3;
 }
 
@@ -7902,15 +7888,15 @@ func private %std__lib__abi__sol__impl_SolEncoder_ce34__new_8670(v0.i256) -> @la
         return v8;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_923b() -> @layout_5 {
+func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_923b() -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v1.constref<@layout_5> = const.ref $const_region_0;
-        v2.objref<@layout_5> = obj.alloc @layout_5;
+        v1.constref<@layout_0> = const.ref $const_region_0;
+        v2.objref<@layout_0> = obj.alloc @layout_0;
         obj.init.const v2 v1;
-        v3.@layout_5 = obj.load v2;
+        v3.@layout_0 = obj.load v2;
         return v3;
 }
 
@@ -7936,49 +7922,50 @@ func private %std__lib__abi__sol__impl_SolEncoder_ce34__new_978f(v0.i256) -> @la
         return v8;
 }
 
-func inline(always) private %impl_Cursor__new__g463e(v0.@layout_2) -> @layout_3 {
+func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_b0b8() -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v4.@layout_3 = insert_value undef.@layout_3 0.i256 v0;
-        v6.@layout_3 = insert_value v4 1.i256 0.i256;
-        return v6;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_b0b8() -> @layout_5 {
-    block0:
-        jump block1;
-
-    block1:
-        v1.constref<@layout_5> = const.ref $const_region_0;
-        v2.objref<@layout_5> = obj.alloc @layout_5;
+        v1.constref<@layout_0> = const.ref $const_region_0;
+        v2.objref<@layout_0> = obj.alloc @layout_0;
         obj.init.const v2 v1;
-        v3.@layout_5 = obj.load v2;
+        v3.@layout_0 = obj.load v2;
         return v3;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_b671() -> @layout_5 {
+func inline(always) private %impl_SolDecoder__new__g463e(v0.@layout_1) -> @layout_3 {
     block0:
         jump block1;
 
     block1:
-        v1.constref<@layout_5> = const.ref $const_region_0;
-        v2.objref<@layout_5> = obj.alloc @layout_5;
+        v2.@layout_2 = call %impl_Cursor__new__g463e v0;
+        v5.@layout_3 = insert_value undef.@layout_3 0.i256 v2;
+        v7.@layout_3 = insert_value v5 1.i256 0.i256;
+        return v7;
+}
+
+func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_b671() -> @layout_0 {
+    block0:
+        jump block1;
+
+    block1:
+        v1.constref<@layout_0> = const.ref $const_region_0;
+        v2.objref<@layout_0> = obj.alloc @layout_0;
         obj.init.const v2 v1;
-        v3.@layout_5 = obj.load v2;
+        v3.@layout_0 = obj.load v2;
         return v3;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_bc34() -> @layout_5 {
+func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_bc34() -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v1.constref<@layout_5> = const.ref $const_region_0;
-        v2.objref<@layout_5> = obj.alloc @layout_5;
+        v1.constref<@layout_0> = const.ref $const_region_0;
+        v2.objref<@layout_0> = obj.alloc @layout_0;
         obj.init.const v2 v1;
-        v3.@layout_5 = obj.load v2;
+        v3.@layout_0 = obj.load v2;
         return v3;
 }
 
@@ -8026,15 +8013,15 @@ func private %std__lib__abi__sol__impl_SolEncoder_ce34__new_c575(v0.i256) -> @la
         return v8;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_d306() -> @layout_5 {
+func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_d306() -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v1.constref<@layout_5> = const.ref $const_region_0;
-        v2.objref<@layout_5> = obj.alloc @layout_5;
+        v1.constref<@layout_0> = const.ref $const_region_0;
+        v2.objref<@layout_0> = obj.alloc @layout_0;
         obj.init.const v2 v1;
-        v3.@layout_5 = obj.load v2;
+        v3.@layout_0 = obj.load v2;
         return v3;
 }
 
@@ -8060,27 +8047,27 @@ func private %std__lib__abi__sol__impl_SolEncoder_ce34__new_f042(v0.i256) -> @la
         return v8;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_f11a() -> @layout_5 {
+func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_f11a() -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v1.constref<@layout_5> = const.ref $const_region_0;
-        v2.objref<@layout_5> = obj.alloc @layout_5;
+        v1.constref<@layout_0> = const.ref $const_region_0;
+        v2.objref<@layout_0> = obj.alloc @layout_0;
         obj.init.const v2 v1;
-        v3.@layout_5 = obj.load v2;
+        v3.@layout_0 = obj.load v2;
         return v3;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_f379() -> @layout_5 {
+func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_f379() -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v1.constref<@layout_5> = const.ref $const_region_0;
-        v2.objref<@layout_5> = obj.alloc @layout_5;
+        v1.constref<@layout_0> = const.ref $const_region_0;
+        v2.objref<@layout_0> = obj.alloc @layout_0;
         obj.init.const v2 v1;
-        v3.@layout_5 = obj.load v2;
+        v3.@layout_0 = obj.load v2;
         return v3;
 }
 
@@ -8466,7 +8453,7 @@ func private %core__lib__abi__impl_trait_String_c06e__payload_size__g3eb7_f656_0
         return v6;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_0de4(v0.objref<@layout_1>) -> i256 {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_06d1(v0.objref<@layout_1>) -> i256 {
     block0:
         jump block1;
 
@@ -8476,7 +8463,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_0de4(v0.objref
         return v4;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_324d(v0.objref<@layout_1>) -> i256 {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_4526(v0.objref<@layout_1>) -> i256 {
     block0:
         jump block1;
 
@@ -8486,29 +8473,49 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_324d(v0.objref
         return v4;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g463e_3f42(v0.objref<@layout_4>) -> i256 {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_6701(v0.objref<@layout_1>) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v3.objref<@layout_3> = obj.proj v0 0.i256;
+        v3.objref<i256> = obj.proj v0 1.i256;
+        v4.i256 = obj.load v3;
+        return v4;
+}
+
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_8ab3(v0.objref<@layout_1>) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v3.objref<i256> = obj.proj v0 1.i256;
+        v4.i256 = obj.load v3;
+        return v4;
+}
+
+func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g463e_9627(v0.objref<@layout_3>) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v3.objref<@layout_2> = obj.proj v0 0.i256;
         v5.objref<i256> = obj.proj v3 1.i256;
         v6.i256 = obj.load v5;
         return v6;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g463e_3f42_0(v0.objref<@layout_4>) -> i256 {
+func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g463e_9627_0(v0.objref<@layout_3>) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v3.objref<@layout_3> = obj.proj v0 0.i256;
+        v3.objref<@layout_2> = obj.proj v0 0.i256;
         v5.objref<i256> = obj.proj v3 1.i256;
         v6.i256 = obj.load v5;
         return v6;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_6cac(v0.objref<@layout_1>) -> i256 {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_a94d(v0.objref<@layout_1>) -> i256 {
     block0:
         jump block1;
 
@@ -8518,39 +8525,19 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_6cac(v0.objref
         return v4;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_7b90(v0.objref<@layout_1>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 1.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_d8ed(v0.objref<@layout_1>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 1.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_0a1c(v0.objref<@layout_4>) -> i256 {
+func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_715d(v0.objref<@layout_3>) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v4.objref<@layout_3> = obj.proj v0 0.i256;
-        v5.objref<@layout_2> = obj.proj v4 0.i256;
-        v6.@layout_2 = obj.load v5;
-        v7.objref<@layout_3> = obj.proj v0 0.i256;
-        v8.objref<@layout_2> = obj.proj v7 0.i256;
-        v9.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_7b50 v8;
-        v10.objref<@layout_3> = obj.proj v0 0.i256;
+        v4.objref<@layout_2> = obj.proj v0 0.i256;
+        v5.objref<@layout_1> = obj.proj v4 0.i256;
+        v6.@layout_1 = obj.load v5;
+        v7.objref<@layout_2> = obj.proj v0 0.i256;
+        v8.objref<@layout_1> = obj.proj v7 0.i256;
+        v9.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_6e3e v8;
+        v10.objref<@layout_2> = obj.proj v0 0.i256;
         v12.objref<i256> = obj.proj v10 1.i256;
         v13.i256 = obj.load v12;
         (v15.i256, v16.i1) = uaddo v13 32.i256;
@@ -8563,16 +8550,16 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         jump block4;
 
     block4:
-        v27.objref<@layout_3> = obj.proj v0 0.i256;
-        v28.objref<@layout_2> = obj.proj v27 0.i256;
-        v29.@layout_2 = obj.load v28;
-        v30.objref<@layout_3> = obj.proj v0 0.i256;
+        v27.objref<@layout_2> = obj.proj v0 0.i256;
+        v28.objref<@layout_1> = obj.proj v27 0.i256;
+        v29.@layout_1 = obj.load v28;
+        v30.objref<@layout_2> = obj.proj v0 0.i256;
         v31.objref<i256> = obj.proj v30 1.i256;
         v32.i256 = obj.load v31;
-        v33.objref<@layout_3> = obj.proj v0 0.i256;
-        v34.objref<@layout_2> = obj.proj v33 0.i256;
-        v35.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_7f19 v34 v32;
-        v37.objref<@layout_3> = obj.proj v0 0.i256;
+        v33.objref<@layout_2> = obj.proj v0 0.i256;
+        v34.objref<@layout_1> = obj.proj v33 0.i256;
+        v35.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_0e64 v34 v32;
+        v37.objref<@layout_2> = obj.proj v0 0.i256;
         v38.objref<i256> = obj.proj v37 1.i256;
         obj.store v38 v15;
         return v35;
@@ -8589,26 +8576,26 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         evm_revert 0.i256 36.i256;
 
     block7:
-        v22.objref<@layout_3> = obj.proj v0 0.i256;
+        v22.objref<@layout_2> = obj.proj v0 0.i256;
         v23.objref<i256> = obj.proj v22 1.i256;
         v24.i256 = obj.load v23;
         v25.i1 = lt v15 v24;
         br v25 block2 block5;
 }
 
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_0a1c_0(v0.objref<@layout_4>) -> i256 {
+func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_715d_0(v0.objref<@layout_3>) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v4.objref<@layout_3> = obj.proj v0 0.i256;
-        v5.objref<@layout_2> = obj.proj v4 0.i256;
-        v6.@layout_2 = obj.load v5;
-        v7.objref<@layout_3> = obj.proj v0 0.i256;
-        v8.objref<@layout_2> = obj.proj v7 0.i256;
-        v9.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_7b50_0 v8;
-        v10.objref<@layout_3> = obj.proj v0 0.i256;
+        v4.objref<@layout_2> = obj.proj v0 0.i256;
+        v5.objref<@layout_1> = obj.proj v4 0.i256;
+        v6.@layout_1 = obj.load v5;
+        v7.objref<@layout_2> = obj.proj v0 0.i256;
+        v8.objref<@layout_1> = obj.proj v7 0.i256;
+        v9.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_6e3e_0 v8;
+        v10.objref<@layout_2> = obj.proj v0 0.i256;
         v12.objref<i256> = obj.proj v10 1.i256;
         v13.i256 = obj.load v12;
         (v15.i256, v16.i1) = uaddo v13 32.i256;
@@ -8621,16 +8608,16 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         jump block4;
 
     block4:
-        v27.objref<@layout_3> = obj.proj v0 0.i256;
-        v28.objref<@layout_2> = obj.proj v27 0.i256;
-        v29.@layout_2 = obj.load v28;
-        v30.objref<@layout_3> = obj.proj v0 0.i256;
+        v27.objref<@layout_2> = obj.proj v0 0.i256;
+        v28.objref<@layout_1> = obj.proj v27 0.i256;
+        v29.@layout_1 = obj.load v28;
+        v30.objref<@layout_2> = obj.proj v0 0.i256;
         v31.objref<i256> = obj.proj v30 1.i256;
         v32.i256 = obj.load v31;
-        v33.objref<@layout_3> = obj.proj v0 0.i256;
-        v34.objref<@layout_2> = obj.proj v33 0.i256;
-        v35.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_7f19_0 v34 v32;
-        v37.objref<@layout_3> = obj.proj v0 0.i256;
+        v33.objref<@layout_2> = obj.proj v0 0.i256;
+        v34.objref<@layout_1> = obj.proj v33 0.i256;
+        v35.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_0e64_0 v34 v32;
+        v37.objref<@layout_2> = obj.proj v0 0.i256;
         v38.objref<i256> = obj.proj v37 1.i256;
         obj.store v38 v15;
         return v35;
@@ -8647,26 +8634,26 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         evm_revert 0.i256 36.i256;
 
     block7:
-        v22.objref<@layout_3> = obj.proj v0 0.i256;
+        v22.objref<@layout_2> = obj.proj v0 0.i256;
         v23.objref<i256> = obj.proj v22 1.i256;
         v24.i256 = obj.load v23;
         v25.i1 = lt v15 v24;
         br v25 block2 block5;
 }
 
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_85d9(v0.objref<@layout_4>) -> i256 {
+func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_99f7(v0.objref<@layout_3>) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v4.objref<@layout_3> = obj.proj v0 0.i256;
-        v5.objref<@layout_2> = obj.proj v4 0.i256;
-        v6.@layout_2 = obj.load v5;
-        v7.objref<@layout_3> = obj.proj v0 0.i256;
-        v8.objref<@layout_2> = obj.proj v7 0.i256;
-        v9.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_48ab v8;
-        v10.objref<@layout_3> = obj.proj v0 0.i256;
+        v4.objref<@layout_2> = obj.proj v0 0.i256;
+        v5.objref<@layout_1> = obj.proj v4 0.i256;
+        v6.@layout_1 = obj.load v5;
+        v7.objref<@layout_2> = obj.proj v0 0.i256;
+        v8.objref<@layout_1> = obj.proj v7 0.i256;
+        v9.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_55d6 v8;
+        v10.objref<@layout_2> = obj.proj v0 0.i256;
         v12.objref<i256> = obj.proj v10 1.i256;
         v13.i256 = obj.load v12;
         (v15.i256, v16.i1) = uaddo v13 32.i256;
@@ -8679,16 +8666,16 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         jump block4;
 
     block4:
-        v27.objref<@layout_3> = obj.proj v0 0.i256;
-        v28.objref<@layout_2> = obj.proj v27 0.i256;
-        v29.@layout_2 = obj.load v28;
-        v30.objref<@layout_3> = obj.proj v0 0.i256;
+        v27.objref<@layout_2> = obj.proj v0 0.i256;
+        v28.objref<@layout_1> = obj.proj v27 0.i256;
+        v29.@layout_1 = obj.load v28;
+        v30.objref<@layout_2> = obj.proj v0 0.i256;
         v31.objref<i256> = obj.proj v30 1.i256;
         v32.i256 = obj.load v31;
-        v33.objref<@layout_3> = obj.proj v0 0.i256;
-        v34.objref<@layout_2> = obj.proj v33 0.i256;
-        v35.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_6576 v34 v32;
-        v37.objref<@layout_3> = obj.proj v0 0.i256;
+        v33.objref<@layout_2> = obj.proj v0 0.i256;
+        v34.objref<@layout_1> = obj.proj v33 0.i256;
+        v35.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_2de0 v34 v32;
+        v37.objref<@layout_2> = obj.proj v0 0.i256;
         v38.objref<i256> = obj.proj v37 1.i256;
         obj.store v38 v15;
         return v35;
@@ -8705,26 +8692,26 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         evm_revert 0.i256 36.i256;
 
     block7:
-        v22.objref<@layout_3> = obj.proj v0 0.i256;
+        v22.objref<@layout_2> = obj.proj v0 0.i256;
         v23.objref<i256> = obj.proj v22 1.i256;
         v24.i256 = obj.load v23;
         v25.i1 = lt v15 v24;
         br v25 block2 block5;
 }
 
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_87b3(v0.objref<@layout_4>) -> i256 {
+func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_d6d9(v0.objref<@layout_3>) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v4.objref<@layout_3> = obj.proj v0 0.i256;
-        v5.objref<@layout_2> = obj.proj v4 0.i256;
-        v6.@layout_2 = obj.load v5;
-        v7.objref<@layout_3> = obj.proj v0 0.i256;
-        v8.objref<@layout_2> = obj.proj v7 0.i256;
-        v9.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_a4fa v8;
-        v10.objref<@layout_3> = obj.proj v0 0.i256;
+        v4.objref<@layout_2> = obj.proj v0 0.i256;
+        v5.objref<@layout_1> = obj.proj v4 0.i256;
+        v6.@layout_1 = obj.load v5;
+        v7.objref<@layout_2> = obj.proj v0 0.i256;
+        v8.objref<@layout_1> = obj.proj v7 0.i256;
+        v9.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_4f7f v8;
+        v10.objref<@layout_2> = obj.proj v0 0.i256;
         v12.objref<i256> = obj.proj v10 1.i256;
         v13.i256 = obj.load v12;
         (v15.i256, v16.i1) = uaddo v13 32.i256;
@@ -8737,16 +8724,16 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         jump block4;
 
     block4:
-        v27.objref<@layout_3> = obj.proj v0 0.i256;
-        v28.objref<@layout_2> = obj.proj v27 0.i256;
-        v29.@layout_2 = obj.load v28;
-        v30.objref<@layout_3> = obj.proj v0 0.i256;
+        v27.objref<@layout_2> = obj.proj v0 0.i256;
+        v28.objref<@layout_1> = obj.proj v27 0.i256;
+        v29.@layout_1 = obj.load v28;
+        v30.objref<@layout_2> = obj.proj v0 0.i256;
         v31.objref<i256> = obj.proj v30 1.i256;
         v32.i256 = obj.load v31;
-        v33.objref<@layout_3> = obj.proj v0 0.i256;
-        v34.objref<@layout_2> = obj.proj v33 0.i256;
-        v35.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_fb71 v34 v32;
-        v37.objref<@layout_3> = obj.proj v0 0.i256;
+        v33.objref<@layout_2> = obj.proj v0 0.i256;
+        v34.objref<@layout_1> = obj.proj v33 0.i256;
+        v35.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_b264 v34 v32;
+        v37.objref<@layout_2> = obj.proj v0 0.i256;
         v38.objref<i256> = obj.proj v37 1.i256;
         obj.store v38 v15;
         return v35;
@@ -8763,7 +8750,7 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         evm_revert 0.i256 36.i256;
 
     block7:
-        v22.objref<@layout_3> = obj.proj v0 0.i256;
+        v22.objref<@layout_2> = obj.proj v0 0.i256;
         v23.objref<i256> = obj.proj v22 1.i256;
         v24.i256 = obj.load v23;
         v25.i1 = lt v15 v24;
@@ -8776,8 +8763,8 @@ func private %require(v0.i256, v1.i256) {
 
     block1:
         v4.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_a1e8__caller_aa40;
-        v7.@layout_16 = insert_value undef.@layout_16 0.i256 v0;
-        v9.@layout_16 = insert_value v7 1.i256 v4;
+        v7.@layout_8 = insert_value undef.@layout_8 0.i256 v0;
+        v9.@layout_8 = insert_value v7 1.i256 v4;
         v10.i1 = call %get__gc9ba v9 v1;
         v12.i1 = eq v10 1.i1;
         br v12 block2 block3;
@@ -9118,7 +9105,7 @@ func inline(always) private %set__gbae5(v0.@layout_0, v1.i256, v2.i256) {
         return;
 }
 
-func inline(always) private %set__gc9ba(v0.@layout_16, v1.i1, v2.i256) {
+func inline(always) private %set__gc9ba(v0.@layout_8, v1.i1, v2.i256) {
     block0:
         jump block1;
 
@@ -9127,27 +9114,7 @@ func inline(always) private %set__gc9ba(v0.@layout_16, v1.i1, v2.i256) {
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_4735(v0.objref<@layout_4>, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v5.objref<i256> = obj.proj v0 1.i256;
-        obj.store v5 v1;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_4735_0(v0.objref<@layout_4>, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v5.objref<i256> = obj.proj v0 1.i256;
-        obj.store v5 v1;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_750c(v0.objref<@layout_1>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_065d(v0.objref<@layout_1>, v1.i256) {
     block0:
         jump block1;
 
@@ -9157,7 +9124,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_750c(v0.o
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_844b(v0.objref<@layout_1>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_1e89(v0.objref<@layout_1>, v1.i256) {
     block0:
         jump block1;
 
@@ -9167,7 +9134,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_844b(v0.o
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_c5ff(v0.objref<@layout_1>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_2121(v0.objref<@layout_1>, v1.i256) {
     block0:
         jump block1;
 
@@ -9177,7 +9144,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_c5ff(v0.o
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_cc2c(v0.objref<@layout_1>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_22b1(v0.objref<@layout_1>, v1.i256) {
     block0:
         jump block1;
 
@@ -9187,7 +9154,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_cc2c(v0.o
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_fa20(v0.objref<@layout_1>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_24e6(v0.objref<@layout_1>, v1.i256) {
     block0:
         jump block1;
 
@@ -9197,25 +9164,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_fa20(v0.o
         return;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__set__ge2d3_c199(v0.@layout_22, v1.i256, v2.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set_unchecked__ge2d3_1d62 v0 v1 v2;
-        return;
-}
-
-func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__set__ge2d3_c199_0(v0.@layout_22, v1.i256, v2.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set_unchecked__ge2d3_1d62_0 v0 v1 v2;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_0f4a(v0.objref<@layout_1>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_6134(v0.objref<@layout_3>, v1.i256) {
     block0:
         jump block1;
 
@@ -9225,7 +9174,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_0f4a(v0.ob
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_3857(v0.objref<@layout_1>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_6134_0(v0.objref<@layout_3>, v1.i256) {
     block0:
         jump block1;
 
@@ -9235,7 +9184,25 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_3857(v0.ob
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_597d(v0.objref<@layout_1>, v1.i256) {
+func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__set__ge2d3_ddb6(v0.@layout_4, v1.i256, v2.i256) {
+    block0:
+        jump block1;
+
+    block1:
+        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set_unchecked__ge2d3_5128 v0 v1 v2;
+        return;
+}
+
+func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__set__ge2d3_ddb6_0(v0.@layout_4, v1.i256, v2.i256) {
+    block0:
+        jump block1;
+
+    block1:
+        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set_unchecked__ge2d3_5128_0 v0 v1 v2;
+        return;
+}
+
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_347a(v0.objref<@layout_1>, v1.i256) {
     block0:
         jump block1;
 
@@ -9245,7 +9212,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_597d(v0.ob
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_7410(v0.objref<@layout_1>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_3e1f(v0.objref<@layout_1>, v1.i256) {
     block0:
         jump block1;
 
@@ -9255,65 +9222,55 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_7410(v0.ob
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_ae9c(v0.objref<@layout_4>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_73c1(v0.objref<@layout_1>, v1.i256) {
     block0:
         jump block1;
 
     block1:
-        v5.objref<@layout_3> = obj.proj v0 0.i256;
+        v5.objref<i256> = obj.proj v0 1.i256;
+        obj.store v5 v1;
+        return;
+}
+
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_75cf(v0.objref<@layout_1>, v1.i256) {
+    block0:
+        jump block1;
+
+    block1:
+        v5.objref<i256> = obj.proj v0 1.i256;
+        obj.store v5 v1;
+        return;
+}
+
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_9125(v0.objref<@layout_1>, v1.i256) {
+    block0:
+        jump block1;
+
+    block1:
+        v5.objref<i256> = obj.proj v0 1.i256;
+        obj.store v5 v1;
+        return;
+}
+
+func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_9c2d(v0.objref<@layout_3>, v1.i256) {
+    block0:
+        jump block1;
+
+    block1:
+        v5.objref<@layout_2> = obj.proj v0 0.i256;
         v7.objref<i256> = obj.proj v5 1.i256;
         obj.store v7 v1;
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_ae9c_0(v0.objref<@layout_4>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_9c2d_0(v0.objref<@layout_3>, v1.i256) {
     block0:
         jump block1;
 
     block1:
-        v5.objref<@layout_3> = obj.proj v0 0.i256;
+        v5.objref<@layout_2> = obj.proj v0 0.i256;
         v7.objref<i256> = obj.proj v5 1.i256;
         obj.store v7 v1;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_b6ef(v0.objref<@layout_1>, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v5.objref<i256> = obj.proj v0 1.i256;
-        obj.store v5 v1;
-        return;
-}
-
-func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__set_unchecked__ge2d3_1d62(v0.@layout_22, v1.i256, v2.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v5.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__to_word_9907 v1;
-        call %std__lib__evm__storage_map__storagemap_set_word_with_salt__g7bf4_4d42 v0 v2 v5;
-        return;
-}
-
-func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__set_unchecked__ge2d3_1d62_0(v0.@layout_22, v1.i256, v2.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v5.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__to_word_9907_0 v1;
-        call %std__lib__evm__storage_map__storagemap_set_word_with_salt__g7bf4_4d42_0 v0 v2 v5;
-        return;
-}
-
-func inline(always) private %set_unchecked__gc9ba(v0.@layout_16, v1.i1, v2.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v5.i256 = call %impl_trait_bool__to_word v1;
-        call %storagemap_set_word_with_salt__g9379 v0 3.i256 v5;
         return;
 }
 
@@ -9327,13 +9284,43 @@ func inline(always) private %set_unchecked__gbae5(v0.@layout_0, v1.i256, v2.i256
         return;
 }
 
-func private %standalone_erc20__erc20__spend_allowance__g13d4_17f7(v0.@layout_0, v1.@layout_0, v2.i256, v3.i256, v4.i256, v5.i256) {
+func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__set_unchecked__ge2d3_5128(v0.@layout_4, v1.i256, v2.i256) {
     block0:
         jump block1;
 
     block1:
-        v11.@layout_22 = insert_value undef.@layout_22 0.i256 v0;
-        v13.@layout_22 = insert_value v11 1.i256 v1;
+        v5.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__to_word_9907 v1;
+        call %std__lib__evm__storage_map__storagemap_set_word_with_salt__g7bf4_dadb v0 v2 v5;
+        return;
+}
+
+func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__set_unchecked__ge2d3_5128_0(v0.@layout_4, v1.i256, v2.i256) {
+    block0:
+        jump block1;
+
+    block1:
+        v5.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__to_word_9907_0 v1;
+        call %std__lib__evm__storage_map__storagemap_set_word_with_salt__g7bf4_dadb_0 v0 v2 v5;
+        return;
+}
+
+func inline(always) private %set_unchecked__gc9ba(v0.@layout_8, v1.i1, v2.i256) {
+    block0:
+        jump block1;
+
+    block1:
+        v5.i256 = call %impl_trait_bool__to_word v1;
+        call %storagemap_set_word_with_salt__g9379 v0 3.i256 v5;
+        return;
+}
+
+func private %standalone_erc20__erc20__spend_allowance__g13d4_a04b(v0.@layout_0, v1.@layout_0, v2.i256, v3.i256, v4.i256, v5.i256) {
+    block0:
+        jump block1;
+
+    block1:
+        v11.@layout_4 = insert_value undef.@layout_4 0.i256 v0;
+        v13.@layout_4 = insert_value v11 1.i256 v1;
         v14.i256 = call %get__ge2d3 v13 2.i256;
         v16.i1 = lt v14 v2;
         v17.i1 = is_zero v16;
@@ -9351,8 +9338,8 @@ func private %standalone_erc20__erc20__spend_allowance__g13d4_17f7(v0.@layout_0,
 
     block4:
         v34.i256 = add v3 1.i256;
-        v38.@layout_22 = insert_value undef.@layout_22 0.i256 v0;
-        v39.@layout_22 = insert_value v38 1.i256 v1;
+        v38.@layout_4 = insert_value undef.@layout_4 0.i256 v0;
+        v39.@layout_4 = insert_value v38 1.i256 v1;
         (v42.i256, v43.i1) = usubo v14 v2;
         br v43 block5 block7;
 
@@ -9366,17 +9353,17 @@ func private %standalone_erc20__erc20__spend_allowance__g13d4_17f7(v0.@layout_0,
         evm_revert v21 36.i256;
 
     block7:
-        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set__ge2d3_c199 v39 v42 2.i256;
+        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set__ge2d3_ddb6 v39 v42 2.i256;
         return;
 }
 
-func private %standalone_erc20__erc20__spend_allowance__g13d4_17f7_0(v0.@layout_0, v1.@layout_0, v2.i256, v3.i256, v4.i256, v5.i256) {
+func private %standalone_erc20__erc20__spend_allowance__g13d4_a04b_0(v0.@layout_0, v1.@layout_0, v2.i256, v3.i256, v4.i256, v5.i256) {
     block0:
         jump block1;
 
     block1:
-        v11.@layout_22 = insert_value undef.@layout_22 0.i256 v0;
-        v13.@layout_22 = insert_value v11 1.i256 v1;
+        v11.@layout_4 = insert_value undef.@layout_4 0.i256 v0;
+        v13.@layout_4 = insert_value v11 1.i256 v1;
         v14.i256 = call %get__ge2d3 v13 2.i256;
         v16.i1 = lt v14 v2;
         v17.i1 = is_zero v16;
@@ -9394,8 +9381,8 @@ func private %standalone_erc20__erc20__spend_allowance__g13d4_17f7_0(v0.@layout_
 
     block4:
         v34.i256 = add v3 1.i256;
-        v38.@layout_22 = insert_value undef.@layout_22 0.i256 v0;
-        v39.@layout_22 = insert_value v38 1.i256 v1;
+        v38.@layout_4 = insert_value undef.@layout_4 0.i256 v0;
+        v39.@layout_4 = insert_value v38 1.i256 v1;
         (v42.i256, v43.i1) = usubo v14 v2;
         br v43 block5 block7;
 
@@ -9409,98 +9396,68 @@ func private %standalone_erc20__erc20__spend_allowance__g13d4_17f7_0(v0.@layout_
         evm_revert v21 36.i256;
 
     block7:
-        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set__ge2d3_c199 v39 v42 2.i256;
+        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set__ge2d3_ddb6 v39 v42 2.i256;
         return;
 }
 
-func inline(always) private %std__lib__evm__storage_map__storagemap_get_word_with_salt__g67a8_4599(v0.@layout_0, v1.i256) -> i256 {
+func inline(always) private %storagemap_get_word_with_salt__g9379(v0.@layout_8, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g67a8_9f5e v0 v1;
+        v4.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g9379_4498 v0 v1;
         v5.i256 = evm_sload v4;
         return v5;
 }
 
-func inline(always) private %std__lib__evm__storage_map__storagemap_get_word_with_salt__g7bf4_af75(v0.@layout_22, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__storagemap_get_word_with_salt__g7bf4_16a4(v0.@layout_4, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_2a19 v0 v1;
+        v4.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_c2f9 v0 v1;
         v5.i256 = evm_sload v4;
         return v5;
 }
 
-func inline(always) private %storagemap_get_word_with_salt__g9379(v0.@layout_16, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__storagemap_get_word_with_salt__g7bf4_16a4_0(v0.@layout_4, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g9379_8aa7 v0 v1;
+        v4.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_c2f9_1 v0 v1;
         v5.i256 = evm_sload v4;
         return v5;
 }
 
-func inline(always) private %std__lib__evm__storage_map__storagemap_get_word_with_salt__g67a8_cb7c(v0.@layout_0, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__storagemap_get_word_with_salt__g7bf4_b354(v0.@layout_4, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g67a8_664a v0 v1;
+        v4.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_1e87 v0 v1;
         v5.i256 = evm_sload v4;
         return v5;
 }
 
-func inline(always) private %std__lib__evm__storage_map__storagemap_get_word_with_salt__g7bf4_d4e7(v0.@layout_22, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__storagemap_get_word_with_salt__g67a8_bb80(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_81f5 v0 v1;
+        v4.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g67a8_0585 v0 v1;
         v5.i256 = evm_sload v4;
         return v5;
 }
 
-func inline(always) private %std__lib__evm__storage_map__storagemap_get_word_with_salt__g7bf4_d4e7_0(v0.@layout_22, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__storagemap_get_word_with_salt__g67a8_bc66(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_81f5_1 v0 v1;
+        v4.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g67a8_e027 v0 v1;
         v5.i256 = evm_sload v4;
         return v5;
-}
-
-func inline(always) private %storagemap_set_word_with_salt__g9379(v0.@layout_16, v1.i256, v2.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v5.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g9379_8aa7_0 v0 v1;
-        evm_sstore v5 v2;
-        return;
-}
-
-func inline(always) private %std__lib__evm__storage_map__storagemap_set_word_with_salt__g7bf4_4d42(v0.@layout_22, v1.i256, v2.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v5.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_81f5 v0 v1;
-        evm_sstore v5 v2;
-        return;
-}
-
-func inline(always) private %std__lib__evm__storage_map__storagemap_set_word_with_salt__g7bf4_4d42_0(v0.@layout_22, v1.i256, v2.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v5.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_81f5_0 v0 v1;
-        evm_sstore v5 v2;
-        return;
 }
 
 func inline(always) private %storagemap_set_word_with_salt__g67a8(v0.@layout_0, v1.i256, v2.i256) {
@@ -9508,19 +9465,49 @@ func inline(always) private %storagemap_set_word_with_salt__g67a8(v0.@layout_0, 
         jump block1;
 
     block1:
-        v5.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g67a8_664a v0 v1;
+        v5.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g67a8_e027 v0 v1;
         evm_sstore v5 v2;
         return;
 }
 
-func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_2a19(v0.@layout_22, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__storagemap_set_word_with_salt__g7bf4_dadb(v0.@layout_4, v1.i256, v2.i256) {
+    block0:
+        jump block1;
+
+    block1:
+        v5.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_c2f9 v0 v1;
+        evm_sstore v5 v2;
+        return;
+}
+
+func inline(always) private %std__lib__evm__storage_map__storagemap_set_word_with_salt__g7bf4_dadb_0(v0.@layout_4, v1.i256, v2.i256) {
+    block0:
+        jump block1;
+
+    block1:
+        v5.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_c2f9_0 v0 v1;
+        evm_sstore v5 v2;
+        return;
+}
+
+func inline(always) private %storagemap_set_word_with_salt__g9379(v0.@layout_8, v1.i256, v2.i256) {
+    block0:
+        jump block1;
+
+    block1:
+        v5.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g9379_4498_0 v0 v1;
+        evm_sstore v5 v2;
+        return;
+}
+
+func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g67a8_0585(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
         v3.*i8 = evm_malloc 0.i256;
         v4.i256 = ptr_to_int v3 i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_2c8a v4 v0;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_3ab2 v4 v0;
         (v7.i256, v8.i1) = uaddo v4 v6;
         br v8 block2 block3;
 
@@ -9539,14 +9526,14 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot
         return v20;
 }
 
-func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g67a8_664a(v0.@layout_0, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_1e87(v0.@layout_4, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
         v3.*i8 = evm_malloc 0.i256;
         v4.i256 = ptr_to_int v3 i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_a18a v4 v0;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_2550 v4 v0;
         (v7.i256, v8.i1) = uaddo v4 v6;
         br v8 block2 block3;
 
@@ -9565,14 +9552,14 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot
         return v20;
 }
 
-func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_81f5(v0.@layout_22, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g9379_4498(v0.@layout_8, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
         v3.*i8 = evm_malloc 0.i256;
         v4.i256 = ptr_to_int v3 i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_8264 v4 v0;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait____9761__write_key__g6d15_1314 v4 v0;
         (v7.i256, v8.i1) = uaddo v4 v6;
         br v8 block2 block3;
 
@@ -9591,14 +9578,14 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot
         return v20;
 }
 
-func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_81f5_0(v0.@layout_22, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g9379_4498_0(v0.@layout_8, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
         v3.*i8 = evm_malloc 0.i256;
         v4.i256 = ptr_to_int v3 i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_8264_0 v4 v0;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait____9761__write_key__g6d15_1314_0 v4 v0;
         (v7.i256, v8.i1) = uaddo v4 v6;
         br v8 block2 block3;
 
@@ -9617,14 +9604,14 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot
         return v20;
 }
 
-func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_81f5_1(v0.@layout_22, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_c2f9(v0.@layout_4, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
         v3.*i8 = evm_malloc 0.i256;
         v4.i256 = ptr_to_int v3 i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_8264_1 v4 v0;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_2afe v4 v0;
         (v7.i256, v8.i1) = uaddo v4 v6;
         br v8 block2 block3;
 
@@ -9643,14 +9630,14 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot
         return v20;
 }
 
-func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g9379_8aa7(v0.@layout_16, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_c2f9_0(v0.@layout_4, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
         v3.*i8 = evm_malloc 0.i256;
         v4.i256 = ptr_to_int v3 i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait____9761__write_key__g6d15_4da6 v4 v0;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_2afe_0 v4 v0;
         (v7.i256, v8.i1) = uaddo v4 v6;
         br v8 block2 block3;
 
@@ -9669,14 +9656,14 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot
         return v20;
 }
 
-func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g9379_8aa7_0(v0.@layout_16, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_c2f9_1(v0.@layout_4, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
         v3.*i8 = evm_malloc 0.i256;
         v4.i256 = ptr_to_int v3 i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait____9761__write_key__g6d15_4da6_0 v4 v0;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_2afe_1 v4 v0;
         (v7.i256, v8.i1) = uaddo v4 v6;
         br v8 block2 block3;
 
@@ -9695,14 +9682,14 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot
         return v20;
 }
 
-func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g67a8_9f5e(v0.@layout_0, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g67a8_e027(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
         v3.*i8 = evm_malloc 0.i256;
         v4.i256 = ptr_to_int v3 i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_3658 v4 v0;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_78f9 v4 v0;
         (v7.i256, v8.i1) = uaddo v4 v6;
         br v8 block2 block3;
 
@@ -9844,7 +9831,7 @@ func private %core__lib__num__impl_trait_String_8f88__to_word__gc7cf_de49(v0.i25
         return v7;
 }
 
-func private %standalone_erc20__erc20__transfer__ga9cb_4eee(v0.@layout_0, v1.@layout_0, v2.i256, v3.i256, v4.i256, v5.i256) {
+func private %standalone_erc20__erc20__transfer__ga9cb_8101(v0.@layout_0, v1.@layout_0, v2.i256, v3.i256, v4.i256, v5.i256) {
     block0:
         v6.objref<@layout_0> = obj.alloc @layout_0;
         v7.objref<@layout_0> = obj.alloc @layout_0;
@@ -9935,14 +9922,14 @@ func private %standalone_erc20__erc20__transfer__ga9cb_4eee(v0.@layout_0, v1.@la
 
     block16:
         call %set__gbae5 v1 v73 1.i256;
-        v82.@layout_20 = insert_value undef.@layout_20 0.i256 v0;
-        v83.@layout_20 = insert_value v82 1.i256 v1;
-        v85.@layout_20 = insert_value v83 2.i256 v2;
+        v82.@layout_6 = insert_value undef.@layout_6 0.i256 v0;
+        v83.@layout_6 = insert_value v82 1.i256 v1;
+        v85.@layout_6 = insert_value v83 2.i256 v2;
         call %emit__g4c3d v85;
         return;
 }
 
-func private %standalone_erc20__erc20__transfer__ga9cb_5037(v0.@layout_0, v1.@layout_0, v2.i256, v3.i256, v4.i256, v5.i256) {
+func private %standalone_erc20__erc20__transfer__ga9cb_db9b(v0.@layout_0, v1.@layout_0, v2.i256, v3.i256, v4.i256, v5.i256) {
     block0:
         v6.objref<@layout_0> = obj.alloc @layout_0;
         v7.objref<@layout_0> = obj.alloc @layout_0;
@@ -10033,14 +10020,14 @@ func private %standalone_erc20__erc20__transfer__ga9cb_5037(v0.@layout_0, v1.@la
 
     block16:
         call %set__gbae5 v1 v73 1.i256;
-        v82.@layout_20 = insert_value undef.@layout_20 0.i256 v0;
-        v83.@layout_20 = insert_value v82 1.i256 v1;
-        v85.@layout_20 = insert_value v83 2.i256 v2;
+        v82.@layout_6 = insert_value undef.@layout_6 0.i256 v0;
+        v83.@layout_6 = insert_value v82 1.i256 v1;
+        v85.@layout_6 = insert_value v83 2.i256 v2;
         call %emit__g4c3d v85;
         return;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_0f5c(v0.@layout_5, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_0df5(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -10051,7 +10038,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v7;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_27ad(v0.@layout_5, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_0df5_0(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -10062,117 +10049,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v7;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3a1f(v0.@layout_5, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3a1f_0(v0.@layout_5, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3ba3(v0.@layout_5, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3ba3_0(v0.@layout_5, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3bad(v0.@layout_5, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3bad_0(v0.@layout_5, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_40a0(v0.@layout_5, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_40a0_0(v0.@layout_5, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_49c5(v0.@layout_5, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_5ce9(v0.@layout_5, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_6576(v0.objref<@layout_2>, v1.i256) -> i256 {
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_0e64(v0.objref<@layout_1>, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -10184,73 +10061,7 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_
         return v8;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_69bf(v0.@layout_5, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_6dae(v0.@layout_5, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_780b(v0.@layout_5, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_790f(v0.@layout_5, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_790f_0(v0.@layout_5, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_7946(v0.@layout_5, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_7f19(v0.objref<@layout_2>, v1.i256) -> i256 {
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_0e64_0(v0.objref<@layout_1>, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -10262,7 +10073,40 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_
         return v8;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_7f19_0(v0.objref<@layout_2>, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_1397(v0.@layout_0, v1.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
+}
+
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_191d(v0.@layout_0, v1.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
+}
+
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_2a43(v0.@layout_0, v1.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
+}
+
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_2de0(v0.objref<@layout_1>, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -10274,7 +10118,7 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_
         return v8;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_8736(v0.@layout_5, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_31f2(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -10285,7 +10129,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v7;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_8736_0(v0.@layout_5, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_31f2_0(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -10296,7 +10140,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v7;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_88a1(v0.@layout_5, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3723(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -10307,7 +10151,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v7;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_9725(v0.@layout_5, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3723_0(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -10318,7 +10162,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v7;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_9757(v0.@layout_5, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3903(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -10329,7 +10173,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v7;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_9757_0(v0.@layout_5, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3903_0(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -10340,7 +10184,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v7;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_a6b2(v0.@layout_5, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_4c6a(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -10351,7 +10195,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v7;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_a6b2_0(v0.@layout_5, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_4de3(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -10362,7 +10206,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v7;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_a8d6(v0.@layout_5, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_5c44(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -10373,7 +10217,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v7;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_a8d6_0(v0.@layout_5, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_6669(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -10384,7 +10228,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v7;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b461(v0.@layout_5, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_6669_0(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -10395,7 +10239,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v7;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b461_0(v0.@layout_5, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_67b2(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -10406,7 +10250,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v7;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b705(v0.@layout_5, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_67b2_0(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -10417,7 +10261,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v7;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b705_0(v0.@layout_5, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_6ca3(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -10428,7 +10272,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v7;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b870(v0.@layout_5, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_6f45(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -10439,7 +10283,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v7;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b9ca(v0.@layout_5, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_78a1(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -10450,7 +10294,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v7;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b9ca_0(v0.@layout_5, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_78a1_0(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -10461,7 +10305,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v7;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_bae8(v0.@layout_5, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_7d6a(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -10472,7 +10316,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v7;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_bae8_0(v0.@layout_5, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_7d6a_0(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -10483,7 +10327,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v7;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c259(v0.@layout_5, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_7e53(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -10494,7 +10338,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v7;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c2d4(v0.@layout_5, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_7e53_0(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -10505,7 +10349,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v7;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c32c(v0.@layout_5, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_86b9(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -10516,7 +10360,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v7;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c700(v0.@layout_5, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_86b9_0(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -10527,7 +10371,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v7;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c700_0(v0.@layout_5, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_8b76(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -10538,7 +10382,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v7;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_ce64(v0.@layout_5, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_8b76_0(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -10549,7 +10393,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v7;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_d831(v0.@layout_5, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_8e74(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -10560,7 +10404,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v7;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_d831_0(v0.@layout_5, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_8e74_0(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -10571,7 +10415,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v7;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_e134(v0.@layout_5, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_9869(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -10582,7 +10426,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v7;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_e134_0(v0.@layout_5, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_9914(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -10593,7 +10437,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v7;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_faf2(v0.@layout_5, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_9c0e(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -10604,7 +10448,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v7;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_fb71(v0.objref<@layout_2>, v1.i256) -> i256 {
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_b264(v0.objref<@layout_1>, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -10616,7 +10460,7 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_
         return v8;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_fdcb(v0.@layout_5, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_bfaf(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -10627,7 +10471,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v7;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_fec2(v0.@layout_5, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_bfaf_0(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -10638,7 +10482,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v7;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_fec2_0(v0.@layout_5, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c0ea(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -10649,61 +10493,150 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v7;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_1cfc(v0.i256, v1.@layout_0) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c0ea_0(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v5.i256 = extract_value v1 0.i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_98d1 v0 v5;
-        return v6;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_2c8a(v0.i256, v1.@layout_22) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c443(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v5.@layout_0 = extract_value v1 0.i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_1cfc v0 v5;
-        (v7.i256, v8.i1) = uaddo v0 v6;
-        br v8 block2 block3;
-
-    block2:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block3:
-        v15.@layout_0 = extract_value v1 1.i256;
-        v16.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_1cfc v7 v15;
-        (v18.i256, v19.i1) = uaddo v6 v16;
-        br v19 block2 block4;
-
-    block4:
-        return v18;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_3658(v0.i256, v1.@layout_0) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c443_0(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v5.i256 = extract_value v1 0.i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_e672 v0 v5;
-        return v6;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_37f0(v0.i256, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_cde4(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        mstore v0 v1 i256;
-        return 32.i256;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__write_key__g6d15_4da6(v0.i256, v1.@layout_16) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_d855(v0.@layout_0, v1.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
+}
+
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_e336(v0.@layout_0, v1.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
+}
+
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_e3fc(v0.@layout_0, v1.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
+}
+
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_e8c5(v0.@layout_0, v1.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
+}
+
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_f73a(v0.@layout_0, v1.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
+}
+
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_fa4a(v0.@layout_0, v1.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
+}
+
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_fa4a_0(v0.@layout_0, v1.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
+}
+
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_fef2(v0.@layout_0, v1.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
+}
+
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_fef2_0(v0.@layout_0, v1.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
+}
+
+func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__write_key__g6d15_1314(v0.i256, v1.@layout_8) -> i256 {
     block0:
         jump block1;
 
@@ -10720,7 +10653,7 @@ func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__wri
 
     block3:
         v15.@layout_0 = extract_value v1 1.i256;
-        v16.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_c339 v7 v15;
+        v16.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_4d28 v7 v15;
         (v18.i256, v19.i1) = uaddo v6 v16;
         br v19 block2 block4;
 
@@ -10728,7 +10661,7 @@ func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__wri
         return v18;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__write_key__g6d15_4da6_0(v0.i256, v1.@layout_16) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__write_key__g6d15_1314_0(v0.i256, v1.@layout_8) -> i256 {
     block0:
         jump block1;
 
@@ -10745,12 +10678,161 @@ func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__wri
 
     block3:
         v15.@layout_0 = extract_value v1 1.i256;
-        v16.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_c339_0 v7 v15;
+        v16.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_4d28_0 v7 v15;
         (v18.i256, v19.i1) = uaddo v6 v16;
         br v19 block2 block4;
 
     block4:
         return v18;
+}
+
+func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_20e7(v0.i256, v1.@layout_0) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v5.i256 = extract_value v1 0.i256;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_98d1 v0 v5;
+        return v6;
+}
+
+func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_2550(v0.i256, v1.@layout_4) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v5.@layout_0 = extract_value v1 0.i256;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_20e7 v0 v5;
+        (v7.i256, v8.i1) = uaddo v0 v6;
+        br v8 block2 block3;
+
+    block2:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block3:
+        v15.@layout_0 = extract_value v1 1.i256;
+        v16.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_20e7 v7 v15;
+        (v18.i256, v19.i1) = uaddo v6 v16;
+        br v19 block2 block4;
+
+    block4:
+        return v18;
+}
+
+func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_2afe(v0.i256, v1.@layout_4) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v5.@layout_0 = extract_value v1 0.i256;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_9818 v0 v5;
+        (v7.i256, v8.i1) = uaddo v0 v6;
+        br v8 block2 block3;
+
+    block2:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block3:
+        v15.@layout_0 = extract_value v1 1.i256;
+        v16.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_9818 v7 v15;
+        (v18.i256, v19.i1) = uaddo v6 v16;
+        br v19 block2 block4;
+
+    block4:
+        return v18;
+}
+
+func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_2afe_0(v0.i256, v1.@layout_4) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v5.@layout_0 = extract_value v1 0.i256;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_9818_0 v0 v5;
+        (v7.i256, v8.i1) = uaddo v0 v6;
+        br v8 block2 block3;
+
+    block2:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block3:
+        v15.@layout_0 = extract_value v1 1.i256;
+        v16.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_9818_0 v7 v15;
+        (v18.i256, v19.i1) = uaddo v6 v16;
+        br v19 block2 block4;
+
+    block4:
+        return v18;
+}
+
+func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_2afe_1(v0.i256, v1.@layout_4) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v5.@layout_0 = extract_value v1 0.i256;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_9818_1 v0 v5;
+        (v7.i256, v8.i1) = uaddo v0 v6;
+        br v8 block2 block3;
+
+    block2:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block3:
+        v15.@layout_0 = extract_value v1 1.i256;
+        v16.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_9818_1 v7 v15;
+        (v18.i256, v19.i1) = uaddo v6 v16;
+        br v19 block2 block4;
+
+    block4:
+        return v18;
+}
+
+func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_37f0(v0.i256, v1.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        mstore v0 v1 i256;
+        return 32.i256;
+}
+
+func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_3ab2(v0.i256, v1.@layout_0) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v5.i256 = extract_value v1 0.i256;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_e672 v0 v5;
+        return v6;
+}
+
+func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_4d28(v0.i256, v1.@layout_0) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v5.i256 = extract_value v1 0.i256;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_9337 v0 v5;
+        return v6;
+}
+
+func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_4d28_0(v0.i256, v1.@layout_0) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v5.i256 = extract_value v1 0.i256;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_9337_0 v0 v5;
+        return v6;
 }
 
 func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_67af(v0.i256, v1.i256) -> i256 {
@@ -10771,79 +10853,14 @@ func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__w
         return 32.i256;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_8264(v0.i256, v1.@layout_22) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_78f9(v0.i256, v1.@layout_0) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v5.@layout_0 = extract_value v1 0.i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_ba7e v0 v5;
-        (v7.i256, v8.i1) = uaddo v0 v6;
-        br v8 block2 block3;
-
-    block2:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block3:
-        v15.@layout_0 = extract_value v1 1.i256;
-        v16.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_ba7e v7 v15;
-        (v18.i256, v19.i1) = uaddo v6 v16;
-        br v19 block2 block4;
-
-    block4:
-        return v18;
-}
-
-func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_8264_0(v0.i256, v1.@layout_22) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v5.@layout_0 = extract_value v1 0.i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_ba7e_0 v0 v5;
-        (v7.i256, v8.i1) = uaddo v0 v6;
-        br v8 block2 block3;
-
-    block2:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block3:
-        v15.@layout_0 = extract_value v1 1.i256;
-        v16.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_ba7e_0 v7 v15;
-        (v18.i256, v19.i1) = uaddo v6 v16;
-        br v19 block2 block4;
-
-    block4:
-        return v18;
-}
-
-func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_8264_1(v0.i256, v1.@layout_22) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v5.@layout_0 = extract_value v1 0.i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_ba7e_1 v0 v5;
-        (v7.i256, v8.i1) = uaddo v0 v6;
-        br v8 block2 block3;
-
-    block2:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block3:
-        v15.@layout_0 = extract_value v1 1.i256;
-        v16.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_ba7e_1 v7 v15;
-        (v18.i256, v19.i1) = uaddo v6 v16;
-        br v19 block2 block4;
-
-    block4:
-        return v18;
+        v5.i256 = extract_value v1 0.i256;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_37f0 v0 v5;
+        return v6;
 }
 
 func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_9337(v0.i256, v1.i256) -> i256 {
@@ -10864,26 +10881,7 @@ func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__w
         return 32.i256;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_98d1(v0.i256, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        mstore v0 v1 i256;
-        return 32.i256;
-}
-
-func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_a18a(v0.i256, v1.@layout_0) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v5.i256 = extract_value v1 0.i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_37f0 v0 v5;
-        return v6;
-}
-
-func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_ba7e(v0.i256, v1.@layout_0) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_9818(v0.i256, v1.@layout_0) -> i256 {
     block0:
         jump block1;
 
@@ -10893,7 +10891,7 @@ func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e
         return v6;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_ba7e_0(v0.i256, v1.@layout_0) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_9818_0(v0.i256, v1.@layout_0) -> i256 {
     block0:
         jump block1;
 
@@ -10903,7 +10901,7 @@ func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e
         return v6;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_ba7e_1(v0.i256, v1.@layout_0) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_9818_1(v0.i256, v1.@layout_0) -> i256 {
     block0:
         jump block1;
 
@@ -10913,24 +10911,13 @@ func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e
         return v6;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_c339(v0.i256, v1.@layout_0) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_98d1(v0.i256, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v5.i256 = extract_value v1 0.i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_9337 v0 v5;
-        return v6;
-}
-
-func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_c339_0(v0.i256, v1.@layout_0) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v5.i256 = extract_value v1 0.i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_9337_0 v0 v5;
-        return v6;
+        mstore v0 v1 i256;
+        return 32.i256;
 }
 
 func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_e672(v0.i256, v1.i256) -> i256 {
@@ -10969,7 +10956,7 @@ func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__w
         return 32.i256;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_0617(v0.objref<@layout_1>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_0ae5(v0.objref<@layout_1>, v1.i256) {
     block0:
         jump block1;
 
@@ -10983,7 +10970,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_0617(v0
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_124f(v0.objref<@layout_1>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_19ab(v0.objref<@layout_1>, v1.i256) {
     block0:
         jump block1;
 
@@ -10997,7 +10984,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_124f(v0
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_1ad1(v0.objref<@layout_1>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_2812(v0.objref<@layout_1>, v1.i256) {
     block0:
         jump block1;
 
@@ -11011,7 +10998,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_1ad1(v0
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_406d(v0.objref<@layout_1>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_4130(v0.objref<@layout_1>, v1.i256) {
     block0:
         jump block1;
 
@@ -11025,7 +11012,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_406d(v0
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_798d(v0.objref<@layout_1>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_50ef(v0.objref<@layout_1>, v1.i256) {
     block0:
         jump block1;
 
@@ -11039,7 +11026,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_798d(v0
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_7a95(v0.objref<@layout_1>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_586c(v0.objref<@layout_1>, v1.i256) {
     block0:
         jump block1;
 
@@ -11053,7 +11040,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_7a95(v0
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_7b53(v0.objref<@layout_1>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_90db(v0.objref<@layout_1>, v1.i256) {
     block0:
         jump block1;
 
@@ -11067,7 +11054,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_7b53(v0
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_8eda(v0.objref<@layout_1>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_9351(v0.objref<@layout_1>, v1.i256) {
     block0:
         jump block1;
 
@@ -11081,35 +11068,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_8eda(v0
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_8f67(v0.objref<@layout_1>, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v4.objref<i256> = obj.proj v0 1.i256;
-        v5.i256 = obj.load v4;
-        mstore v5 v1 i256;
-        v9.i256 = add v5 32.i256;
-        v10.objref<i256> = obj.proj v0 1.i256;
-        obj.store v10 v9;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_aa60(v0.objref<@layout_1>, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v4.objref<i256> = obj.proj v0 1.i256;
-        v5.i256 = obj.load v4;
-        mstore v5 v1 i256;
-        v9.i256 = add v5 32.i256;
-        v10.objref<i256> = obj.proj v0 1.i256;
-        obj.store v10 v9;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_at_7ecd(v0.objref<@layout_1>, v1.i256, v2.i256) {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_at_1360(v0.objref<@layout_1>, v1.i256, v2.i256) {
     block0:
         jump block1;
 
@@ -11118,7 +11077,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_at_7ecd
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_at_e460(v0.objref<@layout_1>, v1.i256, v2.i256) {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_at_7077(v0.objref<@layout_1>, v1.i256, v2.i256) {
     block0:
         jump block1;
 
@@ -11127,7 +11086,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_at_e460
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_d813(v0.objref<@layout_1>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_bbc2(v0.objref<@layout_1>, v1.i256) {
     block0:
         jump block1;
 
@@ -11141,7 +11100,35 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_d813(v0
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_eba3(v0.objref<@layout_1>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_d00a(v0.objref<@layout_1>, v1.i256) {
+    block0:
+        jump block1;
+
+    block1:
+        v4.objref<i256> = obj.proj v0 1.i256;
+        v5.i256 = obj.load v4;
+        mstore v5 v1 i256;
+        v9.i256 = add v5 32.i256;
+        v10.objref<i256> = obj.proj v0 1.i256;
+        obj.store v10 v9;
+        return;
+}
+
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_d10d(v0.objref<@layout_1>, v1.i256) {
+    block0:
+        jump block1;
+
+    block1:
+        v4.objref<i256> = obj.proj v0 1.i256;
+        v5.i256 = obj.load v4;
+        mstore v5 v1 i256;
+        v9.i256 = add v5 32.i256;
+        v10.objref<i256> = obj.proj v0 1.i256;
+        obj.store v10 v9;
+        return;
+}
+
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_d1f3(v0.objref<@layout_1>, v1.i256) {
     block0:
         jump block1;
 
@@ -11160,7 +11147,7 @@ func private %zero() -> @layout_0 {
         jump block1;
 
     block1:
-        v1.constref<@layout_0> = const.ref $const_region_1;
+        v1.constref<@layout_0> = const.ref $const_region_0;
         v2.objref<@layout_0> = obj.alloc @layout_0;
         obj.init.const v2 v1;
         v3.@layout_0 = obj.load v2;
@@ -11176,6 +11163,5 @@ object @CoolCoin {
     section runtime {
         entry %contract_runtime_root_CoolCoin;
         data $const_region_0;
-        data $const_region_1;
     }
 }

--- a/crates/codegen/tests/fixtures/sonatina_ir/erc20.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/erc20.snap
@@ -9,9 +9,9 @@ type @layout_0 = {i256};
 type @layout_1 = {i256, i256};
 type @layout_2 = {@layout_1, i256};
 type @layout_3 = {@layout_2, i256};
-type @layout_4 = {@layout_0, @layout_0};
-type @layout_5 = {@layout_0, i256};
-type @layout_6 = {@layout_0, @layout_0, i256};
+type @layout_4 = {@layout_0, i256};
+type @layout_5 = {@layout_0, @layout_0, i256};
+type @layout_6 = {@layout_0, @layout_0};
 type @layout_7 = {@layout_0};
 type @layout_8 = {i256, @layout_0};
 type @layout_9 = {};
@@ -45,7 +45,7 @@ func private %__CoolCoin_recv_0_0(v0.@layout_0, v1.i256, v2.i256, v3.i256, v4.i2
         jump block1;
 
     block1:
-        v5.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_a1e8__caller_aa40_0;
+        v5.@layout_0 = call %caller;
         call %standalone_erc20__erc20__transfer__ga9cb_db9b v5 v0 v1 v2 1.i256 2.i256;
         return 1.i1;
 }
@@ -55,7 +55,7 @@ func private %__CoolCoin_recv_0_1(v0.@layout_0, v1.i256, v2.i256, v3.i256, v4.i2
         jump block1;
 
     block1:
-        v5.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_a1e8__caller_aa40_0;
+        v5.@layout_0 = call %caller;
         call %standalone_erc20__erc20__approve__ga9cb_7b1c v5 v0 v1 v2 1.i256 2.i256;
         return 1.i1;
 }
@@ -65,7 +65,7 @@ func private %__CoolCoin_recv_0_2(v0.@layout_0, v1.@layout_0, v2.i256, v3.i256, 
         jump block1;
 
     block1:
-        v6.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_a1e8__caller_aa40_0;
+        v6.@layout_0 = call %caller;
         call %standalone_erc20__erc20__spend_allowance__g13d4_a04b v0 v6 v2 v3 1.i256 2.i256;
         call %standalone_erc20__erc20__transfer__ga9cb_8101 v0 v1 v2 v3 1.i256 2.i256;
         return 1.i1;
@@ -85,8 +85,8 @@ func private %__CoolCoin_recv_0_4(v0.@layout_0, v1.@layout_0, v2.i256, v3.i256, 
         jump block1;
 
     block1:
-        v9.@layout_4 = insert_value undef.@layout_4 0.i256 v0;
-        v12.@layout_4 = insert_value v9 1.i256 v1;
+        v9.@layout_6 = insert_value undef.@layout_6 0.i256 v0;
+        v12.@layout_6 = insert_value v9 1.i256 v1;
         v13.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get__g94db_61a4 v12 2.i256;
         return v13;
 }
@@ -139,7 +139,7 @@ func private %__CoolCoin_recv_1_1(v0.i256, v1.i256, v2.i256, v3.i256) -> i1 {
         jump block1;
 
     block1:
-        v4.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_a1e8__caller_aa40_0;
+        v4.@layout_0 = call %caller;
         call %standalone_erc20__erc20__burn__ga9cb_d32b v4 v0 v1 1.i256 2.i256;
         return 1.i1;
 }
@@ -149,7 +149,7 @@ func private %__CoolCoin_recv_1_2(v0.@layout_0, v1.i256, v2.i256, v3.i256, v4.i2
         jump block1;
 
     block1:
-        v5.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_a1e8__caller_aa40_0;
+        v5.@layout_0 = call %caller;
         call %standalone_erc20__erc20__spend_allowance__g13d4_a04b_0 v0 v5 v1 v2 1.i256 2.i256;
         call %standalone_erc20__erc20__burn__ga9cb_d0fb v0 v1 v2 1.i256 2.i256;
         return 1.i1;
@@ -160,9 +160,9 @@ func private %__CoolCoin_recv_1_3(v0.@layout_0, v1.i256, v2.i256, v3.i256, v4.i2
         jump block1;
 
     block1:
-        v5.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_a1e8__caller_aa40_0;
-        v9.@layout_4 = insert_value undef.@layout_4 0.i256 v5;
-        v12.@layout_4 = insert_value v9 1.i256 v0;
+        v5.@layout_0 = call %caller;
+        v9.@layout_6 = insert_value undef.@layout_6 0.i256 v5;
+        v12.@layout_6 = insert_value v9 1.i256 v0;
         v13.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get__g94db_6651 v12 2.i256;
         (v15.i256, v16.i1) = uaddo v13 v1;
         br v16 block2 block3;
@@ -183,9 +183,9 @@ func private %__CoolCoin_recv_1_4(v0.@layout_0, v1.i256, v2.i256, v3.i256, v4.i2
         jump block1;
 
     block1:
-        v6.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_a1e8__caller_aa40_0;
-        v10.@layout_4 = insert_value undef.@layout_4 0.i256 v6;
-        v13.@layout_4 = insert_value v10 1.i256 v0;
+        v6.@layout_0 = call %caller;
+        v10.@layout_6 = insert_value undef.@layout_6 0.i256 v6;
+        v13.@layout_6 = insert_value v10 1.i256 v0;
         v14.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get__g94db_6651 v13 2.i256;
         mstore v5 v1 i256;
         v16.i256 = mload v5 i256;
@@ -226,7 +226,7 @@ func private %abi_field_size__gda9b(v0.i1) -> i256 {
         jump block1;
 
     block1:
-        v2.i256 = call %core__lib__abi__trait_AbiSize__payload_size__gda9b_b33d_0 v0;
+        v2.i256 = call %payload_size__gda9b v0;
         br 0.i1 block2 block3;
 
     block2:
@@ -253,7 +253,7 @@ func private %abi_field_size__g79ff(v0.i8) -> i256 {
         jump block1;
 
     block1:
-        v2.i256 = call %core__lib__abi__trait_AbiSize__payload_size__g79ff_f3e8_0 v0;
+        v2.i256 = call %payload_size__g79ff v0;
         br 0.i1 block2 block3;
 
     block2:
@@ -280,7 +280,7 @@ func private %abi_field_size__g65da(v0.i256) -> i256 {
         jump block1;
 
     block1:
-        v2.i256 = call %core__lib__abi__impl_trait_String_c06e__payload_size__gc7cf_4aab_0 v0;
+        v2.i256 = call %payload_size__gc7cf v0;
         br 1.i1 block2 block3;
 
     block2:
@@ -307,7 +307,7 @@ func private %abi_field_size__g5535(v0.i256) -> i256 {
         jump block1;
 
     block1:
-        v2.i256 = call %core__lib__abi__impl_trait_String_c06e__payload_size__g3eb7_f656_0 v0;
+        v2.i256 = call %payload_size__g3eb7 v0;
         br 1.i1 block2 block3;
 
     block2:
@@ -334,7 +334,7 @@ func private %abi_field_size__ge513(v0.i256) -> i256 {
         jump block1;
 
     block1:
-        v2.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_77e5_0 v0;
+        v2.i256 = call %payload_size__ge513 v0;
         br 0.i1 block2 block3;
 
     block2:
@@ -356,21 +356,21 @@ func private %abi_field_size__ge513(v0.i256) -> i256 {
         return v6;
 }
 
-func private %core__lib__abi__abi_payload_size__ge513_5ba7(v0.i256) -> i256 {
+func private %core__lib__abi__abi_payload_size__ge513_2949(v0.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v2.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_effe v0;
+        v2.i256 = call %payload_size__ge513 v0;
         return v2;
 }
 
-func private %core__lib__abi__abi_payload_size__ge513_d165(v0.i256) -> i256 {
+func private %core__lib__abi__abi_payload_size__ge513_295e(v0.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v2.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_18e9 v0;
+        v2.i256 = call %payload_size__ge513 v0;
         return v2;
 }
 
@@ -419,129 +419,12 @@ func private %abi_single_root_size__g5535(v0.i256) -> i256 {
         return v2;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_c913__abort_0a69() {
+func private %abort() {
     block0:
         jump block1;
 
     block1:
-        call %std__lib__evm__effects__impl_trait_Evm_0098__revert_2b5d 0.i256 0.i256;
-        unreachable;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_c913__abort_12ed() {
-    block0:
-        jump block1;
-
-    block1:
-        call %std__lib__evm__effects__impl_trait_Evm_0098__revert_34f1 0.i256 0.i256;
-        unreachable;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_c913__abort_20f2() {
-    block0:
-        jump block1;
-
-    block1:
-        call %std__lib__evm__effects__impl_trait_Evm_0098__revert_0ea2 0.i256 0.i256;
-        unreachable;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_c913__abort_2f36() {
-    block0:
-        jump block1;
-
-    block1:
-        call %std__lib__evm__effects__impl_trait_Evm_0098__revert_6471 0.i256 0.i256;
-        unreachable;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_c913__abort_57a6() {
-    block0:
-        jump block1;
-
-    block1:
-        call %std__lib__evm__effects__impl_trait_Evm_0098__revert_9e6f 0.i256 0.i256;
-        unreachable;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_c913__abort_66b1() {
-    block0:
-        jump block1;
-
-    block1:
-        call %std__lib__evm__effects__impl_trait_Evm_0098__revert_a28f 0.i256 0.i256;
-        unreachable;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_c913__abort_6993() {
-    block0:
-        jump block1;
-
-    block1:
-        call %std__lib__evm__effects__impl_trait_Evm_0098__revert_41e6 0.i256 0.i256;
-        unreachable;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_c913__abort_98a8() {
-    block0:
-        jump block1;
-
-    block1:
-        call %std__lib__evm__effects__impl_trait_Evm_0098__revert_2efa 0.i256 0.i256;
-        unreachable;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_c913__abort_9941() {
-    block0:
-        jump block1;
-
-    block1:
-        call %std__lib__evm__effects__impl_trait_Evm_0098__revert_35af 0.i256 0.i256;
-        unreachable;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_c913__abort_a20a() {
-    block0:
-        jump block1;
-
-    block1:
-        call %std__lib__evm__effects__impl_trait_Evm_0098__revert_3bd1 0.i256 0.i256;
-        unreachable;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_c913__abort_b229() {
-    block0:
-        jump block1;
-
-    block1:
-        call %std__lib__evm__effects__impl_trait_Evm_0098__revert_9fb4 0.i256 0.i256;
-        unreachable;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_c913__abort_cb5c() {
-    block0:
-        jump block1;
-
-    block1:
-        call %std__lib__evm__effects__impl_trait_Evm_0098__revert_cab9 0.i256 0.i256;
-        unreachable;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_c913__abort_ce6e() {
-    block0:
-        jump block1;
-
-    block1:
-        call %std__lib__evm__effects__impl_trait_Evm_0098__revert_cb12 0.i256 0.i256;
-        unreachable;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_c913__abort_cf57() {
-    block0:
-        jump block1;
-
-    block1:
-        call %std__lib__evm__effects__impl_trait_Evm_0098__revert_62f4 0.i256 0.i256;
+        call %revert 0.i256 0.i256;
         unreachable;
 }
 
@@ -591,12 +474,12 @@ func private %standalone_erc20__erc20__approve__ga9cb_7b1c(v0.@layout_0, v1.@lay
 
     block7:
         v46.i256 = add v3 1.i256;
-        v51.@layout_4 = insert_value undef.@layout_4 0.i256 v0;
-        v52.@layout_4 = insert_value v51 1.i256 v1;
+        v51.@layout_6 = insert_value undef.@layout_6 0.i256 v0;
+        v52.@layout_6 = insert_value v51 1.i256 v1;
         call %std__lib__evm__storage_map__impl_StorageMap_9f54__set__ge2d3_ddb6_0 v52 v2 2.i256;
-        v56.@layout_6 = insert_value undef.@layout_6 0.i256 v0;
-        v57.@layout_6 = insert_value v56 1.i256 v1;
-        v58.@layout_6 = insert_value v57 2.i256 v2;
+        v56.@layout_5 = insert_value undef.@layout_5 0.i256 v0;
+        v57.@layout_5 = insert_value v56 1.i256 v1;
+        v58.@layout_5 = insert_value v57 2.i256 v2;
         call %emit__g9cd0 v58;
         return;
 
@@ -660,12 +543,12 @@ func private %standalone_erc20__erc20__approve__ga9cb_d6ba(v0.@layout_0, v1.@lay
 
     block7:
         v46.i256 = add v3 1.i256;
-        v51.@layout_4 = insert_value undef.@layout_4 0.i256 v0;
-        v52.@layout_4 = insert_value v51 1.i256 v1;
+        v51.@layout_6 = insert_value undef.@layout_6 0.i256 v0;
+        v52.@layout_6 = insert_value v51 1.i256 v1;
         call %std__lib__evm__storage_map__impl_StorageMap_9f54__set__ge2d3_ddb6_0 v52 v2 2.i256;
-        v56.@layout_6 = insert_value undef.@layout_6 0.i256 v0;
-        v57.@layout_6 = insert_value v56 1.i256 v1;
-        v58.@layout_6 = insert_value v57 2.i256 v2;
+        v56.@layout_5 = insert_value undef.@layout_5 0.i256 v0;
+        v57.@layout_5 = insert_value v56 1.i256 v1;
+        v58.@layout_5 = insert_value v57 2.i256 v2;
         call %emit__g9cd0 v58;
         return;
 
@@ -729,12 +612,12 @@ func private %standalone_erc20__erc20__approve__ga9cb_da09(v0.@layout_0, v1.@lay
 
     block7:
         v46.i256 = add v3 1.i256;
-        v51.@layout_4 = insert_value undef.@layout_4 0.i256 v0;
-        v52.@layout_4 = insert_value v51 1.i256 v1;
+        v51.@layout_6 = insert_value undef.@layout_6 0.i256 v0;
+        v52.@layout_6 = insert_value v51 1.i256 v1;
         call %std__lib__evm__storage_map__impl_StorageMap_9f54__set__ge2d3_ddb6_0 v52 v2 2.i256;
-        v56.@layout_6 = insert_value undef.@layout_6 0.i256 v0;
-        v57.@layout_6 = insert_value v56 1.i256 v1;
-        v58.@layout_6 = insert_value v57 2.i256 v2;
+        v56.@layout_5 = insert_value undef.@layout_5 0.i256 v0;
+        v57.@layout_5 = insert_value v56 1.i256 v1;
+        v58.@layout_5 = insert_value v57 2.i256 v2;
         call %emit__g9cd0 v58;
         return;
 
@@ -752,7 +635,7 @@ func private %standalone_erc20__erc20__approve__ga9cb_da09(v0.@layout_0, v1.@lay
         evm_revert v37 36.i256;
 }
 
-func private %std__lib__abi__sol__types__impl_trait_Address_0a07__as_topic_102e(v0.@layout_0) -> i256 {
+func private %as_topic(v0.@layout_0) -> i256 {
     block0:
         jump block1;
 
@@ -761,16 +644,7 @@ func private %std__lib__abi__sol__types__impl_trait_Address_0a07__as_topic_102e(
         return v3;
 }
 
-func private %std__lib__abi__sol__types__impl_trait_Address_0a07__as_topic_d26a(v0.@layout_0) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.i256 = extract_value v0 0.i256;
-        return v3;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_SolEncoder_ce34__at_31d5(v0.i256) -> @layout_1 {
+func inline(always) private %at(v0.i256) -> @layout_1 {
     block0:
         jump block1;
 
@@ -780,97 +654,7 @@ func inline(always) private %std__lib__abi__sol__impl_SolEncoder_ce34__at_31d5(v
         return v6;
 }
 
-func inline(always) private %std__lib__abi__sol__impl_SolEncoder_ce34__at_3361(v0.i256) -> @layout_1 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.@layout_1 = insert_value undef.@layout_1 0.i256 v0;
-        v6.@layout_1 = insert_value v4 1.i256 v0;
-        return v6;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_SolEncoder_ce34__at_65fb(v0.i256) -> @layout_1 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.@layout_1 = insert_value undef.@layout_1 0.i256 v0;
-        v6.@layout_1 = insert_value v4 1.i256 v0;
-        return v6;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_SolEncoder_ce34__at_69c8(v0.i256) -> @layout_1 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.@layout_1 = insert_value undef.@layout_1 0.i256 v0;
-        v6.@layout_1 = insert_value v4 1.i256 v0;
-        return v6;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_SolEncoder_ce34__at_7151(v0.i256) -> @layout_1 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.@layout_1 = insert_value undef.@layout_1 0.i256 v0;
-        v6.@layout_1 = insert_value v4 1.i256 v0;
-        return v6;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_SolEncoder_ce34__at_e384(v0.i256) -> @layout_1 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.@layout_1 = insert_value undef.@layout_1 0.i256 v0;
-        v6.@layout_1 = insert_value v4 1.i256 v0;
-        return v6;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_SolEncoder_ce34__at_fb00(v0.i256) -> @layout_1 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.@layout_1 = insert_value undef.@layout_1 0.i256 v0;
-        v6.@layout_1 = insert_value v4 1.i256 v0;
-        return v6;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_117c(v0.objref<@layout_1>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 0.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_1580(v0.objref<@layout_1>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 0.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_4803(v0.objref<@layout_1>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 0.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_5297(v0.objref<@layout_3>) -> i256 {
+func private %base__g463e(v0.objref<@layout_3>) -> i256 {
     block0:
         jump block1;
 
@@ -880,67 +664,7 @@ func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_5297(v
         return v4;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_5297_0(v0.objref<@layout_3>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 1.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_57cd(v0.objref<@layout_1>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 0.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_61c3(v0.objref<@layout_1>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 0.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_7bd0(v0.objref<@layout_1>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 0.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_b8b6(v0.objref<@layout_1>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 0.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_e214(v0.objref<@layout_1>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 0.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_eb78(v0.objref<@layout_1>) -> i256 {
+func private %impl_trait_SolEncoder__base(v0.objref<@layout_1>) -> i256 {
     block0:
         jump block1;
 
@@ -1017,9 +741,9 @@ func private %standalone_erc20__erc20__burn__ga9cb_d0fb(v0.@layout_0, v1.i256, v
     block12:
         evm_sstore v2 v55;
         v59.@layout_0 = call %zero;
-        v62.@layout_6 = insert_value undef.@layout_6 0.i256 v0;
-        v63.@layout_6 = insert_value v62 1.i256 v59;
-        v65.@layout_6 = insert_value v63 2.i256 v1;
+        v62.@layout_5 = insert_value undef.@layout_5 0.i256 v0;
+        v63.@layout_5 = insert_value v62 1.i256 v59;
+        v65.@layout_5 = insert_value v63 2.i256 v1;
         call %emit__g4c3d v65;
         return;
 }
@@ -1091,14 +815,14 @@ func private %standalone_erc20__erc20__burn__ga9cb_d32b(v0.@layout_0, v1.i256, v
     block12:
         evm_sstore v2 v55;
         v59.@layout_0 = call %zero;
-        v62.@layout_6 = insert_value undef.@layout_6 0.i256 v0;
-        v63.@layout_6 = insert_value v62 1.i256 v59;
-        v65.@layout_6 = insert_value v63 2.i256 v1;
+        v62.@layout_5 = insert_value undef.@layout_5 0.i256 v0;
+        v63.@layout_5 = insert_value v62 1.i256 v59;
+        v65.@layout_5 = insert_value v63 2.i256 v1;
         call %emit__g4c3d v65;
         return;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_a1e8__caller_aa40() -> @layout_0 {
+func private %caller() -> @layout_0 {
     block0:
         jump block1;
 
@@ -1108,17 +832,7 @@ func private %std__lib__evm__effects__impl_trait_Evm_a1e8__caller_aa40() -> @lay
         return v3;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_a1e8__caller_aa40_0() -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v0.i256 = evm_caller;
-        v3.@layout_0 = insert_value undef.@layout_0 0.i256 v0;
-        return v3;
-}
-
-func inline(always) private %core__lib__abi__checked_frame_end__gf13e_01a8(v0.i256, v1.i256, v2.i256) -> i256 {
+func inline(always) private %core__lib__abi__checked_frame_end__gf13e_0c33(v0.i256, v1.i256, v2.i256) -> i256 {
     block0:
         jump block1;
 
@@ -1127,7 +841,7 @@ func inline(always) private %core__lib__abi__checked_frame_end__gf13e_01a8(v0.i2
         br v6 block6 block7;
 
     block2:
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_947f;
+        call %decode_error;
         unreachable;
 
     block3:
@@ -1150,7 +864,7 @@ func inline(always) private %core__lib__abi__checked_frame_end__gf13e_01a8(v0.i2
         br v13 block2 block5;
 }
 
-func inline(always) private %core__lib__abi__checked_frame_end__gf13e_4689(v0.i256, v1.i256, v2.i256) -> i256 {
+func inline(always) private %core__lib__abi__checked_frame_end__gf13e_c491(v0.i256, v1.i256, v2.i256) -> i256 {
     block0:
         jump block1;
 
@@ -1159,7 +873,7 @@ func inline(always) private %core__lib__abi__checked_frame_end__gf13e_4689(v0.i2
         br v6 block6 block7;
 
     block2:
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_733d;
+        call %decode_error;
         unreachable;
 
     block3:
@@ -1182,487 +896,7 @@ func inline(always) private %core__lib__abi__checked_frame_end__gf13e_4689(v0.i2
         br v13 block2 block5;
 }
 
-func inline(always) private %core__lib__abi__checked_frame_end__gf13e_60b4(v0.i256, v1.i256, v2.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        (v5.i256, v6.i1) = uaddo v0 v1;
-        br v6 block6 block7;
-
-    block2:
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_a0e7;
-        unreachable;
-
-    block3:
-        jump block4;
-
-    block4:
-        return v5;
-
-    block5:
-        v17.i1 = gt v5 v2;
-        br v17 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v13.i1 = lt v5 v0;
-        br v13 block2 block5;
-}
-
-func inline(always) private %core__lib__abi__checked_frame_end__gf13e_6403(v0.i256, v1.i256, v2.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        (v5.i256, v6.i1) = uaddo v0 v1;
-        br v6 block6 block7;
-
-    block2:
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_2004;
-        unreachable;
-
-    block3:
-        jump block4;
-
-    block4:
-        return v5;
-
-    block5:
-        v17.i1 = gt v5 v2;
-        br v17 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v13.i1 = lt v5 v0;
-        br v13 block2 block5;
-}
-
-func inline(always) private %core__lib__abi__checked_frame_end__gf13e_9284(v0.i256, v1.i256, v2.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        (v5.i256, v6.i1) = uaddo v0 v1;
-        br v6 block6 block7;
-
-    block2:
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_929c;
-        unreachable;
-
-    block3:
-        jump block4;
-
-    block4:
-        return v5;
-
-    block5:
-        v17.i1 = gt v5 v2;
-        br v17 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v13.i1 = lt v5 v0;
-        br v13 block2 block5;
-}
-
-func inline(always) private %core__lib__abi__checked_frame_end__gf13e_9888(v0.i256, v1.i256, v2.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        (v5.i256, v6.i1) = uaddo v0 v1;
-        br v6 block6 block7;
-
-    block2:
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_7414;
-        unreachable;
-
-    block3:
-        jump block4;
-
-    block4:
-        return v5;
-
-    block5:
-        v17.i1 = gt v5 v2;
-        br v17 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v13.i1 = lt v5 v0;
-        br v13 block2 block5;
-}
-
-func inline(always) private %core__lib__abi__checked_frame_end__gf13e_9b12(v0.i256, v1.i256, v2.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        (v5.i256, v6.i1) = uaddo v0 v1;
-        br v6 block6 block7;
-
-    block2:
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_dc07;
-        unreachable;
-
-    block3:
-        jump block4;
-
-    block4:
-        return v5;
-
-    block5:
-        v17.i1 = gt v5 v2;
-        br v17 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v13.i1 = lt v5 v0;
-        br v13 block2 block5;
-}
-
-func inline(always) private %core__lib__abi__checked_frame_end__gf13e_a584(v0.i256, v1.i256, v2.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        (v5.i256, v6.i1) = uaddo v0 v1;
-        br v6 block6 block7;
-
-    block2:
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_4ce8;
-        unreachable;
-
-    block3:
-        jump block4;
-
-    block4:
-        return v5;
-
-    block5:
-        v17.i1 = gt v5 v2;
-        br v17 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v13.i1 = lt v5 v0;
-        br v13 block2 block5;
-}
-
-func inline(always) private %core__lib__abi__checked_frame_end__gf13e_aaf5(v0.i256, v1.i256, v2.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        (v5.i256, v6.i1) = uaddo v0 v1;
-        br v6 block6 block7;
-
-    block2:
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_39f6;
-        unreachable;
-
-    block3:
-        jump block4;
-
-    block4:
-        return v5;
-
-    block5:
-        v17.i1 = gt v5 v2;
-        br v17 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v13.i1 = lt v5 v0;
-        br v13 block2 block5;
-}
-
-func inline(always) private %core__lib__abi__checked_frame_end__gf13e_b8aa(v0.i256, v1.i256, v2.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        (v5.i256, v6.i1) = uaddo v0 v1;
-        br v6 block6 block7;
-
-    block2:
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_0b81;
-        unreachable;
-
-    block3:
-        jump block4;
-
-    block4:
-        return v5;
-
-    block5:
-        v17.i1 = gt v5 v2;
-        br v17 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v13.i1 = lt v5 v0;
-        br v13 block2 block5;
-}
-
-func inline(always) private %core__lib__abi__checked_frame_end__gf13e_c0b4(v0.i256, v1.i256, v2.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        (v5.i256, v6.i1) = uaddo v0 v1;
-        br v6 block6 block7;
-
-    block2:
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_12a9;
-        unreachable;
-
-    block3:
-        jump block4;
-
-    block4:
-        return v5;
-
-    block5:
-        v17.i1 = gt v5 v2;
-        br v17 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v13.i1 = lt v5 v0;
-        br v13 block2 block5;
-}
-
-func inline(always) private %core__lib__abi__checked_frame_end__gf13e_c3cb(v0.i256, v1.i256, v2.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        (v5.i256, v6.i1) = uaddo v0 v1;
-        br v6 block6 block7;
-
-    block2:
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_a63d;
-        unreachable;
-
-    block3:
-        jump block4;
-
-    block4:
-        return v5;
-
-    block5:
-        v17.i1 = gt v5 v2;
-        br v17 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v13.i1 = lt v5 v0;
-        br v13 block2 block5;
-}
-
-func inline(always) private %core__lib__abi__checked_frame_end__gf13e_cc78(v0.i256, v1.i256, v2.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        (v5.i256, v6.i1) = uaddo v0 v1;
-        br v6 block6 block7;
-
-    block2:
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_6a0c;
-        unreachable;
-
-    block3:
-        jump block4;
-
-    block4:
-        return v5;
-
-    block5:
-        v17.i1 = gt v5 v2;
-        br v17 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v13.i1 = lt v5 v0;
-        br v13 block2 block5;
-}
-
-func inline(always) private %core__lib__abi__checked_frame_end__gf13e_d1eb(v0.i256, v1.i256, v2.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        (v5.i256, v6.i1) = uaddo v0 v1;
-        br v6 block6 block7;
-
-    block2:
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_f9e7;
-        unreachable;
-
-    block3:
-        jump block4;
-
-    block4:
-        return v5;
-
-    block5:
-        v17.i1 = gt v5 v2;
-        br v17 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v13.i1 = lt v5 v0;
-        br v13 block2 block5;
-}
-
-func inline(always) private %core__lib__abi__checked_frame_end__gf13e_de97(v0.i256, v1.i256, v2.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        (v5.i256, v6.i1) = uaddo v0 v1;
-        br v6 block6 block7;
-
-    block2:
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_0d37;
-        unreachable;
-
-    block3:
-        jump block4;
-
-    block4:
-        return v5;
-
-    block5:
-        v17.i1 = gt v5 v2;
-        br v17 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v13.i1 = lt v5 v0;
-        br v13 block2 block5;
-}
-
-func inline(always) private %core__lib__abi__checked_frame_end__gf13e_e706(v0.i256, v1.i256, v2.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        (v5.i256, v6.i1) = uaddo v0 v1;
-        br v6 block6 block7;
-
-    block2:
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_27a8;
-        unreachable;
-
-    block3:
-        jump block4;
-
-    block4:
-        return v5;
-
-    block5:
-        v17.i1 = gt v5 v2;
-        br v17 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v13.i1 = lt v5 v0;
-        br v13 block2 block5;
-}
-
-func inline(always) private %core__lib__abi__checked_frame_end__gf13e_f40a(v0.i256, v1.i256, v2.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        (v5.i256, v6.i1) = uaddo v0 v1;
-        br v6 block6 block7;
-
-    block2:
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_23e2;
-        unreachable;
-
-    block3:
-        jump block4;
-
-    block4:
-        return v5;
-
-    block5:
-        v17.i1 = gt v5 v2;
-        br v17 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v13.i1 = lt v5 v0;
-        br v13 block2 block5;
-}
-
-func inline(always) private %core__lib__abi__checked_tail__gf13e_134e(v0.i256, v1.i256) -> i256 {
+func inline(always) private %core__lib__abi__checked_tail__gf13e_01d8(v0.i256, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -1671,7 +905,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_134e(v0.i256, v
         br v5 block5 block6;
 
     block2:
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_fe05;
+        call %decode_error;
         unreachable;
 
     block3:
@@ -1690,7 +924,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_134e(v0.i256, v
         br v12 block2 block3;
 }
 
-func inline(always) private %core__lib__abi__checked_tail__gf13e_15b4(v0.i256, v1.i256) -> i256 {
+func inline(always) private %core__lib__abi__checked_tail__gf13e_080c(v0.i256, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -1699,7 +933,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_15b4(v0.i256, v
         br v5 block5 block6;
 
     block2:
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_d2b1;
+        call %decode_error;
         unreachable;
 
     block3:
@@ -1718,7 +952,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_15b4(v0.i256, v
         br v12 block2 block3;
 }
 
-func inline(always) private %core__lib__abi__checked_tail__gf13e_2af0(v0.i256, v1.i256) -> i256 {
+func inline(always) private %core__lib__abi__checked_tail__gf13e_20e8(v0.i256, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -1727,7 +961,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_2af0(v0.i256, v
         br v5 block5 block6;
 
     block2:
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_eb20;
+        call %decode_error;
         unreachable;
 
     block3:
@@ -1746,7 +980,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_2af0(v0.i256, v
         br v12 block2 block3;
 }
 
-func inline(always) private %core__lib__abi__checked_tail__gf13e_2d1a(v0.i256, v1.i256) -> i256 {
+func inline(always) private %core__lib__abi__checked_tail__gf13e_24de(v0.i256, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -1755,7 +989,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_2d1a(v0.i256, v
         br v5 block5 block6;
 
     block2:
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_85bb;
+        call %decode_error;
         unreachable;
 
     block3:
@@ -1774,7 +1008,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_2d1a(v0.i256, v
         br v12 block2 block3;
 }
 
-func inline(always) private %core__lib__abi__checked_tail__gf13e_3749(v0.i256, v1.i256) -> i256 {
+func inline(always) private %core__lib__abi__checked_tail__gf13e_510d(v0.i256, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -1783,7 +1017,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_3749(v0.i256, v
         br v5 block5 block6;
 
     block2:
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_e087;
+        call %decode_error;
         unreachable;
 
     block3:
@@ -1802,7 +1036,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_3749(v0.i256, v
         br v12 block2 block3;
 }
 
-func inline(always) private %core__lib__abi__checked_tail__gf13e_45b0(v0.i256, v1.i256) -> i256 {
+func inline(always) private %core__lib__abi__checked_tail__gf13e_595f(v0.i256, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -1811,7 +1045,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_45b0(v0.i256, v
         br v5 block5 block6;
 
     block2:
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_57f0;
+        call %decode_error;
         unreachable;
 
     block3:
@@ -1830,7 +1064,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_45b0(v0.i256, v
         br v12 block2 block3;
 }
 
-func inline(always) private %core__lib__abi__checked_tail__gf13e_46df(v0.i256, v1.i256) -> i256 {
+func inline(always) private %core__lib__abi__checked_tail__gf13e_5edb(v0.i256, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -1839,7 +1073,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_46df(v0.i256, v
         br v5 block5 block6;
 
     block2:
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_9af2;
+        call %decode_error;
         unreachable;
 
     block3:
@@ -1858,7 +1092,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_46df(v0.i256, v
         br v12 block2 block3;
 }
 
-func inline(always) private %core__lib__abi__checked_tail__gf13e_50a2(v0.i256, v1.i256) -> i256 {
+func inline(always) private %core__lib__abi__checked_tail__gf13e_6e47(v0.i256, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -1867,7 +1101,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_50a2(v0.i256, v
         br v5 block5 block6;
 
     block2:
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_60d9;
+        call %decode_error;
         unreachable;
 
     block3:
@@ -1886,7 +1120,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_50a2(v0.i256, v
         br v12 block2 block3;
 }
 
-func inline(always) private %core__lib__abi__checked_tail__gf13e_7a36(v0.i256, v1.i256) -> i256 {
+func inline(always) private %core__lib__abi__checked_tail__gf13e_70ae(v0.i256, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -1895,7 +1129,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_7a36(v0.i256, v
         br v5 block5 block6;
 
     block2:
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_fd54;
+        call %decode_error;
         unreachable;
 
     block3:
@@ -1914,7 +1148,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_7a36(v0.i256, v
         br v12 block2 block3;
 }
 
-func inline(always) private %core__lib__abi__checked_tail__gf13e_8bdb(v0.i256, v1.i256) -> i256 {
+func inline(always) private %core__lib__abi__checked_tail__gf13e_749b(v0.i256, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -1923,7 +1157,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_8bdb(v0.i256, v
         br v5 block5 block6;
 
     block2:
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_bf37;
+        call %decode_error;
         unreachable;
 
     block3:
@@ -1942,7 +1176,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_8bdb(v0.i256, v
         br v12 block2 block3;
 }
 
-func inline(always) private %core__lib__abi__checked_tail__gf13e_9611(v0.i256, v1.i256) -> i256 {
+func inline(always) private %core__lib__abi__checked_tail__gf13e_800b(v0.i256, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -1951,7 +1185,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_9611(v0.i256, v
         br v5 block5 block6;
 
     block2:
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_2515;
+        call %decode_error;
         unreachable;
 
     block3:
@@ -1970,7 +1204,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_9611(v0.i256, v
         br v12 block2 block3;
 }
 
-func inline(always) private %core__lib__abi__checked_tail__gf13e_9794(v0.i256, v1.i256) -> i256 {
+func inline(always) private %core__lib__abi__checked_tail__gf13e_8ca2(v0.i256, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -1979,7 +1213,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_9794(v0.i256, v
         br v5 block5 block6;
 
     block2:
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_6332;
+        call %decode_error;
         unreachable;
 
     block3:
@@ -1998,7 +1232,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_9794(v0.i256, v
         br v12 block2 block3;
 }
 
-func inline(always) private %core__lib__abi__checked_tail__gf13e_9c13(v0.i256, v1.i256) -> i256 {
+func inline(always) private %core__lib__abi__checked_tail__gf13e_9033(v0.i256, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -2007,7 +1241,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_9c13(v0.i256, v
         br v5 block5 block6;
 
     block2:
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_7fdc;
+        call %decode_error;
         unreachable;
 
     block3:
@@ -2026,7 +1260,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_9c13(v0.i256, v
         br v12 block2 block3;
 }
 
-func inline(always) private %core__lib__abi__checked_tail__gf13e_ad42(v0.i256, v1.i256) -> i256 {
+func inline(always) private %core__lib__abi__checked_tail__gf13e_998d(v0.i256, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -2035,7 +1269,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_ad42(v0.i256, v
         br v5 block5 block6;
 
     block2:
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_3f2a;
+        call %decode_error;
         unreachable;
 
     block3:
@@ -2054,7 +1288,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_ad42(v0.i256, v
         br v12 block2 block3;
 }
 
-func inline(always) private %core__lib__abi__checked_tail__gf13e_b743(v0.i256, v1.i256) -> i256 {
+func inline(always) private %core__lib__abi__checked_tail__gf13e_c861(v0.i256, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -2063,7 +1297,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_b743(v0.i256, v
         br v5 block5 block6;
 
     block2:
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_509b;
+        call %decode_error;
         unreachable;
 
     block3:
@@ -2082,7 +1316,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_b743(v0.i256, v
         br v12 block2 block3;
 }
 
-func inline(always) private %core__lib__abi__checked_tail__gf13e_c3ce(v0.i256, v1.i256) -> i256 {
+func inline(always) private %core__lib__abi__checked_tail__gf13e_f0ab(v0.i256, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -2091,7 +1325,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_c3ce(v0.i256, v
         br v5 block5 block6;
 
     block2:
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_2546;
+        call %decode_error;
         unreachable;
 
     block3:
@@ -2110,7 +1344,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_c3ce(v0.i256, v
         br v12 block2 block3;
 }
 
-func inline(always) private %core__lib__abi__checked_tail__gf13e_c89e(v0.i256, v1.i256) -> i256 {
+func inline(always) private %core__lib__abi__checked_tail__gf13e_f8d1(v0.i256, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -2119,7 +1353,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_c89e(v0.i256, v
         br v5 block5 block6;
 
     block2:
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_def1;
+        call %decode_error;
         unreachable;
 
     block3:
@@ -2231,7 +1465,7 @@ func inline(always) private %contract_recv_abi_CoolCoin_1086394137() {
 
     block3:
         v5.objref<@layout_10> = obj.alloc @layout_10;
-        v6.@layout_5 = call %decode_runtime_args__g2273 v5;
+        v6.@layout_4 = call %decode_runtime_args__g2273 v5;
         v7.@layout_0 = extract_value v6 0.i256;
         v9.i256 = extract_value v6 1.i256;
         v12.i1 = call %__CoolCoin_recv_1_0 v7 v9 0.i256 3.i256 1.i256 2.i256 3.i256;
@@ -2303,7 +1537,7 @@ func inline(always) private %contract_recv_abi_CoolCoin_157198259() {
 
     block3:
         v5.objref<@layout_10> = obj.alloc @layout_10;
-        v6.@layout_5 = call %decode_runtime_args__g7a2c v5;
+        v6.@layout_4 = call %decode_runtime_args__g7a2c v5;
         v7.@layout_0 = extract_value v6 0.i256;
         v9.i256 = extract_value v6 1.i256;
         v11.i1 = call %__CoolCoin_recv_0_1 v7 v9 0.i256 1.i256 2.i256;
@@ -2352,7 +1586,7 @@ func inline(always) private %contract_recv_abi_CoolCoin_2043438992() {
 
     block3:
         v5.objref<@layout_10> = obj.alloc @layout_10;
-        v6.@layout_5 = call %decode_runtime_args__g216b v5;
+        v6.@layout_4 = call %decode_runtime_args__g216b v5;
         v7.@layout_0 = extract_value v6 0.i256;
         v9.i256 = extract_value v6 1.i256;
         v11.i1 = call %__CoolCoin_recv_1_2 v7 v9 0.i256 1.i256 2.i256;
@@ -2400,7 +1634,7 @@ func inline(always) private %contract_recv_abi_CoolCoin_2757214935() {
 
     block3:
         v5.objref<@layout_10> = obj.alloc @layout_10;
-        v6.@layout_5 = call %decode_runtime_args__g6a7c v5;
+        v6.@layout_4 = call %decode_runtime_args__g6a7c v5;
         v7.@layout_0 = extract_value v6 0.i256;
         v9.i256 = extract_value v6 1.i256;
         v11.i1 = call %__CoolCoin_recv_1_4 v7 v9 0.i256 1.i256 2.i256;
@@ -2425,7 +1659,7 @@ func inline(always) private %contract_recv_abi_CoolCoin_2835717307() {
 
     block3:
         v5.objref<@layout_10> = obj.alloc @layout_10;
-        v6.@layout_5 = call %decode_runtime_args__ge035 v5;
+        v6.@layout_4 = call %decode_runtime_args__ge035 v5;
         v7.@layout_0 = extract_value v6 0.i256;
         v9.i256 = extract_value v6 1.i256;
         v11.i1 = call %__CoolCoin_recv_0_0 v7 v9 0.i256 1.i256 2.i256;
@@ -2450,7 +1684,7 @@ func inline(always) private %contract_recv_abi_CoolCoin_3714247998() {
 
     block3:
         v5.objref<@layout_10> = obj.alloc @layout_10;
-        v6.@layout_4 = call %decode_runtime_args__gc772 v5;
+        v6.@layout_6 = call %decode_runtime_args__gc772 v5;
         v7.@layout_0 = extract_value v6 0.i256;
         v9.@layout_0 = extract_value v6 1.i256;
         v11.i256 = call %__CoolCoin_recv_0_4 v7 v9 0.i256 1.i256 2.i256;
@@ -2498,7 +1732,7 @@ func inline(always) private %contract_recv_abi_CoolCoin_599290589() {
 
     block3:
         v5.objref<@layout_10> = obj.alloc @layout_10;
-        v6.@layout_6 = call %decode_runtime_args__g4e54 v5;
+        v6.@layout_5 = call %decode_runtime_args__g4e54 v5;
         v7.@layout_0 = extract_value v6 0.i256;
         v9.@layout_0 = extract_value v6 1.i256;
         v11.i256 = extract_value v6 2.i256;
@@ -2547,7 +1781,7 @@ func inline(always) private %contract_recv_abi_CoolCoin_961581905() {
 
     block3:
         v5.objref<@layout_10> = obj.alloc @layout_10;
-        v6.@layout_5 = call %decode_runtime_args__g698d v5;
+        v6.@layout_4 = call %decode_runtime_args__g698d v5;
         v7.@layout_0 = extract_value v6 0.i256;
         v9.i256 = extract_value v6 1.i256;
         v11.i1 = call %__CoolCoin_recv_1_3 v7 v9 0.i256 1.i256 2.i256;
@@ -2632,271 +1866,7 @@ func private %contract_runtime_root_CoolCoin() {
         unreachable;
 }
 
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_0b81() {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert 0.i256 0.i256;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_0d37() {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert 0.i256 0.i256;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_12a9() {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert 0.i256 0.i256;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_2004() {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert 0.i256 0.i256;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_23e2() {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert 0.i256 0.i256;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_2515() {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert 0.i256 0.i256;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_2546() {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert 0.i256 0.i256;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_27a8() {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert 0.i256 0.i256;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_39f6() {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert 0.i256 0.i256;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_3f2a() {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert 0.i256 0.i256;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_4ce8() {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert 0.i256 0.i256;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_509b() {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert 0.i256 0.i256;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_57f0() {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert 0.i256 0.i256;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_60d9() {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert 0.i256 0.i256;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_6332() {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert 0.i256 0.i256;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_6a0c() {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert 0.i256 0.i256;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_733d() {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert 0.i256 0.i256;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_7414() {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert 0.i256 0.i256;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_7fdc() {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert 0.i256 0.i256;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_85bb() {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert 0.i256 0.i256;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_929c() {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert 0.i256 0.i256;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_947f() {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert 0.i256 0.i256;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_9af2() {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert 0.i256 0.i256;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_a0e7() {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert 0.i256 0.i256;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_a63d() {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert 0.i256 0.i256;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_bf37() {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert 0.i256 0.i256;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_d2b1() {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert 0.i256 0.i256;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_dc07() {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert 0.i256 0.i256;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_def1() {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert 0.i256 0.i256;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_e087() {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert 0.i256 0.i256;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_eb20() {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert 0.i256 0.i256;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_f9e7() {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert 0.i256 0.i256;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_fd54() {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert 0.i256 0.i256;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_fe05() {
+func private %decode_error() {
     block0:
         jump block1;
 
@@ -2912,9 +1882,9 @@ func inline(always) private %decode_field__g3854(v0.objref<@layout_3>) -> i256 {
         br 0.i1 block2 block3;
 
     block2:
-        v3.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_715d_0 v0;
-        v4.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_5297_0 v0;
-        v5.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g463e_9627_0 v0;
+        v3.i256 = call %read_word v0;
+        v4.i256 = call %base__g463e v0;
+        v5.i256 = call %pos__g463e v0;
         (v6.i256, v7.i1) = uaddo v4 v3;
         br v7 block5 block6;
 
@@ -2931,12 +1901,12 @@ func inline(always) private %decode_field__g3854(v0.objref<@layout_3>) -> i256 {
         evm_revert 0.i256 36.i256;
 
     block6:
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_6134_0 v0 v6;
-        v15.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_5297_0 v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_9c2d_0 v0 v15;
+        call %set_base__g463e v0 v6;
+        v15.i256 = call %base__g463e v0;
+        call %set_pos__g463e v0 v15;
         v17.i256 = call %impl_trait_u256__decode_payload__g407e v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_6134_0 v0 v4;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_9c2d_0 v0 v5;
+        call %set_base__g463e v0 v4;
+        call %set_pos__g463e v0 v5;
         return v17;
 }
 
@@ -2948,9 +1918,9 @@ func inline(always) private %decode_field__g8463(v0.objref<@layout_3>) -> @layou
         br 0.i1 block2 block3;
 
     block2:
-        v3.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_715d v0;
-        v4.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_5297 v0;
-        v5.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g463e_9627 v0;
+        v3.i256 = call %read_word v0;
+        v4.i256 = call %base__g463e v0;
+        v5.i256 = call %pos__g463e v0;
         (v6.i256, v7.i1) = uaddo v4 v3;
         br v7 block5 block6;
 
@@ -2967,16 +1937,16 @@ func inline(always) private %decode_field__g8463(v0.objref<@layout_3>) -> @layou
         evm_revert 0.i256 36.i256;
 
     block6:
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_6134 v0 v6;
-        v15.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_5297 v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_9c2d v0 v15;
+        call %set_base__g463e v0 v6;
+        v15.i256 = call %base__g463e v0;
+        call %set_pos__g463e v0 v15;
         v17.@layout_0 = call %impl_trait_Address__decode_payload__g407e v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_6134 v0 v4;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_9c2d v0 v5;
+        call %set_base__g463e v0 v4;
+        call %set_pos__g463e v0 v5;
         return v17;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from__g5385_005b(v0.@layout_0, v1.i256, v2.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_field_from__gcfb5_0940(v0.@layout_0, v1.i256, v2.i256) -> @layout_0 {
     block0:
         jump block1;
 
@@ -2984,7 +1954,7 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_005b(v0.@l
         br 0.i1 block2 block3;
 
     block2:
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_d855 v0 v2;
+        v6.i256 = call %impl_trait_CallData__word_at v0 v2;
         (v8.i256, v9.i1) = uaddo v1 v6;
         br v9 block5 block6;
 
@@ -2992,7 +1962,7 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_005b(v0.@l
         jump block4;
 
     block4:
-        v19.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_cab7_0 v0 v2;
+        v19.@layout_0 = call %impl_trait_Address__decode_from__g72ab v0 v2;
         return v19;
 
     block5:
@@ -3001,11 +1971,11 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_005b(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v16.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_cab7_0 v0 v8;
+        v16.@layout_0 = call %impl_trait_Address__decode_from__g72ab v0 v8;
         return v16;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from__g5385_071f(v0.@layout_0, v1.i256, v2.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_field_from__gcfb5_0dd8(v0.@layout_0, v1.i256, v2.i256) -> @layout_0 {
     block0:
         jump block1;
 
@@ -3013,7 +1983,7 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_071f(v0.@l
         br 0.i1 block2 block3;
 
     block2:
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_f73a v0 v2;
+        v6.i256 = call %impl_trait_CallData__word_at v0 v2;
         (v8.i256, v9.i1) = uaddo v1 v6;
         br v9 block5 block6;
 
@@ -3021,7 +1991,7 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_071f(v0.@l
         jump block4;
 
     block4:
-        v19.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f835_0 v0 v2;
+        v19.@layout_0 = call %impl_trait_Address__decode_from__g72ab v0 v2;
         return v19;
 
     block5:
@@ -3030,11 +2000,11 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_071f(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v16.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f835_0 v0 v8;
+        v16.@layout_0 = call %impl_trait_Address__decode_from__g72ab v0 v8;
         return v16;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from__g5385_0b34(v0.@layout_0, v1.i256, v2.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_field_from__g5385_1701(v0.@layout_0, v1.i256, v2.i256) -> i256 {
     block0:
         jump block1;
 
@@ -3042,7 +2012,7 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_0b34(v0.@l
         br 0.i1 block2 block3;
 
     block2:
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_e8c5 v0 v2;
+        v6.i256 = call %impl_trait_CallData__word_at v0 v2;
         (v8.i256, v9.i1) = uaddo v1 v6;
         br v9 block5 block6;
 
@@ -3050,7 +2020,7 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_0b34(v0.@l
         jump block4;
 
     block4:
-        v19.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_ab67_0 v0 v2;
+        v19.i256 = call %impl_trait_u256__decode_from__g72ab v0 v2;
         return v19;
 
     block5:
@@ -3059,11 +2029,11 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_0b34(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v16.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_ab67_0 v0 v8;
+        v16.i256 = call %impl_trait_u256__decode_from__g72ab v0 v8;
         return v16;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from__g5385_3cbb(v0.@layout_0, v1.i256, v2.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_field_from__gcfb5_23dc(v0.@layout_0, v1.i256, v2.i256) -> @layout_0 {
     block0:
         jump block1;
 
@@ -3071,7 +2041,7 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_3cbb(v0.@l
         br 0.i1 block2 block3;
 
     block2:
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_9c0e v0 v2;
+        v6.i256 = call %impl_trait_CallData__word_at v0 v2;
         (v8.i256, v9.i1) = uaddo v1 v6;
         br v9 block5 block6;
 
@@ -3079,7 +2049,7 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_3cbb(v0.@l
         jump block4;
 
     block4:
-        v19.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_337f_0 v0 v2;
+        v19.@layout_0 = call %impl_trait_Address__decode_from__g72ab v0 v2;
         return v19;
 
     block5:
@@ -3088,11 +2058,11 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_3cbb(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v16.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_337f_0 v0 v8;
+        v16.@layout_0 = call %impl_trait_Address__decode_from__g72ab v0 v8;
         return v16;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from__gcfb5_4621(v0.@layout_0, v1.i256, v2.i256) -> @layout_0 {
+func inline(always) private %core__lib__abi__decode_field_from__gcfb5_34e3(v0.@layout_0, v1.i256, v2.i256) -> @layout_0 {
     block0:
         jump block1;
 
@@ -3100,7 +2070,7 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_4621(v0.@l
         br 0.i1 block2 block3;
 
     block2:
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_6f45 v0 v2;
+        v6.i256 = call %impl_trait_CallData__word_at v0 v2;
         (v8.i256, v9.i1) = uaddo v1 v6;
         br v9 block5 block6;
 
@@ -3108,7 +2078,7 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_4621(v0.@l
         jump block4;
 
     block4:
-        v19.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_42a1_0 v0 v2;
+        v19.@layout_0 = call %impl_trait_Address__decode_from__g72ab v0 v2;
         return v19;
 
     block5:
@@ -3117,11 +2087,11 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_4621(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v16.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_42a1_0 v0 v8;
+        v16.@layout_0 = call %impl_trait_Address__decode_from__g72ab v0 v8;
         return v16;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from__gcfb5_57f7(v0.@layout_0, v1.i256, v2.i256) -> @layout_0 {
+func inline(always) private %core__lib__abi__decode_field_from__g5385_35b8(v0.@layout_0, v1.i256, v2.i256) -> i256 {
     block0:
         jump block1;
 
@@ -3129,7 +2099,7 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_57f7(v0.@l
         br 0.i1 block2 block3;
 
     block2:
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_6ca3 v0 v2;
+        v6.i256 = call %impl_trait_CallData__word_at v0 v2;
         (v8.i256, v9.i1) = uaddo v1 v6;
         br v9 block5 block6;
 
@@ -3137,7 +2107,7 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_57f7(v0.@l
         jump block4;
 
     block4:
-        v19.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_a8a8_0 v0 v2;
+        v19.i256 = call %impl_trait_u256__decode_from__g72ab v0 v2;
         return v19;
 
     block5:
@@ -3146,11 +2116,11 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_57f7(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v16.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_a8a8_0 v0 v8;
+        v16.i256 = call %impl_trait_u256__decode_from__g72ab v0 v8;
         return v16;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from__gcfb5_5b19(v0.@layout_0, v1.i256, v2.i256) -> @layout_0 {
+func inline(always) private %core__lib__abi__decode_field_from__g5385_49e2(v0.@layout_0, v1.i256, v2.i256) -> i256 {
     block0:
         jump block1;
 
@@ -3158,7 +2128,7 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_5b19(v0.@l
         br 0.i1 block2 block3;
 
     block2:
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_191d v0 v2;
+        v6.i256 = call %impl_trait_CallData__word_at v0 v2;
         (v8.i256, v9.i1) = uaddo v1 v6;
         br v9 block5 block6;
 
@@ -3166,7 +2136,7 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_5b19(v0.@l
         jump block4;
 
     block4:
-        v19.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_9696_0 v0 v2;
+        v19.i256 = call %impl_trait_u256__decode_from__g72ab v0 v2;
         return v19;
 
     block5:
@@ -3175,11 +2145,11 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_5b19(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v16.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_9696_0 v0 v8;
+        v16.i256 = call %impl_trait_u256__decode_from__g72ab v0 v8;
         return v16;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from__gcfb5_6b0d(v0.@layout_0, v1.i256, v2.i256) -> @layout_0 {
+func inline(always) private %core__lib__abi__decode_field_from__g5385_5374(v0.@layout_0, v1.i256, v2.i256) -> i256 {
     block0:
         jump block1;
 
@@ -3187,7 +2157,7 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_6b0d(v0.@l
         br 0.i1 block2 block3;
 
     block2:
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_9869 v0 v2;
+        v6.i256 = call %impl_trait_CallData__word_at v0 v2;
         (v8.i256, v9.i1) = uaddo v1 v6;
         br v9 block5 block6;
 
@@ -3195,7 +2165,7 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_6b0d(v0.@l
         jump block4;
 
     block4:
-        v19.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_37dd_0 v0 v2;
+        v19.i256 = call %impl_trait_u256__decode_from__g72ab v0 v2;
         return v19;
 
     block5:
@@ -3204,11 +2174,11 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_6b0d(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v16.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_37dd_0 v0 v8;
+        v16.i256 = call %impl_trait_u256__decode_from__g72ab v0 v8;
         return v16;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from__gcfb5_7dae(v0.@layout_0, v1.i256, v2.i256) -> @layout_0 {
+func inline(always) private %core__lib__abi__decode_field_from__gcfb5_5546(v0.@layout_0, v1.i256, v2.i256) -> @layout_0 {
     block0:
         jump block1;
 
@@ -3216,7 +2186,7 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_7dae(v0.@l
         br 0.i1 block2 block3;
 
     block2:
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_9914 v0 v2;
+        v6.i256 = call %impl_trait_CallData__word_at v0 v2;
         (v8.i256, v9.i1) = uaddo v1 v6;
         br v9 block5 block6;
 
@@ -3224,7 +2194,7 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_7dae(v0.@l
         jump block4;
 
     block4:
-        v19.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_6461_0 v0 v2;
+        v19.@layout_0 = call %impl_trait_Address__decode_from__g72ab v0 v2;
         return v19;
 
     block5:
@@ -3233,11 +2203,11 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_7dae(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v16.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_6461_0 v0 v8;
+        v16.@layout_0 = call %impl_trait_Address__decode_from__g72ab v0 v8;
         return v16;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from__g5385_8d0e(v0.@layout_0, v1.i256, v2.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_field_from__gcfb5_764c(v0.@layout_0, v1.i256, v2.i256) -> @layout_0 {
     block0:
         jump block1;
 
@@ -3245,7 +2215,7 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_8d0e(v0.@l
         br 0.i1 block2 block3;
 
     block2:
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_4c6a v0 v2;
+        v6.i256 = call %impl_trait_CallData__word_at v0 v2;
         (v8.i256, v9.i1) = uaddo v1 v6;
         br v9 block5 block6;
 
@@ -3253,7 +2223,7 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_8d0e(v0.@l
         jump block4;
 
     block4:
-        v19.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f48c_0 v0 v2;
+        v19.@layout_0 = call %impl_trait_Address__decode_from__g72ab v0 v2;
         return v19;
 
     block5:
@@ -3262,11 +2232,11 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_8d0e(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v16.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f48c_0 v0 v8;
+        v16.@layout_0 = call %impl_trait_Address__decode_from__g72ab v0 v8;
         return v16;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from__gcfb5_bcba(v0.@layout_0, v1.i256, v2.i256) -> @layout_0 {
+func inline(always) private %core__lib__abi__decode_field_from__g5385_89af(v0.@layout_0, v1.i256, v2.i256) -> i256 {
     block0:
         jump block1;
 
@@ -3274,7 +2244,7 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_bcba(v0.@l
         br 0.i1 block2 block3;
 
     block2:
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_5c44 v0 v2;
+        v6.i256 = call %impl_trait_CallData__word_at v0 v2;
         (v8.i256, v9.i1) = uaddo v1 v6;
         br v9 block5 block6;
 
@@ -3282,7 +2252,7 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_bcba(v0.@l
         jump block4;
 
     block4:
-        v19.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_62af_0 v0 v2;
+        v19.i256 = call %impl_trait_u256__decode_from__g72ab v0 v2;
         return v19;
 
     block5:
@@ -3291,11 +2261,11 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_bcba(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v16.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_62af_0 v0 v8;
+        v16.i256 = call %impl_trait_u256__decode_from__g72ab v0 v8;
         return v16;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from__g5385_cce7(v0.@layout_0, v1.i256, v2.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_field_from__g5385_96ef(v0.@layout_0, v1.i256, v2.i256) -> i256 {
     block0:
         jump block1;
 
@@ -3303,7 +2273,7 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_cce7(v0.@l
         br 0.i1 block2 block3;
 
     block2:
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_cde4 v0 v2;
+        v6.i256 = call %impl_trait_CallData__word_at v0 v2;
         (v8.i256, v9.i1) = uaddo v1 v6;
         br v9 block5 block6;
 
@@ -3311,7 +2281,7 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_cce7(v0.@l
         jump block4;
 
     block4:
-        v19.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_96fc_0 v0 v2;
+        v19.i256 = call %impl_trait_u256__decode_from__g72ab v0 v2;
         return v19;
 
     block5:
@@ -3320,11 +2290,11 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_cce7(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v16.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_96fc_0 v0 v8;
+        v16.i256 = call %impl_trait_u256__decode_from__g72ab v0 v8;
         return v16;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from__g5385_e2bc(v0.@layout_0, v1.i256, v2.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_field_from__g5385_aa66(v0.@layout_0, v1.i256, v2.i256) -> i256 {
     block0:
         jump block1;
 
@@ -3332,7 +2302,7 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_e2bc(v0.@l
         br 0.i1 block2 block3;
 
     block2:
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_1397 v0 v2;
+        v6.i256 = call %impl_trait_CallData__word_at v0 v2;
         (v8.i256, v9.i1) = uaddo v1 v6;
         br v9 block5 block6;
 
@@ -3340,7 +2310,7 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_e2bc(v0.@l
         jump block4;
 
     block4:
-        v19.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f68c_0 v0 v2;
+        v19.i256 = call %impl_trait_u256__decode_from__g72ab v0 v2;
         return v19;
 
     block5:
@@ -3349,11 +2319,11 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_e2bc(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v16.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f68c_0 v0 v8;
+        v16.i256 = call %impl_trait_u256__decode_from__g72ab v0 v8;
         return v16;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from__gcfb5_e707(v0.@layout_0, v1.i256, v2.i256) -> @layout_0 {
+func inline(always) private %core__lib__abi__decode_field_from__gcfb5_bd18(v0.@layout_0, v1.i256, v2.i256) -> @layout_0 {
     block0:
         jump block1;
 
@@ -3361,7 +2331,7 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_e707(v0.@l
         br 0.i1 block2 block3;
 
     block2:
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_e3fc v0 v2;
+        v6.i256 = call %impl_trait_CallData__word_at v0 v2;
         (v8.i256, v9.i1) = uaddo v1 v6;
         br v9 block5 block6;
 
@@ -3369,7 +2339,7 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_e707(v0.@l
         jump block4;
 
     block4:
-        v19.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_b7c4_0 v0 v2;
+        v19.@layout_0 = call %impl_trait_Address__decode_from__g72ab v0 v2;
         return v19;
 
     block5:
@@ -3378,11 +2348,11 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_e707(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v16.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_b7c4_0 v0 v8;
+        v16.@layout_0 = call %impl_trait_Address__decode_from__g72ab v0 v8;
         return v16;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from__gcfb5_eb7d(v0.@layout_0, v1.i256, v2.i256) -> @layout_0 {
+func inline(always) private %core__lib__abi__decode_field_from__g5385_ddc5(v0.@layout_0, v1.i256, v2.i256) -> i256 {
     block0:
         jump block1;
 
@@ -3390,7 +2360,7 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_eb7d(v0.@l
         br 0.i1 block2 block3;
 
     block2:
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_4de3 v0 v2;
+        v6.i256 = call %impl_trait_CallData__word_at v0 v2;
         (v8.i256, v9.i1) = uaddo v1 v6;
         br v9 block5 block6;
 
@@ -3398,7 +2368,7 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_eb7d(v0.@l
         jump block4;
 
     block4:
-        v19.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_0837_0 v0 v2;
+        v19.i256 = call %impl_trait_u256__decode_from__g72ab v0 v2;
         return v19;
 
     block5:
@@ -3407,11 +2377,11 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_eb7d(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v16.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_0837_0 v0 v8;
+        v16.i256 = call %impl_trait_u256__decode_from__g72ab v0 v8;
         return v16;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from__gcfb5_fe88(v0.@layout_0, v1.i256, v2.i256) -> @layout_0 {
+func inline(always) private %core__lib__abi__decode_field_from__gcfb5_df39(v0.@layout_0, v1.i256, v2.i256) -> @layout_0 {
     block0:
         jump block1;
 
@@ -3419,7 +2389,7 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_fe88(v0.@l
         br 0.i1 block2 block3;
 
     block2:
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_2a43 v0 v2;
+        v6.i256 = call %impl_trait_CallData__word_at v0 v2;
         (v8.i256, v9.i1) = uaddo v1 v6;
         br v9 block5 block6;
 
@@ -3427,7 +2397,7 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_fe88(v0.@l
         jump block4;
 
     block4:
-        v19.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_6f9a_0 v0 v2;
+        v19.@layout_0 = call %impl_trait_Address__decode_from__g72ab v0 v2;
         return v19;
 
     block5:
@@ -3436,11 +2406,11 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_fe88(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v16.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_6f9a_0 v0 v8;
+        v16.@layout_0 = call %impl_trait_Address__decode_from__g72ab v0 v8;
         return v16;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from__g5385_ffe6(v0.@layout_0, v1.i256, v2.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_field_from__gcfb5_ecd6(v0.@layout_0, v1.i256, v2.i256) -> @layout_0 {
     block0:
         jump block1;
 
@@ -3448,7 +2418,7 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_ffe6(v0.@l
         br 0.i1 block2 block3;
 
     block2:
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_e336 v0 v2;
+        v6.i256 = call %impl_trait_CallData__word_at v0 v2;
         (v8.i256, v9.i1) = uaddo v1 v6;
         br v9 block5 block6;
 
@@ -3456,7 +2426,7 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_ffe6(v0.@l
         jump block4;
 
     block4:
-        v19.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_d1bc_0 v0 v2;
+        v19.@layout_0 = call %impl_trait_Address__decode_from__g72ab v0 v2;
         return v19;
 
     block5:
@@ -3465,11 +2435,11 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_ffe6(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v16.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_d1bc_0 v0 v8;
+        v16.@layout_0 = call %impl_trait_Address__decode_from__g72ab v0 v8;
         return v16;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__gcfb5_0d46(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> @layout_0 {
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_06c6(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
         jump block1;
 
@@ -3477,20 +2447,20 @@ func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__
         br 0.i1 block2 block3;
 
     block2:
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_191d v0 v2;
-        v9.i256 = call %core__lib__abi__checked_tail__gf13e_c89e v1 v7;
-        v11.@layout_0 = call %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_a671 v0 v9 v3;
+        v7.i256 = call %impl_trait_CallData__word_at v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_5edb v1 v7;
+        v11.i256 = call %decode_from_bounded__g8bef v0 v9 v3;
         return v11;
 
     block3:
         jump block4;
 
     block4:
-        v14.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_9696_0 v0 v2;
+        v14.i256 = call %impl_trait_u256__decode_from__g72ab v0 v2;
         return v14;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__gcfb5_1116(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> @layout_0 {
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_1719(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
         jump block1;
 
@@ -3498,20 +2468,20 @@ func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__
         br 0.i1 block2 block3;
 
     block2:
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_e3fc v0 v2;
-        v9.i256 = call %core__lib__abi__checked_tail__gf13e_7a36 v1 v7;
-        v11.@layout_0 = call %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_2732 v0 v9 v3;
+        v7.i256 = call %impl_trait_CallData__word_at v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_8ca2 v1 v7;
+        v11.i256 = call %decode_from_bounded__g8bef v0 v9 v3;
         return v11;
 
     block3:
         jump block4;
 
     block4:
-        v14.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_b7c4_0 v0 v2;
+        v14.i256 = call %impl_trait_u256__decode_from__g72ab v0 v2;
         return v14;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__gcfb5_2034(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> @layout_0 {
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__gcfb5_2279(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> @layout_0 {
     block0:
         jump block1;
 
@@ -3519,20 +2489,20 @@ func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__
         br 0.i1 block2 block3;
 
     block2:
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_2a43 v0 v2;
-        v9.i256 = call %core__lib__abi__checked_tail__gf13e_ad42 v1 v7;
-        v11.@layout_0 = call %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_d913 v0 v9 v3;
+        v7.i256 = call %impl_trait_CallData__word_at v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_595f v1 v7;
+        v11.@layout_0 = call %decode_from_bounded__gd2f7 v0 v9 v3;
         return v11;
 
     block3:
         jump block4;
 
     block4:
-        v14.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_6f9a_0 v0 v2;
+        v14.@layout_0 = call %impl_trait_Address__decode_from__g72ab v0 v2;
         return v14;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_2d17(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_4880(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
         jump block1;
 
@@ -3540,20 +2510,20 @@ func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__
         br 0.i1 block2 block3;
 
     block2:
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_1397 v0 v2;
-        v9.i256 = call %core__lib__abi__checked_tail__gf13e_b743 v1 v7;
-        v11.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_4417 v0 v9 v3;
+        v7.i256 = call %impl_trait_CallData__word_at v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_f0ab v1 v7;
+        v11.i256 = call %decode_from_bounded__g8bef v0 v9 v3;
         return v11;
 
     block3:
         jump block4;
 
     block4:
-        v14.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f68c_0 v0 v2;
+        v14.i256 = call %impl_trait_u256__decode_from__g72ab v0 v2;
         return v14;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__gcfb5_322a(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> @layout_0 {
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__gcfb5_5b12(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> @layout_0 {
     block0:
         jump block1;
 
@@ -3561,20 +2531,20 @@ func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__
         br 0.i1 block2 block3;
 
     block2:
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_5c44 v0 v2;
-        v9.i256 = call %core__lib__abi__checked_tail__gf13e_3749 v1 v7;
-        v11.@layout_0 = call %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_71be v0 v9 v3;
+        v7.i256 = call %impl_trait_CallData__word_at v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_998d v1 v7;
+        v11.@layout_0 = call %decode_from_bounded__gd2f7 v0 v9 v3;
         return v11;
 
     block3:
         jump block4;
 
     block4:
-        v14.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_62af_0 v0 v2;
+        v14.@layout_0 = call %impl_trait_Address__decode_from__g72ab v0 v2;
         return v14;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_3651(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_75c5(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
         jump block1;
 
@@ -3582,20 +2552,20 @@ func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__
         br 0.i1 block2 block3;
 
     block2:
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_e8c5 v0 v2;
-        v9.i256 = call %core__lib__abi__checked_tail__gf13e_2af0 v1 v7;
-        v11.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_45cc v0 v9 v3;
+        v7.i256 = call %impl_trait_CallData__word_at v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_c861 v1 v7;
+        v11.i256 = call %decode_from_bounded__g8bef v0 v9 v3;
         return v11;
 
     block3:
         jump block4;
 
     block4:
-        v14.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_ab67_0 v0 v2;
+        v14.i256 = call %impl_trait_u256__decode_from__g72ab v0 v2;
         return v14;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__gcfb5_4a33(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> @layout_0 {
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_7cfe(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
         jump block1;
 
@@ -3603,20 +2573,20 @@ func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__
         br 0.i1 block2 block3;
 
     block2:
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_9869 v0 v2;
-        v9.i256 = call %core__lib__abi__checked_tail__gf13e_46df v1 v7;
-        v11.@layout_0 = call %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_63cb v0 v9 v3;
+        v7.i256 = call %impl_trait_CallData__word_at v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_24de v1 v7;
+        v11.i256 = call %decode_from_bounded__g8bef v0 v9 v3;
         return v11;
 
     block3:
         jump block4;
 
     block4:
-        v14.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_37dd_0 v0 v2;
+        v14.i256 = call %impl_trait_u256__decode_from__g72ab v0 v2;
         return v14;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__gcfb5_5304(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> @layout_0 {
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_8e46(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
         jump block1;
 
@@ -3624,20 +2594,20 @@ func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__
         br 0.i1 block2 block3;
 
     block2:
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_6f45 v0 v2;
-        v9.i256 = call %core__lib__abi__checked_tail__gf13e_9794 v1 v7;
-        v11.@layout_0 = call %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_5c48 v0 v9 v3;
+        v7.i256 = call %impl_trait_CallData__word_at v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_20e8 v1 v7;
+        v11.i256 = call %decode_from_bounded__g8bef v0 v9 v3;
         return v11;
 
     block3:
         jump block4;
 
     block4:
-        v14.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_42a1_0 v0 v2;
+        v14.i256 = call %impl_trait_u256__decode_from__g72ab v0 v2;
         return v14;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__gcfb5_56e5(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> @layout_0 {
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__gcfb5_9766(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> @layout_0 {
     block0:
         jump block1;
 
@@ -3645,20 +2615,20 @@ func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__
         br 0.i1 block2 block3;
 
     block2:
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_9914 v0 v2;
-        v9.i256 = call %core__lib__abi__checked_tail__gf13e_45b0 v1 v7;
-        v11.@layout_0 = call %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_b8b8 v0 v9 v3;
+        v7.i256 = call %impl_trait_CallData__word_at v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_510d v1 v7;
+        v11.@layout_0 = call %decode_from_bounded__gd2f7 v0 v9 v3;
         return v11;
 
     block3:
         jump block4;
 
     block4:
-        v14.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_6461_0 v0 v2;
+        v14.@layout_0 = call %impl_trait_Address__decode_from__g72ab v0 v2;
         return v14;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_6632(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__gcfb5_9ae1(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> @layout_0 {
     block0:
         jump block1;
 
@@ -3666,20 +2636,20 @@ func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__
         br 0.i1 block2 block3;
 
     block2:
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_cde4 v0 v2;
-        v9.i256 = call %core__lib__abi__checked_tail__gf13e_8bdb v1 v7;
-        v11.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_8124 v0 v9 v3;
+        v7.i256 = call %impl_trait_CallData__word_at v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_6e47 v1 v7;
+        v11.@layout_0 = call %decode_from_bounded__gd2f7 v0 v9 v3;
         return v11;
 
     block3:
         jump block4;
 
     block4:
-        v14.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_96fc_0 v0 v2;
+        v14.@layout_0 = call %impl_trait_Address__decode_from__g72ab v0 v2;
         return v14;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_75e6(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__gcfb5_9f2a(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> @layout_0 {
     block0:
         jump block1;
 
@@ -3687,20 +2657,20 @@ func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__
         br 0.i1 block2 block3;
 
     block2:
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_4c6a v0 v2;
-        v9.i256 = call %core__lib__abi__checked_tail__gf13e_9611 v1 v7;
-        v11.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_54e2 v0 v9 v3;
+        v7.i256 = call %impl_trait_CallData__word_at v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_70ae v1 v7;
+        v11.@layout_0 = call %decode_from_bounded__gd2f7 v0 v9 v3;
         return v11;
 
     block3:
         jump block4;
 
     block4:
-        v14.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f48c_0 v0 v2;
+        v14.@layout_0 = call %impl_trait_Address__decode_from__g72ab v0 v2;
         return v14;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_76b2(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_a05e(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
         jump block1;
 
@@ -3708,20 +2678,20 @@ func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__
         br 0.i1 block2 block3;
 
     block2:
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_e336 v0 v2;
-        v9.i256 = call %core__lib__abi__checked_tail__gf13e_50a2 v1 v7;
-        v11.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_e4c0 v0 v9 v3;
+        v7.i256 = call %impl_trait_CallData__word_at v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_800b v1 v7;
+        v11.i256 = call %decode_from_bounded__g8bef v0 v9 v3;
         return v11;
 
     block3:
         jump block4;
 
     block4:
-        v14.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_d1bc_0 v0 v2;
+        v14.i256 = call %impl_trait_u256__decode_from__g72ab v0 v2;
         return v14;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_7b37(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_a3eb(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
         jump block1;
 
@@ -3729,20 +2699,20 @@ func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__
         br 0.i1 block2 block3;
 
     block2:
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_f73a v0 v2;
-        v9.i256 = call %core__lib__abi__checked_tail__gf13e_15b4 v1 v7;
-        v11.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_81b3 v0 v9 v3;
+        v7.i256 = call %impl_trait_CallData__word_at v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_9033 v1 v7;
+        v11.i256 = call %decode_from_bounded__g8bef v0 v9 v3;
         return v11;
 
     block3:
         jump block4;
 
     block4:
-        v14.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f835_0 v0 v2;
+        v14.i256 = call %impl_trait_u256__decode_from__g72ab v0 v2;
         return v14;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_88e0(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__gcfb5_a587(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> @layout_0 {
     block0:
         jump block1;
 
@@ -3750,20 +2720,20 @@ func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__
         br 0.i1 block2 block3;
 
     block2:
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_d855 v0 v2;
-        v9.i256 = call %core__lib__abi__checked_tail__gf13e_9c13 v1 v7;
-        v11.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_9915 v0 v9 v3;
+        v7.i256 = call %impl_trait_CallData__word_at v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_f8d1 v1 v7;
+        v11.@layout_0 = call %decode_from_bounded__gd2f7 v0 v9 v3;
         return v11;
 
     block3:
         jump block4;
 
     block4:
-        v14.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_cab7_0 v0 v2;
+        v14.@layout_0 = call %impl_trait_Address__decode_from__g72ab v0 v2;
         return v14;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_8d67(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__gcfb5_b923(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> @layout_0 {
     block0:
         jump block1;
 
@@ -3771,20 +2741,20 @@ func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__
         br 0.i1 block2 block3;
 
     block2:
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_9c0e v0 v2;
-        v9.i256 = call %core__lib__abi__checked_tail__gf13e_134e v1 v7;
-        v11.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_9d3c v0 v9 v3;
+        v7.i256 = call %impl_trait_CallData__word_at v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_749b v1 v7;
+        v11.@layout_0 = call %decode_from_bounded__gd2f7 v0 v9 v3;
         return v11;
 
     block3:
         jump block4;
 
     block4:
-        v14.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_337f_0 v0 v2;
+        v14.@layout_0 = call %impl_trait_Address__decode_from__g72ab v0 v2;
         return v14;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__gcfb5_c901(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> @layout_0 {
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__gcfb5_f709(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> @layout_0 {
     block0:
         jump block1;
 
@@ -3792,20 +2762,20 @@ func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__
         br 0.i1 block2 block3;
 
     block2:
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_6ca3 v0 v2;
-        v9.i256 = call %core__lib__abi__checked_tail__gf13e_2d1a v1 v7;
-        v11.@layout_0 = call %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_00f8 v0 v9 v3;
+        v7.i256 = call %impl_trait_CallData__word_at v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_01d8 v1 v7;
+        v11.@layout_0 = call %decode_from_bounded__gd2f7 v0 v9 v3;
         return v11;
 
     block3:
         jump block4;
 
     block4:
-        v14.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_a8a8_0 v0 v2;
+        v14.@layout_0 = call %impl_trait_Address__decode_from__g72ab v0 v2;
         return v14;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__gcfb5_fee7(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> @layout_0 {
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__gcfb5_fbff(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> @layout_0 {
     block0:
         jump block1;
 
@@ -3813,70 +2783,26 @@ func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__
         br 0.i1 block2 block3;
 
     block2:
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_4de3 v0 v2;
-        v9.i256 = call %core__lib__abi__checked_tail__gf13e_c3ce v1 v7;
-        v11.@layout_0 = call %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_1d36 v0 v9 v3;
+        v7.i256 = call %impl_trait_CallData__word_at v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_080c v1 v7;
+        v11.@layout_0 = call %decode_from_bounded__gd2f7 v0 v9 v3;
         return v11;
 
     block3:
         jump block4;
 
     block4:
-        v14.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_0837_0 v0 v2;
+        v14.@layout_0 = call %impl_trait_Address__decode_from__g72ab v0 v2;
         return v14;
 }
 
-func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_0837(v0.@layout_0, v1.i256) -> @layout_0 {
+func inline(always) private %impl_trait_Approve__decode_from__gd20d(v0.@layout_0, v1.i256) -> @layout_4 {
     block0:
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c0ea v0 v1;
-        v6.i256 = shr 160.i256 v4;
-        v8.i1 = eq v6 0.i256;
-        v9.i1 = is_zero v8;
-        br v9 block2 block3;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v12.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
-        return v12;
-}
-
-func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_0837_0(v0.@layout_0, v1.i256) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c0ea_0 v0 v1;
-        v6.i256 = shr 160.i256 v4;
-        v8.i1 = eq v6 0.i256;
-        v9.i1 = is_zero v8;
-        br v9 block2 block3;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v12.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
-        return v12;
-}
-
-func inline(always) private %impl_trait_Allowance__decode_from__gd20d(v0.@layout_0, v1.i256) -> @layout_4 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_ade7 v0;
-        v5.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_eb2d v0 v1 v1 v3;
+        v3.i256 = call %impl_trait_CallData__len v0;
+        v5.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_e231 v0 v1 v1 v3;
         (v7.i256, v8.i1) = uaddo v1 32.i256;
         br v8 block2 block3;
 
@@ -3886,7 +2812,7 @@ func inline(always) private %impl_trait_Allowance__decode_from__gd20d(v0.@layout
         evm_revert 0.i256 36.i256;
 
     block3:
-        v17.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_eb2d v0 v1 v7 v3;
+        v17.i256 = call %core__lib__abi__decode_msg_field_from__g5385_7eb4 v0 v1 v7 v3;
         v20.@layout_4 = insert_value undef.@layout_4 0.i256 v5;
         v22.@layout_4 = insert_value v20 1.i256 v17;
         return v22;
@@ -3900,110 +2826,12 @@ func inline(always) private %impl_trait_Symbol__decode_from__gd20d(v0.@layout_0,
         return;
 }
 
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_337f(v0.@layout_0, v1.i256) -> i256 {
+func inline(always) private %impl_trait_Decimals__decode_from__gd20d(v0.@layout_0, v1.i256) {
     block0:
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_bfaf v0 v1;
-        return v4;
-}
-
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_337f_0(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_bfaf_0 v0 v1;
-        return v4;
-}
-
-func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_37dd(v0.@layout_0, v1.i256) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_31f2 v0 v1;
-        v6.i256 = shr 160.i256 v4;
-        v8.i1 = eq v6 0.i256;
-        v9.i1 = is_zero v8;
-        br v9 block2 block3;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v12.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
-        return v12;
-}
-
-func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_37dd_0(v0.@layout_0, v1.i256) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_31f2_0 v0 v1;
-        v6.i256 = shr 160.i256 v4;
-        v8.i1 = eq v6 0.i256;
-        v9.i1 = is_zero v8;
-        br v9 block2 block3;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v12.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
-        return v12;
-}
-
-func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_42a1(v0.@layout_0, v1.i256) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_78a1 v0 v1;
-        v6.i256 = shr 160.i256 v4;
-        v8.i1 = eq v6 0.i256;
-        v9.i1 = is_zero v8;
-        br v9 block2 block3;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v12.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
-        return v12;
-}
-
-func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_42a1_0(v0.@layout_0, v1.i256) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_78a1_0 v0 v1;
-        v6.i256 = shr 160.i256 v4;
-        v8.i1 = eq v6 0.i256;
-        v9.i1 = is_zero v8;
-        br v9 block2 block3;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v12.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
-        return v12;
+        return;
 }
 
 func inline(always) private %impl_trait_TotalSupply__decode_from__gd20d(v0.@layout_0, v1.i256) {
@@ -4014,117 +2842,13 @@ func inline(always) private %impl_trait_TotalSupply__decode_from__gd20d(v0.@layo
         return;
 }
 
-func inline(always) private %impl_trait_Name__decode_from__gd20d(v0.@layout_0, v1.i256) {
+func inline(always) private %impl_trait_TransferFrom__decode_from__gd20d(v0.@layout_0, v1.i256) -> @layout_5 {
     block0:
         jump block1;
 
     block1:
-        return;
-}
-
-func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_62af(v0.@layout_0, v1.i256) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_fef2 v0 v1;
-        v6.i256 = shr 160.i256 v4;
-        v8.i1 = eq v6 0.i256;
-        v9.i1 = is_zero v8;
-        br v9 block2 block3;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v12.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
-        return v12;
-}
-
-func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_62af_0(v0.@layout_0, v1.i256) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_fef2_0 v0 v1;
-        v6.i256 = shr 160.i256 v4;
-        v8.i1 = eq v6 0.i256;
-        v9.i1 = is_zero v8;
-        br v9 block2 block3;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v12.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
-        return v12;
-}
-
-func inline(always) private %impl_trait_Decimals__decode_from__gd20d(v0.@layout_0, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        return;
-}
-
-func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_6461(v0.@layout_0, v1.i256) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_7e53 v0 v1;
-        v6.i256 = shr 160.i256 v4;
-        v8.i1 = eq v6 0.i256;
-        v9.i1 = is_zero v8;
-        br v9 block2 block3;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v12.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
-        return v12;
-}
-
-func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_6461_0(v0.@layout_0, v1.i256) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_7e53_0 v0 v1;
-        v6.i256 = shr 160.i256 v4;
-        v8.i1 = eq v6 0.i256;
-        v9.i1 = is_zero v8;
-        br v9 block2 block3;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v12.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
-        return v12;
-}
-
-func inline(always) private %impl_trait_BurnFrom__decode_from__gd20d(v0.@layout_0, v1.i256) -> @layout_5 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_566f v0;
-        v5.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_1421 v0 v1 v1 v3;
+        v3.i256 = call %impl_trait_CallData__len v0;
+        v5.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_93af v0 v1 v1 v3;
         (v7.i256, v8.i1) = uaddo v1 32.i256;
         br v8 block2 block3;
 
@@ -4134,73 +2858,7 @@ func inline(always) private %impl_trait_BurnFrom__decode_from__gd20d(v0.@layout_
         evm_revert 0.i256 36.i256;
 
     block3:
-        v17.i256 = call %core__lib__abi__decode_msg_field_from__g5385_0581 v0 v1 v7 v3;
-        v20.@layout_5 = insert_value undef.@layout_5 0.i256 v5;
-        v22.@layout_5 = insert_value v20 1.i256 v17;
-        return v22;
-}
-
-func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_6f9a(v0.@layout_0, v1.i256) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3903 v0 v1;
-        v6.i256 = shr 160.i256 v4;
-        v8.i1 = eq v6 0.i256;
-        v9.i1 = is_zero v8;
-        br v9 block2 block3;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v12.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
-        return v12;
-}
-
-func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_6f9a_0(v0.@layout_0, v1.i256) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3903_0 v0 v1;
-        v6.i256 = shr 160.i256 v4;
-        v8.i1 = eq v6 0.i256;
-        v9.i1 = is_zero v8;
-        br v9 block2 block3;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v12.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
-        return v12;
-}
-
-func inline(always) private %impl_trait_TransferFrom__decode_from__gd20d(v0.@layout_0, v1.i256) -> @layout_6 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_5dba v0;
-        v5.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_1e96 v0 v1 v1 v3;
-        (v7.i256, v8.i1) = uaddo v1 32.i256;
-        br v8 block2 block3;
-
-    block2:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block3:
-        v17.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_1e96 v0 v1 v7 v3;
+        v17.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_93af v0 v1 v7 v3;
         (v20.i256, v21.i1) = uaddo v1 32.i256;
         br v21 block2 block4;
 
@@ -4209,11 +2867,121 @@ func inline(always) private %impl_trait_TransferFrom__decode_from__gd20d(v0.@lay
         br v23 block2 block5;
 
     block5:
-        v27.i256 = call %core__lib__abi__decode_msg_field_from__g5385_8188 v0 v1 v22 v3;
-        v30.@layout_6 = insert_value undef.@layout_6 0.i256 v5;
-        v33.@layout_6 = insert_value v30 1.i256 v17;
-        v35.@layout_6 = insert_value v33 2.i256 v27;
+        v27.i256 = call %core__lib__abi__decode_msg_field_from__g5385_e7ea v0 v1 v22 v3;
+        v30.@layout_5 = insert_value undef.@layout_5 0.i256 v5;
+        v33.@layout_5 = insert_value v30 1.i256 v17;
+        v35.@layout_5 = insert_value v33 2.i256 v27;
         return v35;
+}
+
+func inline(always) private %impl_trait_Address__decode_from__g72ab(v0.@layout_0, v1.i256) -> @layout_0 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.i256 = call %impl_trait_CallData__word_at v0 v1;
+        v6.i256 = shr 160.i256 v4;
+        v8.i1 = eq v6 0.i256;
+        v9.i1 = is_zero v8;
+        br v9 block2 block3;
+
+    block2:
+        evm_revert 0.i256 0.i256;
+
+    block3:
+        jump block4;
+
+    block4:
+        v12.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
+        return v12;
+}
+
+func inline(always) private %impl_trait_DecreaseAllowance__decode_from__gd20d(v0.@layout_0, v1.i256) -> @layout_4 {
+    block0:
+        jump block1;
+
+    block1:
+        v3.i256 = call %impl_trait_CallData__len v0;
+        v5.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_b89d v0 v1 v1 v3;
+        (v7.i256, v8.i1) = uaddo v1 32.i256;
+        br v8 block2 block3;
+
+    block2:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block3:
+        v17.i256 = call %core__lib__abi__decode_msg_field_from__g5385_71a9 v0 v1 v7 v3;
+        v20.@layout_4 = insert_value undef.@layout_4 0.i256 v5;
+        v22.@layout_4 = insert_value v20 1.i256 v17;
+        return v22;
+}
+
+func inline(always) private %impl_trait_BurnFrom__decode_from__gd20d(v0.@layout_0, v1.i256) -> @layout_4 {
+    block0:
+        jump block1;
+
+    block1:
+        v3.i256 = call %impl_trait_CallData__len v0;
+        v5.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_f486 v0 v1 v1 v3;
+        (v7.i256, v8.i1) = uaddo v1 32.i256;
+        br v8 block2 block3;
+
+    block2:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block3:
+        v17.i256 = call %core__lib__abi__decode_msg_field_from__g5385_b223 v0 v1 v7 v3;
+        v20.@layout_4 = insert_value undef.@layout_4 0.i256 v5;
+        v22.@layout_4 = insert_value v20 1.i256 v17;
+        return v22;
+}
+
+func inline(always) private %impl_trait_Transfer__decode_from__gd20d(v0.@layout_0, v1.i256) -> @layout_4 {
+    block0:
+        jump block1;
+
+    block1:
+        v3.i256 = call %impl_trait_CallData__len v0;
+        v5.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_8379 v0 v1 v1 v3;
+        (v7.i256, v8.i1) = uaddo v1 32.i256;
+        br v8 block2 block3;
+
+    block2:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block3:
+        v17.i256 = call %core__lib__abi__decode_msg_field_from__g5385_d338 v0 v1 v7 v3;
+        v20.@layout_4 = insert_value undef.@layout_4 0.i256 v5;
+        v22.@layout_4 = insert_value v20 1.i256 v17;
+        return v22;
+}
+
+func inline(always) private %impl_trait_IncreaseAllowance__decode_from__gd20d(v0.@layout_0, v1.i256) -> @layout_4 {
+    block0:
+        jump block1;
+
+    block1:
+        v3.i256 = call %impl_trait_CallData__len v0;
+        v5.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_ff47 v0 v1 v1 v3;
+        (v7.i256, v8.i1) = uaddo v1 32.i256;
+        br v8 block2 block3;
+
+    block2:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block3:
+        v17.i256 = call %core__lib__abi__decode_msg_field_from__g5385_14d8 v0 v1 v7 v3;
+        v20.@layout_4 = insert_value undef.@layout_4 0.i256 v5;
+        v22.@layout_4 = insert_value v20 1.i256 v17;
+        return v22;
 }
 
 func inline(always) private %impl_trait_Burn__decode_from__gd20d(v0.@layout_0, v1.i256) -> @layout_0 {
@@ -4221,10 +2989,32 @@ func inline(always) private %impl_trait_Burn__decode_from__gd20d(v0.@layout_0, v
         jump block1;
 
     block1:
-        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_4aee v0;
-        v5.i256 = call %core__lib__abi__decode_msg_field_from__g5385_5e40 v0 v1 v1 v3;
+        v3.i256 = call %impl_trait_CallData__len v0;
+        v5.i256 = call %core__lib__abi__decode_msg_field_from__g5385_9f6b v0 v1 v1 v3;
         v8.@layout_0 = insert_value undef.@layout_0 0.i256 v5;
         return v8;
+}
+
+func inline(always) private %impl_trait_Allowance__decode_from__gd20d(v0.@layout_0, v1.i256) -> @layout_6 {
+    block0:
+        jump block1;
+
+    block1:
+        v3.i256 = call %impl_trait_CallData__len v0;
+        v5.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_edb5 v0 v1 v1 v3;
+        (v7.i256, v8.i1) = uaddo v1 32.i256;
+        br v8 block2 block3;
+
+    block2:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block3:
+        v17.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_edb5 v0 v1 v7 v3;
+        v20.@layout_6 = insert_value undef.@layout_6 0.i256 v5;
+        v22.@layout_6 = insert_value v20 1.i256 v17;
+        return v22;
 }
 
 func inline(always) private %impl_trait_BalanceOf__decode_from__gd20d(v0.@layout_0, v1.i256) -> @layout_7 {
@@ -4232,646 +3022,95 @@ func inline(always) private %impl_trait_BalanceOf__decode_from__gd20d(v0.@layout
         jump block1;
 
     block1:
-        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_c2ce v0;
-        v5.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_4d2f v0 v1 v1 v3;
+        v3.i256 = call %impl_trait_CallData__len v0;
+        v5.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_9b10 v0 v1 v1 v3;
         v8.@layout_7 = insert_value undef.@layout_7 0.i256 v5;
         return v8;
 }
 
-func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_9696(v0.@layout_0, v1.i256) -> @layout_0 {
+func private %decode_from_bounded__gd2f7(v0.@layout_0, v1.i256, v2.i256) -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_86b9 v0 v1;
-        v6.i256 = shr 160.i256 v4;
-        v8.i1 = eq v6 0.i256;
-        v9.i1 = is_zero v8;
-        br v9 block2 block3;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v12.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
-        return v12;
+        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_0c33 v1 32.i256 v2;
+        v8.@layout_0 = call %impl_trait_Address__decode_from__g72ab v0 v1;
+        return v8;
 }
 
-func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_9696_0(v0.@layout_0, v1.i256) -> @layout_0 {
+func private %decode_from_bounded__g8bef(v0.@layout_0, v1.i256, v2.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_86b9_0 v0 v1;
-        v6.i256 = shr 160.i256 v4;
-        v8.i1 = eq v6 0.i256;
-        v9.i1 = is_zero v8;
-        br v9 block2 block3;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v12.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
-        return v12;
+        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_c491 v1 32.i256 v2;
+        v8.i256 = call %impl_trait_u256__decode_from__g72ab v0 v1;
+        return v8;
 }
 
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_96fc(v0.@layout_0, v1.i256) -> i256 {
+func inline(always) private %impl_trait_u256__decode_from__g72ab(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_fa4a v0 v1;
+        v4.i256 = call %impl_trait_CallData__word_at v0 v1;
         return v4;
 }
 
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_96fc_0(v0.@layout_0, v1.i256) -> i256 {
+func inline(always) private %impl_trait_Name__decode_from__gd20d(v0.@layout_0, v1.i256) {
     block0:
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_fa4a_0 v0 v1;
-        return v4;
-}
-
-func inline(always) private %impl_trait_IncreaseAllowance__decode_from__gd20d(v0.@layout_0, v1.i256) -> @layout_5 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_e2e1 v0;
-        v5.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_7613 v0 v1 v1 v3;
-        (v7.i256, v8.i1) = uaddo v1 32.i256;
-        br v8 block2 block3;
-
-    block2:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block3:
-        v17.i256 = call %core__lib__abi__decode_msg_field_from__g5385_711b v0 v1 v7 v3;
-        v20.@layout_5 = insert_value undef.@layout_5 0.i256 v5;
-        v22.@layout_5 = insert_value v20 1.i256 v17;
-        return v22;
-}
-
-func inline(always) private %impl_trait_Mint__decode_from__gd20d(v0.@layout_0, v1.i256) -> @layout_5 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_3418 v0;
-        v5.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_9a55 v0 v1 v1 v3;
-        (v7.i256, v8.i1) = uaddo v1 32.i256;
-        br v8 block2 block3;
-
-    block2:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block3:
-        v17.i256 = call %core__lib__abi__decode_msg_field_from__g5385_e784 v0 v1 v7 v3;
-        v20.@layout_5 = insert_value undef.@layout_5 0.i256 v5;
-        v22.@layout_5 = insert_value v20 1.i256 v17;
-        return v22;
-}
-
-func inline(always) private %impl_trait_DecreaseAllowance__decode_from__gd20d(v0.@layout_0, v1.i256) -> @layout_5 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_f8fd v0;
-        v5.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_db81 v0 v1 v1 v3;
-        (v7.i256, v8.i1) = uaddo v1 32.i256;
-        br v8 block2 block3;
-
-    block2:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block3:
-        v17.i256 = call %core__lib__abi__decode_msg_field_from__g5385_9297 v0 v1 v7 v3;
-        v20.@layout_5 = insert_value undef.@layout_5 0.i256 v5;
-        v22.@layout_5 = insert_value v20 1.i256 v17;
-        return v22;
-}
-
-func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_a8a8(v0.@layout_0, v1.i256) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_8e74 v0 v1;
-        v6.i256 = shr 160.i256 v4;
-        v8.i1 = eq v6 0.i256;
-        v9.i1 = is_zero v8;
-        br v9 block2 block3;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v12.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
-        return v12;
-}
-
-func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_a8a8_0(v0.@layout_0, v1.i256) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_8e74_0 v0 v1;
-        v6.i256 = shr 160.i256 v4;
-        v8.i1 = eq v6 0.i256;
-        v9.i1 = is_zero v8;
-        br v9 block2 block3;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v12.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
-        return v12;
-}
-
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_ab67(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c443 v0 v1;
-        return v4;
-}
-
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_ab67_0(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c443_0 v0 v1;
-        return v4;
-}
-
-func inline(always) private %impl_trait_Transfer__decode_from__gd20d(v0.@layout_0, v1.i256) -> @layout_5 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_13b9 v0;
-        v5.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_db42 v0 v1 v1 v3;
-        (v7.i256, v8.i1) = uaddo v1 32.i256;
-        br v8 block2 block3;
-
-    block2:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block3:
-        v17.i256 = call %core__lib__abi__decode_msg_field_from__g5385_f7b3 v0 v1 v7 v3;
-        v20.@layout_5 = insert_value undef.@layout_5 0.i256 v5;
-        v22.@layout_5 = insert_value v20 1.i256 v17;
-        return v22;
-}
-
-func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_b7c4(v0.@layout_0, v1.i256) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_0df5 v0 v1;
-        v6.i256 = shr 160.i256 v4;
-        v8.i1 = eq v6 0.i256;
-        v9.i1 = is_zero v8;
-        br v9 block2 block3;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v12.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
-        return v12;
-}
-
-func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_b7c4_0(v0.@layout_0, v1.i256) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_0df5_0 v0 v1;
-        v6.i256 = shr 160.i256 v4;
-        v8.i1 = eq v6 0.i256;
-        v9.i1 = is_zero v8;
-        br v9 block2 block3;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v12.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
-        return v12;
-}
-
-func private %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_00f8(v0.@layout_0, v1.i256, v2.i256) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_cc78 v1 32.i256 v2;
-        v8.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_a8a8 v0 v1;
-        return v8;
-}
-
-func private %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_1d36(v0.@layout_0, v1.i256, v2.i256) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_c3cb v1 32.i256 v2;
-        v8.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_0837 v0 v1;
-        return v8;
-}
-
-func private %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_2732(v0.@layout_0, v1.i256, v2.i256) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_e706 v1 32.i256 v2;
-        v8.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_b7c4 v0 v1;
-        return v8;
-}
-
-func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_4417(v0.@layout_0, v1.i256, v2.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_d1eb v1 32.i256 v2;
-        v8.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f68c v0 v1;
-        return v8;
-}
-
-func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_45cc(v0.@layout_0, v1.i256, v2.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_f40a v1 32.i256 v2;
-        v8.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_ab67 v0 v1;
-        return v8;
-}
-
-func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_54e2(v0.@layout_0, v1.i256, v2.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_a584 v1 32.i256 v2;
-        v8.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f48c v0 v1;
-        return v8;
-}
-
-func private %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_5c48(v0.@layout_0, v1.i256, v2.i256) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_de97 v1 32.i256 v2;
-        v8.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_42a1 v0 v1;
-        return v8;
-}
-
-func private %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_63cb(v0.@layout_0, v1.i256, v2.i256) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_60b4 v1 32.i256 v2;
-        v8.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_37dd v0 v1;
-        return v8;
-}
-
-func private %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_71be(v0.@layout_0, v1.i256, v2.i256) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_4689 v1 32.i256 v2;
-        v8.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_62af v0 v1;
-        return v8;
-}
-
-func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_8124(v0.@layout_0, v1.i256, v2.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_aaf5 v1 32.i256 v2;
-        v8.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_96fc v0 v1;
-        return v8;
-}
-
-func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_81b3(v0.@layout_0, v1.i256, v2.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_c0b4 v1 32.i256 v2;
-        v8.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f835 v0 v1;
-        return v8;
-}
-
-func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_9915(v0.@layout_0, v1.i256, v2.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_9284 v1 32.i256 v2;
-        v8.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_cab7 v0 v1;
-        return v8;
-}
-
-func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_9d3c(v0.@layout_0, v1.i256, v2.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_01a8 v1 32.i256 v2;
-        v8.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_337f v0 v1;
-        return v8;
-}
-
-func private %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_a671(v0.@layout_0, v1.i256, v2.i256) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_9b12 v1 32.i256 v2;
-        v8.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_9696 v0 v1;
-        return v8;
-}
-
-func private %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_b8b8(v0.@layout_0, v1.i256, v2.i256) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_b8aa v1 32.i256 v2;
-        v8.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_6461 v0 v1;
-        return v8;
-}
-
-func private %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_d913(v0.@layout_0, v1.i256, v2.i256) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_6403 v1 32.i256 v2;
-        v8.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_6f9a v0 v1;
-        return v8;
-}
-
-func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_e4c0(v0.@layout_0, v1.i256, v2.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_9888 v1 32.i256 v2;
-        v8.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_d1bc v0 v1;
-        return v8;
-}
-
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_cab7(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_67b2 v0 v1;
-        return v4;
-}
-
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_cab7_0(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_67b2_0 v0 v1;
-        return v4;
-}
-
-func inline(always) private %impl_trait_Approve__decode_from__gd20d(v0.@layout_0, v1.i256) -> @layout_5 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_9f1e v0;
-        v5.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_faa5 v0 v1 v1 v3;
-        (v7.i256, v8.i1) = uaddo v1 32.i256;
-        br v8 block2 block3;
-
-    block2:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block3:
-        v17.i256 = call %core__lib__abi__decode_msg_field_from__g5385_d336 v0 v1 v7 v3;
-        v20.@layout_5 = insert_value undef.@layout_5 0.i256 v5;
-        v22.@layout_5 = insert_value v20 1.i256 v17;
-        return v22;
-}
-
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_d1bc(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3723 v0 v1;
-        return v4;
-}
-
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_d1bc_0(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3723_0 v0 v1;
-        return v4;
-}
-
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f48c(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_8b76 v0 v1;
-        return v4;
-}
-
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f48c_0(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_8b76_0 v0 v1;
-        return v4;
-}
-
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f68c(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_6669 v0 v1;
-        return v4;
-}
-
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f68c_0(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_6669_0 v0 v1;
-        return v4;
-}
-
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f835(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_7d6a v0 v1;
-        return v4;
-}
-
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f835_0(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_7d6a_0 v0 v1;
-        return v4;
-}
-
-func inline(always) private %decode_from_prechecked_head__g4997(v0.@layout_0, v1.i256, v2.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        call %impl_trait_Decimals__decode_from__gd20d v0 v1;
         return;
 }
 
-func inline(always) private %decode_from_prechecked_head__gad59(v0.@layout_0, v1.i256, v2.i256) -> @layout_5 {
+func inline(always) private %impl_trait_Mint__decode_from__gd20d(v0.@layout_0, v1.i256) -> @layout_4 {
     block0:
         jump block1;
 
     block1:
-        v6.@layout_5 = call %impl_trait_BurnFrom__decode_from__gd20d v0 v1;
+        v3.i256 = call %impl_trait_CallData__len v0;
+        v5.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_4502 v0 v1 v1 v3;
+        (v7.i256, v8.i1) = uaddo v1 32.i256;
+        br v8 block2 block3;
+
+    block2:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block3:
+        v17.i256 = call %core__lib__abi__decode_msg_field_from__g5385_5dcc v0 v1 v7 v3;
+        v20.@layout_4 = insert_value undef.@layout_4 0.i256 v5;
+        v22.@layout_4 = insert_value v20 1.i256 v17;
+        return v22;
+}
+
+func inline(always) private %decode_from_prechecked_head__gad59(v0.@layout_0, v1.i256, v2.i256) -> @layout_4 {
+    block0:
+        jump block1;
+
+    block1:
+        v6.@layout_4 = call %impl_trait_BurnFrom__decode_from__gd20d v0 v1;
         return v6;
 }
 
-func inline(always) private %decode_from_prechecked_head__g383e(v0.@layout_0, v1.i256, v2.i256) -> @layout_5 {
+func inline(always) private %decode_from_prechecked_head__g5470(v0.@layout_0, v1.i256, v2.i256) -> @layout_6 {
     block0:
         jump block1;
 
     block1:
-        v6.@layout_5 = call %impl_trait_DecreaseAllowance__decode_from__gd20d v0 v1;
+        v6.@layout_6 = call %impl_trait_Allowance__decode_from__gd20d v0 v1;
         return v6;
 }
 
-func inline(always) private %decode_from_prechecked_head__g7ea0(v0.@layout_0, v1.i256, v2.i256) -> @layout_7 {
+func inline(always) private %decode_from_prechecked_head__gab8c(v0.@layout_0, v1.i256, v2.i256) -> @layout_4 {
     block0:
         jump block1;
 
     block1:
-        v6.@layout_7 = call %impl_trait_BalanceOf__decode_from__gd20d v0 v1;
-        return v6;
-}
-
-func inline(always) private %decode_from_prechecked_head__g6690(v0.@layout_0, v1.i256, v2.i256) -> @layout_6 {
-    block0:
-        jump block1;
-
-    block1:
-        v6.@layout_6 = call %impl_trait_TransferFrom__decode_from__gd20d v0 v1;
-        return v6;
-}
-
-func inline(always) private %decode_from_prechecked_head__g051e(v0.@layout_0, v1.i256, v2.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        call %impl_trait_TotalSupply__decode_from__gd20d v0 v1;
-        return;
-}
-
-func inline(always) private %decode_from_prechecked_head__g205f(v0.@layout_0, v1.i256, v2.i256) -> @layout_5 {
-    block0:
-        jump block1;
-
-    block1:
-        v6.@layout_5 = call %impl_trait_Transfer__decode_from__gd20d v0 v1;
-        return v6;
-}
-
-func inline(always) private %decode_from_prechecked_head__g7d8c(v0.@layout_0, v1.i256, v2.i256) -> @layout_5 {
-    block0:
-        jump block1;
-
-    block1:
-        v6.@layout_5 = call %impl_trait_IncreaseAllowance__decode_from__gd20d v0 v1;
-        return v6;
-}
-
-func inline(always) private %decode_from_prechecked_head__gab8c(v0.@layout_0, v1.i256, v2.i256) -> @layout_5 {
-    block0:
-        jump block1;
-
-    block1:
-        v6.@layout_5 = call %impl_trait_Approve__decode_from__gd20d v0 v1;
-        return v6;
-}
-
-func inline(always) private %decode_from_prechecked_head__g76d6(v0.@layout_0, v1.i256, v2.i256) -> @layout_5 {
-    block0:
-        jump block1;
-
-    block1:
-        v6.@layout_5 = call %impl_trait_Mint__decode_from__gd20d v0 v1;
-        return v6;
-}
-
-func inline(always) private %decode_from_prechecked_head__g5470(v0.@layout_0, v1.i256, v2.i256) -> @layout_4 {
-    block0:
-        jump block1;
-
-    block1:
-        v6.@layout_4 = call %impl_trait_Allowance__decode_from__gd20d v0 v1;
+        v6.@layout_4 = call %impl_trait_Approve__decode_from__gd20d v0 v1;
         return v6;
 }
 
@@ -4893,6 +3132,69 @@ func inline(always) private %decode_from_prechecked_head__gbd88(v0.@layout_0, v1
         return;
 }
 
+func inline(always) private %decode_from_prechecked_head__g205f(v0.@layout_0, v1.i256, v2.i256) -> @layout_4 {
+    block0:
+        jump block1;
+
+    block1:
+        v6.@layout_4 = call %impl_trait_Transfer__decode_from__gd20d v0 v1;
+        return v6;
+}
+
+func inline(always) private %decode_from_prechecked_head__g051e(v0.@layout_0, v1.i256, v2.i256) {
+    block0:
+        jump block1;
+
+    block1:
+        call %impl_trait_TotalSupply__decode_from__gd20d v0 v1;
+        return;
+}
+
+func inline(always) private %decode_from_prechecked_head__g4997(v0.@layout_0, v1.i256, v2.i256) {
+    block0:
+        jump block1;
+
+    block1:
+        call %impl_trait_Decimals__decode_from__gd20d v0 v1;
+        return;
+}
+
+func inline(always) private %decode_from_prechecked_head__g7d8c(v0.@layout_0, v1.i256, v2.i256) -> @layout_4 {
+    block0:
+        jump block1;
+
+    block1:
+        v6.@layout_4 = call %impl_trait_IncreaseAllowance__decode_from__gd20d v0 v1;
+        return v6;
+}
+
+func inline(always) private %decode_from_prechecked_head__g76d6(v0.@layout_0, v1.i256, v2.i256) -> @layout_4 {
+    block0:
+        jump block1;
+
+    block1:
+        v6.@layout_4 = call %impl_trait_Mint__decode_from__gd20d v0 v1;
+        return v6;
+}
+
+func inline(always) private %decode_from_prechecked_head__g6690(v0.@layout_0, v1.i256, v2.i256) -> @layout_5 {
+    block0:
+        jump block1;
+
+    block1:
+        v6.@layout_5 = call %impl_trait_TransferFrom__decode_from__gd20d v0 v1;
+        return v6;
+}
+
+func inline(always) private %decode_from_prechecked_head__g7ea0(v0.@layout_0, v1.i256, v2.i256) -> @layout_7 {
+    block0:
+        jump block1;
+
+    block1:
+        v6.@layout_7 = call %impl_trait_BalanceOf__decode_from__gd20d v0 v1;
+        return v6;
+}
+
 func inline(always) private %decode_from_prechecked_head__g691a(v0.@layout_0, v1.i256, v2.i256) {
     block0:
         jump block1;
@@ -4902,7 +3204,16 @@ func inline(always) private %decode_from_prechecked_head__g691a(v0.@layout_0, v1
         return;
 }
 
-func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_0581(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> i256 {
+func inline(always) private %decode_from_prechecked_head__g383e(v0.@layout_0, v1.i256, v2.i256) -> @layout_4 {
+    block0:
+        jump block1;
+
+    block1:
+        v6.@layout_4 = call %impl_trait_DecreaseAllowance__decode_from__gd20d v0 v1;
+        return v6;
+}
+
+func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_14d8(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
         jump block1;
 
@@ -4910,18 +3221,18 @@ func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_0581(v
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_7b37 v0 v1 v2 v3;
+        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_8e46 v0 v1 v2 v3;
         return v9;
 
     block3:
         jump block4;
 
     block4:
-        v14.i256 = call %core__lib__abi__decode_field_from__g5385_071f v0 v1 v2;
+        v14.i256 = call %core__lib__abi__decode_field_from__g5385_89af v0 v1 v2;
         return v14;
 }
 
-func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_1421(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> @layout_0 {
+func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_4502(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> @layout_0 {
     block0:
         jump block1;
 
@@ -4929,18 +3240,18 @@ func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_1421(v
         br 0.i1 block2 block3;
 
     block2:
-        v9.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_2034 v0 v1 v2 v3;
+        v9.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_9f2a v0 v1 v2 v3;
         return v9;
 
     block3:
         jump block4;
 
     block4:
-        v14.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_fe88 v0 v1 v2;
+        v14.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_0940 v0 v1 v2;
         return v14;
 }
 
-func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_1e96(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> @layout_0 {
+func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_5dcc(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
         jump block1;
 
@@ -4948,18 +3259,18 @@ func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_1e96(v
         br 0.i1 block2 block3;
 
     block2:
-        v9.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_c901 v0 v1 v2 v3;
+        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_a05e v0 v1 v2 v3;
         return v9;
 
     block3:
         jump block4;
 
     block4:
-        v14.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_57f7 v0 v1 v2;
+        v14.i256 = call %core__lib__abi__decode_field_from__g5385_49e2 v0 v1 v2;
         return v14;
 }
 
-func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_4d2f(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> @layout_0 {
+func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_71a9(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
         jump block1;
 
@@ -4967,18 +3278,18 @@ func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_4d2f(v
         br 0.i1 block2 block3;
 
     block2:
-        v9.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_0d46 v0 v1 v2 v3;
+        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_a3eb v0 v1 v2 v3;
         return v9;
 
     block3:
         jump block4;
 
     block4:
-        v14.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_5b19 v0 v1 v2;
+        v14.i256 = call %core__lib__abi__decode_field_from__g5385_ddc5 v0 v1 v2;
         return v14;
 }
 
-func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_5e40(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_7eb4(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
         jump block1;
 
@@ -4986,18 +3297,18 @@ func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_5e40(v
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_76b2 v0 v1 v2 v3;
+        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_7cfe v0 v1 v2 v3;
         return v9;
 
     block3:
         jump block4;
 
     block4:
-        v14.i256 = call %core__lib__abi__decode_field_from__g5385_ffe6 v0 v1 v2;
+        v14.i256 = call %core__lib__abi__decode_field_from__g5385_5374 v0 v1 v2;
         return v14;
 }
 
-func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_711b(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_8379(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> @layout_0 {
     block0:
         jump block1;
 
@@ -5005,18 +3316,18 @@ func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_711b(v
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_6632 v0 v1 v2 v3;
+        v9.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_9ae1 v0 v1 v2 v3;
         return v9;
 
     block3:
         jump block4;
 
     block4:
-        v14.i256 = call %core__lib__abi__decode_field_from__g5385_cce7 v0 v1 v2;
+        v14.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_0dd8 v0 v1 v2;
         return v14;
 }
 
-func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_7613(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> @layout_0 {
+func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_93af(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> @layout_0 {
     block0:
         jump block1;
 
@@ -5024,18 +3335,18 @@ func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_7613(v
         br 0.i1 block2 block3;
 
     block2:
-        v9.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_322a v0 v1 v2 v3;
+        v9.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_f709 v0 v1 v2 v3;
         return v9;
 
     block3:
         jump block4;
 
     block4:
-        v14.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_bcba v0 v1 v2;
+        v14.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_764c v0 v1 v2;
         return v14;
 }
 
-func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_8188(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_9b10(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> @layout_0 {
     block0:
         jump block1;
 
@@ -5043,18 +3354,18 @@ func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_8188(v
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_3651 v0 v1 v2 v3;
+        v9.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_a587 v0 v1 v2 v3;
         return v9;
 
     block3:
         jump block4;
 
     block4:
-        v14.i256 = call %core__lib__abi__decode_field_from__g5385_0b34 v0 v1 v2;
+        v14.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_bd18 v0 v1 v2;
         return v14;
 }
 
-func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_9297(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_9f6b(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
         jump block1;
 
@@ -5062,18 +3373,18 @@ func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_9297(v
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_8d67 v0 v1 v2 v3;
+        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_75c5 v0 v1 v2 v3;
         return v9;
 
     block3:
         jump block4;
 
     block4:
-        v14.i256 = call %core__lib__abi__decode_field_from__g5385_3cbb v0 v1 v2;
+        v14.i256 = call %core__lib__abi__decode_field_from__g5385_1701 v0 v1 v2;
         return v14;
 }
 
-func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_9a55(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> @layout_0 {
+func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_b223(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
         jump block1;
 
@@ -5081,18 +3392,18 @@ func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_9a55(v
         br 0.i1 block2 block3;
 
     block2:
-        v9.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_4a33 v0 v1 v2 v3;
+        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_06c6 v0 v1 v2 v3;
         return v9;
 
     block3:
         jump block4;
 
     block4:
-        v14.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_6b0d v0 v1 v2;
+        v14.i256 = call %core__lib__abi__decode_field_from__g5385_96ef v0 v1 v2;
         return v14;
 }
 
-func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_d336(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_b89d(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> @layout_0 {
     block0:
         jump block1;
 
@@ -5100,18 +3411,18 @@ func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_d336(v
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_75e6 v0 v1 v2 v3;
+        v9.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_9766 v0 v1 v2 v3;
         return v9;
 
     block3:
         jump block4;
 
     block4:
-        v14.i256 = call %core__lib__abi__decode_field_from__g5385_8d0e v0 v1 v2;
+        v14.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_df39 v0 v1 v2;
         return v14;
 }
 
-func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_db42(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> @layout_0 {
+func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_d338(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
         jump block1;
 
@@ -5119,18 +3430,18 @@ func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_db42(v
         br 0.i1 block2 block3;
 
     block2:
-        v9.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_fee7 v0 v1 v2 v3;
+        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_1719 v0 v1 v2 v3;
         return v9;
 
     block3:
         jump block4;
 
     block4:
-        v14.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_eb7d v0 v1 v2;
+        v14.i256 = call %core__lib__abi__decode_field_from__g5385_aa66 v0 v1 v2;
         return v14;
 }
 
-func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_db81(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> @layout_0 {
+func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_e231(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> @layout_0 {
     block0:
         jump block1;
 
@@ -5138,18 +3449,18 @@ func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_db81(v
         br 0.i1 block2 block3;
 
     block2:
-        v9.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_1116 v0 v1 v2 v3;
+        v9.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_b923 v0 v1 v2 v3;
         return v9;
 
     block3:
         jump block4;
 
     block4:
-        v14.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_e707 v0 v1 v2;
+        v14.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_34e3 v0 v1 v2;
         return v14;
 }
 
-func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_e784(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_e7ea(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
         jump block1;
 
@@ -5157,18 +3468,18 @@ func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_e784(v
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_2d17 v0 v1 v2 v3;
+        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_4880 v0 v1 v2 v3;
         return v9;
 
     block3:
         jump block4;
 
     block4:
-        v14.i256 = call %core__lib__abi__decode_field_from__g5385_e2bc v0 v1 v2;
+        v14.i256 = call %core__lib__abi__decode_field_from__g5385_35b8 v0 v1 v2;
         return v14;
 }
 
-func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_eb2d(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> @layout_0 {
+func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_edb5(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> @layout_0 {
     block0:
         jump block1;
 
@@ -5176,18 +3487,18 @@ func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_eb2d(v
         br 0.i1 block2 block3;
 
     block2:
-        v9.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_5304 v0 v1 v2 v3;
+        v9.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_2279 v0 v1 v2 v3;
         return v9;
 
     block3:
         jump block4;
 
     block4:
-        v14.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_4621 v0 v1 v2;
+        v14.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_23dc v0 v1 v2;
         return v14;
 }
 
-func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_f7b3(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_f486(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> @layout_0 {
     block0:
         jump block1;
 
@@ -5195,18 +3506,18 @@ func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_f7b3(v
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_88e0 v0 v1 v2 v3;
+        v9.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_5b12 v0 v1 v2 v3;
         return v9;
 
     block3:
         jump block4;
 
     block4:
-        v14.i256 = call %core__lib__abi__decode_field_from__g5385_005b v0 v1 v2;
+        v14.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_ecd6 v0 v1 v2;
         return v14;
 }
 
-func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_faa5(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> @layout_0 {
+func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_ff47(v0.@layout_0, v1.i256, v2.i256, v3.i256) -> @layout_0 {
     block0:
         jump block1;
 
@@ -5214,24 +3525,15 @@ func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_faa5(v
         br 0.i1 block2 block3;
 
     block2:
-        v9.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_56e5 v0 v1 v2 v3;
+        v9.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_fbff v0 v1 v2 v3;
         return v9;
 
     block3:
         jump block4;
 
     block4:
-        v14.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_7dae v0 v1 v2;
+        v14.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_5546 v0 v1 v2;
         return v14;
-}
-
-func inline(always) private %impl_trait_u256__decode_payload__g407e(v0.objref<@layout_3>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_d6d9 v0;
-        return v2;
 }
 
 func inline(always) private %impl_trait_Address__decode_payload__g407e(v0.objref<@layout_3>) -> @layout_0 {
@@ -5239,7 +3541,7 @@ func inline(always) private %impl_trait_Address__decode_payload__g407e(v0.objref
         jump block1;
 
     block1:
-        v2.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_99f7 v0;
+        v2.i256 = call %read_word v0;
         v4.i256 = shr 160.i256 v2;
         v6.i1 = eq v4 0.i256;
         v7.i1 = is_zero v6;
@@ -5268,27 +3570,36 @@ func private %decode_payload__gf566(v0.objref<@layout_3>) -> @layout_8 {
         return v8;
 }
 
-func inline(always) private %decode_runtime_args__g698d(v0.objref<@layout_10>) -> @layout_5 {
+func inline(always) private %impl_trait_u256__decode_payload__g407e(v0.objref<@layout_3>) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v2.i256 = call %read_word v0;
+        return v2;
+}
+
+func inline(always) private %decode_runtime_args__g698d(v0.objref<@layout_10>) -> @layout_4 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_d673;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_25ce v3;
+        v3.@layout_0 = call %input;
+        v5.i256 = call %impl_trait_CallData__len v3;
         mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
 
     block2:
-        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_cb5c;
+        call %abort;
         unreachable;
 
     block3:
         jump block4;
 
     block4:
-        v12.@layout_5 = call %decode_from_prechecked_head__g7d8c v3 4.i256 v5;
+        v12.@layout_4 = call %decode_from_prechecked_head__g7d8c v3 4.i256 v5;
         return v12;
 
     block5:
@@ -5298,27 +3609,27 @@ func inline(always) private %decode_runtime_args__g698d(v0.objref<@layout_10>) -
         br v16 block2 block3;
 }
 
-func inline(always) private %decode_runtime_args__g216b(v0.objref<@layout_10>) -> @layout_5 {
+func inline(always) private %decode_runtime_args__g216b(v0.objref<@layout_10>) -> @layout_4 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_6a54;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_a72b v3;
+        v3.@layout_0 = call %input;
+        v5.i256 = call %impl_trait_CallData__len v3;
         mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
 
     block2:
-        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_cf57;
+        call %abort;
         unreachable;
 
     block3:
         jump block4;
 
     block4:
-        v12.@layout_5 = call %decode_from_prechecked_head__gad59 v3 4.i256 v5;
+        v12.@layout_4 = call %decode_from_prechecked_head__gad59 v3 4.i256 v5;
         return v12;
 
     block5:
@@ -5335,13 +3646,13 @@ func inline(always) private %decode_runtime_args__g295c(v0.objref<@layout_10>) {
         jump block1;
 
     block1:
-        v3.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_5bd8;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_0a2a v3;
+        v3.@layout_0 = call %input;
+        v5.i256 = call %impl_trait_CallData__len v3;
         mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
 
     block2:
-        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_9941;
+        call %abort;
         unreachable;
 
     block3:
@@ -5358,27 +3669,27 @@ func inline(always) private %decode_runtime_args__g295c(v0.objref<@layout_10>) {
         br v15 block2 block3;
 }
 
-func inline(always) private %decode_runtime_args__g2273(v0.objref<@layout_10>) -> @layout_5 {
+func inline(always) private %decode_runtime_args__g2273(v0.objref<@layout_10>) -> @layout_4 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_f89e;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_f197 v3;
+        v3.@layout_0 = call %input;
+        v5.i256 = call %impl_trait_CallData__len v3;
         mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
 
     block2:
-        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_0a69;
+        call %abort;
         unreachable;
 
     block3:
         jump block4;
 
     block4:
-        v12.@layout_5 = call %decode_from_prechecked_head__g76d6 v3 4.i256 v5;
+        v12.@layout_4 = call %decode_from_prechecked_head__g76d6 v3 4.i256 v5;
         return v12;
 
     block5:
@@ -5395,13 +3706,13 @@ func inline(always) private %decode_runtime_args__gce2e(v0.objref<@layout_10>) {
         jump block1;
 
     block1:
-        v3.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_844a;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_b402 v3;
+        v3.@layout_0 = call %input;
+        v5.i256 = call %impl_trait_CallData__len v3;
         mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
 
     block2:
-        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_66b1;
+        call %abort;
         unreachable;
 
     block3:
@@ -5418,27 +3729,27 @@ func inline(always) private %decode_runtime_args__gce2e(v0.objref<@layout_10>) {
         br v15 block2 block3;
 }
 
-func inline(always) private %decode_runtime_args__g7a2c(v0.objref<@layout_10>) -> @layout_5 {
+func inline(always) private %decode_runtime_args__g7a2c(v0.objref<@layout_10>) -> @layout_4 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_a580;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_d7d7 v3;
+        v3.@layout_0 = call %input;
+        v5.i256 = call %impl_trait_CallData__len v3;
         mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
 
     block2:
-        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_ce6e;
+        call %abort;
         unreachable;
 
     block3:
         jump block4;
 
     block4:
-        v12.@layout_5 = call %decode_from_prechecked_head__gab8c v3 4.i256 v5;
+        v12.@layout_4 = call %decode_from_prechecked_head__gab8c v3 4.i256 v5;
         return v12;
 
     block5:
@@ -5455,13 +3766,13 @@ func inline(always) private %decode_runtime_args__g953d(v0.objref<@layout_10>) -
         jump block1;
 
     block1:
-        v3.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_b73f;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_f6a9 v3;
+        v3.@layout_0 = call %input;
+        v5.i256 = call %impl_trait_CallData__len v3;
         mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
 
     block2:
-        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_6993;
+        call %abort;
         unreachable;
 
     block3:
@@ -5478,27 +3789,27 @@ func inline(always) private %decode_runtime_args__g953d(v0.objref<@layout_10>) -
         br v16 block2 block3;
 }
 
-func inline(always) private %decode_runtime_args__gc772(v0.objref<@layout_10>) -> @layout_4 {
+func inline(always) private %decode_runtime_args__gc772(v0.objref<@layout_10>) -> @layout_6 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_3347;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_2c20 v3;
+        v3.@layout_0 = call %input;
+        v5.i256 = call %impl_trait_CallData__len v3;
         mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
 
     block2:
-        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_12ed;
+        call %abort;
         unreachable;
 
     block3:
         jump block4;
 
     block4:
-        v12.@layout_4 = call %decode_from_prechecked_head__g5470 v3 4.i256 v5;
+        v12.@layout_6 = call %decode_from_prechecked_head__g5470 v3 4.i256 v5;
         return v12;
 
     block5:
@@ -5508,27 +3819,27 @@ func inline(always) private %decode_runtime_args__gc772(v0.objref<@layout_10>) -
         br v16 block2 block3;
 }
 
-func inline(always) private %decode_runtime_args__g6a7c(v0.objref<@layout_10>) -> @layout_5 {
+func inline(always) private %decode_runtime_args__g6a7c(v0.objref<@layout_10>) -> @layout_4 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_663b;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_a0e3 v3;
+        v3.@layout_0 = call %input;
+        v5.i256 = call %impl_trait_CallData__len v3;
         mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
 
     block2:
-        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_20f2;
+        call %abort;
         unreachable;
 
     block3:
         jump block4;
 
     block4:
-        v12.@layout_5 = call %decode_from_prechecked_head__g383e v3 4.i256 v5;
+        v12.@layout_4 = call %decode_from_prechecked_head__g383e v3 4.i256 v5;
         return v12;
 
     block5:
@@ -5545,13 +3856,13 @@ func inline(always) private %decode_runtime_args__g5a0b(v0.objref<@layout_10>) {
         jump block1;
 
     block1:
-        v3.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_cd56;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_d815 v3;
+        v3.@layout_0 = call %input;
+        v5.i256 = call %impl_trait_CallData__len v3;
         mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
 
     block2:
-        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_57a6;
+        call %abort;
         unreachable;
 
     block3:
@@ -5575,13 +3886,13 @@ func inline(always) private %decode_runtime_args__gce7d(v0.objref<@layout_10>) {
         jump block1;
 
     block1:
-        v3.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_88e5;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_c091 v3;
+        v3.@layout_0 = call %input;
+        v5.i256 = call %impl_trait_CallData__len v3;
         mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
 
     block2:
-        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_b229;
+        call %abort;
         unreachable;
 
     block3:
@@ -5598,27 +3909,27 @@ func inline(always) private %decode_runtime_args__gce7d(v0.objref<@layout_10>) {
         br v15 block2 block3;
 }
 
-func inline(always) private %decode_runtime_args__g4e54(v0.objref<@layout_10>) -> @layout_6 {
+func inline(always) private %decode_runtime_args__g4e54(v0.objref<@layout_10>) -> @layout_5 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_3dc9;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_bbea v3;
+        v3.@layout_0 = call %input;
+        v5.i256 = call %impl_trait_CallData__len v3;
         mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
 
     block2:
-        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_2f36;
+        call %abort;
         unreachable;
 
     block3:
         jump block4;
 
     block4:
-        v12.@layout_6 = call %decode_from_prechecked_head__g6690 v3 4.i256 v5;
+        v12.@layout_5 = call %decode_from_prechecked_head__g6690 v3 4.i256 v5;
         return v12;
 
     block5:
@@ -5628,27 +3939,27 @@ func inline(always) private %decode_runtime_args__g4e54(v0.objref<@layout_10>) -
         br v16 block2 block3;
 }
 
-func inline(always) private %decode_runtime_args__ge035(v0.objref<@layout_10>) -> @layout_5 {
+func inline(always) private %decode_runtime_args__ge035(v0.objref<@layout_10>) -> @layout_4 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_dac7;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_cea7 v3;
+        v3.@layout_0 = call %input;
+        v5.i256 = call %impl_trait_CallData__len v3;
         mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
 
     block2:
-        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_a20a;
+        call %abort;
         unreachable;
 
     block3:
         jump block4;
 
     block4:
-        v12.@layout_5 = call %decode_from_prechecked_head__g205f v3 4.i256 v5;
+        v12.@layout_4 = call %decode_from_prechecked_head__g205f v3 4.i256 v5;
         return v12;
 
     block5:
@@ -5665,13 +3976,13 @@ func inline(always) private %decode_runtime_args__gf629(v0.objref<@layout_10>) -
         jump block1;
 
     block1:
-        v3.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_e029;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_8c59 v3;
+        v3.@layout_0 = call %input;
+        v5.i256 = call %impl_trait_CallData__len v3;
         mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
 
     block2:
-        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_98a8;
+        call %abort;
         unreachable;
 
     block3:
@@ -5697,41 +4008,7 @@ func private %decoder_new(v0.@layout_1) -> @layout_3 {
         return v2;
 }
 
-func inline(always) private %impl_trait_ApprovalEvent__emit__gcd5c(v0.@layout_6) {
-    block0:
-        jump block1;
-
-    block1:
-        v3.i256 = extract_value v0 2.i256;
-        v4.@layout_1 = call %std__lib__evm__effects__encode_abi_payload__ge513_a2dc v3;
-        v6.i256 = extract_value v4 0.i256;
-        v8.i256 = extract_value v4 1.i256;
-        v10.@layout_0 = extract_value v0 0.i256;
-        v11.i256 = call %std__lib__abi__sol__types__impl_trait_Address_0a07__as_topic_d26a v10;
-        v12.@layout_0 = extract_value v0 1.i256;
-        v13.i256 = call %std__lib__abi__sol__types__impl_trait_Address_0a07__as_topic_d26a v12;
-        call %std__lib__evm__effects__impl_trait_Evm_476c__log3_ebb3 v6 v8 3682740849240848158437977969522068712009226744993583420104789809440898259342.i256 v11 v13;
-        return;
-}
-
-func inline(always) private %impl_trait_TransferEvent__emit__gcd5c(v0.@layout_6) {
-    block0:
-        jump block1;
-
-    block1:
-        v3.i256 = extract_value v0 2.i256;
-        v4.@layout_1 = call %std__lib__evm__effects__encode_abi_payload__ge513_3306 v3;
-        v6.i256 = extract_value v4 0.i256;
-        v8.i256 = extract_value v4 1.i256;
-        v10.@layout_0 = extract_value v0 0.i256;
-        v11.i256 = call %std__lib__abi__sol__types__impl_trait_Address_0a07__as_topic_102e v10;
-        v12.@layout_0 = extract_value v0 1.i256;
-        v13.i256 = call %std__lib__abi__sol__types__impl_trait_Address_0a07__as_topic_102e v12;
-        call %std__lib__evm__effects__impl_trait_Evm_476c__log3_89cc v6 v8 -9523714936405215257252364384647749786687397661936385964149718923739779436176.i256 v11 v13;
-        return;
-}
-
-func private %emit__g9cd0(v0.@layout_6) {
+func private %emit__g9cd0(v0.@layout_5) {
     block0:
         jump block1;
 
@@ -5740,7 +4017,7 @@ func private %emit__g9cd0(v0.@layout_6) {
         return;
 }
 
-func private %emit__g4c3d(v0.@layout_6) {
+func private %emit__g4c3d(v0.@layout_5) {
     block0:
         jump block1;
 
@@ -5749,12 +4026,37 @@ func private %emit__g4c3d(v0.@layout_6) {
         return;
 }
 
-func private %core__lib__abi__impl_trait_u256_d99e__encode__g426c_18aa(v0.i256, v1.objref<@layout_1>) {
+func inline(always) private %impl_trait_ApprovalEvent__emit__gcd5c(v0.@layout_5) {
     block0:
         jump block1;
 
     block1:
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_d1f3 v1 v0;
+        v3.i256 = extract_value v0 2.i256;
+        v4.@layout_1 = call %std__lib__evm__effects__encode_abi_payload__ge513_80ac v3;
+        v6.i256 = extract_value v4 0.i256;
+        v8.i256 = extract_value v4 1.i256;
+        v10.@layout_0 = extract_value v0 0.i256;
+        v11.i256 = call %as_topic v10;
+        v12.@layout_0 = extract_value v0 1.i256;
+        v13.i256 = call %as_topic v12;
+        call %log3 v6 v8 3682740849240848158437977969522068712009226744993583420104789809440898259342.i256 v11 v13;
+        return;
+}
+
+func inline(always) private %impl_trait_TransferEvent__emit__gcd5c(v0.@layout_5) {
+    block0:
+        jump block1;
+
+    block1:
+        v3.i256 = extract_value v0 2.i256;
+        v4.@layout_1 = call %std__lib__evm__effects__encode_abi_payload__ge513_3e7d v3;
+        v6.i256 = extract_value v4 0.i256;
+        v8.i256 = extract_value v4 1.i256;
+        v10.@layout_0 = extract_value v0 0.i256;
+        v11.i256 = call %as_topic v10;
+        v12.@layout_0 = extract_value v0 1.i256;
+        v13.i256 = call %as_topic v12;
+        call %log3 v6 v8 -9523714936405215257252364384647749786687397661936385964149718923739779436176.i256 v11 v13;
         return;
 }
 
@@ -5764,141 +4066,7 @@ func private %impl_trait_u8__encode__g426c(v0.i8, v1.objref<@layout_1>) {
 
     block1:
         v3.i256 = zext v0 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_bbc2 v1 v3;
-        return;
-}
-
-func private %core__lib__abi__impl_trait_u256_d99e__encode__g426c_7413(v0.i256, v1.objref<@layout_1>) {
-    block0:
-        jump block1;
-
-    block1:
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_9351 v1 v0;
-        return;
-}
-
-func private %std__lib__evm__effects__encode_abi_payload__ge513_3306(v0.i256) -> @layout_1 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.@layout_1 = call %core__lib__abi__encode_alloc__gac80_5c94 v0;
-        return v2;
-}
-
-func private %std__lib__evm__effects__encode_abi_payload__ge513_a2dc(v0.i256) -> @layout_1 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.@layout_1 = call %core__lib__abi__encode_alloc__gac80_4157 v0;
-        return v2;
-}
-
-func inline(always) private %core__lib__abi__encode_alloc__gac80_4157(v0.i256) -> @layout_1 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.i256 = call %core__lib__abi__abi_payload_size__ge513_5ba7 v0;
-        v3.@layout_1 = call %std__lib__abi__sol__impl_trait_Sol_1f5f__encoder_new_ddf2 v2;
-        v4.objref<@layout_1> = obj.alloc @layout_1;
-        v6.objref<i256> = obj.proj v4 0.i256;
-        v7.i256 = extract_value v3 0.i256;
-        obj.store v6 v7;
-        v9.objref<i256> = obj.proj v4 1.i256;
-        v10.i256 = extract_value v3 1.i256;
-        obj.store v9 v10;
-        v11.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_57cd v4;
-        call %core__lib__abi__impl_trait_u256_d99e__encode__g426c_bc5c v0 v4;
-        v14.@layout_1 = insert_value undef.@layout_1 0.i256 v11;
-        v15.@layout_1 = insert_value v14 1.i256 v2;
-        return v15;
-}
-
-func inline(always) private %core__lib__abi__encode_alloc__gac80_5c94(v0.i256) -> @layout_1 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.i256 = call %core__lib__abi__abi_payload_size__ge513_d165 v0;
-        v3.@layout_1 = call %std__lib__abi__sol__impl_trait_Sol_1f5f__encoder_new_721a v2;
-        v4.objref<@layout_1> = obj.alloc @layout_1;
-        v6.objref<i256> = obj.proj v4 0.i256;
-        v7.i256 = extract_value v3 0.i256;
-        obj.store v6 v7;
-        v9.objref<i256> = obj.proj v4 1.i256;
-        v10.i256 = extract_value v3 1.i256;
-        obj.store v9 v10;
-        v11.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_4803 v4;
-        call %core__lib__abi__impl_trait_u256_d99e__encode__g426c_7413 v0 v4;
-        v14.@layout_1 = insert_value undef.@layout_1 0.i256 v11;
-        v15.@layout_1 = insert_value v14 1.i256 v2;
-        return v15;
-}
-
-func private %encode__g3cd9(v0.i256, v1.objref<@layout_1>) {
-    block0:
-        jump block1;
-
-    block1:
-        v3.i256 = call %core__lib__num__impl_trait_String_8f88__to_word__g3eb7_4283 v0;
-        v4.i256 = call %core__lib__abi__packed_string_len_c13a v3;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_19ab v1 v4;
-        v8.i1 = eq v4 0.i256;
-        v9.i1 = is_zero v8;
-        br v9 block2 block3;
-
-    block2:
-        v11.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_7bd0 v1;
-        v13.i256 = add v11 32.i256;
-        v15.i256 = sub 32.i256 v4;
-        v17.i256 = mul v15 8.i256;
-        v19.i256 = shl v17 v3;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_at_7077 v1 v13 v19;
-        jump block4;
-
-    block3:
-        jump block4;
-
-    block4:
-        return;
-}
-
-func private %core__lib__abi__impl_trait_u256_d99e__encode__g426c_bc5c(v0.i256, v1.objref<@layout_1>) {
-    block0:
-        jump block1;
-
-    block1:
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_d00a v1 v0;
-        return;
-}
-
-func private %encode__gbe21(v0.i256, v1.objref<@layout_1>) {
-    block0:
-        jump block1;
-
-    block1:
-        v3.i256 = call %core__lib__num__impl_trait_String_8f88__to_word__gc7cf_de49 v0;
-        v4.i256 = call %core__lib__abi__packed_string_len_29ef v3;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_d10d v1 v4;
-        v8.i1 = eq v4 0.i256;
-        v9.i1 = is_zero v8;
-        br v9 block2 block3;
-
-    block2:
-        v11.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_eb78 v1;
-        v13.i256 = add v11 32.i256;
-        v15.i256 = sub 32.i256 v4;
-        v17.i256 = mul v15 8.i256;
-        v19.i256 = shl v17 v3;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_at_1360 v1 v13 v19;
-        jump block4;
-
-    block3:
-        jump block4;
-
-    block4:
+        call %write_word v1 v3;
         return;
 }
 
@@ -5910,14 +4078,139 @@ func private %impl_trait_bool__encode__g426c(v0.i1, v1.objref<@layout_1>) {
         br v0 block2 block3;
 
     block2:
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_4130 v1 1.i256;
+        call %write_word v1 1.i256;
         jump block4;
 
     block3:
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_4130 v1 0.i256;
+        call %write_word v1 0.i256;
         jump block4;
 
     block4:
+        return;
+}
+
+func private %encode__gbe21(v0.i256, v1.objref<@layout_1>) {
+    block0:
+        jump block1;
+
+    block1:
+        v3.i256 = call %to_word__gc7cf v0;
+        v4.i256 = call %core__lib__abi__packed_string_len_4544 v3;
+        call %write_word v1 v4;
+        v8.i1 = eq v4 0.i256;
+        v9.i1 = is_zero v8;
+        br v9 block2 block3;
+
+    block2:
+        v11.i256 = call %impl_trait_SolEncoder__base v1;
+        v13.i256 = add v11 32.i256;
+        v15.i256 = sub 32.i256 v4;
+        v17.i256 = mul v15 8.i256;
+        v19.i256 = shl v17 v3;
+        call %write_word_at v1 v13 v19;
+        jump block4;
+
+    block3:
+        jump block4;
+
+    block4:
+        return;
+}
+
+func private %std__lib__evm__effects__encode_abi_payload__ge513_3e7d(v0.i256) -> @layout_1 {
+    block0:
+        jump block1;
+
+    block1:
+        v2.@layout_1 = call %core__lib__abi__encode_alloc__gac80_41de v0;
+        return v2;
+}
+
+func private %std__lib__evm__effects__encode_abi_payload__ge513_80ac(v0.i256) -> @layout_1 {
+    block0:
+        jump block1;
+
+    block1:
+        v2.@layout_1 = call %core__lib__abi__encode_alloc__gac80_ec86 v0;
+        return v2;
+}
+
+func inline(always) private %core__lib__abi__encode_alloc__gac80_41de(v0.i256) -> @layout_1 {
+    block0:
+        jump block1;
+
+    block1:
+        v2.i256 = call %core__lib__abi__abi_payload_size__ge513_2949 v0;
+        v3.@layout_1 = call %encoder_new v2;
+        v4.objref<@layout_1> = obj.alloc @layout_1;
+        v6.objref<i256> = obj.proj v4 0.i256;
+        v7.i256 = extract_value v3 0.i256;
+        obj.store v6 v7;
+        v9.objref<i256> = obj.proj v4 1.i256;
+        v10.i256 = extract_value v3 1.i256;
+        obj.store v9 v10;
+        v11.i256 = call %impl_trait_SolEncoder__base v4;
+        call %impl_trait_u256__encode__g426c v0 v4;
+        v14.@layout_1 = insert_value undef.@layout_1 0.i256 v11;
+        v15.@layout_1 = insert_value v14 1.i256 v2;
+        return v15;
+}
+
+func inline(always) private %core__lib__abi__encode_alloc__gac80_ec86(v0.i256) -> @layout_1 {
+    block0:
+        jump block1;
+
+    block1:
+        v2.i256 = call %core__lib__abi__abi_payload_size__ge513_295e v0;
+        v3.@layout_1 = call %encoder_new v2;
+        v4.objref<@layout_1> = obj.alloc @layout_1;
+        v6.objref<i256> = obj.proj v4 0.i256;
+        v7.i256 = extract_value v3 0.i256;
+        obj.store v6 v7;
+        v9.objref<i256> = obj.proj v4 1.i256;
+        v10.i256 = extract_value v3 1.i256;
+        obj.store v9 v10;
+        v11.i256 = call %impl_trait_SolEncoder__base v4;
+        call %impl_trait_u256__encode__g426c v0 v4;
+        v14.@layout_1 = insert_value undef.@layout_1 0.i256 v11;
+        v15.@layout_1 = insert_value v14 1.i256 v2;
+        return v15;
+}
+
+func private %encode__g3cd9(v0.i256, v1.objref<@layout_1>) {
+    block0:
+        jump block1;
+
+    block1:
+        v3.i256 = call %to_word__g3eb7 v0;
+        v4.i256 = call %core__lib__abi__packed_string_len_b2ee v3;
+        call %write_word v1 v4;
+        v8.i1 = eq v4 0.i256;
+        v9.i1 = is_zero v8;
+        br v9 block2 block3;
+
+    block2:
+        v11.i256 = call %impl_trait_SolEncoder__base v1;
+        v13.i256 = add v11 32.i256;
+        v15.i256 = sub 32.i256 v4;
+        v17.i256 = mul v15 8.i256;
+        v19.i256 = shl v17 v3;
+        call %write_word_at v1 v13 v19;
+        jump block4;
+
+    block3:
+        jump block4;
+
+    block4:
+        return;
+}
+
+func private %impl_trait_u256__encode__g426c(v0.i256, v1.objref<@layout_1>) {
+    block0:
+        jump block1;
+
+    block1:
+        call %write_word v1 v0;
         return;
 }
 
@@ -5929,19 +4222,19 @@ func private %encode_field__ge927(v0.i1, v1.objref<@layout_1>, v2.i256) {
         br 0.i1 block2 block3;
 
     block2:
-        v5.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_1580 v1;
-        v8.i256 = call %core__lib__abi__trait_AbiSize__payload_size__gda9b_b33d v0;
+        v5.i256 = call %impl_trait_SolEncoder__base v1;
+        v8.i256 = call %payload_size__gda9b v0;
         v9.i256 = mload v2 i256;
         v10.i256 = sub v9 v5;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_2812 v1 v10;
-        v12.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_4526 v1;
+        call %write_word v1 v10;
+        v12.i256 = call %impl_trait_SolEncoder__pos v1;
         v13.i256 = mload v2 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_22b1 v1 v13;
+        call %impl_trait_SolEncoder__set_base v1 v13;
         v15.i256 = mload v2 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_73c1 v1 v15;
+        call %impl_trait_SolEncoder__set_pos v1 v15;
         call %impl_trait_bool__encode__g426c v0 v1;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_22b1 v1 v5;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_73c1 v1 v12;
+        call %impl_trait_SolEncoder__set_base v1 v5;
+        call %impl_trait_SolEncoder__set_pos v1 v12;
         v20.i256 = mload v2 i256;
         v21.i256 = add v20 v8;
         mstore v2 v21 i256;
@@ -5954,10 +4247,10 @@ func private %encode_field__ge927(v0.i1, v1.objref<@layout_1>, v2.i256) {
         br 1.i1 block5 block6;
 
     block5:
-        v24.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_4526 v1;
+        v24.i256 = call %impl_trait_SolEncoder__pos v1;
         call %impl_trait_bool__encode_to_ptr__gf13e v0 v24;
         v28.i256 = add v24 32.i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_73c1 v1 v28;
+        call %impl_trait_SolEncoder__set_pos v1 v28;
         return;
 
     block6:
@@ -5976,19 +4269,19 @@ func private %encode_field__g859f(v0.i256, v1.objref<@layout_1>, v2.i256) {
         br 1.i1 block2 block3;
 
     block2:
-        v5.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_61c3 v1;
-        v8.i256 = call %core__lib__abi__impl_trait_String_c06e__payload_size__g3eb7_f656 v0;
+        v5.i256 = call %impl_trait_SolEncoder__base v1;
+        v8.i256 = call %payload_size__g3eb7 v0;
         v9.i256 = mload v2 i256;
         v10.i256 = sub v9 v5;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_0ae5 v1 v10;
-        v12.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_6701 v1;
+        call %write_word v1 v10;
+        v12.i256 = call %impl_trait_SolEncoder__pos v1;
         v13.i256 = mload v2 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_1e89 v1 v13;
+        call %impl_trait_SolEncoder__set_base v1 v13;
         v15.i256 = mload v2 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_3e1f v1 v15;
+        call %impl_trait_SolEncoder__set_pos v1 v15;
         call %encode__g3cd9 v0 v1;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_1e89 v1 v5;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_3e1f v1 v12;
+        call %impl_trait_SolEncoder__set_base v1 v5;
+        call %impl_trait_SolEncoder__set_pos v1 v12;
         v20.i256 = mload v2 i256;
         v21.i256 = add v20 v8;
         mstore v2 v21 i256;
@@ -6001,7 +4294,7 @@ func private %encode_field__g859f(v0.i256, v1.objref<@layout_1>, v2.i256) {
         br 0.i1 block5 block6;
 
     block5:
-        v24.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_6701 v1;
+        v24.i256 = call %impl_trait_SolEncoder__pos v1;
         call %encode_to_ptr__g4320 v0 v24;
         unreachable;
 
@@ -6021,19 +4314,19 @@ func private %encode_field__g6d7e(v0.i256, v1.objref<@layout_1>, v2.i256) {
         br 1.i1 block2 block3;
 
     block2:
-        v5.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_e214 v1;
-        v8.i256 = call %core__lib__abi__impl_trait_String_c06e__payload_size__gc7cf_4aab v0;
+        v5.i256 = call %impl_trait_SolEncoder__base v1;
+        v8.i256 = call %payload_size__gc7cf v0;
         v9.i256 = mload v2 i256;
         v10.i256 = sub v9 v5;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_90db v1 v10;
-        v12.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_8ab3 v1;
+        call %write_word v1 v10;
+        v12.i256 = call %impl_trait_SolEncoder__pos v1;
         v13.i256 = mload v2 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_24e6 v1 v13;
+        call %impl_trait_SolEncoder__set_base v1 v13;
         v15.i256 = mload v2 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_347a v1 v15;
+        call %impl_trait_SolEncoder__set_pos v1 v15;
         call %encode__gbe21 v0 v1;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_24e6 v1 v5;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_347a v1 v12;
+        call %impl_trait_SolEncoder__set_base v1 v5;
+        call %impl_trait_SolEncoder__set_pos v1 v12;
         v20.i256 = mload v2 i256;
         v21.i256 = add v20 v8;
         mstore v2 v21 i256;
@@ -6046,7 +4339,7 @@ func private %encode_field__g6d7e(v0.i256, v1.objref<@layout_1>, v2.i256) {
         br 0.i1 block5 block6;
 
     block5:
-        v24.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_8ab3 v1;
+        v24.i256 = call %impl_trait_SolEncoder__pos v1;
         call %encode_to_ptr__g30cc v0 v24;
         unreachable;
 
@@ -6066,19 +4359,19 @@ func private %encode_field__g2e64(v0.i256, v1.objref<@layout_1>, v2.i256) {
         br 0.i1 block2 block3;
 
     block2:
-        v5.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_117c v1;
-        v8.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_77e5 v0;
+        v5.i256 = call %impl_trait_SolEncoder__base v1;
+        v8.i256 = call %payload_size__ge513 v0;
         v9.i256 = mload v2 i256;
         v10.i256 = sub v9 v5;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_586c v1 v10;
-        v12.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_a94d v1;
+        call %write_word v1 v10;
+        v12.i256 = call %impl_trait_SolEncoder__pos v1;
         v13.i256 = mload v2 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_2121 v1 v13;
+        call %impl_trait_SolEncoder__set_base v1 v13;
         v15.i256 = mload v2 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_75cf v1 v15;
-        call %core__lib__abi__impl_trait_u256_d99e__encode__g426c_18aa v0 v1;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_2121 v1 v5;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_75cf v1 v12;
+        call %impl_trait_SolEncoder__set_pos v1 v15;
+        call %impl_trait_u256__encode__g426c v0 v1;
+        call %impl_trait_SolEncoder__set_base v1 v5;
+        call %impl_trait_SolEncoder__set_pos v1 v12;
         v20.i256 = mload v2 i256;
         v21.i256 = add v20 v8;
         mstore v2 v21 i256;
@@ -6091,17 +4384,17 @@ func private %encode_field__g2e64(v0.i256, v1.objref<@layout_1>, v2.i256) {
         br 1.i1 block5 block6;
 
     block5:
-        v24.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_a94d v1;
+        v24.i256 = call %impl_trait_SolEncoder__pos v1;
         call %impl_trait_u256__encode_to_ptr__gf13e v0 v24;
         v28.i256 = add v24 32.i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_75cf v1 v28;
+        call %impl_trait_SolEncoder__set_pos v1 v28;
         return;
 
     block6:
         jump block7;
 
     block7:
-        call %core__lib__abi__impl_trait_u256_d99e__encode__g426c_18aa v0 v1;
+        call %impl_trait_u256__encode__g426c v0 v1;
         return;
 }
 
@@ -6113,19 +4406,19 @@ func private %encode_field__g0a88(v0.i8, v1.objref<@layout_1>, v2.i256) {
         br 0.i1 block2 block3;
 
     block2:
-        v5.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_b8b6 v1;
-        v8.i256 = call %core__lib__abi__trait_AbiSize__payload_size__g79ff_f3e8 v0;
+        v5.i256 = call %impl_trait_SolEncoder__base v1;
+        v8.i256 = call %payload_size__g79ff v0;
         v9.i256 = mload v2 i256;
         v10.i256 = sub v9 v5;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_50ef v1 v10;
-        v12.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_06d1 v1;
+        call %write_word v1 v10;
+        v12.i256 = call %impl_trait_SolEncoder__pos v1;
         v13.i256 = mload v2 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_065d v1 v13;
+        call %impl_trait_SolEncoder__set_base v1 v13;
         v15.i256 = mload v2 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_9125 v1 v15;
+        call %impl_trait_SolEncoder__set_pos v1 v15;
         call %impl_trait_u8__encode__g426c v0 v1;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_065d v1 v5;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_9125 v1 v12;
+        call %impl_trait_SolEncoder__set_base v1 v5;
+        call %impl_trait_SolEncoder__set_pos v1 v12;
         v20.i256 = mload v2 i256;
         v21.i256 = add v20 v8;
         mstore v2 v21 i256;
@@ -6138,10 +4431,10 @@ func private %encode_field__g0a88(v0.i8, v1.objref<@layout_1>, v2.i256) {
         br 1.i1 block5 block6;
 
     block5:
-        v24.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_06d1 v1;
+        v24.i256 = call %impl_trait_SolEncoder__pos v1;
         call %impl_trait_u8__encode_to_ptr__gf13e v0 v24;
         v28.i256 = add v24 32.i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_9125 v1 v28;
+        call %impl_trait_SolEncoder__set_pos v1 v28;
         return;
 
     block6:
@@ -6158,7 +4451,7 @@ func private %encode_single_root__g2e64(v0.i256, v1.objref<@layout_1>) {
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_117c v1;
+        v4.i256 = call %impl_trait_SolEncoder__base v1;
         v6.i256 = add v4 32.i256;
         mstore v2 v6 i256;
         v7.i256 = ptr_to_int v2 i256;
@@ -6172,7 +4465,7 @@ func private %encode_single_root__ge927(v0.i1, v1.objref<@layout_1>) {
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_1580 v1;
+        v4.i256 = call %impl_trait_SolEncoder__base v1;
         v6.i256 = add v4 32.i256;
         mstore v2 v6 i256;
         v7.i256 = ptr_to_int v2 i256;
@@ -6186,7 +4479,7 @@ func private %encode_single_root__g6d7e(v0.i256, v1.objref<@layout_1>) {
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_e214 v1;
+        v4.i256 = call %impl_trait_SolEncoder__base v1;
         v6.i256 = add v4 32.i256;
         mstore v2 v6 i256;
         v7.i256 = ptr_to_int v2 i256;
@@ -6200,7 +4493,7 @@ func private %encode_single_root_alloc__gcb0a(v0.i8) -> @layout_1 {
 
     block1:
         v2.i256 = call %abi_single_root_size__g79ff v0;
-        v3.@layout_1 = call %std__lib__abi__sol__impl_trait_Sol_1f5f__encoder_new_513f v2;
+        v3.@layout_1 = call %encoder_new v2;
         v4.objref<@layout_1> = obj.alloc @layout_1;
         v6.objref<i256> = obj.proj v4 0.i256;
         v7.i256 = extract_value v3 0.i256;
@@ -6208,7 +4501,7 @@ func private %encode_single_root_alloc__gcb0a(v0.i8) -> @layout_1 {
         v9.objref<i256> = obj.proj v4 1.i256;
         v10.i256 = extract_value v3 1.i256;
         obj.store v9 v10;
-        v11.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_b8b6 v4;
+        v11.i256 = call %impl_trait_SolEncoder__base v4;
         call %encode_single_root__g0a88 v0 v4;
         v14.@layout_1 = insert_value undef.@layout_1 0.i256 v11;
         v15.@layout_1 = insert_value v14 1.i256 v2;
@@ -6221,7 +4514,7 @@ func private %encode_single_root_alloc__gac80(v0.i256) -> @layout_1 {
 
     block1:
         v2.i256 = call %abi_single_root_size__ge513 v0;
-        v3.@layout_1 = call %std__lib__abi__sol__impl_trait_Sol_1f5f__encoder_new_94e9 v2;
+        v3.@layout_1 = call %encoder_new v2;
         v4.objref<@layout_1> = obj.alloc @layout_1;
         v6.objref<i256> = obj.proj v4 0.i256;
         v7.i256 = extract_value v3 0.i256;
@@ -6229,7 +4522,7 @@ func private %encode_single_root_alloc__gac80(v0.i256) -> @layout_1 {
         v9.objref<i256> = obj.proj v4 1.i256;
         v10.i256 = extract_value v3 1.i256;
         obj.store v9 v10;
-        v11.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_117c v4;
+        v11.i256 = call %impl_trait_SolEncoder__base v4;
         call %encode_single_root__g2e64 v0 v4;
         v14.@layout_1 = insert_value undef.@layout_1 0.i256 v11;
         v15.@layout_1 = insert_value v14 1.i256 v2;
@@ -6242,7 +4535,7 @@ func private %encode_single_root_alloc__g0c18(v0.i256) -> @layout_1 {
 
     block1:
         v2.i256 = call %abi_single_root_size__g65da v0;
-        v3.@layout_1 = call %std__lib__abi__sol__impl_trait_Sol_1f5f__encoder_new_30df v2;
+        v3.@layout_1 = call %encoder_new v2;
         v4.objref<@layout_1> = obj.alloc @layout_1;
         v6.objref<i256> = obj.proj v4 0.i256;
         v7.i256 = extract_value v3 0.i256;
@@ -6250,7 +4543,7 @@ func private %encode_single_root_alloc__g0c18(v0.i256) -> @layout_1 {
         v9.objref<i256> = obj.proj v4 1.i256;
         v10.i256 = extract_value v3 1.i256;
         obj.store v9 v10;
-        v11.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_e214 v4;
+        v11.i256 = call %impl_trait_SolEncoder__base v4;
         call %encode_single_root__g6d7e v0 v4;
         v14.@layout_1 = insert_value undef.@layout_1 0.i256 v11;
         v15.@layout_1 = insert_value v14 1.i256 v2;
@@ -6263,7 +4556,7 @@ func private %encode_single_root_alloc__g09ca(v0.i1) -> @layout_1 {
 
     block1:
         v2.i256 = call %abi_single_root_size__gda9b v0;
-        v3.@layout_1 = call %std__lib__abi__sol__impl_trait_Sol_1f5f__encoder_new_1514 v2;
+        v3.@layout_1 = call %encoder_new v2;
         v4.objref<@layout_1> = obj.alloc @layout_1;
         v6.objref<i256> = obj.proj v4 0.i256;
         v7.i256 = extract_value v3 0.i256;
@@ -6271,7 +4564,7 @@ func private %encode_single_root_alloc__g09ca(v0.i1) -> @layout_1 {
         v9.objref<i256> = obj.proj v4 1.i256;
         v10.i256 = extract_value v3 1.i256;
         obj.store v9 v10;
-        v11.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_1580 v4;
+        v11.i256 = call %impl_trait_SolEncoder__base v4;
         call %encode_single_root__ge927 v0 v4;
         v14.@layout_1 = insert_value undef.@layout_1 0.i256 v11;
         v15.@layout_1 = insert_value v14 1.i256 v2;
@@ -6284,7 +4577,7 @@ func private %encode_single_root_alloc__g472d(v0.i256) -> @layout_1 {
 
     block1:
         v2.i256 = call %abi_single_root_size__g5535 v0;
-        v3.@layout_1 = call %std__lib__abi__sol__impl_trait_Sol_1f5f__encoder_new_a948 v2;
+        v3.@layout_1 = call %encoder_new v2;
         v4.objref<@layout_1> = obj.alloc @layout_1;
         v6.objref<i256> = obj.proj v4 0.i256;
         v7.i256 = extract_value v3 0.i256;
@@ -6292,7 +4585,7 @@ func private %encode_single_root_alloc__g472d(v0.i256) -> @layout_1 {
         v9.objref<i256> = obj.proj v4 1.i256;
         v10.i256 = extract_value v3 1.i256;
         obj.store v9 v10;
-        v11.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_61c3 v4;
+        v11.i256 = call %impl_trait_SolEncoder__base v4;
         call %encode_single_root__g859f v0 v4;
         v14.@layout_1 = insert_value undef.@layout_1 0.i256 v11;
         v15.@layout_1 = insert_value v14 1.i256 v2;
@@ -6305,7 +4598,7 @@ func private %encode_single_root__g0a88(v0.i8, v1.objref<@layout_1>) {
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_b8b6 v1;
+        v4.i256 = call %impl_trait_SolEncoder__base v1;
         v6.i256 = add v4 32.i256;
         mstore v2 v6 i256;
         v7.i256 = ptr_to_int v2 i256;
@@ -6319,7 +4612,7 @@ func private %encode_single_root__g859f(v0.i256, v1.objref<@layout_1>) {
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_61c3 v1;
+        v4.i256 = call %impl_trait_SolEncoder__base v1;
         v6.i256 = add v4 32.i256;
         mstore v2 v6 i256;
         v7.i256 = ptr_to_int v2 i256;
@@ -6327,16 +4620,7 @@ func private %encode_single_root__g859f(v0.i256, v1.objref<@layout_1>) {
         return;
 }
 
-func private %impl_trait_u256__encode_to_ptr__gf13e(v0.i256, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__store_word_2361 v1 v0;
-        return;
-}
-
-func private %encode_to_ptr__g4320(v0.i256, v1.i256) {
+func private %encode_to_ptr__g30cc(v0.i256, v1.i256) {
     block0:
         jump block1;
 
@@ -6352,23 +4636,15 @@ func private %impl_trait_bool__encode_to_ptr__gf13e(v0.i1, v1.i256) {
         br v0 block2 block3;
 
     block2:
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__store_word_be96 v1 1.i256;
+        call %store_word v1 1.i256;
         jump block4;
 
     block3:
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__store_word_be96 v1 0.i256;
+        call %store_word v1 0.i256;
         jump block4;
 
     block4:
         return;
-}
-
-func private %encode_to_ptr__g30cc(v0.i256, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        evm_invalid;
 }
 
 func private %impl_trait_u8__encode_to_ptr__gf13e(v0.i8, v1.i256) {
@@ -6377,70 +4653,33 @@ func private %impl_trait_u8__encode_to_ptr__gf13e(v0.i8, v1.i256) {
 
     block1:
         v4.i256 = zext v0 i256;
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__store_word_2c7e v1 v4;
+        call %store_word v1 v4;
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__encoder_new_1514(v0.i256) -> @layout_1 {
+func private %impl_trait_u256__encode_to_ptr__gf13e(v0.i256, v1.i256) {
     block0:
         jump block1;
 
     block1:
-        v2.@layout_1 = call %std__lib__abi__sol__impl_SolEncoder_ce34__new_978f v0;
-        return v2;
+        call %store_word v1 v0;
+        return;
 }
 
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__encoder_new_30df(v0.i256) -> @layout_1 {
+func private %encode_to_ptr__g4320(v0.i256, v1.i256) {
     block0:
         jump block1;
 
     block1:
-        v2.@layout_1 = call %std__lib__abi__sol__impl_SolEncoder_ce34__new_c575 v0;
-        return v2;
+        evm_invalid;
 }
 
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__encoder_new_513f(v0.i256) -> @layout_1 {
+func private %encoder_new(v0.i256) -> @layout_1 {
     block0:
         jump block1;
 
     block1:
-        v2.@layout_1 = call %std__lib__abi__sol__impl_SolEncoder_ce34__new_f042 v0;
-        return v2;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__encoder_new_721a(v0.i256) -> @layout_1 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.@layout_1 = call %std__lib__abi__sol__impl_SolEncoder_ce34__new_fdc1 v0;
-        return v2;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__encoder_new_94e9(v0.i256) -> @layout_1 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.@layout_1 = call %std__lib__abi__sol__impl_SolEncoder_ce34__new_c2ff v0;
-        return v2;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__encoder_new_a948(v0.i256) -> @layout_1 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.@layout_1 = call %std__lib__abi__sol__impl_SolEncoder_ce34__new_8670 v0;
-        return v2;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__encoder_new_ddf2(v0.i256) -> @layout_1 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.@layout_1 = call %std__lib__abi__sol__impl_SolEncoder_ce34__new_36b0 v0;
+        v2.@layout_1 = call %impl_SolEncoder__new v0;
         return v2;
 }
 
@@ -6455,39 +4694,7 @@ func private %eq(v0.@layout_0, v1.@layout_0) -> i1 {
         return v7;
 }
 
-func private %std__lib__evm__word__impl_trait_u256_1f9e__from_word_83e7(v0.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        return v0;
-}
-
-func private %std__lib__evm__word__impl_trait_u256_1f9e__from_word_896a(v0.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        return v0;
-}
-
-func private %std__lib__evm__word__impl_trait_u256_1f9e__from_word_896a_0(v0.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        return v0;
-}
-
-func private %std__lib__evm__word__impl_trait_u256_1f9e__from_word_c764(v0.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        return v0;
-}
-
-func private %std__lib__evm__word__impl_trait_u256_1f9e__from_word_db05(v0.i256) -> i256 {
+func private %impl_trait_u256__from_word(v0.i256) -> i256 {
     block0:
         jump block1;
 
@@ -6523,7 +4730,7 @@ func inline(always) private %get__g636d(v0.@layout_0, v1.i256) -> i256 {
         return v4;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__get__g94db_61a4(v0.@layout_4, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__get__g94db_61a4(v0.@layout_6, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -6532,7 +4739,7 @@ func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__g
         return v4;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__get__g94db_6651(v0.@layout_4, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__get__g94db_6651(v0.@layout_6, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -6541,7 +4748,7 @@ func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__g
         return v4;
 }
 
-func inline(always) private %get__ge2d3(v0.@layout_4, v1.i256) -> i256 {
+func inline(always) private %get__ge2d3(v0.@layout_6, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -6565,7 +4772,7 @@ func inline(always) private %get_unchecked__g636d(v0.@layout_0, v1.i256) -> i256
 
     block1:
         v4.i256 = call %std__lib__evm__storage_map__storagemap_get_word_with_salt__g67a8_bb80 v0 1.i256;
-        v5.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__from_word_c764 v4;
+        v5.i256 = call %impl_trait_u256__from_word v4;
         return v5;
 }
 
@@ -6585,37 +4792,37 @@ func inline(always) private %get_unchecked__gbae5(v0.@layout_0, v1.i256) -> i256
 
     block1:
         v4.i256 = call %std__lib__evm__storage_map__storagemap_get_word_with_salt__g67a8_bc66 v0 v1;
-        v5.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__from_word_db05 v4;
+        v5.i256 = call %impl_trait_u256__from_word v4;
         return v5;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__get_unchecked__g94db_c7cc(v0.@layout_4, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__get_unchecked__g94db_c7cc(v0.@layout_6, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
         v4.i256 = call %std__lib__evm__storage_map__storagemap_get_word_with_salt__g7bf4_b354 v0 2.i256;
-        v5.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__from_word_83e7 v4;
+        v5.i256 = call %impl_trait_u256__from_word v4;
         return v5;
 }
 
-func inline(always) private %get_unchecked__ge2d3(v0.@layout_4, v1.i256) -> i256 {
+func inline(always) private %get_unchecked__ge2d3(v0.@layout_6, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
         v4.i256 = call %std__lib__evm__storage_map__storagemap_get_word_with_salt__g7bf4_16a4 v0 v1;
-        v5.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__from_word_896a v4;
+        v5.i256 = call %impl_trait_u256__from_word v4;
         return v5;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__get_unchecked__g94db_fd0a(v0.@layout_4, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__get_unchecked__g94db_fd0a(v0.@layout_6, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
         v4.i256 = call %std__lib__evm__storage_map__storagemap_get_word_with_salt__g7bf4_16a4_0 v0 2.i256;
-        v5.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__from_word_896a_0 v4;
+        v5.i256 = call %impl_trait_u256__from_word v4;
         return v5;
 }
 
@@ -6630,337 +4837,16 @@ func private %grant(v0.i256, v1.@layout_0, v2.i256) {
         return;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_3347() -> @layout_0 {
+func private %input() -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v0.@layout_0 = call %std__lib__evm__calldata__impl_CallData_8f43__new_f11a;
+        v0.@layout_0 = call %impl_CallData__new;
         return v0;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_3dc9() -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v0.@layout_0 = call %std__lib__evm__calldata__impl_CallData_8f43__new_0d2c;
-        return v0;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_5bd8() -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v0.@layout_0 = call %std__lib__evm__calldata__impl_CallData_8f43__new_b0b8;
-        return v0;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_663b() -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v0.@layout_0 = call %std__lib__evm__calldata__impl_CallData_8f43__new_0fa9;
-        return v0;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_6a54() -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v0.@layout_0 = call %std__lib__evm__calldata__impl_CallData_8f43__new_147c;
-        return v0;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_844a() -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v0.@layout_0 = call %std__lib__evm__calldata__impl_CallData_8f43__new_923b;
-        return v0;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_88e5() -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v0.@layout_0 = call %std__lib__evm__calldata__impl_CallData_8f43__new_53e2;
-        return v0;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_a580() -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v0.@layout_0 = call %std__lib__evm__calldata__impl_CallData_8f43__new_8102;
-        return v0;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_b73f() -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v0.@layout_0 = call %std__lib__evm__calldata__impl_CallData_8f43__new_bc34;
-        return v0;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_cd56() -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v0.@layout_0 = call %std__lib__evm__calldata__impl_CallData_8f43__new_5438;
-        return v0;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_d673() -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v0.@layout_0 = call %std__lib__evm__calldata__impl_CallData_8f43__new_d306;
-        return v0;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_dac7() -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v0.@layout_0 = call %std__lib__evm__calldata__impl_CallData_8f43__new_0199;
-        return v0;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_e029() -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v0.@layout_0 = call %std__lib__evm__calldata__impl_CallData_8f43__new_f379;
-        return v0;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_f89e() -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v0.@layout_0 = call %std__lib__evm__calldata__impl_CallData_8f43__new_b671;
-        return v0;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_0a2a(v0.@layout_0) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v2.i256 = evm_calldata_size;
-        v5.i256 = extract_value v0 0.i256;
-        mstore v1 v2 i256;
-        v6.i256 = mload v1 i256;
-        v7.i1 = gt v5 v6;
-        br v7 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v9.i256 = extract_value v0 0.i256;
-        (v11.i256, v12.i1) = usubo v2 v9;
-        br v12 block5 block6;
-
-    block4:
-        v17.i256 = phi (0.i256 block2) (v11 block6);
-        return v17;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_13b9(v0.@layout_0) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v2.i256 = evm_calldata_size;
-        v5.i256 = extract_value v0 0.i256;
-        mstore v1 v2 i256;
-        v6.i256 = mload v1 i256;
-        v7.i1 = gt v5 v6;
-        br v7 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v9.i256 = extract_value v0 0.i256;
-        (v11.i256, v12.i1) = usubo v2 v9;
-        br v12 block5 block6;
-
-    block4:
-        v17.i256 = phi (0.i256 block2) (v11 block6);
-        return v17;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_25ce(v0.@layout_0) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v2.i256 = evm_calldata_size;
-        v5.i256 = extract_value v0 0.i256;
-        mstore v1 v2 i256;
-        v6.i256 = mload v1 i256;
-        v7.i1 = gt v5 v6;
-        br v7 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v9.i256 = extract_value v0 0.i256;
-        (v11.i256, v12.i1) = usubo v2 v9;
-        br v12 block5 block6;
-
-    block4:
-        v17.i256 = phi (0.i256 block2) (v11 block6);
-        return v17;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_2c20(v0.@layout_0) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v2.i256 = evm_calldata_size;
-        v5.i256 = extract_value v0 0.i256;
-        mstore v1 v2 i256;
-        v6.i256 = mload v1 i256;
-        v7.i1 = gt v5 v6;
-        br v7 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v9.i256 = extract_value v0 0.i256;
-        (v11.i256, v12.i1) = usubo v2 v9;
-        br v12 block5 block6;
-
-    block4:
-        v17.i256 = phi (0.i256 block2) (v11 block6);
-        return v17;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_3418(v0.@layout_0) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v2.i256 = evm_calldata_size;
-        v5.i256 = extract_value v0 0.i256;
-        mstore v1 v2 i256;
-        v6.i256 = mload v1 i256;
-        v7.i1 = gt v5 v6;
-        br v7 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v9.i256 = extract_value v0 0.i256;
-        (v11.i256, v12.i1) = usubo v2 v9;
-        br v12 block5 block6;
-
-    block4:
-        v17.i256 = phi (0.i256 block2) (v11 block6);
-        return v17;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_4aee(v0.@layout_0) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v2.i256 = evm_calldata_size;
-        v5.i256 = extract_value v0 0.i256;
-        mstore v1 v2 i256;
-        v6.i256 = mload v1 i256;
-        v7.i1 = gt v5 v6;
-        br v7 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v9.i256 = extract_value v0 0.i256;
-        (v11.i256, v12.i1) = usubo v2 v9;
-        br v12 block5 block6;
-
-    block4:
-        v17.i256 = phi (0.i256 block2) (v11 block6);
-        return v17;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_4f7f(v0.objref<@layout_1>) -> i256 {
+func private %impl_trait_MemoryBytes__len(v0.objref<@layout_1>) -> i256 {
     block0:
         jump block1;
 
@@ -6970,17 +4856,7 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_4f7f
         return v4;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_55d6(v0.objref<@layout_1>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 1.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_566f(v0.@layout_0) -> i256 {
+func inline(always) private %impl_trait_CallData__len(v0.@layout_0) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         jump block1;
@@ -7014,614 +4890,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         jump block4;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_5dba(v0.@layout_0) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v2.i256 = evm_calldata_size;
-        v5.i256 = extract_value v0 0.i256;
-        mstore v1 v2 i256;
-        v6.i256 = mload v1 i256;
-        v7.i1 = gt v5 v6;
-        br v7 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v9.i256 = extract_value v0 0.i256;
-        (v11.i256, v12.i1) = usubo v2 v9;
-        br v12 block5 block6;
-
-    block4:
-        v17.i256 = phi (0.i256 block2) (v11 block6);
-        return v17;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_6e3e(v0.objref<@layout_1>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 1.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_6e3e_0(v0.objref<@layout_1>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 1.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_8c59(v0.@layout_0) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v2.i256 = evm_calldata_size;
-        v5.i256 = extract_value v0 0.i256;
-        mstore v1 v2 i256;
-        v6.i256 = mload v1 i256;
-        v7.i1 = gt v5 v6;
-        br v7 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v9.i256 = extract_value v0 0.i256;
-        (v11.i256, v12.i1) = usubo v2 v9;
-        br v12 block5 block6;
-
-    block4:
-        v17.i256 = phi (0.i256 block2) (v11 block6);
-        return v17;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_9f1e(v0.@layout_0) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v2.i256 = evm_calldata_size;
-        v5.i256 = extract_value v0 0.i256;
-        mstore v1 v2 i256;
-        v6.i256 = mload v1 i256;
-        v7.i1 = gt v5 v6;
-        br v7 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v9.i256 = extract_value v0 0.i256;
-        (v11.i256, v12.i1) = usubo v2 v9;
-        br v12 block5 block6;
-
-    block4:
-        v17.i256 = phi (0.i256 block2) (v11 block6);
-        return v17;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_a0e3(v0.@layout_0) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v2.i256 = evm_calldata_size;
-        v5.i256 = extract_value v0 0.i256;
-        mstore v1 v2 i256;
-        v6.i256 = mload v1 i256;
-        v7.i1 = gt v5 v6;
-        br v7 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v9.i256 = extract_value v0 0.i256;
-        (v11.i256, v12.i1) = usubo v2 v9;
-        br v12 block5 block6;
-
-    block4:
-        v17.i256 = phi (0.i256 block2) (v11 block6);
-        return v17;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_a72b(v0.@layout_0) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v2.i256 = evm_calldata_size;
-        v5.i256 = extract_value v0 0.i256;
-        mstore v1 v2 i256;
-        v6.i256 = mload v1 i256;
-        v7.i1 = gt v5 v6;
-        br v7 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v9.i256 = extract_value v0 0.i256;
-        (v11.i256, v12.i1) = usubo v2 v9;
-        br v12 block5 block6;
-
-    block4:
-        v17.i256 = phi (0.i256 block2) (v11 block6);
-        return v17;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_ade7(v0.@layout_0) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v2.i256 = evm_calldata_size;
-        v5.i256 = extract_value v0 0.i256;
-        mstore v1 v2 i256;
-        v6.i256 = mload v1 i256;
-        v7.i1 = gt v5 v6;
-        br v7 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v9.i256 = extract_value v0 0.i256;
-        (v11.i256, v12.i1) = usubo v2 v9;
-        br v12 block5 block6;
-
-    block4:
-        v17.i256 = phi (0.i256 block2) (v11 block6);
-        return v17;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_b402(v0.@layout_0) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v2.i256 = evm_calldata_size;
-        v5.i256 = extract_value v0 0.i256;
-        mstore v1 v2 i256;
-        v6.i256 = mload v1 i256;
-        v7.i1 = gt v5 v6;
-        br v7 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v9.i256 = extract_value v0 0.i256;
-        (v11.i256, v12.i1) = usubo v2 v9;
-        br v12 block5 block6;
-
-    block4:
-        v17.i256 = phi (0.i256 block2) (v11 block6);
-        return v17;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_bbea(v0.@layout_0) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v2.i256 = evm_calldata_size;
-        v5.i256 = extract_value v0 0.i256;
-        mstore v1 v2 i256;
-        v6.i256 = mload v1 i256;
-        v7.i1 = gt v5 v6;
-        br v7 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v9.i256 = extract_value v0 0.i256;
-        (v11.i256, v12.i1) = usubo v2 v9;
-        br v12 block5 block6;
-
-    block4:
-        v17.i256 = phi (0.i256 block2) (v11 block6);
-        return v17;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_c091(v0.@layout_0) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v2.i256 = evm_calldata_size;
-        v5.i256 = extract_value v0 0.i256;
-        mstore v1 v2 i256;
-        v6.i256 = mload v1 i256;
-        v7.i1 = gt v5 v6;
-        br v7 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v9.i256 = extract_value v0 0.i256;
-        (v11.i256, v12.i1) = usubo v2 v9;
-        br v12 block5 block6;
-
-    block4:
-        v17.i256 = phi (0.i256 block2) (v11 block6);
-        return v17;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_c2ce(v0.@layout_0) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v2.i256 = evm_calldata_size;
-        v5.i256 = extract_value v0 0.i256;
-        mstore v1 v2 i256;
-        v6.i256 = mload v1 i256;
-        v7.i1 = gt v5 v6;
-        br v7 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v9.i256 = extract_value v0 0.i256;
-        (v11.i256, v12.i1) = usubo v2 v9;
-        br v12 block5 block6;
-
-    block4:
-        v17.i256 = phi (0.i256 block2) (v11 block6);
-        return v17;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_cea7(v0.@layout_0) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v2.i256 = evm_calldata_size;
-        v5.i256 = extract_value v0 0.i256;
-        mstore v1 v2 i256;
-        v6.i256 = mload v1 i256;
-        v7.i1 = gt v5 v6;
-        br v7 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v9.i256 = extract_value v0 0.i256;
-        (v11.i256, v12.i1) = usubo v2 v9;
-        br v12 block5 block6;
-
-    block4:
-        v17.i256 = phi (0.i256 block2) (v11 block6);
-        return v17;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_d7d7(v0.@layout_0) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v2.i256 = evm_calldata_size;
-        v5.i256 = extract_value v0 0.i256;
-        mstore v1 v2 i256;
-        v6.i256 = mload v1 i256;
-        v7.i1 = gt v5 v6;
-        br v7 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v9.i256 = extract_value v0 0.i256;
-        (v11.i256, v12.i1) = usubo v2 v9;
-        br v12 block5 block6;
-
-    block4:
-        v17.i256 = phi (0.i256 block2) (v11 block6);
-        return v17;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_d815(v0.@layout_0) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v2.i256 = evm_calldata_size;
-        v5.i256 = extract_value v0 0.i256;
-        mstore v1 v2 i256;
-        v6.i256 = mload v1 i256;
-        v7.i1 = gt v5 v6;
-        br v7 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v9.i256 = extract_value v0 0.i256;
-        (v11.i256, v12.i1) = usubo v2 v9;
-        br v12 block5 block6;
-
-    block4:
-        v17.i256 = phi (0.i256 block2) (v11 block6);
-        return v17;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_e2e1(v0.@layout_0) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v2.i256 = evm_calldata_size;
-        v5.i256 = extract_value v0 0.i256;
-        mstore v1 v2 i256;
-        v6.i256 = mload v1 i256;
-        v7.i1 = gt v5 v6;
-        br v7 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v9.i256 = extract_value v0 0.i256;
-        (v11.i256, v12.i1) = usubo v2 v9;
-        br v12 block5 block6;
-
-    block4:
-        v17.i256 = phi (0.i256 block2) (v11 block6);
-        return v17;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_f197(v0.@layout_0) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v2.i256 = evm_calldata_size;
-        v5.i256 = extract_value v0 0.i256;
-        mstore v1 v2 i256;
-        v6.i256 = mload v1 i256;
-        v7.i1 = gt v5 v6;
-        br v7 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v9.i256 = extract_value v0 0.i256;
-        (v11.i256, v12.i1) = usubo v2 v9;
-        br v12 block5 block6;
-
-    block4:
-        v17.i256 = phi (0.i256 block2) (v11 block6);
-        return v17;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_f6a9(v0.@layout_0) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v2.i256 = evm_calldata_size;
-        v5.i256 = extract_value v0 0.i256;
-        mstore v1 v2 i256;
-        v6.i256 = mload v1 i256;
-        v7.i1 = gt v5 v6;
-        br v7 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v9.i256 = extract_value v0 0.i256;
-        (v11.i256, v12.i1) = usubo v2 v9;
-        br v12 block5 block6;
-
-    block4:
-        v17.i256 = phi (0.i256 block2) (v11 block6);
-        return v17;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_f8fd(v0.@layout_0) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v2.i256 = evm_calldata_size;
-        v5.i256 = extract_value v0 0.i256;
-        mstore v1 v2 i256;
-        v6.i256 = mload v1 i256;
-        v7.i1 = gt v5 v6;
-        br v7 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v9.i256 = extract_value v0 0.i256;
-        (v11.i256, v12.i1) = usubo v2 v9;
-        br v12 block5 block6;
-
-    block4:
-        v17.i256 = phi (0.i256 block2) (v11 block6);
-        return v17;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_476c__log3_89cc(v0.i256, v1.i256, v2.i256, v3.i256, v4.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        evm_log3 v0 v1 v2 v3 v4;
-        return;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_476c__log3_ebb3(v0.i256, v1.i256, v2.i256, v3.i256, v4.i256) {
+func private %log3(v0.i256, v1.i256, v2.i256, v3.i256, v4.i256) {
     block0:
         jump block1;
 
@@ -7678,9 +4947,9 @@ func private %standalone_erc20__erc20__mint__ga9cb_2b3b(v0.@layout_0, v1.i256, v
     block8:
         call %set__gbae5 v0 v40 1.i256;
         v45.@layout_0 = call %zero;
-        v49.@layout_6 = insert_value undef.@layout_6 0.i256 v45;
-        v50.@layout_6 = insert_value v49 1.i256 v0;
-        v52.@layout_6 = insert_value v50 2.i256 v1;
+        v49.@layout_5 = insert_value undef.@layout_5 0.i256 v45;
+        v50.@layout_5 = insert_value v49 1.i256 v0;
+        v52.@layout_5 = insert_value v50 2.i256 v1;
         call %emit__g4c3d v52;
         return;
 }
@@ -7733,9 +5002,9 @@ func private %standalone_erc20__erc20__mint__ga9cb_527c(v0.@layout_0, v1.i256, v
     block8:
         call %set__gbae5 v0 v40 1.i256;
         v45.@layout_0 = call %zero;
-        v49.@layout_6 = insert_value undef.@layout_6 0.i256 v45;
-        v50.@layout_6 = insert_value v49 1.i256 v0;
-        v52.@layout_6 = insert_value v50 2.i256 v1;
+        v49.@layout_5 = insert_value undef.@layout_5 0.i256 v45;
+        v50.@layout_5 = insert_value v49 1.i256 v0;
+        v52.@layout_5 = insert_value v50 2.i256 v1;
         call %emit__g4c3d v52;
         return;
 }
@@ -7750,55 +5019,7 @@ func private %ne(v0.@layout_0, v1.@layout_0) -> i1 {
         return v5;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_0199() -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v1.constref<@layout_0> = const.ref $const_region_0;
-        v2.objref<@layout_0> = obj.alloc @layout_0;
-        obj.init.const v2 v1;
-        v3.@layout_0 = obj.load v2;
-        return v3;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_0d2c() -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v1.constref<@layout_0> = const.ref $const_region_0;
-        v2.objref<@layout_0> = obj.alloc @layout_0;
-        obj.init.const v2 v1;
-        v3.@layout_0 = obj.load v2;
-        return v3;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_0fa9() -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v1.constref<@layout_0> = const.ref $const_region_0;
-        v2.objref<@layout_0> = obj.alloc @layout_0;
-        obj.init.const v2 v1;
-        v3.@layout_0 = obj.load v2;
-        return v3;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_147c() -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v1.constref<@layout_0> = const.ref $const_region_0;
-        v2.objref<@layout_0> = obj.alloc @layout_0;
-        obj.init.const v2 v1;
-        v3.@layout_0 = obj.load v2;
-        return v3;
-}
-
-func private %std__lib__abi__sol__impl_SolEncoder_ce34__new_36b0(v0.i256) -> @layout_1 {
+func private %impl_SolEncoder__new(v0.i256) -> @layout_1 {
     block0:
         jump block1;
 
@@ -7816,23 +5037,11 @@ func private %std__lib__abi__sol__impl_SolEncoder_ce34__new_36b0(v0.i256) -> @la
 
     block4:
         v7.i256 = phi (0.i256 block2) (v6 block3);
-        v8.@layout_1 = call %std__lib__abi__sol__impl_SolEncoder_ce34__at_e384 v7;
+        v8.@layout_1 = call %at v7;
         return v8;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_53e2() -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v1.constref<@layout_0> = const.ref $const_region_0;
-        v2.objref<@layout_0> = obj.alloc @layout_0;
-        obj.init.const v2 v1;
-        v3.@layout_0 = obj.load v2;
-        return v3;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_5438() -> @layout_0 {
+func inline(always) private %impl_CallData__new() -> @layout_0 {
     block0:
         jump block1;
 
@@ -7854,86 +5063,6 @@ func inline(always) private %impl_Cursor__new__g463e(v0.@layout_1) -> @layout_2 
         return v6;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_8102() -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v1.constref<@layout_0> = const.ref $const_region_0;
-        v2.objref<@layout_0> = obj.alloc @layout_0;
-        obj.init.const v2 v1;
-        v3.@layout_0 = obj.load v2;
-        return v3;
-}
-
-func private %std__lib__abi__sol__impl_SolEncoder_ce34__new_8670(v0.i256) -> @layout_1 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.i1 = eq v0 0.i256;
-        br v3 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v5.*i8 = evm_malloc v0;
-        v6.i256 = ptr_to_int v5 i256;
-        jump block4;
-
-    block4:
-        v7.i256 = phi (0.i256 block2) (v6 block3);
-        v8.@layout_1 = call %std__lib__abi__sol__impl_SolEncoder_ce34__at_65fb v7;
-        return v8;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_923b() -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v1.constref<@layout_0> = const.ref $const_region_0;
-        v2.objref<@layout_0> = obj.alloc @layout_0;
-        obj.init.const v2 v1;
-        v3.@layout_0 = obj.load v2;
-        return v3;
-}
-
-func private %std__lib__abi__sol__impl_SolEncoder_ce34__new_978f(v0.i256) -> @layout_1 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.i1 = eq v0 0.i256;
-        br v3 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v5.*i8 = evm_malloc v0;
-        v6.i256 = ptr_to_int v5 i256;
-        jump block4;
-
-    block4:
-        v7.i256 = phi (0.i256 block2) (v6 block3);
-        v8.@layout_1 = call %std__lib__abi__sol__impl_SolEncoder_ce34__at_fb00 v7;
-        return v8;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_b0b8() -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v1.constref<@layout_0> = const.ref $const_region_0;
-        v2.objref<@layout_0> = obj.alloc @layout_0;
-        obj.init.const v2 v1;
-        v3.@layout_0 = obj.load v2;
-        return v3;
-}
-
 func inline(always) private %impl_SolDecoder__new__g463e(v0.@layout_1) -> @layout_3 {
     block0:
         jump block1;
@@ -7945,155 +5074,7 @@ func inline(always) private %impl_SolDecoder__new__g463e(v0.@layout_1) -> @layou
         return v7;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_b671() -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v1.constref<@layout_0> = const.ref $const_region_0;
-        v2.objref<@layout_0> = obj.alloc @layout_0;
-        obj.init.const v2 v1;
-        v3.@layout_0 = obj.load v2;
-        return v3;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_bc34() -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v1.constref<@layout_0> = const.ref $const_region_0;
-        v2.objref<@layout_0> = obj.alloc @layout_0;
-        obj.init.const v2 v1;
-        v3.@layout_0 = obj.load v2;
-        return v3;
-}
-
-func private %std__lib__abi__sol__impl_SolEncoder_ce34__new_c2ff(v0.i256) -> @layout_1 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.i1 = eq v0 0.i256;
-        br v3 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v5.*i8 = evm_malloc v0;
-        v6.i256 = ptr_to_int v5 i256;
-        jump block4;
-
-    block4:
-        v7.i256 = phi (0.i256 block2) (v6 block3);
-        v8.@layout_1 = call %std__lib__abi__sol__impl_SolEncoder_ce34__at_69c8 v7;
-        return v8;
-}
-
-func private %std__lib__abi__sol__impl_SolEncoder_ce34__new_c575(v0.i256) -> @layout_1 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.i1 = eq v0 0.i256;
-        br v3 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v5.*i8 = evm_malloc v0;
-        v6.i256 = ptr_to_int v5 i256;
-        jump block4;
-
-    block4:
-        v7.i256 = phi (0.i256 block2) (v6 block3);
-        v8.@layout_1 = call %std__lib__abi__sol__impl_SolEncoder_ce34__at_3361 v7;
-        return v8;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_d306() -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v1.constref<@layout_0> = const.ref $const_region_0;
-        v2.objref<@layout_0> = obj.alloc @layout_0;
-        obj.init.const v2 v1;
-        v3.@layout_0 = obj.load v2;
-        return v3;
-}
-
-func private %std__lib__abi__sol__impl_SolEncoder_ce34__new_f042(v0.i256) -> @layout_1 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.i1 = eq v0 0.i256;
-        br v3 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v5.*i8 = evm_malloc v0;
-        v6.i256 = ptr_to_int v5 i256;
-        jump block4;
-
-    block4:
-        v7.i256 = phi (0.i256 block2) (v6 block3);
-        v8.@layout_1 = call %std__lib__abi__sol__impl_SolEncoder_ce34__at_31d5 v7;
-        return v8;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_f11a() -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v1.constref<@layout_0> = const.ref $const_region_0;
-        v2.objref<@layout_0> = obj.alloc @layout_0;
-        obj.init.const v2 v1;
-        v3.@layout_0 = obj.load v2;
-        return v3;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_f379() -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v1.constref<@layout_0> = const.ref $const_region_0;
-        v2.objref<@layout_0> = obj.alloc @layout_0;
-        obj.init.const v2 v1;
-        v3.@layout_0 = obj.load v2;
-        return v3;
-}
-
-func private %std__lib__abi__sol__impl_SolEncoder_ce34__new_fdc1(v0.i256) -> @layout_1 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.i1 = eq v0 0.i256;
-        br v3 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v5.*i8 = evm_malloc v0;
-        v6.i256 = ptr_to_int v5 i256;
-        jump block4;
-
-    block4:
-        v7.i256 = phi (0.i256 block2) (v6 block3);
-        v8.@layout_1 = call %std__lib__abi__sol__impl_SolEncoder_ce34__at_7151 v7;
-        return v8;
-}
-
-func private %core__lib__abi__packed_string_len_225d(v0.i256) -> i256 {
+func private %core__lib__abi__packed_string_len_38ff(v0.i256) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         jump block1;
@@ -8129,7 +5110,7 @@ func private %core__lib__abi__packed_string_len_225d(v0.i256) -> i256 {
         jump block2;
 }
 
-func private %core__lib__abi__packed_string_len_225d_0(v0.i256) -> i256 {
+func private %core__lib__abi__packed_string_len_4544(v0.i256) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         jump block1;
@@ -8165,7 +5146,7 @@ func private %core__lib__abi__packed_string_len_225d_0(v0.i256) -> i256 {
         jump block2;
 }
 
-func private %core__lib__abi__packed_string_len_29ef(v0.i256) -> i256 {
+func private %core__lib__abi__packed_string_len_740b(v0.i256) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         jump block1;
@@ -8201,7 +5182,7 @@ func private %core__lib__abi__packed_string_len_29ef(v0.i256) -> i256 {
         jump block2;
 }
 
-func private %core__lib__abi__packed_string_len_c13a(v0.i256) -> i256 {
+func private %core__lib__abi__packed_string_len_b2ee(v0.i256) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         jump block1;
@@ -8237,94 +5218,14 @@ func private %core__lib__abi__packed_string_len_c13a(v0.i256) -> i256 {
         jump block2;
 }
 
-func private %core__lib__abi__packed_string_len_ecb6(v0.i256) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        mstore v1 0.i256 i256;
-        jump block2;
-
-    block2:
-        v4.i256 = phi (v0 block1) (v19 block6);
-        v5.i1 = eq v4 0.i256;
-        v6.i1 = is_zero v5;
-        br v6 block3 block4;
-
-    block3:
-        v7.i256 = ptr_to_int v1 i256;
-        v9.i256 = mload v7 i256;
-        (v10.i256, v11.i1) = uaddo v9 1.i256;
-        br v11 block5 block6;
-
-    block4:
-        v20.i256 = mload v1 i256;
-        return v20;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        mstore v7 v10 i256;
-        v19.i256 = shr 8.i256 v4;
-        jump block2;
-}
-
-func private %core__lib__abi__packed_string_len_ecb6_0(v0.i256) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        mstore v1 0.i256 i256;
-        jump block2;
-
-    block2:
-        v4.i256 = phi (v0 block1) (v19 block6);
-        v5.i1 = eq v4 0.i256;
-        v6.i1 = is_zero v5;
-        br v6 block3 block4;
-
-    block3:
-        v7.i256 = ptr_to_int v1 i256;
-        v9.i256 = mload v7 i256;
-        (v10.i256, v11.i1) = uaddo v9 1.i256;
-        br v11 block5 block6;
-
-    block4:
-        v20.i256 = mload v1 i256;
-        return v20;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        mstore v7 v10 i256;
-        v19.i256 = shr 8.i256 v4;
-        jump block2;
-}
-
-func private %core__lib__abi__trait_AbiSize__payload_size__ge513_18e9(v0.i256) -> i256 {
+func private %payload_size__gc7cf(v0.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        return 32.i256;
-}
-
-func private %core__lib__abi__impl_trait_String_c06e__payload_size__gc7cf_4aab(v0.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.i256 = call %core__lib__num__impl_trait_String_8f88__to_word__gc7cf_518a v0;
-        v4.i256 = call %core__lib__abi__packed_string_len_ecb6 v3;
-        v5.i256 = call %core__lib__abi__round_up_words_a41d v4;
+        v3.i256 = call %to_word__gc7cf v0;
+        v4.i256 = call %core__lib__abi__packed_string_len_740b v3;
+        v5.i256 = call %core__lib__abi__round_up_words_9426 v4;
         (v6.i256, v7.i1) = uaddo 32.i256 v5;
         br v7 block2 block3;
 
@@ -8337,14 +5238,22 @@ func private %core__lib__abi__impl_trait_String_c06e__payload_size__gc7cf_4aab(v
         return v6;
 }
 
-func private %core__lib__abi__impl_trait_String_c06e__payload_size__gc7cf_4aab_0(v0.i256) -> i256 {
+func private %payload_size__g79ff(v0.i8) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v3.i256 = call %core__lib__num__impl_trait_String_8f88__to_word__gc7cf_518a_0 v0;
-        v4.i256 = call %core__lib__abi__packed_string_len_ecb6_0 v3;
-        v5.i256 = call %core__lib__abi__round_up_words_a41d_0 v4;
+        return 32.i256;
+}
+
+func private %payload_size__g3eb7(v0.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v3.i256 = call %to_word__g3eb7 v0;
+        v4.i256 = call %core__lib__abi__packed_string_len_38ff v3;
+        v5.i256 = call %core__lib__abi__round_up_words_6704 v4;
         (v6.i256, v7.i1) = uaddo 32.i256 v5;
         br v7 block2 block3;
 
@@ -8357,7 +5266,7 @@ func private %core__lib__abi__impl_trait_String_c06e__payload_size__gc7cf_4aab_0
         return v6;
 }
 
-func private %core__lib__abi__trait_AbiSize__payload_size__ge513_77e5(v0.i256) -> i256 {
+func private %payload_size__gda9b(v0.i1) -> i256 {
     block0:
         jump block1;
 
@@ -8365,7 +5274,7 @@ func private %core__lib__abi__trait_AbiSize__payload_size__ge513_77e5(v0.i256) -
         return 32.i256;
 }
 
-func private %core__lib__abi__trait_AbiSize__payload_size__ge513_77e5_0(v0.i256) -> i256 {
+func private %payload_size__ge513(v0.i256) -> i256 {
     block0:
         jump block1;
 
@@ -8373,127 +5282,7 @@ func private %core__lib__abi__trait_AbiSize__payload_size__ge513_77e5_0(v0.i256)
         return 32.i256;
 }
 
-func private %core__lib__abi__trait_AbiSize__payload_size__gda9b_b33d(v0.i1) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        return 32.i256;
-}
-
-func private %core__lib__abi__trait_AbiSize__payload_size__gda9b_b33d_0(v0.i1) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        return 32.i256;
-}
-
-func private %core__lib__abi__trait_AbiSize__payload_size__ge513_effe(v0.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        return 32.i256;
-}
-
-func private %core__lib__abi__trait_AbiSize__payload_size__g79ff_f3e8(v0.i8) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        return 32.i256;
-}
-
-func private %core__lib__abi__trait_AbiSize__payload_size__g79ff_f3e8_0(v0.i8) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        return 32.i256;
-}
-
-func private %core__lib__abi__impl_trait_String_c06e__payload_size__g3eb7_f656(v0.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.i256 = call %core__lib__num__impl_trait_String_8f88__to_word__g3eb7_38b3 v0;
-        v4.i256 = call %core__lib__abi__packed_string_len_225d v3;
-        v5.i256 = call %core__lib__abi__round_up_words_b13c v4;
-        (v6.i256, v7.i1) = uaddo 32.i256 v5;
-        br v7 block2 block3;
-
-    block2:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block3:
-        return v6;
-}
-
-func private %core__lib__abi__impl_trait_String_c06e__payload_size__g3eb7_f656_0(v0.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.i256 = call %core__lib__num__impl_trait_String_8f88__to_word__g3eb7_38b3_0 v0;
-        v4.i256 = call %core__lib__abi__packed_string_len_225d_0 v3;
-        v5.i256 = call %core__lib__abi__round_up_words_b13c_0 v4;
-        (v6.i256, v7.i1) = uaddo 32.i256 v5;
-        br v7 block2 block3;
-
-    block2:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block3:
-        return v6;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_06d1(v0.objref<@layout_1>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 1.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_4526(v0.objref<@layout_1>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 1.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_6701(v0.objref<@layout_1>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 1.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_8ab3(v0.objref<@layout_1>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 1.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g463e_9627(v0.objref<@layout_3>) -> i256 {
+func private %pos__g463e(v0.objref<@layout_3>) -> i256 {
     block0:
         jump block1;
 
@@ -8504,18 +5293,7 @@ func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g463e_9627(v0
         return v6;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g463e_9627_0(v0.objref<@layout_3>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<@layout_2> = obj.proj v0 0.i256;
-        v5.objref<i256> = obj.proj v3 1.i256;
-        v6.i256 = obj.load v5;
-        return v6;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_a94d(v0.objref<@layout_1>) -> i256 {
+func private %impl_trait_SolEncoder__pos(v0.objref<@layout_1>) -> i256 {
     block0:
         jump block1;
 
@@ -8525,7 +5303,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_a94d(v0.objref
         return v4;
 }
 
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_715d(v0.objref<@layout_3>) -> i256 {
+func inline(always) private %read_word(v0.objref<@layout_3>) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         jump block1;
@@ -8536,7 +5314,7 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         v6.@layout_1 = obj.load v5;
         v7.objref<@layout_2> = obj.proj v0 0.i256;
         v8.objref<@layout_1> = obj.proj v7 0.i256;
-        v9.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_6e3e v8;
+        v9.i256 = call %impl_trait_MemoryBytes__len v8;
         v10.objref<@layout_2> = obj.proj v0 0.i256;
         v12.objref<i256> = obj.proj v10 1.i256;
         v13.i256 = obj.load v12;
@@ -8558,181 +5336,7 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         v32.i256 = obj.load v31;
         v33.objref<@layout_2> = obj.proj v0 0.i256;
         v34.objref<@layout_1> = obj.proj v33 0.i256;
-        v35.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_0e64 v34 v32;
-        v37.objref<@layout_2> = obj.proj v0 0.i256;
-        v38.objref<i256> = obj.proj v37 1.i256;
-        obj.store v38 v15;
-        return v35;
-
-    block5:
-        mstore v1 v9 i256;
-        v41.i256 = mload v1 i256;
-        v42.i1 = gt v15 v41;
-        br v42 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v22.objref<@layout_2> = obj.proj v0 0.i256;
-        v23.objref<i256> = obj.proj v22 1.i256;
-        v24.i256 = obj.load v23;
-        v25.i1 = lt v15 v24;
-        br v25 block2 block5;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_715d_0(v0.objref<@layout_3>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v4.objref<@layout_2> = obj.proj v0 0.i256;
-        v5.objref<@layout_1> = obj.proj v4 0.i256;
-        v6.@layout_1 = obj.load v5;
-        v7.objref<@layout_2> = obj.proj v0 0.i256;
-        v8.objref<@layout_1> = obj.proj v7 0.i256;
-        v9.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_6e3e_0 v8;
-        v10.objref<@layout_2> = obj.proj v0 0.i256;
-        v12.objref<i256> = obj.proj v10 1.i256;
-        v13.i256 = obj.load v12;
-        (v15.i256, v16.i1) = uaddo v13 32.i256;
-        br v16 block6 block7;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v27.objref<@layout_2> = obj.proj v0 0.i256;
-        v28.objref<@layout_1> = obj.proj v27 0.i256;
-        v29.@layout_1 = obj.load v28;
-        v30.objref<@layout_2> = obj.proj v0 0.i256;
-        v31.objref<i256> = obj.proj v30 1.i256;
-        v32.i256 = obj.load v31;
-        v33.objref<@layout_2> = obj.proj v0 0.i256;
-        v34.objref<@layout_1> = obj.proj v33 0.i256;
-        v35.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_0e64_0 v34 v32;
-        v37.objref<@layout_2> = obj.proj v0 0.i256;
-        v38.objref<i256> = obj.proj v37 1.i256;
-        obj.store v38 v15;
-        return v35;
-
-    block5:
-        mstore v1 v9 i256;
-        v41.i256 = mload v1 i256;
-        v42.i1 = gt v15 v41;
-        br v42 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v22.objref<@layout_2> = obj.proj v0 0.i256;
-        v23.objref<i256> = obj.proj v22 1.i256;
-        v24.i256 = obj.load v23;
-        v25.i1 = lt v15 v24;
-        br v25 block2 block5;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_99f7(v0.objref<@layout_3>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v4.objref<@layout_2> = obj.proj v0 0.i256;
-        v5.objref<@layout_1> = obj.proj v4 0.i256;
-        v6.@layout_1 = obj.load v5;
-        v7.objref<@layout_2> = obj.proj v0 0.i256;
-        v8.objref<@layout_1> = obj.proj v7 0.i256;
-        v9.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_55d6 v8;
-        v10.objref<@layout_2> = obj.proj v0 0.i256;
-        v12.objref<i256> = obj.proj v10 1.i256;
-        v13.i256 = obj.load v12;
-        (v15.i256, v16.i1) = uaddo v13 32.i256;
-        br v16 block6 block7;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v27.objref<@layout_2> = obj.proj v0 0.i256;
-        v28.objref<@layout_1> = obj.proj v27 0.i256;
-        v29.@layout_1 = obj.load v28;
-        v30.objref<@layout_2> = obj.proj v0 0.i256;
-        v31.objref<i256> = obj.proj v30 1.i256;
-        v32.i256 = obj.load v31;
-        v33.objref<@layout_2> = obj.proj v0 0.i256;
-        v34.objref<@layout_1> = obj.proj v33 0.i256;
-        v35.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_2de0 v34 v32;
-        v37.objref<@layout_2> = obj.proj v0 0.i256;
-        v38.objref<i256> = obj.proj v37 1.i256;
-        obj.store v38 v15;
-        return v35;
-
-    block5:
-        mstore v1 v9 i256;
-        v41.i256 = mload v1 i256;
-        v42.i1 = gt v15 v41;
-        br v42 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v22.objref<@layout_2> = obj.proj v0 0.i256;
-        v23.objref<i256> = obj.proj v22 1.i256;
-        v24.i256 = obj.load v23;
-        v25.i1 = lt v15 v24;
-        br v25 block2 block5;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_d6d9(v0.objref<@layout_3>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v4.objref<@layout_2> = obj.proj v0 0.i256;
-        v5.objref<@layout_1> = obj.proj v4 0.i256;
-        v6.@layout_1 = obj.load v5;
-        v7.objref<@layout_2> = obj.proj v0 0.i256;
-        v8.objref<@layout_1> = obj.proj v7 0.i256;
-        v9.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_4f7f v8;
-        v10.objref<@layout_2> = obj.proj v0 0.i256;
-        v12.objref<i256> = obj.proj v10 1.i256;
-        v13.i256 = obj.load v12;
-        (v15.i256, v16.i1) = uaddo v13 32.i256;
-        br v16 block6 block7;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v27.objref<@layout_2> = obj.proj v0 0.i256;
-        v28.objref<@layout_1> = obj.proj v27 0.i256;
-        v29.@layout_1 = obj.load v28;
-        v30.objref<@layout_2> = obj.proj v0 0.i256;
-        v31.objref<i256> = obj.proj v30 1.i256;
-        v32.i256 = obj.load v31;
-        v33.objref<@layout_2> = obj.proj v0 0.i256;
-        v34.objref<@layout_1> = obj.proj v33 0.i256;
-        v35.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_b264 v34 v32;
+        v35.i256 = call %impl_trait_MemoryBytes__word_at v34 v32;
         v37.objref<@layout_2> = obj.proj v0 0.i256;
         v38.objref<i256> = obj.proj v37 1.i256;
         obj.store v38 v15;
@@ -8762,7 +5366,7 @@ func private %require(v0.i256, v1.i256) {
         jump block1;
 
     block1:
-        v4.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_a1e8__caller_aa40;
+        v4.@layout_0 = call %caller;
         v7.@layout_8 = insert_value undef.@layout_8 0.i256 v0;
         v9.@layout_8 = insert_value v7 1.i256 v4;
         v10.i1 = call %get__gc9ba v9 v1;
@@ -8792,7 +5396,7 @@ func private %require(v0.i256, v1.i256) {
         evm_revert v16 36.i256;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_0ea2(v0.i256, v1.i256) {
+func private %revert(v0.i256, v1.i256) {
     block0:
         jump block1;
 
@@ -8800,111 +5404,7 @@ func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_0ea2(v0.i256, 
         evm_revert v0 v1;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_2b5d(v0.i256, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert v0 v1;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_2efa(v0.i256, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert v0 v1;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_34f1(v0.i256, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert v0 v1;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_35af(v0.i256, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert v0 v1;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_3bd1(v0.i256, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert v0 v1;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_41e6(v0.i256, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert v0 v1;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_62f4(v0.i256, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert v0 v1;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_6471(v0.i256, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert v0 v1;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_9e6f(v0.i256, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert v0 v1;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_9fb4(v0.i256, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert v0 v1;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_a28f(v0.i256, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert v0 v1;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_cab9(v0.i256, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert v0 v1;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_cb12(v0.i256, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert v0 v1;
-}
-
-func private %core__lib__abi__round_up_words_a41d(v0.i256) -> i256 {
+func private %core__lib__abi__round_up_words_6704(v0.i256) -> i256 {
     block0:
         jump block1;
 
@@ -8952,103 +5452,7 @@ func private %core__lib__abi__round_up_words_a41d(v0.i256) -> i256 {
         return v19;
 }
 
-func private %core__lib__abi__round_up_words_a41d_0(v0.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.i1 = eq v0 0.i256;
-        br v3 block2 block3;
-
-    block2:
-        return 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        (v6.i256, v7.i1) = usubo v0 1.i256;
-        br v7 block5 block6;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        v13.i1 = eq 32.i256 0.i256;
-        br v13 block7 block8;
-
-    block7:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 18.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block8:
-        (v15.i256, v16.i1) = evm_udivo v6 32.i256;
-        br v16 block5 block9;
-
-    block9:
-        (v17.i256, v18.i1) = uaddo v15 1.i256;
-        br v18 block5 block10;
-
-    block10:
-        (v19.i256, v20.i1) = umulo v17 32.i256;
-        br v20 block5 block11;
-
-    block11:
-        return v19;
-}
-
-func private %core__lib__abi__round_up_words_b13c(v0.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.i1 = eq v0 0.i256;
-        br v3 block2 block3;
-
-    block2:
-        return 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        (v6.i256, v7.i1) = usubo v0 1.i256;
-        br v7 block5 block6;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        v13.i1 = eq 32.i256 0.i256;
-        br v13 block7 block8;
-
-    block7:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 18.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block8:
-        (v15.i256, v16.i1) = evm_udivo v6 32.i256;
-        br v16 block5 block9;
-
-    block9:
-        (v17.i256, v18.i1) = uaddo v15 1.i256;
-        br v18 block5 block10;
-
-    block10:
-        (v19.i256, v20.i1) = umulo v17 32.i256;
-        br v20 block5 block11;
-
-    block11:
-        return v19;
-}
-
-func private %core__lib__abi__round_up_words_b13c_0(v0.i256) -> i256 {
+func private %core__lib__abi__round_up_words_9426(v0.i256) -> i256 {
     block0:
         jump block1;
 
@@ -9114,7 +5518,7 @@ func inline(always) private %set__gc9ba(v0.@layout_8, v1.i1, v2.i256) {
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_065d(v0.objref<@layout_1>, v1.i256) {
+func private %impl_trait_SolEncoder__set_base(v0.objref<@layout_1>, v1.i256) {
     block0:
         jump block1;
 
@@ -9124,47 +5528,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_065d(v0.o
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_1e89(v0.objref<@layout_1>, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        obj.store v5 v1;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_2121(v0.objref<@layout_1>, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        obj.store v5 v1;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_22b1(v0.objref<@layout_1>, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        obj.store v5 v1;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_24e6(v0.objref<@layout_1>, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        obj.store v5 v1;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_6134(v0.objref<@layout_3>, v1.i256) {
+func private %set_base__g463e(v0.objref<@layout_3>, v1.i256) {
     block0:
         jump block1;
 
@@ -9174,17 +5538,7 @@ func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_61
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_6134_0(v0.objref<@layout_3>, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v5.objref<i256> = obj.proj v0 1.i256;
-        obj.store v5 v1;
-        return;
-}
-
-func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__set__ge2d3_ddb6(v0.@layout_4, v1.i256, v2.i256) {
+func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__set__ge2d3_ddb6(v0.@layout_6, v1.i256, v2.i256) {
     block0:
         jump block1;
 
@@ -9193,7 +5547,7 @@ func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__s
         return;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__set__ge2d3_ddb6_0(v0.@layout_4, v1.i256, v2.i256) {
+func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__set__ge2d3_ddb6_0(v0.@layout_6, v1.i256, v2.i256) {
     block0:
         jump block1;
 
@@ -9202,7 +5556,7 @@ func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__s
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_347a(v0.objref<@layout_1>, v1.i256) {
+func private %impl_trait_SolEncoder__set_pos(v0.objref<@layout_1>, v1.i256) {
     block0:
         jump block1;
 
@@ -9212,58 +5566,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_347a(v0.ob
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_3e1f(v0.objref<@layout_1>, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v5.objref<i256> = obj.proj v0 1.i256;
-        obj.store v5 v1;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_73c1(v0.objref<@layout_1>, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v5.objref<i256> = obj.proj v0 1.i256;
-        obj.store v5 v1;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_75cf(v0.objref<@layout_1>, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v5.objref<i256> = obj.proj v0 1.i256;
-        obj.store v5 v1;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_9125(v0.objref<@layout_1>, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v5.objref<i256> = obj.proj v0 1.i256;
-        obj.store v5 v1;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_9c2d(v0.objref<@layout_3>, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v5.objref<@layout_2> = obj.proj v0 0.i256;
-        v7.objref<i256> = obj.proj v5 1.i256;
-        obj.store v7 v1;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_9c2d_0(v0.objref<@layout_3>, v1.i256) {
+func private %set_pos__g463e(v0.objref<@layout_3>, v1.i256) {
     block0:
         jump block1;
 
@@ -9279,27 +5582,27 @@ func inline(always) private %set_unchecked__gbae5(v0.@layout_0, v1.i256, v2.i256
         jump block1;
 
     block1:
-        v5.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__to_word_3a17 v1;
+        v5.i256 = call %impl_trait_u256__to_word v1;
         call %storagemap_set_word_with_salt__g67a8 v0 v2 v5;
         return;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__set_unchecked__ge2d3_5128(v0.@layout_4, v1.i256, v2.i256) {
+func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__set_unchecked__ge2d3_5128(v0.@layout_6, v1.i256, v2.i256) {
     block0:
         jump block1;
 
     block1:
-        v5.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__to_word_9907 v1;
+        v5.i256 = call %impl_trait_u256__to_word v1;
         call %std__lib__evm__storage_map__storagemap_set_word_with_salt__g7bf4_dadb v0 v2 v5;
         return;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__set_unchecked__ge2d3_5128_0(v0.@layout_4, v1.i256, v2.i256) {
+func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__set_unchecked__ge2d3_5128_0(v0.@layout_6, v1.i256, v2.i256) {
     block0:
         jump block1;
 
     block1:
-        v5.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__to_word_9907_0 v1;
+        v5.i256 = call %impl_trait_u256__to_word v1;
         call %std__lib__evm__storage_map__storagemap_set_word_with_salt__g7bf4_dadb_0 v0 v2 v5;
         return;
 }
@@ -9319,8 +5622,8 @@ func private %standalone_erc20__erc20__spend_allowance__g13d4_a04b(v0.@layout_0,
         jump block1;
 
     block1:
-        v11.@layout_4 = insert_value undef.@layout_4 0.i256 v0;
-        v13.@layout_4 = insert_value v11 1.i256 v1;
+        v11.@layout_6 = insert_value undef.@layout_6 0.i256 v0;
+        v13.@layout_6 = insert_value v11 1.i256 v1;
         v14.i256 = call %get__ge2d3 v13 2.i256;
         v16.i1 = lt v14 v2;
         v17.i1 = is_zero v16;
@@ -9338,8 +5641,8 @@ func private %standalone_erc20__erc20__spend_allowance__g13d4_a04b(v0.@layout_0,
 
     block4:
         v34.i256 = add v3 1.i256;
-        v38.@layout_4 = insert_value undef.@layout_4 0.i256 v0;
-        v39.@layout_4 = insert_value v38 1.i256 v1;
+        v38.@layout_6 = insert_value undef.@layout_6 0.i256 v0;
+        v39.@layout_6 = insert_value v38 1.i256 v1;
         (v42.i256, v43.i1) = usubo v14 v2;
         br v43 block5 block7;
 
@@ -9362,8 +5665,8 @@ func private %standalone_erc20__erc20__spend_allowance__g13d4_a04b_0(v0.@layout_
         jump block1;
 
     block1:
-        v11.@layout_4 = insert_value undef.@layout_4 0.i256 v0;
-        v13.@layout_4 = insert_value v11 1.i256 v1;
+        v11.@layout_6 = insert_value undef.@layout_6 0.i256 v0;
+        v13.@layout_6 = insert_value v11 1.i256 v1;
         v14.i256 = call %get__ge2d3 v13 2.i256;
         v16.i1 = lt v14 v2;
         v17.i1 = is_zero v16;
@@ -9381,8 +5684,8 @@ func private %standalone_erc20__erc20__spend_allowance__g13d4_a04b_0(v0.@layout_
 
     block4:
         v34.i256 = add v3 1.i256;
-        v38.@layout_4 = insert_value undef.@layout_4 0.i256 v0;
-        v39.@layout_4 = insert_value v38 1.i256 v1;
+        v38.@layout_6 = insert_value undef.@layout_6 0.i256 v0;
+        v39.@layout_6 = insert_value v38 1.i256 v1;
         (v42.i256, v43.i1) = usubo v14 v2;
         br v43 block5 block7;
 
@@ -9410,7 +5713,7 @@ func inline(always) private %storagemap_get_word_with_salt__g9379(v0.@layout_8, 
         return v5;
 }
 
-func inline(always) private %std__lib__evm__storage_map__storagemap_get_word_with_salt__g7bf4_16a4(v0.@layout_4, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__storagemap_get_word_with_salt__g7bf4_16a4(v0.@layout_6, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -9420,7 +5723,7 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_get_word_wit
         return v5;
 }
 
-func inline(always) private %std__lib__evm__storage_map__storagemap_get_word_with_salt__g7bf4_16a4_0(v0.@layout_4, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__storagemap_get_word_with_salt__g7bf4_16a4_0(v0.@layout_6, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -9430,7 +5733,7 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_get_word_wit
         return v5;
 }
 
-func inline(always) private %std__lib__evm__storage_map__storagemap_get_word_with_salt__g7bf4_b354(v0.@layout_4, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__storagemap_get_word_with_salt__g7bf4_b354(v0.@layout_6, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -9470,7 +5773,7 @@ func inline(always) private %storagemap_set_word_with_salt__g67a8(v0.@layout_0, 
         return;
 }
 
-func inline(always) private %std__lib__evm__storage_map__storagemap_set_word_with_salt__g7bf4_dadb(v0.@layout_4, v1.i256, v2.i256) {
+func inline(always) private %std__lib__evm__storage_map__storagemap_set_word_with_salt__g7bf4_dadb(v0.@layout_6, v1.i256, v2.i256) {
     block0:
         jump block1;
 
@@ -9480,7 +5783,7 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_set_word_wit
         return;
 }
 
-func inline(always) private %std__lib__evm__storage_map__storagemap_set_word_with_salt__g7bf4_dadb_0(v0.@layout_4, v1.i256, v2.i256) {
+func inline(always) private %std__lib__evm__storage_map__storagemap_set_word_with_salt__g7bf4_dadb_0(v0.@layout_6, v1.i256, v2.i256) {
     block0:
         jump block1;
 
@@ -9507,7 +5810,7 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot
     block1:
         v3.*i8 = evm_malloc 0.i256;
         v4.i256 = ptr_to_int v3 i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_3ab2 v4 v0;
+        v6.i256 = call %impl_trait_Address__write_key v4 v0;
         (v7.i256, v8.i1) = uaddo v4 v6;
         br v8 block2 block3;
 
@@ -9526,14 +5829,14 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot
         return v20;
 }
 
-func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_1e87(v0.@layout_4, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_1e87(v0.@layout_6, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
         v3.*i8 = evm_malloc 0.i256;
         v4.i256 = ptr_to_int v3 i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_2550 v4 v0;
+        v6.i256 = call %write_key__g7528 v4 v0;
         (v7.i256, v8.i1) = uaddo v4 v6;
         br v8 block2 block3;
 
@@ -9559,7 +5862,7 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot
     block1:
         v3.*i8 = evm_malloc 0.i256;
         v4.i256 = ptr_to_int v3 i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait____9761__write_key__g6d15_1314 v4 v0;
+        v6.i256 = call %write_key__g6d15 v4 v0;
         (v7.i256, v8.i1) = uaddo v4 v6;
         br v8 block2 block3;
 
@@ -9585,7 +5888,7 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot
     block1:
         v3.*i8 = evm_malloc 0.i256;
         v4.i256 = ptr_to_int v3 i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait____9761__write_key__g6d15_1314_0 v4 v0;
+        v6.i256 = call %write_key__g6d15 v4 v0;
         (v7.i256, v8.i1) = uaddo v4 v6;
         br v8 block2 block3;
 
@@ -9604,14 +5907,14 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot
         return v20;
 }
 
-func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_c2f9(v0.@layout_4, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_c2f9(v0.@layout_6, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
         v3.*i8 = evm_malloc 0.i256;
         v4.i256 = ptr_to_int v3 i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_2afe v4 v0;
+        v6.i256 = call %write_key__g7528 v4 v0;
         (v7.i256, v8.i1) = uaddo v4 v6;
         br v8 block2 block3;
 
@@ -9630,14 +5933,14 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot
         return v20;
 }
 
-func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_c2f9_0(v0.@layout_4, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_c2f9_0(v0.@layout_6, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
         v3.*i8 = evm_malloc 0.i256;
         v4.i256 = ptr_to_int v3 i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_2afe_0 v4 v0;
+        v6.i256 = call %write_key__g7528 v4 v0;
         (v7.i256, v8.i1) = uaddo v4 v6;
         br v8 block2 block3;
 
@@ -9656,14 +5959,14 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot
         return v20;
 }
 
-func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_c2f9_1(v0.@layout_4, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_c2f9_1(v0.@layout_6, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
         v3.*i8 = evm_malloc 0.i256;
         v4.i256 = ptr_to_int v3 i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_2afe_1 v4 v0;
+        v6.i256 = call %write_key__g7528 v4 v0;
         (v7.i256, v8.i1) = uaddo v4 v6;
         br v8 block2 block3;
 
@@ -9689,7 +5992,7 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot
     block1:
         v3.*i8 = evm_malloc 0.i256;
         v4.i256 = ptr_to_int v3 i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_78f9 v4 v0;
+        v6.i256 = call %impl_trait_Address__write_key v4 v0;
         (v7.i256, v8.i1) = uaddo v4 v6;
         br v8 block2 block3;
 
@@ -9708,7 +6011,7 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot
         return v20;
 }
 
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__store_word_2361(v0.i256, v1.i256) {
+func private %store_word(v0.i256, v1.i256) {
     block0:
         jump block1;
 
@@ -9717,43 +6020,7 @@ func private %std__lib__abi__sol__impl_trait_Sol_1f5f__store_word_2361(v0.i256, 
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__store_word_2c7e(v0.i256, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        mstore v0 v1 i256;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__store_word_be96(v0.i256, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        mstore v0 v1 i256;
-        return;
-}
-
-func private %core__lib__num__impl_trait_String_8f88__to_word__g3eb7_38b3(v0.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v8.i256 = and v0 452312848583266388373324160190187140051835877600158453279131187530910662655.i256;
-        return v8;
-}
-
-func private %core__lib__num__impl_trait_String_8f88__to_word__g3eb7_38b3_0(v0.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v8.i256 = and v0 452312848583266388373324160190187140051835877600158453279131187530910662655.i256;
-        return v8;
-}
-
-func private %std__lib__evm__word__impl_trait_u256_1f9e__to_word_3a17(v0.i256) -> i256 {
+func private %impl_trait_u256__to_word(v0.i256) -> i256 {
     block0:
         jump block1;
 
@@ -9761,31 +6028,22 @@ func private %std__lib__evm__word__impl_trait_u256_1f9e__to_word_3a17(v0.i256) -
         return v0;
 }
 
-func private %core__lib__num__impl_trait_String_8f88__to_word__g3eb7_4283(v0.i256) -> i256 {
+func private %to_word__gc7cf(v0.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v7.i256 = and v0 18446744073709551615.i256;
+        return v7;
+}
+
+func private %to_word__g3eb7(v0.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
         v8.i256 = and v0 452312848583266388373324160190187140051835877600158453279131187530910662655.i256;
         return v8;
-}
-
-func private %core__lib__num__impl_trait_String_8f88__to_word__gc7cf_518a(v0.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v7.i256 = and v0 18446744073709551615.i256;
-        return v7;
-}
-
-func private %core__lib__num__impl_trait_String_8f88__to_word__gc7cf_518a_0(v0.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v7.i256 = and v0 18446744073709551615.i256;
-        return v7;
 }
 
 func private %impl_trait_bool__to_word(v0.i1) -> i256 {
@@ -9804,31 +6062,6 @@ func private %impl_trait_bool__to_word(v0.i1) -> i256 {
     block4:
         v4.i256 = phi (1.i256 block2) (0.i256 block3);
         return v4;
-}
-
-func private %std__lib__evm__word__impl_trait_u256_1f9e__to_word_9907(v0.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        return v0;
-}
-
-func private %std__lib__evm__word__impl_trait_u256_1f9e__to_word_9907_0(v0.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        return v0;
-}
-
-func private %core__lib__num__impl_trait_String_8f88__to_word__gc7cf_de49(v0.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v7.i256 = and v0 18446744073709551615.i256;
-        return v7;
 }
 
 func private %standalone_erc20__erc20__transfer__ga9cb_8101(v0.@layout_0, v1.@layout_0, v2.i256, v3.i256, v4.i256, v5.i256) {
@@ -9922,9 +6155,9 @@ func private %standalone_erc20__erc20__transfer__ga9cb_8101(v0.@layout_0, v1.@la
 
     block16:
         call %set__gbae5 v1 v73 1.i256;
-        v82.@layout_6 = insert_value undef.@layout_6 0.i256 v0;
-        v83.@layout_6 = insert_value v82 1.i256 v1;
-        v85.@layout_6 = insert_value v83 2.i256 v2;
+        v82.@layout_5 = insert_value undef.@layout_5 0.i256 v0;
+        v83.@layout_5 = insert_value v82 1.i256 v1;
+        v85.@layout_5 = insert_value v83 2.i256 v2;
         call %emit__g4c3d v85;
         return;
 }
@@ -10020,14 +6253,14 @@ func private %standalone_erc20__erc20__transfer__ga9cb_db9b(v0.@layout_0, v1.@la
 
     block16:
         call %set__gbae5 v1 v73 1.i256;
-        v82.@layout_6 = insert_value undef.@layout_6 0.i256 v0;
-        v83.@layout_6 = insert_value v82 1.i256 v1;
-        v85.@layout_6 = insert_value v83 2.i256 v2;
+        v82.@layout_5 = insert_value undef.@layout_5 0.i256 v0;
+        v83.@layout_5 = insert_value v82 1.i256 v1;
+        v85.@layout_5 = insert_value v83 2.i256 v2;
         call %emit__g4c3d v85;
         return;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_0df5(v0.@layout_0, v1.i256) -> i256 {
+func inline(always) private %impl_trait_CallData__word_at(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -10038,18 +6271,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v7;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_0df5_0(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_0e64(v0.objref<@layout_1>, v1.i256) -> i256 {
+func private %impl_trait_MemoryBytes__word_at(v0.objref<@layout_1>, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -10061,588 +6283,13 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_
         return v8;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_0e64_0(v0.objref<@layout_1>, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.objref<i256> = obj.proj v0 0.i256;
-        v5.i256 = obj.load v4;
-        v7.i256 = add v5 v1;
-        v8.i256 = mload v7 i256;
-        return v8;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_1397(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_191d(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_2a43(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_2de0(v0.objref<@layout_1>, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.objref<i256> = obj.proj v0 0.i256;
-        v5.i256 = obj.load v4;
-        v7.i256 = add v5 v1;
-        v8.i256 = mload v7 i256;
-        return v8;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_31f2(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_31f2_0(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3723(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3723_0(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3903(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3903_0(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_4c6a(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_4de3(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_5c44(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_6669(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_6669_0(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_67b2(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_67b2_0(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_6ca3(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_6f45(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_78a1(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_78a1_0(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_7d6a(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_7d6a_0(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_7e53(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_7e53_0(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_86b9(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_86b9_0(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_8b76(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_8b76_0(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_8e74(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_8e74_0(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_9869(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_9914(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_9c0e(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_b264(v0.objref<@layout_1>, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.objref<i256> = obj.proj v0 0.i256;
-        v5.i256 = obj.load v4;
-        v7.i256 = add v5 v1;
-        v8.i256 = mload v7 i256;
-        return v8;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_bfaf(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_bfaf_0(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c0ea(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c0ea_0(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c443(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c443_0(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_cde4(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_d855(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_e336(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_e3fc(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_e8c5(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_f73a(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_fa4a(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_fa4a_0(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_fef2(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_fef2_0(v0.@layout_0, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__write_key__g6d15_1314(v0.i256, v1.@layout_8) -> i256 {
+func inline(always) private %write_key__g6d15(v0.i256, v1.@layout_8) -> i256 {
     block0:
         jump block1;
 
     block1:
         v5.i256 = extract_value v1 0.i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_67af v0 v5;
+        v6.i256 = call %impl_trait_u256__write_key v0 v5;
         (v7.i256, v8.i1) = uaddo v0 v6;
         br v8 block2 block3;
 
@@ -10653,7 +6300,7 @@ func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__wri
 
     block3:
         v15.@layout_0 = extract_value v1 1.i256;
-        v16.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_4d28 v7 v15;
+        v16.i256 = call %impl_trait_Address__write_key v7 v15;
         (v18.i256, v19.i1) = uaddo v6 v16;
         br v19 block2 block4;
 
@@ -10661,48 +6308,22 @@ func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__wri
         return v18;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__write_key__g6d15_1314_0(v0.i256, v1.@layout_8) -> i256 {
+func inline(always) private %impl_trait_u256__write_key(v0.i256, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v5.i256 = extract_value v1 0.i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_67af_0 v0 v5;
-        (v7.i256, v8.i1) = uaddo v0 v6;
-        br v8 block2 block3;
-
-    block2:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block3:
-        v15.@layout_0 = extract_value v1 1.i256;
-        v16.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_4d28_0 v7 v15;
-        (v18.i256, v19.i1) = uaddo v6 v16;
-        br v19 block2 block4;
-
-    block4:
-        return v18;
+        mstore v0 v1 i256;
+        return 32.i256;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_20e7(v0.i256, v1.@layout_0) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v5.i256 = extract_value v1 0.i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_98d1 v0 v5;
-        return v6;
-}
-
-func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_2550(v0.i256, v1.@layout_4) -> i256 {
+func inline(always) private %write_key__g7528(v0.i256, v1.@layout_6) -> i256 {
     block0:
         jump block1;
 
     block1:
         v5.@layout_0 = extract_value v1 0.i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_20e7 v0 v5;
+        v6.i256 = call %impl_trait_Address__write_key v0 v5;
         (v7.i256, v8.i1) = uaddo v0 v6;
         br v8 block2 block3;
 
@@ -10713,7 +6334,7 @@ func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__wri
 
     block3:
         v15.@layout_0 = extract_value v1 1.i256;
-        v16.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_20e7 v7 v15;
+        v16.i256 = call %impl_trait_Address__write_key v7 v15;
         (v18.i256, v19.i1) = uaddo v6 v16;
         br v19 block2 block4;
 
@@ -10721,242 +6342,17 @@ func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__wri
         return v18;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_2afe(v0.i256, v1.@layout_4) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v5.@layout_0 = extract_value v1 0.i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_9818 v0 v5;
-        (v7.i256, v8.i1) = uaddo v0 v6;
-        br v8 block2 block3;
-
-    block2:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block3:
-        v15.@layout_0 = extract_value v1 1.i256;
-        v16.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_9818 v7 v15;
-        (v18.i256, v19.i1) = uaddo v6 v16;
-        br v19 block2 block4;
-
-    block4:
-        return v18;
-}
-
-func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_2afe_0(v0.i256, v1.@layout_4) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v5.@layout_0 = extract_value v1 0.i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_9818_0 v0 v5;
-        (v7.i256, v8.i1) = uaddo v0 v6;
-        br v8 block2 block3;
-
-    block2:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block3:
-        v15.@layout_0 = extract_value v1 1.i256;
-        v16.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_9818_0 v7 v15;
-        (v18.i256, v19.i1) = uaddo v6 v16;
-        br v19 block2 block4;
-
-    block4:
-        return v18;
-}
-
-func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_2afe_1(v0.i256, v1.@layout_4) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v5.@layout_0 = extract_value v1 0.i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_9818_1 v0 v5;
-        (v7.i256, v8.i1) = uaddo v0 v6;
-        br v8 block2 block3;
-
-    block2:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block3:
-        v15.@layout_0 = extract_value v1 1.i256;
-        v16.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_9818_1 v7 v15;
-        (v18.i256, v19.i1) = uaddo v6 v16;
-        br v19 block2 block4;
-
-    block4:
-        return v18;
-}
-
-func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_37f0(v0.i256, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        mstore v0 v1 i256;
-        return 32.i256;
-}
-
-func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_3ab2(v0.i256, v1.@layout_0) -> i256 {
+func inline(always) private %impl_trait_Address__write_key(v0.i256, v1.@layout_0) -> i256 {
     block0:
         jump block1;
 
     block1:
         v5.i256 = extract_value v1 0.i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_e672 v0 v5;
+        v6.i256 = call %impl_trait_u256__write_key v0 v5;
         return v6;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_4d28(v0.i256, v1.@layout_0) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v5.i256 = extract_value v1 0.i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_9337 v0 v5;
-        return v6;
-}
-
-func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_4d28_0(v0.i256, v1.@layout_0) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v5.i256 = extract_value v1 0.i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_9337_0 v0 v5;
-        return v6;
-}
-
-func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_67af(v0.i256, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        mstore v0 v1 i256;
-        return 32.i256;
-}
-
-func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_67af_0(v0.i256, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        mstore v0 v1 i256;
-        return 32.i256;
-}
-
-func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_78f9(v0.i256, v1.@layout_0) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v5.i256 = extract_value v1 0.i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_37f0 v0 v5;
-        return v6;
-}
-
-func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_9337(v0.i256, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        mstore v0 v1 i256;
-        return 32.i256;
-}
-
-func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_9337_0(v0.i256, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        mstore v0 v1 i256;
-        return 32.i256;
-}
-
-func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_9818(v0.i256, v1.@layout_0) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v5.i256 = extract_value v1 0.i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_fecd v0 v5;
-        return v6;
-}
-
-func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_9818_0(v0.i256, v1.@layout_0) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v5.i256 = extract_value v1 0.i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_fecd_0 v0 v5;
-        return v6;
-}
-
-func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_9818_1(v0.i256, v1.@layout_0) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v5.i256 = extract_value v1 0.i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_fecd_1 v0 v5;
-        return v6;
-}
-
-func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_98d1(v0.i256, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        mstore v0 v1 i256;
-        return 32.i256;
-}
-
-func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_e672(v0.i256, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        mstore v0 v1 i256;
-        return 32.i256;
-}
-
-func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_fecd(v0.i256, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        mstore v0 v1 i256;
-        return 32.i256;
-}
-
-func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_fecd_0(v0.i256, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        mstore v0 v1 i256;
-        return 32.i256;
-}
-
-func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_fecd_1(v0.i256, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        mstore v0 v1 i256;
-        return 32.i256;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_0ae5(v0.objref<@layout_1>, v1.i256) {
+func private %write_word(v0.objref<@layout_1>, v1.i256) {
     block0:
         jump block1;
 
@@ -10970,175 +6366,12 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_0ae5(v0
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_19ab(v0.objref<@layout_1>, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v4.objref<i256> = obj.proj v0 1.i256;
-        v5.i256 = obj.load v4;
-        mstore v5 v1 i256;
-        v9.i256 = add v5 32.i256;
-        v10.objref<i256> = obj.proj v0 1.i256;
-        obj.store v10 v9;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_2812(v0.objref<@layout_1>, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v4.objref<i256> = obj.proj v0 1.i256;
-        v5.i256 = obj.load v4;
-        mstore v5 v1 i256;
-        v9.i256 = add v5 32.i256;
-        v10.objref<i256> = obj.proj v0 1.i256;
-        obj.store v10 v9;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_4130(v0.objref<@layout_1>, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v4.objref<i256> = obj.proj v0 1.i256;
-        v5.i256 = obj.load v4;
-        mstore v5 v1 i256;
-        v9.i256 = add v5 32.i256;
-        v10.objref<i256> = obj.proj v0 1.i256;
-        obj.store v10 v9;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_50ef(v0.objref<@layout_1>, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v4.objref<i256> = obj.proj v0 1.i256;
-        v5.i256 = obj.load v4;
-        mstore v5 v1 i256;
-        v9.i256 = add v5 32.i256;
-        v10.objref<i256> = obj.proj v0 1.i256;
-        obj.store v10 v9;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_586c(v0.objref<@layout_1>, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v4.objref<i256> = obj.proj v0 1.i256;
-        v5.i256 = obj.load v4;
-        mstore v5 v1 i256;
-        v9.i256 = add v5 32.i256;
-        v10.objref<i256> = obj.proj v0 1.i256;
-        obj.store v10 v9;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_90db(v0.objref<@layout_1>, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v4.objref<i256> = obj.proj v0 1.i256;
-        v5.i256 = obj.load v4;
-        mstore v5 v1 i256;
-        v9.i256 = add v5 32.i256;
-        v10.objref<i256> = obj.proj v0 1.i256;
-        obj.store v10 v9;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_9351(v0.objref<@layout_1>, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v4.objref<i256> = obj.proj v0 1.i256;
-        v5.i256 = obj.load v4;
-        mstore v5 v1 i256;
-        v9.i256 = add v5 32.i256;
-        v10.objref<i256> = obj.proj v0 1.i256;
-        obj.store v10 v9;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_at_1360(v0.objref<@layout_1>, v1.i256, v2.i256) {
+func private %write_word_at(v0.objref<@layout_1>, v1.i256, v2.i256) {
     block0:
         jump block1;
 
     block1:
         mstore v1 v2 i256;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_at_7077(v0.objref<@layout_1>, v1.i256, v2.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        mstore v1 v2 i256;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_bbc2(v0.objref<@layout_1>, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v4.objref<i256> = obj.proj v0 1.i256;
-        v5.i256 = obj.load v4;
-        mstore v5 v1 i256;
-        v9.i256 = add v5 32.i256;
-        v10.objref<i256> = obj.proj v0 1.i256;
-        obj.store v10 v9;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_d00a(v0.objref<@layout_1>, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v4.objref<i256> = obj.proj v0 1.i256;
-        v5.i256 = obj.load v4;
-        mstore v5 v1 i256;
-        v9.i256 = add v5 32.i256;
-        v10.objref<i256> = obj.proj v0 1.i256;
-        obj.store v10 v9;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_d10d(v0.objref<@layout_1>, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v4.objref<i256> = obj.proj v0 1.i256;
-        v5.i256 = obj.load v4;
-        mstore v5 v1 i256;
-        v9.i256 = add v5 32.i256;
-        v10.objref<i256> = obj.proj v0 1.i256;
-        obj.store v10 v9;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_d1f3(v0.objref<@layout_1>, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v4.objref<i256> = obj.proj v0 1.i256;
-        v5.i256 = obj.load v4;
-        mstore v5 v1 i256;
-        v9.i256 = add v5 32.i256;
-        v10.objref<i256> = obj.proj v0 1.i256;
-        obj.store v10 v9;
         return;
 }
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/erc20_low_level.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/erc20_low_level.snap
@@ -19,7 +19,7 @@ func private %abi_encode_string(v0.i256, v1.i256) {
         call %mstore 0.i256 32.i256;
         call %mstore 32.i256 v1;
         call %mstore 64.i256 v0;
-        call %std__lib__evm__effects__impl_trait_Evm_0098__return_data_3b86 0.i256 96.i256;
+        call %return_data 0.i256 96.i256;
         unreachable;
 }
 
@@ -29,7 +29,7 @@ func private %abi_encode_u256(v0.i256) {
 
     block1:
         call %mstore 0.i256 v0;
-        call %std__lib__evm__effects__impl_trait_Evm_0098__return_data_3b86 0.i256 32.i256;
+        call %return_data 0.i256 32.i256;
         unreachable;
 }
 
@@ -60,7 +60,7 @@ func private %approve__g44bd(v0.@layout_0, v1.i256, v2.i256) -> i256 {
         jump block1;
 
     block1:
-        v6.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_a1e8__caller_8a6b;
+        v6.@layout_0 = call %caller;
         call %approve__g35d6 v2 v6 v0 v1 0.i256 1.i256;
         return 1.i256;
 }
@@ -121,37 +121,7 @@ func private %calldataload(v0.i256) -> i256 {
         return v2;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_a1e8__caller_8a6b() -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v0.i256 = evm_caller;
-        v3.@layout_0 = insert_value undef.@layout_0 0.i256 v0;
-        return v3;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_a1e8__caller_c33e() -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v0.i256 = evm_caller;
-        v3.@layout_0 = insert_value undef.@layout_0 0.i256 v0;
-        return v3;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_a1e8__caller_c33e_0() -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v0.i256 = evm_caller;
-        v3.@layout_0 = insert_value undef.@layout_0 0.i256 v0;
-        return v3;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_a1e8__caller_c33e_1() -> @layout_0 {
+func private %caller() -> @layout_0 {
     block0:
         jump block1;
 
@@ -175,23 +145,12 @@ func private %do_init(v0.i256) {
         jump block1;
 
     block1:
-        v4.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_a1e8__caller_c33e_0;
+        v4.@layout_0 = call %caller;
         call %set_owner_once v0 v4 0.i256 1.i256;
         return;
 }
 
-func private %std__lib__evm__effects__impl_trait_Address_3ffb__eq_13ab(v0.i256, v1.@layout_0) -> i1 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.i256 = evm_sload v0;
-        v6.i256 = extract_value v1 0.i256;
-        v7.i1 = eq v3 v6;
-        return v7;
-}
-
-func private %std__lib__evm__effects__impl_trait_Address_3ffb__eq_85bf(v0.@layout_0, v1.i256) -> i1 {
+func private %std__lib__evm__effects__impl_trait_Address_3ffb__eq_519f(v0.@layout_0, v1.i256) -> i1 {
     block0:
         jump block1;
 
@@ -202,7 +161,18 @@ func private %std__lib__evm__effects__impl_trait_Address_3ffb__eq_85bf(v0.@layou
         return v7;
 }
 
-func private %core__lib__effect_ref__impl_trait_StorPtr_27da__from_raw__gb51e_866d(v0.i256, v1.i256, v2.i256) -> @layout_1 {
+func private %std__lib__evm__effects__impl_trait_Address_3ffb__eq_f155(v0.i256, v1.@layout_0) -> i1 {
+    block0:
+        jump block1;
+
+    block1:
+        v3.i256 = evm_sload v0;
+        v6.i256 = extract_value v1 0.i256;
+        v7.i1 = eq v3 v6;
+        return v7;
+}
+
+func private %from_raw(v0.i256, v1.i256, v2.i256) -> @layout_1 {
     block0:
         jump block1;
 
@@ -214,59 +184,7 @@ func private %core__lib__effect_ref__impl_trait_StorPtr_27da__from_raw__gb51e_86
         return v14;
 }
 
-func private %core__lib__effect_ref__impl_trait_StorPtr_27da__from_raw__gb51e_866d_0(v0.i256, v1.i256, v2.i256) -> @layout_1 {
-    block0:
-        jump block1;
-
-    block1:
-        v6.@layout_0 = insert_value undef.@layout_0 0.i256 v0;
-        v10.@layout_1 = insert_value undef.@layout_1 0.i256 v6;
-        v12.@layout_1 = insert_value v10 1.i256 v1;
-        v14.@layout_1 = insert_value v12 2.i256 v2;
-        return v14;
-}
-
-func private %std__lib__evm__word__impl_trait_u256_1f9e__from_word_09f5(v0.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        return v0;
-}
-
-func private %std__lib__evm__word__impl_trait_u256_1f9e__from_word_3cf5(v0.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        return v0;
-}
-
-func private %std__lib__evm__word__impl_trait_u256_1f9e__from_word_51d4(v0.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        return v0;
-}
-
-func private %std__lib__evm__word__impl_trait_u256_1f9e__from_word_51d4_0(v0.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        return v0;
-}
-
-func private %std__lib__evm__word__impl_trait_u256_1f9e__from_word_51d4_1(v0.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        return v0;
-}
-
-func private %std__lib__evm__word__impl_trait_u256_1f9e__from_word_89ed(v0.i256) -> i256 {
+func private %from_word(v0.i256) -> i256 {
     block0:
         jump block1;
 
@@ -334,7 +252,7 @@ func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__g
 
     block1:
         v4.i256 = call %std__lib__evm__storage_map__storagemap_get_word_with_salt__g7bf4_3a59 v0 1.i256;
-        v5.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__from_word_09f5 v4;
+        v5.i256 = call %from_word v4;
         return v5;
 }
 
@@ -344,7 +262,7 @@ func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__g
 
     block1:
         v4.i256 = call %std__lib__evm__storage_map__storagemap_get_word_with_salt__g67a8_6b6a v0 0.i256;
-        v5.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__from_word_3cf5 v4;
+        v5.i256 = call %from_word v4;
         return v5;
 }
 
@@ -354,7 +272,7 @@ func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__g
 
     block1:
         v4.i256 = call %std__lib__evm__storage_map__storagemap_get_word_with_salt__g7bf4_dd35 v0 1.i256;
-        v5.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__from_word_89ed v4;
+        v5.i256 = call %from_word v4;
         return v5;
 }
 
@@ -364,7 +282,7 @@ func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__g
 
     block1:
         v4.i256 = call %std__lib__evm__storage_map__storagemap_get_word_with_salt__g67a8_7573 v0 0.i256;
-        v5.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__from_word_51d4 v4;
+        v5.i256 = call %from_word v4;
         return v5;
 }
 
@@ -374,7 +292,7 @@ func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__g
 
     block1:
         v4.i256 = call %std__lib__evm__storage_map__storagemap_get_word_with_salt__g67a8_7573_0 v0 0.i256;
-        v5.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__from_word_51d4_0 v4;
+        v5.i256 = call %from_word v4;
         return v5;
 }
 
@@ -384,7 +302,7 @@ func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__g
 
     block1:
         v4.i256 = call %std__lib__evm__storage_map__storagemap_get_word_with_salt__g67a8_7573_1 v0 0.i256;
-        v5.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__from_word_51d4_1 v4;
+        v5.i256 = call %from_word v4;
         return v5;
 }
 
@@ -393,7 +311,7 @@ func private %init() {
         jump block1;
 
     block1:
-        v2.@layout_1 = call %std__lib__evm__effects__trait_RawStorage__stor_ptr__g3730_6bd4_0 0.i256 0.i256 1.i256;
+        v2.@layout_1 = call %stor_ptr 0.i256 0.i256 1.i256;
         v3.@layout_0 = extract_value v2 0.i256;
         v4.i256 = extract_value v2 1.i256;
         v6.i256 = extract_value v2 2.i256;
@@ -404,7 +322,7 @@ func private %init() {
         v11.*i8 = evm_malloc v9;
         v12.i256 = ptr_to_int v11 i256;
         call %codecopy v12 v10 v9;
-        call %std__lib__evm__effects__impl_trait_Evm_0098__return_data_0402 v12 v9;
+        call %return_data v12 v9;
         unreachable;
 }
 
@@ -431,13 +349,13 @@ func private %mint__g0502(v0.i256, v1.@layout_0, v2.i256, v3.i256, v4.i256) {
         jump block1;
 
     block1:
-        v5.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_a1e8__caller_c33e_1;
+        v5.@layout_0 = call %caller;
         v8.i256 = add v0 1.i256;
-        v9.i1 = call %core__lib__ops__trait_Eq__ne__g7528_700d v5 v8;
+        v9.i1 = call %core__lib__ops__trait_Eq__ne__g7528_2614 v5 v8;
         br v9 block2 block3;
 
     block2:
-        call %std__lib__evm__effects__impl_trait_Evm_0098__revert_aec5 0.i256 0.i256;
+        call %revert 0.i256 0.i256;
         unreachable;
 
     block3:
@@ -482,22 +400,22 @@ func private %mstore(v0.i256, v1.i256) {
         return;
 }
 
-func private %core__lib__ops__trait_Eq__ne__g7528_13f9(v0.i256, v1.@layout_0) -> i1 {
+func private %core__lib__ops__trait_Eq__ne__g7528_2614(v0.@layout_0, v1.i256) -> i1 {
     block0:
         jump block1;
 
     block1:
-        v4.i1 = call %std__lib__evm__effects__impl_trait_Address_3ffb__eq_13ab v0 v1;
+        v4.i1 = call %std__lib__evm__effects__impl_trait_Address_3ffb__eq_519f v0 v1;
         v5.i1 = is_zero v4;
         return v5;
 }
 
-func private %core__lib__ops__trait_Eq__ne__g7528_700d(v0.@layout_0, v1.i256) -> i1 {
+func private %core__lib__ops__trait_Eq__ne__g7528_ba99(v0.i256, v1.@layout_0) -> i1 {
     block0:
         jump block1;
 
     block1:
-        v4.i1 = call %std__lib__evm__effects__impl_trait_Address_3ffb__eq_85bf v0 v1;
+        v4.i1 = call %std__lib__evm__effects__impl_trait_Address_3ffb__eq_f155 v0 v1;
         v5.i1 = is_zero v4;
         return v5;
 }
@@ -520,7 +438,7 @@ func private %core__lib__effect_ref__impl_trait_StorPtr_27da__raw__gb51e_9bd1_0(
         return v5;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_0098__return_data_0402(v0.i256, v1.i256) {
+func private %return_data(v0.i256, v1.i256) {
     block0:
         jump block1;
 
@@ -528,47 +446,7 @@ func private %std__lib__evm__effects__impl_trait_Evm_0098__return_data_0402(v0.i
         evm_return v0 v1;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_0098__return_data_3b86(v0.i256, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        evm_return v0 v1;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_61f0(v0.i256, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert v0 v1;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_aec5(v0.i256, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert v0 v1;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_aec5_0(v0.i256, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert v0 v1;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_aec5_1(v0.i256, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert v0 v1;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_aec5_2(v0.i256, v1.i256) {
+func private %revert(v0.i256, v1.i256) {
     block0:
         jump block1;
 
@@ -581,7 +459,7 @@ func private %runtime() {
         jump block1;
 
     block1:
-        v2.@layout_1 = call %std__lib__evm__effects__trait_RawStorage__stor_ptr__g3730_6bd4 0.i256 0.i256 1.i256;
+        v2.@layout_1 = call %stor_ptr 0.i256 0.i256 1.i256;
         v3.@layout_0 = extract_value v2 0.i256;
         v4.i256 = extract_value v2 1.i256;
         v6.i256 = extract_value v2 2.i256;
@@ -659,7 +537,7 @@ func private %runtime() {
         unreachable;
 
     block11:
-        call %std__lib__evm__effects__impl_trait_Evm_0098__revert_61f0 0.i256 0.i256;
+        call %revert 0.i256 0.i256;
         unreachable;
 
     block12:
@@ -758,11 +636,11 @@ func private %set_owner_once(v0.i256, v1.@layout_0, v2.i256, v3.i256) {
         obj.store v13 v14;
         v15.i256 = add v0 1.i256;
         v16.@layout_0 = obj.load v4;
-        v17.i1 = call %core__lib__ops__trait_Eq__ne__g7528_13f9 v15 v16;
+        v17.i1 = call %core__lib__ops__trait_Eq__ne__g7528_ba99 v15 v16;
         br v17 block2 block3;
 
     block2:
-        call %std__lib__evm__effects__impl_trait_Evm_0098__revert_aec5_1 0.i256 0.i256;
+        call %revert 0.i256 0.i256;
         unreachable;
 
     block3:
@@ -780,7 +658,7 @@ func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__s
         jump block1;
 
     block1:
-        v5.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__to_word_fb94 v1;
+        v5.i256 = call %to_word v1;
         call %std__lib__evm__storage_map__storagemap_set_word_with_salt__g67a8_0b75 v0 0.i256 v5;
         return;
 }
@@ -790,7 +668,7 @@ func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__s
         jump block1;
 
     block1:
-        v5.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__to_word_fb94_0 v1;
+        v5.i256 = call %to_word v1;
         call %std__lib__evm__storage_map__storagemap_set_word_with_salt__g67a8_0b75_0 v0 0.i256 v5;
         return;
 }
@@ -800,7 +678,7 @@ func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__s
         jump block1;
 
     block1:
-        v5.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__to_word_fb94_1 v1;
+        v5.i256 = call %to_word v1;
         call %std__lib__evm__storage_map__storagemap_set_word_with_salt__g67a8_0b75_1 v0 0.i256 v5;
         return;
 }
@@ -810,7 +688,7 @@ func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__s
         jump block1;
 
     block1:
-        v5.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__to_word_b350 v1;
+        v5.i256 = call %to_word v1;
         call %std__lib__evm__storage_map__storagemap_set_word_with_salt__g7bf4_ec70 v0 1.i256 v5;
         return;
 }
@@ -820,32 +698,17 @@ func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__s
         jump block1;
 
     block1:
-        v5.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__to_word_c57e v1;
+        v5.i256 = call %to_word v1;
         call %std__lib__evm__storage_map__storagemap_set_word_with_salt__g7bf4_9d7e v0 1.i256 v5;
         return;
 }
 
-func private %std__lib__evm__effects__trait_RawStorage__stor_ptr__g3730_6bd4(v0.i256, v1.i256, v2.i256) -> @layout_1 {
+func private %stor_ptr(v0.i256, v1.i256, v2.i256) -> @layout_1 {
     block0:
         jump block1;
 
     block1:
-        v6.@layout_1 = call %core__lib__effect_ref__impl_trait_StorPtr_27da__from_raw__gb51e_866d v0 v1 v2;
-        v8.@layout_0 = extract_value v6 0.i256;
-        v10.i256 = extract_value v6 1.i256;
-        v12.i256 = extract_value v6 2.i256;
-        v14.@layout_1 = insert_value undef.@layout_1 0.i256 v8;
-        v15.@layout_1 = insert_value v14 1.i256 v10;
-        v16.@layout_1 = insert_value v15 2.i256 v12;
-        return v16;
-}
-
-func private %std__lib__evm__effects__trait_RawStorage__stor_ptr__g3730_6bd4_0(v0.i256, v1.i256, v2.i256) -> @layout_1 {
-    block0:
-        jump block1;
-
-    block1:
-        v6.@layout_1 = call %core__lib__effect_ref__impl_trait_StorPtr_27da__from_raw__gb51e_866d_0 v0 v1 v2;
+        v6.@layout_1 = call %from_raw v0 v1 v2;
         v8.@layout_0 = extract_value v6 0.i256;
         v10.i256 = extract_value v6 1.i256;
         v12.i256 = extract_value v6 2.i256;
@@ -972,7 +835,7 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot
     block1:
         v3.*i8 = evm_malloc 0.i256;
         v4.i256 = ptr_to_int v3 i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_29cb v4 v0;
+        v6.i256 = call %write_key__g7528 v4 v0;
         (v7.i256, v8.i1) = uaddo v4 v6;
         br v8 block2 block3;
 
@@ -998,7 +861,7 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot
     block1:
         v3.*i8 = evm_malloc 0.i256;
         v4.i256 = ptr_to_int v3 i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_c70a v4 v0;
+        v6.i256 = call %impl_trait_Address__write_key v4 v0;
         (v7.i256, v8.i1) = uaddo v4 v6;
         br v8 block2 block3;
 
@@ -1024,7 +887,7 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot
     block1:
         v3.*i8 = evm_malloc 0.i256;
         v4.i256 = ptr_to_int v3 i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_6e8f v4 v0;
+        v6.i256 = call %write_key__g7528 v4 v0;
         (v7.i256, v8.i1) = uaddo v4 v6;
         br v8 block2 block3;
 
@@ -1050,7 +913,7 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot
     block1:
         v3.*i8 = evm_malloc 0.i256;
         v4.i256 = ptr_to_int v3 i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_226d v4 v0;
+        v6.i256 = call %write_key__g7528 v4 v0;
         (v7.i256, v8.i1) = uaddo v4 v6;
         br v8 block2 block3;
 
@@ -1076,7 +939,7 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot
     block1:
         v3.*i8 = evm_malloc 0.i256;
         v4.i256 = ptr_to_int v3 i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_7747 v4 v0;
+        v6.i256 = call %impl_trait_Address__write_key v4 v0;
         (v7.i256, v8.i1) = uaddo v4 v6;
         br v8 block2 block3;
 
@@ -1102,7 +965,7 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot
     block1:
         v3.*i8 = evm_malloc 0.i256;
         v4.i256 = ptr_to_int v3 i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_7747_0 v4 v0;
+        v6.i256 = call %impl_trait_Address__write_key v4 v0;
         (v7.i256, v8.i1) = uaddo v4 v6;
         br v8 block2 block3;
 
@@ -1128,7 +991,7 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot
     block1:
         v3.*i8 = evm_malloc 0.i256;
         v4.i256 = ptr_to_int v3 i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_7747_1 v4 v0;
+        v6.i256 = call %impl_trait_Address__write_key v4 v0;
         (v7.i256, v8.i1) = uaddo v4 v6;
         br v8 block2 block3;
 
@@ -1147,39 +1010,7 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot
         return v20;
 }
 
-func private %std__lib__evm__word__impl_trait_u256_1f9e__to_word_b350(v0.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        return v0;
-}
-
-func private %std__lib__evm__word__impl_trait_u256_1f9e__to_word_c57e(v0.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        return v0;
-}
-
-func private %std__lib__evm__word__impl_trait_u256_1f9e__to_word_fb94(v0.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        return v0;
-}
-
-func private %std__lib__evm__word__impl_trait_u256_1f9e__to_word_fb94_0(v0.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        return v0;
-}
-
-func private %std__lib__evm__word__impl_trait_u256_1f9e__to_word_fb94_1(v0.i256) -> i256 {
+func private %to_word(v0.i256) -> i256 {
     block0:
         jump block1;
 
@@ -1192,7 +1023,7 @@ func private %transfer__g2ee9(v0.@layout_0, v1.i256, v2.i256) -> i256 {
         jump block1;
 
     block1:
-        v6.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_a1e8__caller_c33e;
+        v6.@layout_0 = call %caller;
         call %standalone_erc20_low_level__erc20_low_level__impl_Erc20_ee5d__transfer__g0f37_84af v2 v6 v0 v1 0.i256 1.i256;
         return 1.i256;
 }
@@ -1207,7 +1038,7 @@ func private %standalone_erc20_low_level__erc20_low_level__impl_Erc20_ee5d__tran
         br v12 block2 block3;
 
     block2:
-        call %std__lib__evm__effects__impl_trait_Evm_0098__revert_aec5_0 0.i256 0.i256;
+        call %revert 0.i256 0.i256;
         unreachable;
 
     block3:
@@ -1243,7 +1074,7 @@ func private %standalone_erc20_low_level__erc20_low_level__impl_Erc20_ee5d__tran
         br v12 block2 block3;
 
     block2:
-        call %std__lib__evm__effects__impl_trait_Evm_0098__revert_aec5_2 0.i256 0.i256;
+        call %revert 0.i256 0.i256;
         unreachable;
 
     block3:
@@ -1283,13 +1114,13 @@ func private %transfer_from__g0502(v0.i256, v1.@layout_0, v2.@layout_0, v3.i256,
         jump block1;
 
     block1:
-        v6.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_a1e8__caller_c33e_1;
+        v6.@layout_0 = call %caller;
         v11.i256 = call %allowance__g35d6 v0 v1 v6 v4 v5;
         v13.i1 = lt v11 v3;
         br v13 block2 block3;
 
     block2:
-        call %std__lib__evm__effects__impl_trait_Evm_0098__revert_aec5 0.i256 0.i256;
+        call %revert 0.i256 0.i256;
         unreachable;
 
     block3:
@@ -1312,23 +1143,22 @@ func private %transfer_from__g0502(v0.i256, v1.@layout_0, v2.@layout_0, v3.i256,
         return;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_1c01(v0.i256, v1.@layout_0) -> i256 {
+func inline(always) private %impl_trait_u256__write_key(v0.i256, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v5.i256 = extract_value v1 0.i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_a6f4 v0 v5;
-        return v6;
+        mstore v0 v1 i256;
+        return 32.i256;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_226d(v0.i256, v1.@layout_2) -> i256 {
+func inline(always) private %write_key__g7528(v0.i256, v1.@layout_2) -> i256 {
     block0:
         jump block1;
 
     block1:
         v5.@layout_0 = extract_value v1 0.i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_56aa v0 v5;
+        v6.i256 = call %impl_trait_Address__write_key v0 v5;
         (v7.i256, v8.i1) = uaddo v0 v6;
         br v8 block2 block3;
 
@@ -1339,7 +1169,7 @@ func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__wri
 
     block3:
         v15.@layout_0 = extract_value v1 1.i256;
-        v16.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_56aa v7 v15;
+        v16.i256 = call %impl_trait_Address__write_key v7 v15;
         (v18.i256, v19.i1) = uaddo v6 v16;
         br v19 block2 block4;
 
@@ -1347,177 +1177,14 @@ func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__wri
         return v18;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_29cb(v0.i256, v1.@layout_2) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v5.@layout_0 = extract_value v1 0.i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_1c01 v0 v5;
-        (v7.i256, v8.i1) = uaddo v0 v6;
-        br v8 block2 block3;
-
-    block2:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block3:
-        v15.@layout_0 = extract_value v1 1.i256;
-        v16.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_1c01 v7 v15;
-        (v18.i256, v19.i1) = uaddo v6 v16;
-        br v19 block2 block4;
-
-    block4:
-        return v18;
-}
-
-func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_4327(v0.i256, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        mstore v0 v1 i256;
-        return 32.i256;
-}
-
-func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_56aa(v0.i256, v1.@layout_0) -> i256 {
+func inline(always) private %impl_trait_Address__write_key(v0.i256, v1.@layout_0) -> i256 {
     block0:
         jump block1;
 
     block1:
         v5.i256 = extract_value v1 0.i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_7d35 v0 v5;
+        v6.i256 = call %impl_trait_u256__write_key v0 v5;
         return v6;
-}
-
-func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_6e8f(v0.i256, v1.@layout_2) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v5.@layout_0 = extract_value v1 0.i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_9858 v0 v5;
-        (v7.i256, v8.i1) = uaddo v0 v6;
-        br v8 block2 block3;
-
-    block2:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block3:
-        v15.@layout_0 = extract_value v1 1.i256;
-        v16.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_9858 v7 v15;
-        (v18.i256, v19.i1) = uaddo v6 v16;
-        br v19 block2 block4;
-
-    block4:
-        return v18;
-}
-
-func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_7747(v0.i256, v1.@layout_0) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v5.i256 = extract_value v1 0.i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_7bb3 v0 v5;
-        return v6;
-}
-
-func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_7747_0(v0.i256, v1.@layout_0) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v5.i256 = extract_value v1 0.i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_7bb3_0 v0 v5;
-        return v6;
-}
-
-func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_7747_1(v0.i256, v1.@layout_0) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v5.i256 = extract_value v1 0.i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_7bb3_1 v0 v5;
-        return v6;
-}
-
-func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_7bb3(v0.i256, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        mstore v0 v1 i256;
-        return 32.i256;
-}
-
-func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_7bb3_0(v0.i256, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        mstore v0 v1 i256;
-        return 32.i256;
-}
-
-func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_7bb3_1(v0.i256, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        mstore v0 v1 i256;
-        return 32.i256;
-}
-
-func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_7d35(v0.i256, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        mstore v0 v1 i256;
-        return 32.i256;
-}
-
-func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_9858(v0.i256, v1.@layout_0) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v5.i256 = extract_value v1 0.i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_4327 v0 v5;
-        return v6;
-}
-
-func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_a6f4(v0.i256, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        mstore v0 v1 i256;
-        return 32.i256;
-}
-
-func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_c70a(v0.i256, v1.@layout_0) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v5.i256 = extract_value v1 0.i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_f2a4 v0 v5;
-        return v6;
-}
-
-func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_f2a4(v0.i256, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        mstore v0 v1 i256;
-        return 32.i256;
 }
 
 func private %zero() -> @layout_0 {

--- a/crates/codegen/tests/fixtures/sonatina_ir/erc20_low_level.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/erc20_low_level.snap
@@ -6,9 +6,8 @@ input_file: crates/codegen/tests/fixtures/erc20_low_level.fe
 target = "evm-ethereum-osaka"
 
 type @layout_0 = {i256};
-type @layout_1 = {i256};
-type @layout_2 = {@layout_1, i256, i256};
-type @layout_3 = {@layout_0, @layout_0};
+type @layout_1 = {@layout_0, i256, i256};
+type @layout_2 = {@layout_0, @layout_0};
 
 global private const @layout_0 $const_region_0 = {0};
 
@@ -39,9 +38,9 @@ func private %allowance__g26d5(v0.@layout_0, v1.@layout_0, v2.i256) -> i256 {
         jump block1;
 
     block1:
-        v8.@layout_3 = insert_value undef.@layout_3 0.i256 v0;
-        v9.@layout_3 = insert_value v8 1.i256 v1;
-        v10.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get__ga15b_679e v9 1.i256;
+        v8.@layout_2 = insert_value undef.@layout_2 0.i256 v0;
+        v9.@layout_2 = insert_value v8 1.i256 v1;
+        v10.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get__ga15b_ddb0 v9 1.i256;
         return v10;
 }
 
@@ -50,21 +49,10 @@ func private %allowance__g35d6(v0.i256, v1.@layout_0, v2.@layout_0, v3.i256, v4.
         jump block1;
 
     block1:
-        v10.@layout_3 = insert_value undef.@layout_3 0.i256 v1;
-        v12.@layout_3 = insert_value v10 1.i256 v2;
-        v13.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get__ga15b_bf76 v12 v4;
+        v10.@layout_2 = insert_value undef.@layout_2 0.i256 v1;
+        v12.@layout_2 = insert_value v10 1.i256 v2;
+        v13.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get__ga15b_bdb0 v12 v4;
         return v13;
-}
-
-func private %approve__g35d6(v0.i256, v1.@layout_0, v2.@layout_0, v3.i256, v4.i256, v5.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v12.@layout_3 = insert_value undef.@layout_3 0.i256 v1;
-        v14.@layout_3 = insert_value v12 1.i256 v2;
-        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set__ga15b_1b1b v14 v3 v5;
-        return;
 }
 
 func private %approve__g44bd(v0.@layout_0, v1.i256, v2.i256) -> i256 {
@@ -77,30 +65,41 @@ func private %approve__g44bd(v0.@layout_0, v1.i256, v2.i256) -> i256 {
         return 1.i256;
 }
 
-func private %standalone_erc20_low_level__erc20_low_level__impl_Erc20_ee5d__balance_of__g35d6_1112(v0.i256, v1.@layout_0, v2.i256, v3.i256) -> i256 {
+func private %approve__g35d6(v0.i256, v1.@layout_0, v2.@layout_0, v3.i256, v4.i256, v5.i256) {
     block0:
         jump block1;
 
     block1:
-        v6.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get__g2163_2521 v1 v2;
+        v12.@layout_2 = insert_value undef.@layout_2 0.i256 v1;
+        v14.@layout_2 = insert_value v12 1.i256 v2;
+        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set__ga15b_cb5f v14 v3 v5;
+        return;
+}
+
+func private %standalone_erc20_low_level__erc20_low_level__impl_Erc20_ee5d__balance_of__g35d6_3e9c(v0.i256, v1.@layout_0, v2.i256, v3.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v6.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get__g2163_17b6 v1 v2;
         return v6;
 }
 
-func private %standalone_erc20_low_level__erc20_low_level__impl_Erc20_ee5d__balance_of__g35d6_1112_0(v0.i256, v1.@layout_0, v2.i256, v3.i256) -> i256 {
+func private %standalone_erc20_low_level__erc20_low_level__impl_Erc20_ee5d__balance_of__g35d6_3e9c_0(v0.i256, v1.@layout_0, v2.i256, v3.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v6.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get__g2163_2521_0 v1 v2;
+        v6.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get__g2163_17b6_0 v1 v2;
         return v6;
 }
 
-func private %standalone_erc20_low_level__erc20_low_level__impl_Erc20_ee5d__balance_of__g35d6_1112_1(v0.i256, v1.@layout_0, v2.i256, v3.i256) -> i256 {
+func private %standalone_erc20_low_level__erc20_low_level__impl_Erc20_ee5d__balance_of__g35d6_3e9c_1(v0.i256, v1.@layout_0, v2.i256, v3.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v6.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get__g2163_2521_1 v1 v2;
+        v6.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get__g2163_17b6_1 v1 v2;
         return v6;
 }
 
@@ -109,7 +108,7 @@ func private %balance_of__g26d5(v0.@layout_0, v1.i256) -> i256 {
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get__g2163_e6b0 v0 0.i256;
+        v4.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get__g2163_6eef v0 0.i256;
         return v4;
 }
 
@@ -181,7 +180,7 @@ func private %do_init(v0.i256) {
         return;
 }
 
-func private %std__lib__evm__effects__impl_trait_Address_3ffb__eq_3b13(v0.i256, v1.@layout_0) -> i1 {
+func private %std__lib__evm__effects__impl_trait_Address_3ffb__eq_13ab(v0.i256, v1.@layout_0) -> i1 {
     block0:
         jump block1;
 
@@ -192,7 +191,7 @@ func private %std__lib__evm__effects__impl_trait_Address_3ffb__eq_3b13(v0.i256, 
         return v7;
 }
 
-func private %std__lib__evm__effects__impl_trait_Address_3ffb__eq_fb60(v0.@layout_0, v1.i256) -> i1 {
+func private %std__lib__evm__effects__impl_trait_Address_3ffb__eq_85bf(v0.@layout_0, v1.i256) -> i1 {
     block0:
         jump block1;
 
@@ -203,27 +202,27 @@ func private %std__lib__evm__effects__impl_trait_Address_3ffb__eq_fb60(v0.@layou
         return v7;
 }
 
-func private %core__lib__effect_ref__impl_trait_StorPtr_27da__from_raw__gb51e_866d(v0.i256, v1.i256, v2.i256) -> @layout_2 {
+func private %core__lib__effect_ref__impl_trait_StorPtr_27da__from_raw__gb51e_866d(v0.i256, v1.i256, v2.i256) -> @layout_1 {
     block0:
         jump block1;
 
     block1:
-        v6.@layout_1 = insert_value undef.@layout_1 0.i256 v0;
-        v10.@layout_2 = insert_value undef.@layout_2 0.i256 v6;
-        v12.@layout_2 = insert_value v10 1.i256 v1;
-        v14.@layout_2 = insert_value v12 2.i256 v2;
+        v6.@layout_0 = insert_value undef.@layout_0 0.i256 v0;
+        v10.@layout_1 = insert_value undef.@layout_1 0.i256 v6;
+        v12.@layout_1 = insert_value v10 1.i256 v1;
+        v14.@layout_1 = insert_value v12 2.i256 v2;
         return v14;
 }
 
-func private %core__lib__effect_ref__impl_trait_StorPtr_27da__from_raw__gb51e_866d_0(v0.i256, v1.i256, v2.i256) -> @layout_2 {
+func private %core__lib__effect_ref__impl_trait_StorPtr_27da__from_raw__gb51e_866d_0(v0.i256, v1.i256, v2.i256) -> @layout_1 {
     block0:
         jump block1;
 
     block1:
-        v6.@layout_1 = insert_value undef.@layout_1 0.i256 v0;
-        v10.@layout_2 = insert_value undef.@layout_2 0.i256 v6;
-        v12.@layout_2 = insert_value v10 1.i256 v1;
-        v14.@layout_2 = insert_value v12 2.i256 v2;
+        v6.@layout_0 = insert_value undef.@layout_0 0.i256 v0;
+        v10.@layout_1 = insert_value undef.@layout_1 0.i256 v6;
+        v12.@layout_1 = insert_value v10 1.i256 v1;
+        v14.@layout_1 = insert_value v12 2.i256 v2;
         return v14;
 }
 
@@ -275,116 +274,116 @@ func private %std__lib__evm__word__impl_trait_u256_1f9e__from_word_89ed(v0.i256)
         return v0;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__get__g2163_2521(v0.@layout_0, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__get__g2163_17b6(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get_unchecked__g2163_cd4e v0 v1;
+        v4.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get_unchecked__g2163_e390 v0 v1;
         return v4;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__get__g2163_2521_0(v0.@layout_0, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__get__g2163_17b6_0(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get_unchecked__g2163_cd4e_0 v0 v1;
+        v4.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get_unchecked__g2163_e390_0 v0 v1;
         return v4;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__get__g2163_2521_1(v0.@layout_0, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__get__g2163_17b6_1(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get_unchecked__g2163_cd4e_1 v0 v1;
+        v4.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get_unchecked__g2163_e390_1 v0 v1;
         return v4;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__get__ga15b_679e(v0.@layout_3, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__get__g2163_6eef(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get_unchecked__ga15b_c992 v0 v1;
+        v4.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get_unchecked__g2163_3a8a v0 v1;
         return v4;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__get__ga15b_bf76(v0.@layout_3, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__get__ga15b_bdb0(v0.@layout_2, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get_unchecked__ga15b_60b3 v0 v1;
+        v4.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get_unchecked__ga15b_b967 v0 v1;
         return v4;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__get__g2163_e6b0(v0.@layout_0, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__get__ga15b_ddb0(v0.@layout_2, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get_unchecked__g2163_1022 v0 v1;
+        v4.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get_unchecked__ga15b_23a5 v0 v1;
         return v4;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__get_unchecked__g2163_1022(v0.@layout_0, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__get_unchecked__ga15b_23a5(v0.@layout_2, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__storage_map__storagemap_get_word_with_salt__g67a8_bfbb v0 0.i256;
-        v5.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__from_word_3cf5 v4;
-        return v5;
-}
-
-func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__get_unchecked__ga15b_60b3(v0.@layout_3, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__storage_map__storagemap_get_word_with_salt__g7bf4_df22 v0 1.i256;
-        v5.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__from_word_89ed v4;
-        return v5;
-}
-
-func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__get_unchecked__ga15b_c992(v0.@layout_3, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__storage_map__storagemap_get_word_with_salt__g7bf4_fdb1 v0 1.i256;
+        v4.i256 = call %std__lib__evm__storage_map__storagemap_get_word_with_salt__g7bf4_3a59 v0 1.i256;
         v5.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__from_word_09f5 v4;
         return v5;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__get_unchecked__g2163_cd4e(v0.@layout_0, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__get_unchecked__g2163_3a8a(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__storage_map__storagemap_get_word_with_salt__g67a8_71c2 v0 0.i256;
+        v4.i256 = call %std__lib__evm__storage_map__storagemap_get_word_with_salt__g67a8_6b6a v0 0.i256;
+        v5.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__from_word_3cf5 v4;
+        return v5;
+}
+
+func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__get_unchecked__ga15b_b967(v0.@layout_2, v1.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.i256 = call %std__lib__evm__storage_map__storagemap_get_word_with_salt__g7bf4_dd35 v0 1.i256;
+        v5.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__from_word_89ed v4;
+        return v5;
+}
+
+func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__get_unchecked__g2163_e390(v0.@layout_0, v1.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.i256 = call %std__lib__evm__storage_map__storagemap_get_word_with_salt__g67a8_7573 v0 0.i256;
         v5.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__from_word_51d4 v4;
         return v5;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__get_unchecked__g2163_cd4e_0(v0.@layout_0, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__get_unchecked__g2163_e390_0(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__storage_map__storagemap_get_word_with_salt__g67a8_71c2_0 v0 0.i256;
+        v4.i256 = call %std__lib__evm__storage_map__storagemap_get_word_with_salt__g67a8_7573_0 v0 0.i256;
         v5.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__from_word_51d4_0 v4;
         return v5;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__get_unchecked__g2163_cd4e_1(v0.@layout_0, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__get_unchecked__g2163_e390_1(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__storage_map__storagemap_get_word_with_salt__g67a8_71c2_1 v0 0.i256;
+        v4.i256 = call %std__lib__evm__storage_map__storagemap_get_word_with_salt__g67a8_7573_1 v0 0.i256;
         v5.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__from_word_51d4_1 v4;
         return v5;
 }
@@ -394,11 +393,11 @@ func private %init() {
         jump block1;
 
     block1:
-        v2.@layout_2 = call %std__lib__evm__effects__trait_RawStorage__stor_ptr__g3730_6bd4_0 0.i256 0.i256 1.i256;
-        v3.@layout_1 = extract_value v2 0.i256;
+        v2.@layout_1 = call %std__lib__evm__effects__trait_RawStorage__stor_ptr__g3730_6bd4_0 0.i256 0.i256 1.i256;
+        v3.@layout_0 = extract_value v2 0.i256;
         v4.i256 = extract_value v2 1.i256;
         v6.i256 = extract_value v2 2.i256;
-        v7.i256 = call %core__lib__effect_ref__impl_trait_StorPtr_27da__raw__gb51e_8117_0 v3 v4 v6;
+        v7.i256 = call %core__lib__effect_ref__impl_trait_StorPtr_27da__raw__gb51e_9bd1_0 v3 v4 v6;
         call %do_init v7;
         v9.i256 = sym_size &__Erc20Contract_runtime;
         v10.i256 = sym_addr &__Erc20Contract_runtime;
@@ -427,15 +426,6 @@ func private %manual_contract_runtime_root_Erc20Contract() {
         evm_stop;
 }
 
-func private %mint__g2ee9(v0.@layout_0, v1.i256, v2.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        call %mint__g0502 v2 v0 v1 0.i256 1.i256;
-        return 1.i256;
-}
-
 func private %mint__g0502(v0.i256, v1.@layout_0, v2.i256, v3.i256, v4.i256) {
     block0:
         jump block1;
@@ -443,7 +433,7 @@ func private %mint__g0502(v0.i256, v1.@layout_0, v2.i256, v3.i256, v4.i256) {
     block1:
         v5.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_a1e8__caller_c33e_1;
         v8.i256 = add v0 1.i256;
-        v9.i1 = call %core__lib__ops__trait_Eq__ne__g7528_7551 v5 v8;
+        v9.i1 = call %core__lib__ops__trait_Eq__ne__g7528_700d v5 v8;
         br v9 block2 block3;
 
     block2:
@@ -454,7 +444,7 @@ func private %mint__g0502(v0.i256, v1.@layout_0, v2.i256, v3.i256, v4.i256) {
         jump block4;
 
     block4:
-        v15.i256 = call %standalone_erc20_low_level__erc20_low_level__impl_Erc20_ee5d__balance_of__g35d6_1112 v0 v1 v3 v4;
+        v15.i256 = call %standalone_erc20_low_level__erc20_low_level__impl_Erc20_ee5d__balance_of__g35d6_3e9c v0 v1 v3 v4;
         (v17.i256, v18.i1) = uaddo v15 v2;
         br v18 block5 block6;
 
@@ -464,7 +454,7 @@ func private %mint__g0502(v0.i256, v1.@layout_0, v2.i256, v3.i256, v4.i256) {
         evm_revert 0.i256 36.i256;
 
     block6:
-        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set__g2163_9079 v1 v17 v3;
+        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set__g2163_339e v1 v17 v3;
         v27.i256 = evm_sload v0;
         (v29.i256, v30.i1) = uaddo v27 v2;
         br v30 block5 block7;
@@ -472,6 +462,15 @@ func private %mint__g0502(v0.i256, v1.@layout_0, v2.i256, v3.i256, v4.i256) {
     block7:
         evm_sstore v0 v29;
         return;
+}
+
+func private %mint__g2ee9(v0.@layout_0, v1.i256, v2.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        call %mint__g0502 v2 v0 v1 0.i256 1.i256;
+        return 1.i256;
 }
 
 func private %mstore(v0.i256, v1.i256) {
@@ -483,27 +482,27 @@ func private %mstore(v0.i256, v1.i256) {
         return;
 }
 
-func private %core__lib__ops__trait_Eq__ne__g7528_324d(v0.i256, v1.@layout_0) -> i1 {
+func private %core__lib__ops__trait_Eq__ne__g7528_13f9(v0.i256, v1.@layout_0) -> i1 {
     block0:
         jump block1;
 
     block1:
-        v4.i1 = call %std__lib__evm__effects__impl_trait_Address_3ffb__eq_3b13 v0 v1;
+        v4.i1 = call %std__lib__evm__effects__impl_trait_Address_3ffb__eq_13ab v0 v1;
         v5.i1 = is_zero v4;
         return v5;
 }
 
-func private %core__lib__ops__trait_Eq__ne__g7528_7551(v0.@layout_0, v1.i256) -> i1 {
+func private %core__lib__ops__trait_Eq__ne__g7528_700d(v0.@layout_0, v1.i256) -> i1 {
     block0:
         jump block1;
 
     block1:
-        v4.i1 = call %std__lib__evm__effects__impl_trait_Address_3ffb__eq_fb60 v0 v1;
+        v4.i1 = call %std__lib__evm__effects__impl_trait_Address_3ffb__eq_85bf v0 v1;
         v5.i1 = is_zero v4;
         return v5;
 }
 
-func private %core__lib__effect_ref__impl_trait_StorPtr_27da__raw__gb51e_8117(v0.@layout_1, v1.i256, v2.i256) -> i256 {
+func private %core__lib__effect_ref__impl_trait_StorPtr_27da__raw__gb51e_9bd1(v0.@layout_0, v1.i256, v2.i256) -> i256 {
     block0:
         jump block1;
 
@@ -512,7 +511,7 @@ func private %core__lib__effect_ref__impl_trait_StorPtr_27da__raw__gb51e_8117(v0
         return v5;
 }
 
-func private %core__lib__effect_ref__impl_trait_StorPtr_27da__raw__gb51e_8117_0(v0.@layout_1, v1.i256, v2.i256) -> i256 {
+func private %core__lib__effect_ref__impl_trait_StorPtr_27da__raw__gb51e_9bd1_0(v0.@layout_0, v1.i256, v2.i256) -> i256 {
     block0:
         jump block1;
 
@@ -582,8 +581,8 @@ func private %runtime() {
         jump block1;
 
     block1:
-        v2.@layout_2 = call %std__lib__evm__effects__trait_RawStorage__stor_ptr__g3730_6bd4 0.i256 0.i256 1.i256;
-        v3.@layout_1 = extract_value v2 0.i256;
+        v2.@layout_1 = call %std__lib__evm__effects__trait_RawStorage__stor_ptr__g3730_6bd4 0.i256 0.i256 1.i256;
+        v3.@layout_0 = extract_value v2 0.i256;
         v4.i256 = extract_value v2 1.i256;
         v6.i256 = extract_value v2 2.i256;
         v7.i256 = call %calldataload 0.i256;
@@ -594,7 +593,7 @@ func private %runtime() {
     block2:
         v13.i256 = call %calldataload 4.i256;
         v15.@layout_0 = insert_value undef.@layout_0 0.i256 v13;
-        v19.i256 = call %core__lib__effect_ref__impl_trait_StorPtr_27da__raw__gb51e_8117 v3 v4 v6;
+        v19.i256 = call %core__lib__effect_ref__impl_trait_StorPtr_27da__raw__gb51e_9bd1 v3 v4 v6;
         v20.i256 = call %balance_of__g26d5 v15 v19;
         call %abi_encode_u256 v20;
         unreachable;
@@ -604,7 +603,7 @@ func private %runtime() {
         v23.@layout_0 = insert_value undef.@layout_0 0.i256 v21;
         v25.i256 = call %calldataload 36.i256;
         v27.@layout_0 = insert_value undef.@layout_0 0.i256 v25;
-        v31.i256 = call %core__lib__effect_ref__impl_trait_StorPtr_27da__raw__gb51e_8117 v3 v4 v6;
+        v31.i256 = call %core__lib__effect_ref__impl_trait_StorPtr_27da__raw__gb51e_9bd1 v3 v4 v6;
         v32.i256 = call %allowance__g26d5 v23 v27 v31;
         call %abi_encode_u256 v32;
         unreachable;
@@ -625,7 +624,7 @@ func private %runtime() {
         v38.i256 = call %calldataload 4.i256;
         v40.@layout_0 = insert_value undef.@layout_0 0.i256 v38;
         v41.i256 = call %calldataload 36.i256;
-        v45.i256 = call %core__lib__effect_ref__impl_trait_StorPtr_27da__raw__gb51e_8117 v3 v4 v6;
+        v45.i256 = call %core__lib__effect_ref__impl_trait_StorPtr_27da__raw__gb51e_9bd1 v3 v4 v6;
         v46.i256 = call %transfer__g2ee9 v40 v41 v45;
         call %abi_encode_u256 v46;
         unreachable;
@@ -634,7 +633,7 @@ func private %runtime() {
         v47.i256 = call %calldataload 4.i256;
         v49.@layout_0 = insert_value undef.@layout_0 0.i256 v47;
         v50.i256 = call %calldataload 36.i256;
-        v54.i256 = call %core__lib__effect_ref__impl_trait_StorPtr_27da__raw__gb51e_8117 v3 v4 v6;
+        v54.i256 = call %core__lib__effect_ref__impl_trait_StorPtr_27da__raw__gb51e_9bd1 v3 v4 v6;
         v55.i256 = call %approve__g44bd v49 v50 v54;
         call %abi_encode_u256 v55;
         unreachable;
@@ -645,7 +644,7 @@ func private %runtime() {
         v59.i256 = call %calldataload 36.i256;
         v61.@layout_0 = insert_value undef.@layout_0 0.i256 v59;
         v63.i256 = call %calldataload 68.i256;
-        v67.i256 = call %core__lib__effect_ref__impl_trait_StorPtr_27da__raw__gb51e_8117 v3 v4 v6;
+        v67.i256 = call %core__lib__effect_ref__impl_trait_StorPtr_27da__raw__gb51e_9bd1 v3 v4 v6;
         v68.i256 = call %transfer_from__g2ee9 v58 v61 v63 v67;
         call %abi_encode_u256 v68;
         unreachable;
@@ -654,7 +653,7 @@ func private %runtime() {
         v69.i256 = call %calldataload 4.i256;
         v71.@layout_0 = insert_value undef.@layout_0 0.i256 v69;
         v72.i256 = call %calldataload 36.i256;
-        v76.i256 = call %core__lib__effect_ref__impl_trait_StorPtr_27da__raw__gb51e_8117 v3 v4 v6;
+        v76.i256 = call %core__lib__effect_ref__impl_trait_StorPtr_27da__raw__gb51e_9bd1 v3 v4 v6;
         v77.i256 = call %mint__g2ee9 v71 v72 v76;
         call %abi_encode_u256 v77;
         unreachable;
@@ -699,48 +698,48 @@ func private %runtime() {
         jump block11;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__set__ga15b_1b1b(v0.@layout_3, v1.i256, v2.i256) {
+func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__set__g2163_339e(v0.@layout_0, v1.i256, v2.i256) {
     block0:
         jump block1;
 
     block1:
-        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set_unchecked__ga15b_1aea v0 v1 v2;
+        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set_unchecked__g2163_061f v0 v1 v2;
         return;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__set__g2163_9079(v0.@layout_0, v1.i256, v2.i256) {
+func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__set__g2163_339e_0(v0.@layout_0, v1.i256, v2.i256) {
     block0:
         jump block1;
 
     block1:
-        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set_unchecked__g2163_e55f v0 v1 v2;
+        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set_unchecked__g2163_061f_0 v0 v1 v2;
         return;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__set__g2163_9079_0(v0.@layout_0, v1.i256, v2.i256) {
+func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__set__g2163_339e_1(v0.@layout_0, v1.i256, v2.i256) {
     block0:
         jump block1;
 
     block1:
-        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set_unchecked__g2163_e55f_0 v0 v1 v2;
+        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set_unchecked__g2163_061f_1 v0 v1 v2;
         return;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__set__g2163_9079_1(v0.@layout_0, v1.i256, v2.i256) {
+func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__set__ga15b_cb5f(v0.@layout_2, v1.i256, v2.i256) {
     block0:
         jump block1;
 
     block1:
-        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set_unchecked__g2163_e55f_1 v0 v1 v2;
+        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set_unchecked__ga15b_4af1 v0 v1 v2;
         return;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__set__ga15b_ae8b(v0.@layout_3, v1.i256, v2.i256) {
+func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__set__ga15b_e67f(v0.@layout_2, v1.i256, v2.i256) {
     block0:
         jump block1;
 
     block1:
-        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set_unchecked__ga15b_b0e2 v0 v1 v2;
+        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set_unchecked__ga15b_9254 v0 v1 v2;
         return;
 }
 
@@ -759,7 +758,7 @@ func private %set_owner_once(v0.i256, v1.@layout_0, v2.i256, v3.i256) {
         obj.store v13 v14;
         v15.i256 = add v0 1.i256;
         v16.@layout_0 = obj.load v4;
-        v17.i1 = call %core__lib__ops__trait_Eq__ne__g7528_324d v15 v16;
+        v17.i1 = call %core__lib__ops__trait_Eq__ne__g7528_13f9 v15 v16;
         br v17 block2 block3;
 
     block2:
@@ -776,204 +775,204 @@ func private %set_owner_once(v0.i256, v1.@layout_0, v2.i256, v3.i256) {
         return;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__set_unchecked__ga15b_1aea(v0.@layout_3, v1.i256, v2.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v5.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__to_word_b350 v1;
-        call %std__lib__evm__storage_map__storagemap_set_word_with_salt__g7bf4_f41c v0 1.i256 v5;
-        return;
-}
-
-func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__set_unchecked__ga15b_b0e2(v0.@layout_3, v1.i256, v2.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v5.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__to_word_c57e v1;
-        call %std__lib__evm__storage_map__storagemap_set_word_with_salt__g7bf4_84d2 v0 1.i256 v5;
-        return;
-}
-
-func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__set_unchecked__g2163_e55f(v0.@layout_0, v1.i256, v2.i256) {
+func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__set_unchecked__g2163_061f(v0.@layout_0, v1.i256, v2.i256) {
     block0:
         jump block1;
 
     block1:
         v5.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__to_word_fb94 v1;
-        call %std__lib__evm__storage_map__storagemap_set_word_with_salt__g67a8_1609 v0 0.i256 v5;
+        call %std__lib__evm__storage_map__storagemap_set_word_with_salt__g67a8_0b75 v0 0.i256 v5;
         return;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__set_unchecked__g2163_e55f_0(v0.@layout_0, v1.i256, v2.i256) {
+func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__set_unchecked__g2163_061f_0(v0.@layout_0, v1.i256, v2.i256) {
     block0:
         jump block1;
 
     block1:
         v5.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__to_word_fb94_0 v1;
-        call %std__lib__evm__storage_map__storagemap_set_word_with_salt__g67a8_1609_0 v0 0.i256 v5;
+        call %std__lib__evm__storage_map__storagemap_set_word_with_salt__g67a8_0b75_0 v0 0.i256 v5;
         return;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__set_unchecked__g2163_e55f_1(v0.@layout_0, v1.i256, v2.i256) {
+func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__set_unchecked__g2163_061f_1(v0.@layout_0, v1.i256, v2.i256) {
     block0:
         jump block1;
 
     block1:
         v5.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__to_word_fb94_1 v1;
-        call %std__lib__evm__storage_map__storagemap_set_word_with_salt__g67a8_1609_1 v0 0.i256 v5;
+        call %std__lib__evm__storage_map__storagemap_set_word_with_salt__g67a8_0b75_1 v0 0.i256 v5;
         return;
 }
 
-func private %std__lib__evm__effects__trait_RawStorage__stor_ptr__g3730_6bd4(v0.i256, v1.i256, v2.i256) -> @layout_2 {
+func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__set_unchecked__ga15b_4af1(v0.@layout_2, v1.i256, v2.i256) {
     block0:
         jump block1;
 
     block1:
-        v6.@layout_2 = call %core__lib__effect_ref__impl_trait_StorPtr_27da__from_raw__gb51e_866d v0 v1 v2;
-        v8.@layout_1 = extract_value v6 0.i256;
+        v5.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__to_word_b350 v1;
+        call %std__lib__evm__storage_map__storagemap_set_word_with_salt__g7bf4_ec70 v0 1.i256 v5;
+        return;
+}
+
+func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__set_unchecked__ga15b_9254(v0.@layout_2, v1.i256, v2.i256) {
+    block0:
+        jump block1;
+
+    block1:
+        v5.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__to_word_c57e v1;
+        call %std__lib__evm__storage_map__storagemap_set_word_with_salt__g7bf4_9d7e v0 1.i256 v5;
+        return;
+}
+
+func private %std__lib__evm__effects__trait_RawStorage__stor_ptr__g3730_6bd4(v0.i256, v1.i256, v2.i256) -> @layout_1 {
+    block0:
+        jump block1;
+
+    block1:
+        v6.@layout_1 = call %core__lib__effect_ref__impl_trait_StorPtr_27da__from_raw__gb51e_866d v0 v1 v2;
+        v8.@layout_0 = extract_value v6 0.i256;
         v10.i256 = extract_value v6 1.i256;
         v12.i256 = extract_value v6 2.i256;
-        v14.@layout_2 = insert_value undef.@layout_2 0.i256 v8;
-        v15.@layout_2 = insert_value v14 1.i256 v10;
-        v16.@layout_2 = insert_value v15 2.i256 v12;
+        v14.@layout_1 = insert_value undef.@layout_1 0.i256 v8;
+        v15.@layout_1 = insert_value v14 1.i256 v10;
+        v16.@layout_1 = insert_value v15 2.i256 v12;
         return v16;
 }
 
-func private %std__lib__evm__effects__trait_RawStorage__stor_ptr__g3730_6bd4_0(v0.i256, v1.i256, v2.i256) -> @layout_2 {
+func private %std__lib__evm__effects__trait_RawStorage__stor_ptr__g3730_6bd4_0(v0.i256, v1.i256, v2.i256) -> @layout_1 {
     block0:
         jump block1;
 
     block1:
-        v6.@layout_2 = call %core__lib__effect_ref__impl_trait_StorPtr_27da__from_raw__gb51e_866d_0 v0 v1 v2;
-        v8.@layout_1 = extract_value v6 0.i256;
+        v6.@layout_1 = call %core__lib__effect_ref__impl_trait_StorPtr_27da__from_raw__gb51e_866d_0 v0 v1 v2;
+        v8.@layout_0 = extract_value v6 0.i256;
         v10.i256 = extract_value v6 1.i256;
         v12.i256 = extract_value v6 2.i256;
-        v14.@layout_2 = insert_value undef.@layout_2 0.i256 v8;
-        v15.@layout_2 = insert_value v14 1.i256 v10;
-        v16.@layout_2 = insert_value v15 2.i256 v12;
+        v14.@layout_1 = insert_value undef.@layout_1 0.i256 v8;
+        v15.@layout_1 = insert_value v14 1.i256 v10;
+        v16.@layout_1 = insert_value v15 2.i256 v12;
         return v16;
 }
 
-func inline(always) private %std__lib__evm__storage_map__storagemap_get_word_with_salt__g67a8_71c2(v0.@layout_0, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__storagemap_get_word_with_salt__g7bf4_3a59(v0.@layout_2, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g67a8_501d v0 v1;
+        v4.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_5f7e v0 v1;
         v5.i256 = evm_sload v4;
         return v5;
 }
 
-func inline(always) private %std__lib__evm__storage_map__storagemap_get_word_with_salt__g67a8_71c2_0(v0.@layout_0, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__storagemap_get_word_with_salt__g67a8_6b6a(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g67a8_501d_0 v0 v1;
+        v4.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g67a8_784f v0 v1;
         v5.i256 = evm_sload v4;
         return v5;
 }
 
-func inline(always) private %std__lib__evm__storage_map__storagemap_get_word_with_salt__g67a8_71c2_1(v0.@layout_0, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__storagemap_get_word_with_salt__g67a8_7573(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g67a8_501d_1 v0 v1;
+        v4.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g67a8_f828 v0 v1;
         v5.i256 = evm_sload v4;
         return v5;
 }
 
-func inline(always) private %std__lib__evm__storage_map__storagemap_get_word_with_salt__g67a8_bfbb(v0.@layout_0, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__storagemap_get_word_with_salt__g67a8_7573_0(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g67a8_e7af v0 v1;
+        v4.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g67a8_f828_0 v0 v1;
         v5.i256 = evm_sload v4;
         return v5;
 }
 
-func inline(always) private %std__lib__evm__storage_map__storagemap_get_word_with_salt__g7bf4_df22(v0.@layout_3, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__storagemap_get_word_with_salt__g67a8_7573_1(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_a633 v0 v1;
+        v4.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g67a8_f828_1 v0 v1;
         v5.i256 = evm_sload v4;
         return v5;
 }
 
-func inline(always) private %std__lib__evm__storage_map__storagemap_get_word_with_salt__g7bf4_fdb1(v0.@layout_3, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__storagemap_get_word_with_salt__g7bf4_dd35(v0.@layout_2, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_d8a5 v0 v1;
+        v4.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_9de1 v0 v1;
         v5.i256 = evm_sload v4;
         return v5;
 }
 
-func inline(always) private %std__lib__evm__storage_map__storagemap_set_word_with_salt__g67a8_1609(v0.@layout_0, v1.i256, v2.i256) {
+func inline(always) private %std__lib__evm__storage_map__storagemap_set_word_with_salt__g67a8_0b75(v0.@layout_0, v1.i256, v2.i256) {
     block0:
         jump block1;
 
     block1:
-        v5.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g67a8_501d v0 v1;
+        v5.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g67a8_f828 v0 v1;
         evm_sstore v5 v2;
         return;
 }
 
-func inline(always) private %std__lib__evm__storage_map__storagemap_set_word_with_salt__g67a8_1609_0(v0.@layout_0, v1.i256, v2.i256) {
+func inline(always) private %std__lib__evm__storage_map__storagemap_set_word_with_salt__g67a8_0b75_0(v0.@layout_0, v1.i256, v2.i256) {
     block0:
         jump block1;
 
     block1:
-        v5.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g67a8_501d_0 v0 v1;
+        v5.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g67a8_f828_0 v0 v1;
         evm_sstore v5 v2;
         return;
 }
 
-func inline(always) private %std__lib__evm__storage_map__storagemap_set_word_with_salt__g67a8_1609_1(v0.@layout_0, v1.i256, v2.i256) {
+func inline(always) private %std__lib__evm__storage_map__storagemap_set_word_with_salt__g67a8_0b75_1(v0.@layout_0, v1.i256, v2.i256) {
     block0:
         jump block1;
 
     block1:
-        v5.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g67a8_501d_1 v0 v1;
+        v5.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g67a8_f828_1 v0 v1;
         evm_sstore v5 v2;
         return;
 }
 
-func inline(always) private %std__lib__evm__storage_map__storagemap_set_word_with_salt__g7bf4_84d2(v0.@layout_3, v1.i256, v2.i256) {
+func inline(always) private %std__lib__evm__storage_map__storagemap_set_word_with_salt__g7bf4_9d7e(v0.@layout_2, v1.i256, v2.i256) {
     block0:
         jump block1;
 
     block1:
-        v5.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_a633 v0 v1;
+        v5.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_9de1 v0 v1;
         evm_sstore v5 v2;
         return;
 }
 
-func inline(always) private %std__lib__evm__storage_map__storagemap_set_word_with_salt__g7bf4_f41c(v0.@layout_3, v1.i256, v2.i256) {
+func inline(always) private %std__lib__evm__storage_map__storagemap_set_word_with_salt__g7bf4_ec70(v0.@layout_2, v1.i256, v2.i256) {
     block0:
         jump block1;
 
     block1:
-        v5.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_288a v0 v1;
+        v5.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_bf9d v0 v1;
         evm_sstore v5 v2;
         return;
 }
 
-func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_288a(v0.@layout_3, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_5f7e(v0.@layout_2, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
         v3.*i8 = evm_malloc 0.i256;
         v4.i256 = ptr_to_int v3 i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_9295 v4 v0;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_29cb v4 v0;
         (v7.i256, v8.i1) = uaddo v4 v6;
         br v8 block2 block3;
 
@@ -992,14 +991,14 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot
         return v20;
 }
 
-func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g67a8_501d(v0.@layout_0, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g67a8_784f(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
         v3.*i8 = evm_malloc 0.i256;
         v4.i256 = ptr_to_int v3 i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_5efc v4 v0;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_c70a v4 v0;
         (v7.i256, v8.i1) = uaddo v4 v6;
         br v8 block2 block3;
 
@@ -1018,14 +1017,14 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot
         return v20;
 }
 
-func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g67a8_501d_0(v0.@layout_0, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_9de1(v0.@layout_2, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
         v3.*i8 = evm_malloc 0.i256;
         v4.i256 = ptr_to_int v3 i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_5efc_0 v4 v0;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_6e8f v4 v0;
         (v7.i256, v8.i1) = uaddo v4 v6;
         br v8 block2 block3;
 
@@ -1044,14 +1043,14 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot
         return v20;
 }
 
-func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g67a8_501d_1(v0.@layout_0, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_bf9d(v0.@layout_2, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
         v3.*i8 = evm_malloc 0.i256;
         v4.i256 = ptr_to_int v3 i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_5efc_1 v4 v0;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_226d v4 v0;
         (v7.i256, v8.i1) = uaddo v4 v6;
         br v8 block2 block3;
 
@@ -1070,14 +1069,14 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot
         return v20;
 }
 
-func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_a633(v0.@layout_3, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g67a8_f828(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
         v3.*i8 = evm_malloc 0.i256;
         v4.i256 = ptr_to_int v3 i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_2879 v4 v0;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_7747 v4 v0;
         (v7.i256, v8.i1) = uaddo v4 v6;
         br v8 block2 block3;
 
@@ -1096,14 +1095,14 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot
         return v20;
 }
 
-func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_d8a5(v0.@layout_3, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g67a8_f828_0(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
         v3.*i8 = evm_malloc 0.i256;
         v4.i256 = ptr_to_int v3 i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_d74c v4 v0;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_7747_0 v4 v0;
         (v7.i256, v8.i1) = uaddo v4 v6;
         br v8 block2 block3;
 
@@ -1122,14 +1121,14 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot
         return v20;
 }
 
-func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g67a8_e7af(v0.@layout_0, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g67a8_f828_1(v0.@layout_0, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
         v3.*i8 = evm_malloc 0.i256;
         v4.i256 = ptr_to_int v3 i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_72b5 v4 v0;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_7747_1 v4 v0;
         (v7.i256, v8.i1) = uaddo v4 v6;
         br v8 block2 block3;
 
@@ -1188,12 +1187,22 @@ func private %std__lib__evm__word__impl_trait_u256_1f9e__to_word_fb94_1(v0.i256)
         return v0;
 }
 
-func private %standalone_erc20_low_level__erc20_low_level__impl_Erc20_ee5d__transfer__g0f37_2a09(v0.i256, v1.@layout_0, v2.@layout_0, v3.i256, v4.i256, v5.i256) {
+func private %transfer__g2ee9(v0.@layout_0, v1.i256, v2.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v10.i256 = call %standalone_erc20_low_level__erc20_low_level__impl_Erc20_ee5d__balance_of__g35d6_1112_0 v0 v1 v4 v5;
+        v6.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_a1e8__caller_c33e;
+        call %standalone_erc20_low_level__erc20_low_level__impl_Erc20_ee5d__transfer__g0f37_84af v2 v6 v0 v1 0.i256 1.i256;
+        return 1.i256;
+}
+
+func private %standalone_erc20_low_level__erc20_low_level__impl_Erc20_ee5d__transfer__g0f37_84af(v0.i256, v1.@layout_0, v2.@layout_0, v3.i256, v4.i256, v5.i256) {
+    block0:
+        jump block1;
+
+    block1:
+        v10.i256 = call %standalone_erc20_low_level__erc20_low_level__impl_Erc20_ee5d__balance_of__g35d6_3e9c_0 v0 v1 v4 v5;
         v12.i1 = lt v10 v3;
         br v12 block2 block3;
 
@@ -1205,7 +1214,7 @@ func private %standalone_erc20_low_level__erc20_low_level__impl_Erc20_ee5d__tran
         jump block4;
 
     block4:
-        v18.i256 = call %standalone_erc20_low_level__erc20_low_level__impl_Erc20_ee5d__balance_of__g35d6_1112_0 v0 v2 v4 v5;
+        v18.i256 = call %standalone_erc20_low_level__erc20_low_level__impl_Erc20_ee5d__balance_of__g35d6_3e9c_0 v0 v2 v4 v5;
         (v22.i256, v23.i1) = usubo v10 v3;
         br v23 block5 block6;
 
@@ -1215,21 +1224,21 @@ func private %standalone_erc20_low_level__erc20_low_level__impl_Erc20_ee5d__tran
         evm_revert 0.i256 36.i256;
 
     block6:
-        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set__g2163_9079_0 v1 v22 v4;
+        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set__g2163_339e_0 v1 v22 v4;
         (v36.i256, v37.i1) = uaddo v18 v3;
         br v37 block5 block7;
 
     block7:
-        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set__g2163_9079_0 v2 v36 v4;
+        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set__g2163_339e_0 v2 v36 v4;
         return;
 }
 
-func private %standalone_erc20_low_level__erc20_low_level__impl_Erc20_ee5d__transfer__g0f37_2a09_0(v0.i256, v1.@layout_0, v2.@layout_0, v3.i256, v4.i256, v5.i256) {
+func private %standalone_erc20_low_level__erc20_low_level__impl_Erc20_ee5d__transfer__g0f37_84af_0(v0.i256, v1.@layout_0, v2.@layout_0, v3.i256, v4.i256, v5.i256) {
     block0:
         jump block1;
 
     block1:
-        v10.i256 = call %standalone_erc20_low_level__erc20_low_level__impl_Erc20_ee5d__balance_of__g35d6_1112_1 v0 v1 v4 v5;
+        v10.i256 = call %standalone_erc20_low_level__erc20_low_level__impl_Erc20_ee5d__balance_of__g35d6_3e9c_1 v0 v1 v4 v5;
         v12.i1 = lt v10 v3;
         br v12 block2 block3;
 
@@ -1241,7 +1250,7 @@ func private %standalone_erc20_low_level__erc20_low_level__impl_Erc20_ee5d__tran
         jump block4;
 
     block4:
-        v18.i256 = call %standalone_erc20_low_level__erc20_low_level__impl_Erc20_ee5d__balance_of__g35d6_1112_1 v0 v2 v4 v5;
+        v18.i256 = call %standalone_erc20_low_level__erc20_low_level__impl_Erc20_ee5d__balance_of__g35d6_3e9c_1 v0 v2 v4 v5;
         (v22.i256, v23.i1) = usubo v10 v3;
         br v23 block5 block6;
 
@@ -1251,22 +1260,21 @@ func private %standalone_erc20_low_level__erc20_low_level__impl_Erc20_ee5d__tran
         evm_revert 0.i256 36.i256;
 
     block6:
-        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set__g2163_9079_1 v1 v22 v4;
+        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set__g2163_339e_1 v1 v22 v4;
         (v36.i256, v37.i1) = uaddo v18 v3;
         br v37 block5 block7;
 
     block7:
-        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set__g2163_9079_1 v2 v36 v4;
+        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set__g2163_339e_1 v2 v36 v4;
         return;
 }
 
-func private %transfer__g2ee9(v0.@layout_0, v1.i256, v2.i256) -> i256 {
+func private %transfer_from__g2ee9(v0.@layout_0, v1.@layout_0, v2.i256, v3.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v6.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_a1e8__caller_c33e;
-        call %standalone_erc20_low_level__erc20_low_level__impl_Erc20_ee5d__transfer__g0f37_2a09 v2 v6 v0 v1 0.i256 1.i256;
+        call %transfer_from__g0502 v3 v0 v1 v2 0.i256 1.i256;
         return 1.i256;
 }
 
@@ -1288,9 +1296,9 @@ func private %transfer_from__g0502(v0.i256, v1.@layout_0, v2.@layout_0, v3.i256,
         jump block4;
 
     block4:
-        call %standalone_erc20_low_level__erc20_low_level__impl_Erc20_ee5d__transfer__g0f37_2a09_0 v0 v1 v2 v3 v4 v5;
-        v23.@layout_3 = insert_value undef.@layout_3 0.i256 v1;
-        v26.@layout_3 = insert_value v23 1.i256 v6;
+        call %standalone_erc20_low_level__erc20_low_level__impl_Erc20_ee5d__transfer__g0f37_84af_0 v0 v1 v2 v3 v4 v5;
+        v23.@layout_2 = insert_value undef.@layout_2 0.i256 v1;
+        v26.@layout_2 = insert_value v23 1.i256 v6;
         (v28.i256, v29.i1) = usubo v11 v3;
         br v29 block5 block6;
 
@@ -1300,20 +1308,11 @@ func private %transfer_from__g0502(v0.i256, v1.@layout_0, v2.@layout_0, v3.i256,
         evm_revert 0.i256 36.i256;
 
     block6:
-        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set__ga15b_ae8b v26 v28 v5;
+        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set__ga15b_e67f v26 v28 v5;
         return;
 }
 
-func private %transfer_from__g2ee9(v0.@layout_0, v1.@layout_0, v2.i256, v3.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        call %transfer_from__g0502 v3 v0 v1 v2 0.i256 1.i256;
-        return 1.i256;
-}
-
-func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_1ccc(v0.i256, v1.@layout_0) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_1c01(v0.i256, v1.@layout_0) -> i256 {
     block0:
         jump block1;
 
@@ -1323,13 +1322,13 @@ func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e
         return v6;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_2879(v0.i256, v1.@layout_3) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_226d(v0.i256, v1.@layout_2) -> i256 {
     block0:
         jump block1;
 
     block1:
         v5.@layout_0 = extract_value v1 0.i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_b135 v0 v5;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_56aa v0 v5;
         (v7.i256, v8.i1) = uaddo v0 v6;
         br v8 block2 block3;
 
@@ -1340,7 +1339,32 @@ func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__wri
 
     block3:
         v15.@layout_0 = extract_value v1 1.i256;
-        v16.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_b135 v7 v15;
+        v16.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_56aa v7 v15;
+        (v18.i256, v19.i1) = uaddo v6 v16;
+        br v19 block2 block4;
+
+    block4:
+        return v18;
+}
+
+func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_29cb(v0.i256, v1.@layout_2) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v5.@layout_0 = extract_value v1 0.i256;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_1c01 v0 v5;
+        (v7.i256, v8.i1) = uaddo v0 v6;
+        br v8 block2 block3;
+
+    block2:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block3:
+        v15.@layout_0 = extract_value v1 1.i256;
+        v16.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_1c01 v7 v15;
         (v18.i256, v19.i1) = uaddo v6 v16;
         br v19 block2 block4;
 
@@ -1357,7 +1381,42 @@ func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__w
         return 32.i256;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_5efc(v0.i256, v1.@layout_0) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_56aa(v0.i256, v1.@layout_0) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v5.i256 = extract_value v1 0.i256;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_7d35 v0 v5;
+        return v6;
+}
+
+func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_6e8f(v0.i256, v1.@layout_2) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v5.@layout_0 = extract_value v1 0.i256;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_9858 v0 v5;
+        (v7.i256, v8.i1) = uaddo v0 v6;
+        br v8 block2 block3;
+
+    block2:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block3:
+        v15.@layout_0 = extract_value v1 1.i256;
+        v16.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_9858 v7 v15;
+        (v18.i256, v19.i1) = uaddo v6 v16;
+        br v19 block2 block4;
+
+    block4:
+        return v18;
+}
+
+func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_7747(v0.i256, v1.@layout_0) -> i256 {
     block0:
         jump block1;
 
@@ -1367,7 +1426,7 @@ func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e
         return v6;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_5efc_0(v0.i256, v1.@layout_0) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_7747_0(v0.i256, v1.@layout_0) -> i256 {
     block0:
         jump block1;
 
@@ -1377,23 +1436,13 @@ func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e
         return v6;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_5efc_1(v0.i256, v1.@layout_0) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_7747_1(v0.i256, v1.@layout_0) -> i256 {
     block0:
         jump block1;
 
     block1:
         v5.i256 = extract_value v1 0.i256;
         v6.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_7bb3_1 v0 v5;
-        return v6;
-}
-
-func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_72b5(v0.i256, v1.@layout_0) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v5.i256 = extract_value v1 0.i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_f2a4 v0 v5;
         return v6;
 }
 
@@ -1433,39 +1482,14 @@ func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__w
         return 32.i256;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_8589(v0.i256, v1.@layout_0) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_9858(v0.i256, v1.@layout_0) -> i256 {
     block0:
         jump block1;
 
     block1:
         v5.i256 = extract_value v1 0.i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_7d35 v0 v5;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_4327 v0 v5;
         return v6;
-}
-
-func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_9295(v0.i256, v1.@layout_3) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v5.@layout_0 = extract_value v1 0.i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_8589 v0 v5;
-        (v7.i256, v8.i1) = uaddo v0 v6;
-        br v8 block2 block3;
-
-    block2:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block3:
-        v15.@layout_0 = extract_value v1 1.i256;
-        v16.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_8589 v7 v15;
-        (v18.i256, v19.i1) = uaddo v6 v16;
-        br v19 block2 block4;
-
-    block4:
-        return v18;
 }
 
 func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_a6f4(v0.i256, v1.i256) -> i256 {
@@ -1477,39 +1501,14 @@ func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__w
         return 32.i256;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_b135(v0.i256, v1.@layout_0) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_c70a(v0.i256, v1.@layout_0) -> i256 {
     block0:
         jump block1;
 
     block1:
         v5.i256 = extract_value v1 0.i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_4327 v0 v5;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_f2a4 v0 v5;
         return v6;
-}
-
-func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_d74c(v0.i256, v1.@layout_3) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v5.@layout_0 = extract_value v1 0.i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_1ccc v0 v5;
-        (v7.i256, v8.i1) = uaddo v0 v6;
-        br v8 block2 block3;
-
-    block2:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block3:
-        v15.@layout_0 = extract_value v1 1.i256;
-        v16.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_1ccc v7 v15;
-        (v18.i256, v19.i1) = uaddo v6 v16;
-        br v19 block2 block4;
-
-    block4:
-        return v18;
 }
 
 func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_f2a4(v0.i256, v1.i256) -> i256 {

--- a/crates/codegen/tests/fixtures/sonatina_ir/event_logging.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/event_logging.snap
@@ -8,7 +8,6 @@ target = "evm-ethereum-osaka"
 type @layout_0 = {i256};
 type @layout_1 = {i256, i256};
 type @layout_2 = {@layout_0, @layout_0, i256};
-type @layout_3 = {i256, i256};
 
 global private const @layout_0 $const_region_0 = {1};
 global private const @layout_0 $const_region_1 = {2};
@@ -57,7 +56,7 @@ func inline(always) private %emit(v0.@layout_2) {
 
     block1:
         v3.i256 = extract_value v0 2.i256;
-        v4.@layout_3 = call %encode_abi_payload v3;
+        v4.@layout_1 = call %encode_abi_payload v3;
         v6.i256 = extract_value v4 0.i256;
         v8.i256 = extract_value v4 1.i256;
         v10.@layout_0 = extract_value v0 0.i256;
@@ -95,16 +94,16 @@ func private %encode(v0.i256, v1.objref<@layout_1>) {
         return;
 }
 
-func private %encode_abi_payload(v0.i256) -> @layout_3 {
+func private %encode_abi_payload(v0.i256) -> @layout_1 {
     block0:
         jump block1;
 
     block1:
-        v2.@layout_3 = call %encode_alloc v0;
+        v2.@layout_1 = call %encode_alloc v0;
         return v2;
 }
 
-func inline(always) private %encode_alloc(v0.i256) -> @layout_3 {
+func inline(always) private %encode_alloc(v0.i256) -> @layout_1 {
     block0:
         jump block1;
 
@@ -120,8 +119,8 @@ func inline(always) private %encode_alloc(v0.i256) -> @layout_3 {
         obj.store v9 v10;
         v11.i256 = call %base v4;
         call %encode v0 v4;
-        v14.@layout_3 = insert_value undef.@layout_3 0.i256 v11;
-        v15.@layout_3 = insert_value v14 1.i256 v2;
+        v14.@layout_1 = insert_value undef.@layout_1 0.i256 v11;
+        v15.@layout_1 = insert_value v14 1.i256 v2;
         return v15;
 }
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/event_logging_via_log.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/event_logging_via_log.snap
@@ -8,7 +8,6 @@ target = "evm-ethereum-osaka"
 type @layout_0 = {i256};
 type @layout_1 = {i256, i256};
 type @layout_2 = {@layout_0, @layout_0, i256};
-type @layout_3 = {i256, i256};
 
 global private const @layout_0 $const_region_0 = {1};
 global private const @layout_0 $const_region_1 = {2};
@@ -51,22 +50,13 @@ func private %base(v0.objref<@layout_1>) -> i256 {
         return v4;
 }
 
-func private %emit__g4f95(v0.@layout_2) {
-    block0:
-        jump block1;
-
-    block1:
-        call %emit__gcd5c v0;
-        return;
-}
-
 func inline(always) private %emit__gcd5c(v0.@layout_2) {
     block0:
         jump block1;
 
     block1:
         v3.i256 = extract_value v0 2.i256;
-        v4.@layout_3 = call %encode_abi_payload v3;
+        v4.@layout_1 = call %encode_abi_payload v3;
         v6.i256 = extract_value v4 0.i256;
         v8.i256 = extract_value v4 1.i256;
         v10.@layout_0 = extract_value v0 0.i256;
@@ -74,6 +64,15 @@ func inline(always) private %emit__gcd5c(v0.@layout_2) {
         v12.@layout_0 = extract_value v0 1.i256;
         v13.i256 = call %as_topic v12;
         call %log3 v6 v8 -15402802100530019096323380498944738953123845089667699673314898783681816316945.i256 v11 v13;
+        return;
+}
+
+func private %emit__g4f95(v0.@layout_2) {
+    block0:
+        jump block1;
+
+    block1:
+        call %emit__gcd5c v0;
         return;
 }
 
@@ -104,16 +103,16 @@ func private %encode(v0.i256, v1.objref<@layout_1>) {
         return;
 }
 
-func private %encode_abi_payload(v0.i256) -> @layout_3 {
+func private %encode_abi_payload(v0.i256) -> @layout_1 {
     block0:
         jump block1;
 
     block1:
-        v2.@layout_3 = call %encode_alloc v0;
+        v2.@layout_1 = call %encode_alloc v0;
         return v2;
 }
 
-func inline(always) private %encode_alloc(v0.i256) -> @layout_3 {
+func inline(always) private %encode_alloc(v0.i256) -> @layout_1 {
     block0:
         jump block1;
 
@@ -129,8 +128,8 @@ func inline(always) private %encode_alloc(v0.i256) -> @layout_3 {
         obj.store v9 v10;
         v11.i256 = call %base v4;
         call %encode v0 v4;
-        v14.@layout_3 = insert_value undef.@layout_3 0.i256 v11;
-        v15.@layout_3 = insert_value v14 1.i256 v2;
+        v14.@layout_1 = insert_value undef.@layout_1 0.i256 v11;
+        v15.@layout_1 = insert_value v14 1.i256 v2;
         return v15;
 }
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/explicit_raw_boundaries.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/explicit_raw_boundaries.snap
@@ -40,15 +40,6 @@ func private %explicit_raw_boundaries() {
         return;
 }
 
-func private %core__lib__effect_ref__impl_trait_MemPtr_ec03__from_raw__g4a95_3d2c(v0.i256) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.@layout_0 = insert_value undef.@layout_0 0.i256 v0;
-        return v4;
-}
-
 func private %from_raw__ge513(v0.i256) -> @layout_0 {
     block0:
         jump block1;
@@ -76,6 +67,15 @@ func private %core__lib__effect_ref__impl_trait_MemPtr_ec03__from_raw__g4a95_bb4
         return v4;
 }
 
+func private %core__lib__effect_ref__impl_trait_MemPtr_ec03__from_raw__g4a95_f72c(v0.i256) -> @layout_0 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.@layout_0 = insert_value undef.@layout_0 0.i256 v0;
+        return v4;
+}
+
 func private %main_root() {
     block0:
         jump block1;
@@ -83,15 +83,6 @@ func private %main_root() {
     block1:
         call %explicit_raw_boundaries;
         evm_stop;
-}
-
-func private %mem_ptr__g9700(v0.i256) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.@layout_0 = call %core__lib__effect_ref__impl_trait_MemPtr_ec03__from_raw__g4a95_3d2c v0;
-        return v2;
 }
 
 func private %mem_ptr__g8840(v0.i256) -> @layout_0 {
@@ -103,16 +94,16 @@ func private %mem_ptr__g8840(v0.i256) -> @layout_0 {
         return v2;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_d0d8__mstore_c9f4(v0.i256, v1.i256) {
+func private %mem_ptr__g9700(v0.i256) -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        mstore v0 v1 i256;
-        return;
+        v2.@layout_0 = call %core__lib__effect_ref__impl_trait_MemPtr_ec03__from_raw__g4a95_f72c v0;
+        return v2;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_d0d8__mstore_c9f4_0(v0.i256, v1.i256) {
+func private %mstore(v0.i256, v1.i256) {
     block0:
         jump block1;
 
@@ -139,17 +130,7 @@ func private %raw__ge513(v0.@layout_0) -> i256 {
         return v3;
 }
 
-func private %core__lib__effect_ref__impl_trait_MemPtr_ec03__raw__g4a95_a164(v0.objref<@layout_0>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 0.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
-func private %core__lib__effect_ref__impl_trait_MemPtr_ec03__raw__g4a95_a164_0(v0.objref<@layout_0>) -> i256 {
+func private %core__lib__effect_ref__impl_trait_MemPtr_ec03__raw__g4a95_a0e3(v0.objref<@layout_0>) -> i256 {
     block0:
         jump block1;
 
@@ -169,8 +150,8 @@ func private %raw_store__gc18b(v0.i256) {
         v5.objref<i256> = obj.proj v3 0.i256;
         v6.i256 = extract_value v2 0.i256;
         obj.store v5 v6;
-        v7.i256 = call %core__lib__effect_ref__impl_trait_MemPtr_ec03__raw__g4a95_a164_0 v3;
-        call %std__lib__evm__effects__impl_trait_Evm_d0d8__mstore_c9f4_0 v7 8.i256;
+        v7.i256 = call %core__lib__effect_ref__impl_trait_MemPtr_ec03__raw__g4a95_a0e3 v3;
+        call %mstore v7 8.i256;
         return;
 }
 
@@ -184,8 +165,8 @@ func private %raw_store__g64c6(v0.i256) {
         v5.objref<i256> = obj.proj v3 0.i256;
         v6.i256 = extract_value v2 0.i256;
         obj.store v5 v6;
-        v7.i256 = call %core__lib__effect_ref__impl_trait_MemPtr_ec03__raw__g4a95_a164 v3;
-        call %std__lib__evm__effects__impl_trait_Evm_d0d8__mstore_c9f4 v7 8.i256;
+        v7.i256 = call %core__lib__effect_ref__impl_trait_MemPtr_ec03__raw__g4a95_a0e3 v3;
+        call %mstore v7 8.i256;
         return;
 }
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/explicit_raw_boundaries.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/explicit_raw_boundaries.snap
@@ -6,7 +6,6 @@ input_file: crates/codegen/tests/fixtures/explicit_raw_boundaries.fe
 target = "evm-ethereum-osaka"
 
 type @layout_0 = {i256};
-type @layout_1 = {i256};
 
 func private %bump(v0.i256) {
     block0:
@@ -32,11 +31,11 @@ func private %explicit_raw_boundaries() {
         jump block1;
 
     block1:
-        v1.@layout_1 = call %mem_ptr__g8840 256.i256;
+        v1.@layout_0 = call %mem_ptr__g8840 256.i256;
         v2.i256 = call %raw__ge513 v1;
         call %bump v2;
         v5.@layout_0 = call %mem_ptr__g9700 288.i256;
-        v6.i256 = call %core__lib__effect_ref__impl_trait_MemPtr_ec03__raw__g4a95_ce7a v5;
+        v6.i256 = call %core__lib__effect_ref__impl_trait_MemPtr_ec03__raw__g4a95_0cf6 v5;
         call %raw_store__gc18b v6;
         return;
 }
@@ -50,12 +49,12 @@ func private %core__lib__effect_ref__impl_trait_MemPtr_ec03__from_raw__g4a95_3d2
         return v4;
 }
 
-func private %from_raw__ge513(v0.i256) -> @layout_1 {
+func private %from_raw__ge513(v0.i256) -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v4.@layout_1 = insert_value undef.@layout_1 0.i256 v0;
+        v4.@layout_0 = insert_value undef.@layout_0 0.i256 v0;
         return v4;
 }
 
@@ -95,12 +94,12 @@ func private %mem_ptr__g9700(v0.i256) -> @layout_0 {
         return v2;
 }
 
-func private %mem_ptr__g8840(v0.i256) -> @layout_1 {
+func private %mem_ptr__g8840(v0.i256) -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v2.@layout_1 = call %from_raw__ge513 v0;
+        v2.@layout_0 = call %from_raw__ge513 v0;
         return v2;
 }
 
@@ -122,7 +121,25 @@ func private %std__lib__evm__effects__impl_trait_Evm_d0d8__mstore_c9f4_0(v0.i256
         return;
 }
 
-func private %core__lib__effect_ref__impl_trait_MemPtr_ec03__raw__g4a95_0f88(v0.objref<@layout_0>) -> i256 {
+func private %core__lib__effect_ref__impl_trait_MemPtr_ec03__raw__g4a95_0cf6(v0.@layout_0) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v3.i256 = extract_value v0 0.i256;
+        return v3;
+}
+
+func private %raw__ge513(v0.@layout_0) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v3.i256 = extract_value v0 0.i256;
+        return v3;
+}
+
+func private %core__lib__effect_ref__impl_trait_MemPtr_ec03__raw__g4a95_a164(v0.objref<@layout_0>) -> i256 {
     block0:
         jump block1;
 
@@ -132,7 +149,7 @@ func private %core__lib__effect_ref__impl_trait_MemPtr_ec03__raw__g4a95_0f88(v0.
         return v4;
 }
 
-func private %core__lib__effect_ref__impl_trait_MemPtr_ec03__raw__g4a95_0f88_0(v0.objref<@layout_0>) -> i256 {
+func private %core__lib__effect_ref__impl_trait_MemPtr_ec03__raw__g4a95_a164_0(v0.objref<@layout_0>) -> i256 {
     block0:
         jump block1;
 
@@ -140,24 +157,6 @@ func private %core__lib__effect_ref__impl_trait_MemPtr_ec03__raw__g4a95_0f88_0(v
         v3.objref<i256> = obj.proj v0 0.i256;
         v4.i256 = obj.load v3;
         return v4;
-}
-
-func private %raw__ge513(v0.@layout_1) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.i256 = extract_value v0 0.i256;
-        return v3;
-}
-
-func private %core__lib__effect_ref__impl_trait_MemPtr_ec03__raw__g4a95_ce7a(v0.@layout_0) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.i256 = extract_value v0 0.i256;
-        return v3;
 }
 
 func private %raw_store__gc18b(v0.i256) {
@@ -170,7 +169,7 @@ func private %raw_store__gc18b(v0.i256) {
         v5.objref<i256> = obj.proj v3 0.i256;
         v6.i256 = extract_value v2 0.i256;
         obj.store v5 v6;
-        v7.i256 = call %core__lib__effect_ref__impl_trait_MemPtr_ec03__raw__g4a95_0f88_0 v3;
+        v7.i256 = call %core__lib__effect_ref__impl_trait_MemPtr_ec03__raw__g4a95_a164_0 v3;
         call %std__lib__evm__effects__impl_trait_Evm_d0d8__mstore_c9f4_0 v7 8.i256;
         return;
 }
@@ -185,7 +184,7 @@ func private %raw_store__g64c6(v0.i256) {
         v5.objref<i256> = obj.proj v3 0.i256;
         v6.i256 = extract_value v2 0.i256;
         obj.store v5 v6;
-        v7.i256 = call %core__lib__effect_ref__impl_trait_MemPtr_ec03__raw__g4a95_0f88 v3;
+        v7.i256 = call %core__lib__effect_ref__impl_trait_MemPtr_ec03__raw__g4a95_a164 v3;
         call %std__lib__evm__effects__impl_trait_Evm_d0d8__mstore_c9f4 v7 8.i256;
         return;
 }

--- a/crates/codegen/tests/fixtures/sonatina_ir/full_contract.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/full_contract.snap
@@ -14,7 +14,7 @@ func private %abi_encode(v0.i256) {
 
     block1:
         call %mstore 0.i256 v0;
-        call %std__lib__evm__effects__impl_trait_Evm_0098__return_data_b74b 0.i256 32.i256;
+        call %return_data 0.i256 32.i256;
         unreachable;
 }
 
@@ -126,7 +126,7 @@ func private %dispatch() {
         jump block7;
 
     block7:
-        call %std__lib__evm__effects__impl_trait_Evm_0098__return_data_b16a 0.i256 0.i256;
+        call %return_data 0.i256 0.i256;
         unreachable;
 
     block8:
@@ -167,7 +167,7 @@ func private %init() {
         v2.*i8 = evm_malloc v0;
         v3.i256 = ptr_to_int v2 i256;
         call %codecopy v3 v1 v0;
-        call %std__lib__evm__effects__impl_trait_Evm_0098__return_data_b16a_0 v3 v0;
+        call %return_data v3 v0;
         unreachable;
 }
 
@@ -198,23 +198,7 @@ func private %mstore(v0.i256, v1.i256) {
         return;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_0098__return_data_b16a(v0.i256, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        evm_return v0 v1;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_0098__return_data_b16a_0(v0.i256, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        evm_return v0 v1;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_0098__return_data_b74b(v0.i256, v1.i256) {
+func private %return_data(v0.i256, v1.i256) {
     block0:
         jump block1;
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/full_contract.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/full_contract.snap
@@ -5,8 +5,8 @@ input_file: crates/codegen/tests/fixtures/full_contract.fe
 ---
 target = "evm-ethereum-osaka"
 
-type @layout_0 = {i256};
-type @layout_1 = {i256, i256};
+type @layout_0 = {i256, i256};
+type @layout_1 = {i256};
 
 func private %abi_encode(v0.i256) {
     block0:
@@ -18,26 +18,7 @@ func private %abi_encode(v0.i256) {
         unreachable;
 }
 
-func private %impl_Square__area(v0.objref<@layout_0>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 0.i256;
-        v4.i256 = obj.load v3;
-        (v5.i256, v6.i1) = umulo v4 v4;
-        br v6 block2 block3;
-
-    block2:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block3:
-        return v5;
-}
-
-func private %impl_Point__area(v0.objref<@layout_1>) -> i256 {
+func private %impl_Point__area(v0.objref<@layout_0>) -> i256 {
     block0:
         jump block1;
 
@@ -56,6 +37,25 @@ func private %impl_Point__area(v0.objref<@layout_1>) -> i256 {
 
     block3:
         return v8;
+}
+
+func private %impl_Square__area(v0.objref<@layout_1>) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v3.objref<i256> = obj.proj v0 0.i256;
+        v4.i256 = obj.load v3;
+        (v5.i256, v6.i1) = umulo v4 v4;
+        br v6 block2 block3;
+
+    block2:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block3:
+        return v5;
 }
 
 func private %calldataload(v0.i256) -> i256 {
@@ -89,9 +89,9 @@ func private %dispatch() {
     block2:
         v7.i256 = call %calldataload 4.i256;
         v9.i256 = call %calldataload 36.i256;
-        v11.@layout_1 = insert_value undef.@layout_1 0.i256 v7;
-        v13.@layout_1 = insert_value v11 1.i256 v9;
-        v14.objref<@layout_1> = obj.alloc @layout_1;
+        v11.@layout_0 = insert_value undef.@layout_0 0.i256 v7;
+        v13.@layout_0 = insert_value v11 1.i256 v9;
+        v14.objref<@layout_0> = obj.alloc @layout_0;
         v15.objref<i256> = obj.proj v14 0.i256;
         v16.i256 = extract_value v13 0.i256;
         obj.store v15 v16;
@@ -112,8 +112,8 @@ func private %dispatch() {
 
     block5:
         v38.i256 = call %calldataload 4.i256;
-        v40.@layout_0 = insert_value undef.@layout_0 0.i256 v38;
-        v41.objref<@layout_0> = obj.alloc @layout_0;
+        v40.@layout_1 = insert_value undef.@layout_1 0.i256 v38;
+        v41.objref<@layout_1> = obj.alloc @layout_1;
         v42.objref<i256> = obj.proj v41 0.i256;
         v43.i256 = extract_value v40 0.i256;
         obj.store v42 v43;

--- a/crates/codegen/tests/fixtures/sonatina_ir/high_level_contract.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/high_level_contract.snap
@@ -6,16 +6,13 @@ input_file: crates/codegen/tests/fixtures/high_level_contract.fe
 target = "evm-ethereum-osaka"
 
 type @layout_0 = {i256, i256};
-type @layout_1 = {i256, i256};
+type @layout_1 = {@layout_0, i256};
 type @layout_2 = {@layout_1, i256};
-type @layout_3 = {@layout_2, i256};
-type @layout_4 = {i256};
-type @layout_5 = {i256};
-type @layout_6 = {i256, i256};
-type @layout_7 = {};
-type @layout_8 = {@layout_7};
+type @layout_3 = {i256};
+type @layout_4 = {};
+type @layout_5 = {@layout_4};
 
-global private const @layout_4 $const_region_0 = {0};
+global private const @layout_3 $const_region_0 = {0};
 
 func private %__EchoContract_init(v0.i256, v1.i256, v2.i256) {
     block0:
@@ -126,7 +123,7 @@ func inline(always) private %at(v0.i256) -> @layout_0 {
         return v6;
 }
 
-func private %base__g463e(v0.objref<@layout_3>) -> i256 {
+func private %base__g463e(v0.objref<@layout_2>) -> i256 {
     block0:
         jump block1;
 
@@ -208,8 +205,8 @@ func inline(always) private %checked_tail(v0.i256, v1.i256) -> i256 {
 
 func inline(always) private %contract_init_abi_EchoContract() {
     block0:
-        v0.objref<@layout_1> = obj.alloc @layout_1;
-        v1.objref<@layout_3> = obj.alloc @layout_3;
+        v0.objref<@layout_0> = obj.alloc @layout_0;
+        v1.objref<@layout_2> = obj.alloc @layout_2;
         jump block1;
 
     block1:
@@ -247,12 +244,12 @@ func inline(always) private %contract_init_abi_EchoContract() {
         obj.store v23 v20;
         v25.objref<i256> = obj.proj v0 1.i256;
         obj.store v25 v13;
-        v26.@layout_1 = obj.load v0;
-        v27.@layout_3 = call %decoder_new v26;
-        v28.objref<@layout_2> = obj.proj v1 0.i256;
-        v29.@layout_2 = extract_value v27 0.i256;
-        v30.objref<@layout_1> = obj.proj v28 0.i256;
-        v31.@layout_1 = extract_value v29 0.i256;
+        v26.@layout_0 = obj.load v0;
+        v27.@layout_2 = call %decoder_new v26;
+        v28.objref<@layout_1> = obj.proj v1 0.i256;
+        v29.@layout_1 = extract_value v27 0.i256;
+        v30.objref<@layout_0> = obj.proj v28 0.i256;
+        v31.@layout_0 = extract_value v29 0.i256;
         v32.objref<i256> = obj.proj v30 0.i256;
         v33.i256 = extract_value v31 0.i256;
         obj.store v32 v33;
@@ -265,7 +262,7 @@ func inline(always) private %contract_init_abi_EchoContract() {
         v38.objref<i256> = obj.proj v1 1.i256;
         v39.i256 = extract_value v27 1.i256;
         obj.store v38 v39;
-        v40.@layout_6 = call %decode_payload__g4770 v1;
+        v40.@layout_0 = call %decode_payload__g4770 v1;
         v41.i256 = extract_value v40 0.i256;
         v42.i256 = extract_value v40 1.i256;
         call %__EchoContract_init v41 v42 0.i256;
@@ -298,10 +295,10 @@ func inline(always) private %contract_recv_abi_EchoContract_1() {
         evm_revert 0.i256 0.i256;
 
     block3:
-        v5.objref<@layout_8> = obj.alloc @layout_8;
+        v5.objref<@layout_5> = obj.alloc @layout_5;
         call %decode_runtime_args__g235a v5;
         v7.i256 = call %__EchoContract_recv_0_0;
-        v8.@layout_6 = call %encode_single_root_alloc v7;
+        v8.@layout_0 = call %encode_single_root_alloc v7;
         v9.i256 = extract_value v8 0.i256;
         v11.i256 = extract_value v8 1.i256;
         evm_return v9 v11;
@@ -321,11 +318,11 @@ func inline(always) private %contract_recv_abi_EchoContract_2() {
         evm_revert 0.i256 0.i256;
 
     block3:
-        v5.objref<@layout_8> = obj.alloc @layout_8;
-        v6.@layout_5 = call %decode_runtime_args__g9e33 v5;
+        v5.objref<@layout_5> = obj.alloc @layout_5;
+        v6.@layout_3 = call %decode_runtime_args__g9e33 v5;
         v7.i256 = extract_value v6 0.i256;
         v8.i256 = call %__EchoContract_recv_0_1 v7;
-        v9.@layout_6 = call %encode_single_root_alloc v8;
+        v9.@layout_0 = call %encode_single_root_alloc v8;
         v10.i256 = extract_value v9 0.i256;
         v12.i256 = extract_value v9 1.i256;
         evm_return v10 v12;
@@ -345,10 +342,10 @@ func inline(always) private %contract_recv_abi_EchoContract_3() {
         evm_revert 0.i256 0.i256;
 
     block3:
-        v5.objref<@layout_8> = obj.alloc @layout_8;
+        v5.objref<@layout_5> = obj.alloc @layout_5;
         call %decode_runtime_args__gf173 v5;
         v7.i256 = call %__EchoContract_recv_0_2 0.i256;
-        v8.@layout_6 = call %encode_single_root_alloc v7;
+        v8.@layout_0 = call %encode_single_root_alloc v7;
         v9.i256 = extract_value v8 0.i256;
         v11.i256 = extract_value v8 1.i256;
         evm_return v9 v11;
@@ -401,7 +398,7 @@ func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_f5d2() {
         evm_revert 0.i256 0.i256;
 }
 
-func inline(always) private %decode_field(v0.objref<@layout_3>) -> i256 {
+func inline(always) private %decode_field(v0.objref<@layout_2>) -> i256 {
     block0:
         jump block1;
 
@@ -409,7 +406,7 @@ func inline(always) private %decode_field(v0.objref<@layout_3>) -> i256 {
         br 0.i1 block2 block3;
 
     block2:
-        v3.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_66f1 v0;
+        v3.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_0bb7 v0;
         v4.i256 = call %base__g463e v0;
         v5.i256 = call %pos__g463e v0;
         (v6.i256, v7.i1) = uaddo v4 v3;
@@ -437,7 +434,7 @@ func inline(always) private %decode_field(v0.objref<@layout_3>) -> i256 {
         return v17;
 }
 
-func inline(always) private %decode_field_from(v0.@layout_4, v1.i256, v2.i256) -> i256 {
+func inline(always) private %decode_field_from(v0.@layout_3, v1.i256, v2.i256) -> i256 {
     block0:
         jump block1;
 
@@ -445,7 +442,7 @@ func inline(always) private %decode_field_from(v0.@layout_4, v1.i256, v2.i256) -
         br 0.i1 block2 block3;
 
     block2:
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_1f7f v0 v2;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_6c3a v0 v2;
         (v8.i256, v9.i1) = uaddo v1 v6;
         br v9 block5 block6;
 
@@ -453,7 +450,7 @@ func inline(always) private %decode_field_from(v0.@layout_4, v1.i256, v2.i256) -
         jump block4;
 
     block4:
-        v19.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_4818_0 v0 v2;
+        v19.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_b229_0 v0 v2;
         return v19;
 
     block5:
@@ -462,11 +459,11 @@ func inline(always) private %decode_field_from(v0.@layout_4, v1.i256, v2.i256) -
         evm_revert 0.i256 36.i256;
 
     block6:
-        v16.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_4818_0 v0 v8;
+        v16.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_b229_0 v0 v8;
         return v16;
 }
 
-func inline(always) private %decode_field_from_prechecked_head(v0.@layout_4, v1.i256, v2.i256, v3.i256) -> i256 {
+func inline(always) private %decode_field_from_prechecked_head(v0.@layout_3, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
         jump block1;
 
@@ -474,7 +471,7 @@ func inline(always) private %decode_field_from_prechecked_head(v0.@layout_4, v1.
         br 0.i1 block2 block3;
 
     block2:
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_1f7f v0 v2;
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_6c3a v0 v2;
         v9.i256 = call %checked_tail v1 v7;
         v11.i256 = call %decode_from_bounded v0 v9 v3;
         return v11;
@@ -483,22 +480,48 @@ func inline(always) private %decode_field_from_prechecked_head(v0.@layout_4, v1.
         jump block4;
 
     block4:
-        v14.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_4818_0 v0 v2;
+        v14.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_b229_0 v0 v2;
         return v14;
 }
 
-func inline(always) private %impl_trait_Echo__decode_from__gd20d(v0.@layout_4, v1.i256) -> @layout_5 {
+func inline(always) private %impl_trait_Answer__decode_from__gd20d(v0.@layout_3, v1.i256) {
     block0:
         jump block1;
 
     block1:
-        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_6a97 v0;
+        return;
+}
+
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_b229(v0.@layout_3, v1.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_ef3a v0 v1;
+        return v4;
+}
+
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_b229_0(v0.@layout_3, v1.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_ef3a_0 v0 v1;
+        return v4;
+}
+
+func inline(always) private %impl_trait_Echo__decode_from__gd20d(v0.@layout_3, v1.i256) -> @layout_3 {
+    block0:
+        jump block1;
+
+    block1:
+        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_0523 v0;
         v5.i256 = call %decode_msg_field_from v0 v1 v1 v3;
-        v8.@layout_5 = insert_value undef.@layout_5 0.i256 v5;
+        v8.@layout_3 = insert_value undef.@layout_3 0.i256 v5;
         return v8;
 }
 
-func inline(always) private %impl_trait_Answer__decode_from__gd20d(v0.@layout_4, v1.i256) {
+func inline(always) private %impl_trait_GetX__decode_from__gd20d(v0.@layout_3, v1.i256) {
     block0:
         jump block1;
 
@@ -506,52 +529,17 @@ func inline(always) private %impl_trait_Answer__decode_from__gd20d(v0.@layout_4,
         return;
 }
 
-func inline(always) private %impl_trait_GetX__decode_from__gd20d(v0.@layout_4, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        return;
-}
-
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_4818(v0.@layout_4, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_81b2 v0 v1;
-        return v4;
-}
-
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_4818_0(v0.@layout_4, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_81b2_0 v0 v1;
-        return v4;
-}
-
-func private %decode_from_bounded(v0.@layout_4, v1.i256, v2.i256) -> i256 {
+func private %decode_from_bounded(v0.@layout_3, v1.i256, v2.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
         v6.i256 = call %checked_frame_end v1 32.i256 v2;
-        v8.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_4818 v0 v1;
+        v8.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_b229 v0 v1;
         return v8;
 }
 
-func inline(always) private %decode_from_prechecked_head__g2d0f(v0.@layout_4, v1.i256, v2.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        call %impl_trait_GetX__decode_from__gd20d v0 v1;
-        return;
-}
-
-func inline(always) private %decode_from_prechecked_head__g2f3f(v0.@layout_4, v1.i256, v2.i256) {
+func inline(always) private %decode_from_prechecked_head__g2f3f(v0.@layout_3, v1.i256, v2.i256) {
     block0:
         jump block1;
 
@@ -560,16 +548,25 @@ func inline(always) private %decode_from_prechecked_head__g2f3f(v0.@layout_4, v1
         return;
 }
 
-func inline(always) private %decode_from_prechecked_head__g6fcf(v0.@layout_4, v1.i256, v2.i256) -> @layout_5 {
+func inline(always) private %decode_from_prechecked_head__g6fcf(v0.@layout_3, v1.i256, v2.i256) -> @layout_3 {
     block0:
         jump block1;
 
     block1:
-        v6.@layout_5 = call %impl_trait_Echo__decode_from__gd20d v0 v1;
+        v6.@layout_3 = call %impl_trait_Echo__decode_from__gd20d v0 v1;
         return v6;
 }
 
-func inline(always) private %decode_msg_field_from(v0.@layout_4, v1.i256, v2.i256, v3.i256) -> i256 {
+func inline(always) private %decode_from_prechecked_head__g2d0f(v0.@layout_3, v1.i256, v2.i256) {
+    block0:
+        jump block1;
+
+    block1:
+        call %impl_trait_GetX__decode_from__gd20d v0 v1;
+        return;
+}
+
+func inline(always) private %decode_msg_field_from(v0.@layout_3, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
         jump block1;
 
@@ -588,66 +585,36 @@ func inline(always) private %decode_msg_field_from(v0.@layout_4, v1.i256, v2.i25
         return v14;
 }
 
-func inline(always) private %decode_payload__g407e(v0.objref<@layout_3>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_d95a v0;
-        return v2;
-}
-
-func private %decode_payload__g4770(v0.objref<@layout_3>) -> @layout_6 {
+func private %decode_payload__g4770(v0.objref<@layout_2>) -> @layout_0 {
     block0:
         jump block1;
 
     block1:
         v2.i256 = call %decode_field v0;
         v3.i256 = call %decode_field v0;
-        v6.@layout_6 = insert_value undef.@layout_6 0.i256 v2;
-        v8.@layout_6 = insert_value v6 1.i256 v3;
+        v6.@layout_0 = insert_value undef.@layout_0 0.i256 v2;
+        v8.@layout_0 = insert_value v6 1.i256 v3;
         return v8;
 }
 
-func inline(always) private %decode_runtime_args__g9e33(v0.objref<@layout_8>) -> @layout_5 {
+func inline(always) private %decode_payload__g407e(v0.objref<@layout_2>) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.@layout_4 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_024f;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_7c2f v3;
-        mstore v1 4.i256 i256;
-        br 0.i1 block2 block5;
-
-    block2:
-        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_87bf;
-        unreachable;
-
-    block3:
-        jump block4;
-
-    block4:
-        v12.@layout_5 = call %decode_from_prechecked_head__g6fcf v3 4.i256 v5;
-        return v12;
-
-    block5:
-        mstore v2 v5 i256;
-        v15.i256 = mload v2 i256;
-        v16.i1 = gt 36.i256 v15;
-        br v16 block2 block3;
+        v2.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_3b1d v0;
+        return v2;
 }
 
-func inline(always) private %decode_runtime_args__gf173(v0.objref<@layout_8>) {
+func inline(always) private %decode_runtime_args__gf173(v0.objref<@layout_5>) {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.@layout_4 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_58ca;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_34dc v3;
+        v3.@layout_3 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_58ca;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_2fcc v3;
         mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
 
@@ -669,15 +636,15 @@ func inline(always) private %decode_runtime_args__gf173(v0.objref<@layout_8>) {
         br v15 block2 block3;
 }
 
-func inline(always) private %decode_runtime_args__g235a(v0.objref<@layout_8>) {
+func inline(always) private %decode_runtime_args__g235a(v0.objref<@layout_5>) {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.@layout_4 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_414c;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_1779 v3;
+        v3.@layout_3 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_414c;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_c3b0 v3;
         mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
 
@@ -699,12 +666,42 @@ func inline(always) private %decode_runtime_args__g235a(v0.objref<@layout_8>) {
         br v15 block2 block3;
 }
 
-func private %decoder_new(v0.@layout_1) -> @layout_3 {
+func inline(always) private %decode_runtime_args__g9e33(v0.objref<@layout_5>) -> @layout_3 {
+    block0:
+        v1.*i256 = alloca i256;
+        v2.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v3.@layout_3 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_024f;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_ab72 v3;
+        mstore v1 4.i256 i256;
+        br 0.i1 block2 block5;
+
+    block2:
+        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_87bf;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        v12.@layout_3 = call %decode_from_prechecked_head__g6fcf v3 4.i256 v5;
+        return v12;
+
+    block5:
+        mstore v2 v5 i256;
+        v15.i256 = mload v2 i256;
+        v16.i1 = gt 36.i256 v15;
+        br v16 block2 block3;
+}
+
+func private %decoder_new(v0.@layout_0) -> @layout_2 {
     block0:
         jump block1;
 
     block1:
-        v2.@layout_3 = call %impl_SolDecoder__new__g463e v0;
+        v2.@layout_2 = call %impl_SolDecoder__new__g463e v0;
         return v2;
 }
 
@@ -713,7 +710,7 @@ func private %encode(v0.i256, v1.objref<@layout_0>) {
         jump block1;
 
     block1:
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_d116 v1 v0;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_e5d7 v1 v0;
         return;
 }
 
@@ -729,7 +726,7 @@ func private %encode_field(v0.i256, v1.objref<@layout_0>, v2.i256) {
         v8.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_9950 v0;
         v9.i256 = mload v2 i256;
         v10.i256 = sub v9 v5;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_6213 v1 v10;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_dd9c v1 v10;
         v12.i256 = call %impl_trait_SolEncoder__pos v1;
         v13.i256 = mload v2 i256;
         call %impl_trait_SolEncoder__set_base v1 v13;
@@ -778,7 +775,7 @@ func private %encode_single_root(v0.i256, v1.objref<@layout_0>) {
         return;
 }
 
-func private %encode_single_root_alloc(v0.i256) -> @layout_6 {
+func private %encode_single_root_alloc(v0.i256) -> @layout_0 {
     block0:
         jump block1;
 
@@ -794,8 +791,8 @@ func private %encode_single_root_alloc(v0.i256) -> @layout_6 {
         obj.store v9 v10;
         v11.i256 = call %impl_trait_SolEncoder__base v4;
         call %encode_single_root v0 v4;
-        v14.@layout_6 = insert_value undef.@layout_6 0.i256 v11;
-        v15.@layout_6 = insert_value v14 1.i256 v2;
+        v14.@layout_0 = insert_value undef.@layout_0 0.i256 v11;
+        v15.@layout_0 = insert_value v14 1.i256 v2;
         return v15;
 }
 
@@ -817,34 +814,34 @@ func private %encoder_new(v0.i256) -> @layout_0 {
         return v2;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_024f() -> @layout_4 {
+func private %std__lib__evm__effects__impl_trait_Evm_c913__input_024f() -> @layout_3 {
     block0:
         jump block1;
 
     block1:
-        v0.@layout_4 = call %std__lib__evm__calldata__impl_CallData_8f43__new_45d4;
+        v0.@layout_3 = call %std__lib__evm__calldata__impl_CallData_8f43__new_45d4;
         return v0;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_414c() -> @layout_4 {
+func private %std__lib__evm__effects__impl_trait_Evm_c913__input_414c() -> @layout_3 {
     block0:
         jump block1;
 
     block1:
-        v0.@layout_4 = call %std__lib__evm__calldata__impl_CallData_8f43__new_c043;
+        v0.@layout_3 = call %std__lib__evm__calldata__impl_CallData_8f43__new_c043;
         return v0;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_58ca() -> @layout_4 {
+func private %std__lib__evm__effects__impl_trait_Evm_c913__input_58ca() -> @layout_3 {
     block0:
         jump block1;
 
     block1:
-        v0.@layout_4 = call %std__lib__evm__calldata__impl_CallData_8f43__new_bdf6;
+        v0.@layout_3 = call %std__lib__evm__calldata__impl_CallData_8f43__new_bdf6;
         return v0;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_1779(v0.@layout_4) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_0523(v0.@layout_3) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         jump block1;
@@ -878,7 +875,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         jump block4;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_34dc(v0.@layout_4) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_2fcc(v0.@layout_3) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         jump block1;
@@ -912,75 +909,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         jump block4;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_6a97(v0.@layout_4) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v2.i256 = evm_calldata_size;
-        v5.i256 = extract_value v0 0.i256;
-        mstore v1 v2 i256;
-        v6.i256 = mload v1 i256;
-        v7.i1 = gt v5 v6;
-        br v7 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v9.i256 = extract_value v0 0.i256;
-        (v11.i256, v12.i1) = usubo v2 v9;
-        br v12 block5 block6;
-
-    block4:
-        v17.i256 = phi (0.i256 block2) (v11 block6);
-        return v17;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_7c2f(v0.@layout_4) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v2.i256 = evm_calldata_size;
-        v5.i256 = extract_value v0 0.i256;
-        mstore v1 v2 i256;
-        v6.i256 = mload v1 i256;
-        v7.i1 = gt v5 v6;
-        br v7 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v9.i256 = extract_value v0 0.i256;
-        (v11.i256, v12.i1) = usubo v2 v9;
-        br v12 block5 block6;
-
-    block4:
-        v17.i256 = phi (0.i256 block2) (v11 block6);
-        return v17;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_8748(v0.objref<@layout_1>) -> i256 {
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_30f9(v0.objref<@layout_0>) -> i256 {
     block0:
         jump block1;
 
@@ -990,7 +919,41 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_8748
         return v4;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_f8db(v0.objref<@layout_1>) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_ab72(v0.@layout_3) -> i256 {
+    block0:
+        v1.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v2.i256 = evm_calldata_size;
+        v5.i256 = extract_value v0 0.i256;
+        mstore v1 v2 i256;
+        v6.i256 = mload v1 i256;
+        v7.i1 = gt v5 v6;
+        br v7 block2 block3;
+
+    block2:
+        jump block4;
+
+    block3:
+        v9.i256 = extract_value v0 0.i256;
+        (v11.i256, v12.i1) = usubo v2 v9;
+        br v12 block5 block6;
+
+    block4:
+        v17.i256 = phi (0.i256 block2) (v11 block6);
+        return v17;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        jump block4;
+}
+
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_beb1(v0.objref<@layout_0>) -> i256 {
     block0:
         jump block1;
 
@@ -998,6 +961,50 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_f8db
         v3.objref<i256> = obj.proj v0 1.i256;
         v4.i256 = obj.load v3;
         return v4;
+}
+
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_c3b0(v0.@layout_3) -> i256 {
+    block0:
+        v1.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v2.i256 = evm_calldata_size;
+        v5.i256 = extract_value v0 0.i256;
+        mstore v1 v2 i256;
+        v6.i256 = mload v1 i256;
+        v7.i1 = gt v5 v6;
+        br v7 block2 block3;
+
+    block2:
+        jump block4;
+
+    block3:
+        v9.i256 = extract_value v0 0.i256;
+        (v11.i256, v12.i1) = usubo v2 v9;
+        br v12 block5 block6;
+
+    block4:
+        v17.i256 = phi (0.i256 block2) (v11 block6);
+        return v17;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        jump block4;
+}
+
+func inline(always) private %impl_Cursor__new__g463e(v0.@layout_0) -> @layout_1 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.@layout_1 = insert_value undef.@layout_1 0.i256 v0;
+        v6.@layout_1 = insert_value v4 1.i256 0.i256;
+        return v6;
 }
 
 func private %impl_SolEncoder__new(v0.i256) -> @layout_0 {
@@ -1022,60 +1029,50 @@ func private %impl_SolEncoder__new(v0.i256) -> @layout_0 {
         return v8;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_45d4() -> @layout_4 {
+func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_45d4() -> @layout_3 {
     block0:
         jump block1;
 
     block1:
-        v1.constref<@layout_4> = const.ref $const_region_0;
-        v2.objref<@layout_4> = obj.alloc @layout_4;
+        v1.constref<@layout_3> = const.ref $const_region_0;
+        v2.objref<@layout_3> = obj.alloc @layout_3;
         obj.init.const v2 v1;
-        v3.@layout_4 = obj.load v2;
+        v3.@layout_3 = obj.load v2;
         return v3;
 }
 
-func inline(always) private %impl_Cursor__new__g463e(v0.@layout_1) -> @layout_2 {
+func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_bdf6() -> @layout_3 {
     block0:
         jump block1;
 
     block1:
-        v4.@layout_2 = insert_value undef.@layout_2 0.i256 v0;
-        v6.@layout_2 = insert_value v4 1.i256 0.i256;
-        return v6;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_bdf6() -> @layout_4 {
-    block0:
-        jump block1;
-
-    block1:
-        v1.constref<@layout_4> = const.ref $const_region_0;
-        v2.objref<@layout_4> = obj.alloc @layout_4;
+        v1.constref<@layout_3> = const.ref $const_region_0;
+        v2.objref<@layout_3> = obj.alloc @layout_3;
         obj.init.const v2 v1;
-        v3.@layout_4 = obj.load v2;
+        v3.@layout_3 = obj.load v2;
         return v3;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_c043() -> @layout_4 {
+func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_c043() -> @layout_3 {
     block0:
         jump block1;
 
     block1:
-        v1.constref<@layout_4> = const.ref $const_region_0;
-        v2.objref<@layout_4> = obj.alloc @layout_4;
+        v1.constref<@layout_3> = const.ref $const_region_0;
+        v2.objref<@layout_3> = obj.alloc @layout_3;
         obj.init.const v2 v1;
-        v3.@layout_4 = obj.load v2;
+        v3.@layout_3 = obj.load v2;
         return v3;
 }
 
-func inline(always) private %impl_SolDecoder__new__g463e(v0.@layout_1) -> @layout_3 {
+func inline(always) private %impl_SolDecoder__new__g463e(v0.@layout_0) -> @layout_2 {
     block0:
         jump block1;
 
     block1:
-        v2.@layout_2 = call %impl_Cursor__new__g463e v0;
-        v5.@layout_3 = insert_value undef.@layout_3 0.i256 v2;
-        v7.@layout_3 = insert_value v5 1.i256 0.i256;
+        v2.@layout_1 = call %impl_Cursor__new__g463e v0;
+        v5.@layout_2 = insert_value undef.@layout_2 0.i256 v2;
+        v7.@layout_2 = insert_value v5 1.i256 0.i256;
         return v7;
 }
 
@@ -1095,12 +1092,12 @@ func private %core__lib__abi__trait_AbiSize__payload_size__ge513_9950_0(v0.i256)
         return 32.i256;
 }
 
-func private %pos__g463e(v0.objref<@layout_3>) -> i256 {
+func private %pos__g463e(v0.objref<@layout_2>) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v3.objref<@layout_2> = obj.proj v0 0.i256;
+        v3.objref<@layout_1> = obj.proj v0 0.i256;
         v5.objref<i256> = obj.proj v3 1.i256;
         v6.i256 = obj.load v5;
         return v6;
@@ -1116,19 +1113,19 @@ func private %impl_trait_SolEncoder__pos(v0.objref<@layout_0>) -> i256 {
         return v4;
 }
 
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_66f1(v0.objref<@layout_3>) -> i256 {
+func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_0bb7(v0.objref<@layout_2>) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v4.objref<@layout_2> = obj.proj v0 0.i256;
-        v5.objref<@layout_1> = obj.proj v4 0.i256;
-        v6.@layout_1 = obj.load v5;
-        v7.objref<@layout_2> = obj.proj v0 0.i256;
-        v8.objref<@layout_1> = obj.proj v7 0.i256;
-        v9.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_f8db v8;
-        v10.objref<@layout_2> = obj.proj v0 0.i256;
+        v4.objref<@layout_1> = obj.proj v0 0.i256;
+        v5.objref<@layout_0> = obj.proj v4 0.i256;
+        v6.@layout_0 = obj.load v5;
+        v7.objref<@layout_1> = obj.proj v0 0.i256;
+        v8.objref<@layout_0> = obj.proj v7 0.i256;
+        v9.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_30f9 v8;
+        v10.objref<@layout_1> = obj.proj v0 0.i256;
         v12.objref<i256> = obj.proj v10 1.i256;
         v13.i256 = obj.load v12;
         (v15.i256, v16.i1) = uaddo v13 32.i256;
@@ -1141,16 +1138,16 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         jump block4;
 
     block4:
-        v27.objref<@layout_2> = obj.proj v0 0.i256;
-        v28.objref<@layout_1> = obj.proj v27 0.i256;
-        v29.@layout_1 = obj.load v28;
-        v30.objref<@layout_2> = obj.proj v0 0.i256;
+        v27.objref<@layout_1> = obj.proj v0 0.i256;
+        v28.objref<@layout_0> = obj.proj v27 0.i256;
+        v29.@layout_0 = obj.load v28;
+        v30.objref<@layout_1> = obj.proj v0 0.i256;
         v31.objref<i256> = obj.proj v30 1.i256;
         v32.i256 = obj.load v31;
-        v33.objref<@layout_2> = obj.proj v0 0.i256;
-        v34.objref<@layout_1> = obj.proj v33 0.i256;
-        v35.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_7f06 v34 v32;
-        v37.objref<@layout_2> = obj.proj v0 0.i256;
+        v33.objref<@layout_1> = obj.proj v0 0.i256;
+        v34.objref<@layout_0> = obj.proj v33 0.i256;
+        v35.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_3fe6 v34 v32;
+        v37.objref<@layout_1> = obj.proj v0 0.i256;
         v38.objref<i256> = obj.proj v37 1.i256;
         obj.store v38 v15;
         return v35;
@@ -1167,26 +1164,26 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         evm_revert 0.i256 36.i256;
 
     block7:
-        v22.objref<@layout_2> = obj.proj v0 0.i256;
+        v22.objref<@layout_1> = obj.proj v0 0.i256;
         v23.objref<i256> = obj.proj v22 1.i256;
         v24.i256 = obj.load v23;
         v25.i1 = lt v15 v24;
         br v25 block2 block5;
 }
 
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_d95a(v0.objref<@layout_3>) -> i256 {
+func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_3b1d(v0.objref<@layout_2>) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v4.objref<@layout_2> = obj.proj v0 0.i256;
-        v5.objref<@layout_1> = obj.proj v4 0.i256;
-        v6.@layout_1 = obj.load v5;
-        v7.objref<@layout_2> = obj.proj v0 0.i256;
-        v8.objref<@layout_1> = obj.proj v7 0.i256;
-        v9.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_8748 v8;
-        v10.objref<@layout_2> = obj.proj v0 0.i256;
+        v4.objref<@layout_1> = obj.proj v0 0.i256;
+        v5.objref<@layout_0> = obj.proj v4 0.i256;
+        v6.@layout_0 = obj.load v5;
+        v7.objref<@layout_1> = obj.proj v0 0.i256;
+        v8.objref<@layout_0> = obj.proj v7 0.i256;
+        v9.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_beb1 v8;
+        v10.objref<@layout_1> = obj.proj v0 0.i256;
         v12.objref<i256> = obj.proj v10 1.i256;
         v13.i256 = obj.load v12;
         (v15.i256, v16.i1) = uaddo v13 32.i256;
@@ -1199,16 +1196,16 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         jump block4;
 
     block4:
-        v27.objref<@layout_2> = obj.proj v0 0.i256;
-        v28.objref<@layout_1> = obj.proj v27 0.i256;
-        v29.@layout_1 = obj.load v28;
-        v30.objref<@layout_2> = obj.proj v0 0.i256;
+        v27.objref<@layout_1> = obj.proj v0 0.i256;
+        v28.objref<@layout_0> = obj.proj v27 0.i256;
+        v29.@layout_0 = obj.load v28;
+        v30.objref<@layout_1> = obj.proj v0 0.i256;
         v31.objref<i256> = obj.proj v30 1.i256;
         v32.i256 = obj.load v31;
-        v33.objref<@layout_2> = obj.proj v0 0.i256;
-        v34.objref<@layout_1> = obj.proj v33 0.i256;
-        v35.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_38bd v34 v32;
-        v37.objref<@layout_2> = obj.proj v0 0.i256;
+        v33.objref<@layout_1> = obj.proj v0 0.i256;
+        v34.objref<@layout_0> = obj.proj v33 0.i256;
+        v35.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_8d2c v34 v32;
+        v37.objref<@layout_1> = obj.proj v0 0.i256;
         v38.objref<i256> = obj.proj v37 1.i256;
         obj.store v38 v15;
         return v35;
@@ -1225,7 +1222,7 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         evm_revert 0.i256 36.i256;
 
     block7:
-        v22.objref<@layout_2> = obj.proj v0 0.i256;
+        v22.objref<@layout_1> = obj.proj v0 0.i256;
         v23.objref<i256> = obj.proj v22 1.i256;
         v24.i256 = obj.load v23;
         v25.i1 = lt v15 v24;
@@ -1266,24 +1263,13 @@ func private %impl_trait_SolEncoder__set_base(v0.objref<@layout_0>, v1.i256) {
         return;
 }
 
-func private %set_base__g463e(v0.objref<@layout_3>, v1.i256) {
+func private %set_base__g463e(v0.objref<@layout_2>, v1.i256) {
     block0:
         jump block1;
 
     block1:
         v5.objref<i256> = obj.proj v0 1.i256;
         obj.store v5 v1;
-        return;
-}
-
-func private %set_pos__g463e(v0.objref<@layout_3>, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v5.objref<@layout_2> = obj.proj v0 0.i256;
-        v7.objref<i256> = obj.proj v5 1.i256;
-        obj.store v7 v1;
         return;
 }
 
@@ -1297,6 +1283,17 @@ func private %impl_trait_SolEncoder__set_pos(v0.objref<@layout_0>, v1.i256) {
         return;
 }
 
+func private %set_pos__g463e(v0.objref<@layout_2>, v1.i256) {
+    block0:
+        jump block1;
+
+    block1:
+        v5.objref<@layout_1> = obj.proj v0 0.i256;
+        v7.objref<i256> = obj.proj v5 1.i256;
+        obj.store v7 v1;
+        return;
+}
+
 func private %store_word(v0.i256, v1.i256) {
     block0:
         jump block1;
@@ -1306,18 +1303,7 @@ func private %store_word(v0.i256, v1.i256) {
         return;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_1f7f(v0.@layout_4, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_38bd(v0.objref<@layout_1>, v1.i256) -> i256 {
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_3fe6(v0.objref<@layout_0>, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -1329,7 +1315,18 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_
         return v8;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_7f06(v0.objref<@layout_1>, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_6c3a(v0.@layout_3, v1.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
+}
+
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_8d2c(v0.objref<@layout_0>, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -1341,7 +1338,7 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_
         return v8;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_81b2(v0.@layout_4, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_ef3a(v0.@layout_3, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -1352,7 +1349,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v7;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_81b2_0(v0.@layout_4, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_ef3a_0(v0.@layout_3, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -1363,7 +1360,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v7;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_6213(v0.objref<@layout_0>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_dd9c(v0.objref<@layout_0>, v1.i256) {
     block0:
         jump block1;
 
@@ -1377,7 +1374,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_6213(v0
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_d116(v0.objref<@layout_0>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_e5d7(v0.objref<@layout_0>, v1.i256) {
     block0:
         jump block1;
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/high_level_contract.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/high_level_contract.snap
@@ -55,7 +55,7 @@ func private %abi_field_size(v0.i256) -> i256 {
         jump block1;
 
     block1:
-        v2.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_9950_0 v0;
+        v2.i256 = call %payload_size v0;
         br 0.i1 block2 block3;
 
     block2:
@@ -86,30 +86,12 @@ func private %abi_single_root_size(v0.i256) -> i256 {
         return v2;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_c913__abort_2725() {
+func private %abort() {
     block0:
         jump block1;
 
     block1:
-        call %std__lib__evm__effects__impl_trait_Evm_0098__revert_a97d 0.i256 0.i256;
-        unreachable;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_c913__abort_87bf() {
-    block0:
-        jump block1;
-
-    block1:
-        call %std__lib__evm__effects__impl_trait_Evm_0098__revert_f892 0.i256 0.i256;
-        unreachable;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_c913__abort_ee4e() {
-    block0:
-        jump block1;
-
-    block1:
-        call %std__lib__evm__effects__impl_trait_Evm_0098__revert_6da5 0.i256 0.i256;
+        call %revert 0.i256 0.i256;
         unreachable;
 }
 
@@ -152,7 +134,7 @@ func inline(always) private %checked_frame_end(v0.i256, v1.i256, v2.i256) -> i25
         br v6 block6 block7;
 
     block2:
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_f5d2;
+        call %decode_error;
         unreachable;
 
     block3:
@@ -184,7 +166,7 @@ func inline(always) private %checked_tail(v0.i256, v1.i256) -> i256 {
         br v5 block5 block6;
 
     block2:
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_eb34;
+        call %decode_error;
         unreachable;
 
     block3:
@@ -382,15 +364,7 @@ func private %contract_runtime_root_EchoContract() {
         unreachable;
 }
 
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_eb34() {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert 0.i256 0.i256;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_f5d2() {
+func private %decode_error() {
     block0:
         jump block1;
 
@@ -406,7 +380,7 @@ func inline(always) private %decode_field(v0.objref<@layout_2>) -> i256 {
         br 0.i1 block2 block3;
 
     block2:
-        v3.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_0bb7 v0;
+        v3.i256 = call %read_word v0;
         v4.i256 = call %base__g463e v0;
         v5.i256 = call %pos__g463e v0;
         (v6.i256, v7.i1) = uaddo v4 v3;
@@ -442,7 +416,7 @@ func inline(always) private %decode_field_from(v0.@layout_3, v1.i256, v2.i256) -
         br 0.i1 block2 block3;
 
     block2:
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_6c3a v0 v2;
+        v6.i256 = call %impl_trait_CallData__word_at v0 v2;
         (v8.i256, v9.i1) = uaddo v1 v6;
         br v9 block5 block6;
 
@@ -450,7 +424,7 @@ func inline(always) private %decode_field_from(v0.@layout_3, v1.i256, v2.i256) -
         jump block4;
 
     block4:
-        v19.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_b229_0 v0 v2;
+        v19.i256 = call %decode_from__g72ab v0 v2;
         return v19;
 
     block5:
@@ -459,7 +433,7 @@ func inline(always) private %decode_field_from(v0.@layout_3, v1.i256, v2.i256) -
         evm_revert 0.i256 36.i256;
 
     block6:
-        v16.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_b229_0 v0 v8;
+        v16.i256 = call %decode_from__g72ab v0 v8;
         return v16;
 }
 
@@ -471,7 +445,7 @@ func inline(always) private %decode_field_from_prechecked_head(v0.@layout_3, v1.
         br 0.i1 block2 block3;
 
     block2:
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_6c3a v0 v2;
+        v7.i256 = call %impl_trait_CallData__word_at v0 v2;
         v9.i256 = call %checked_tail v1 v7;
         v11.i256 = call %decode_from_bounded v0 v9 v3;
         return v11;
@@ -480,34 +454,8 @@ func inline(always) private %decode_field_from_prechecked_head(v0.@layout_3, v1.
         jump block4;
 
     block4:
-        v14.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_b229_0 v0 v2;
+        v14.i256 = call %decode_from__g72ab v0 v2;
         return v14;
-}
-
-func inline(always) private %impl_trait_Answer__decode_from__gd20d(v0.@layout_3, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        return;
-}
-
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_b229(v0.@layout_3, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_ef3a v0 v1;
-        return v4;
-}
-
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_b229_0(v0.@layout_3, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_ef3a_0 v0 v1;
-        return v4;
 }
 
 func inline(always) private %impl_trait_Echo__decode_from__gd20d(v0.@layout_3, v1.i256) -> @layout_3 {
@@ -515,13 +463,13 @@ func inline(always) private %impl_trait_Echo__decode_from__gd20d(v0.@layout_3, v
         jump block1;
 
     block1:
-        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_0523 v0;
+        v3.i256 = call %impl_trait_CallData__len v0;
         v5.i256 = call %decode_msg_field_from v0 v1 v1 v3;
         v8.@layout_3 = insert_value undef.@layout_3 0.i256 v5;
         return v8;
 }
 
-func inline(always) private %impl_trait_GetX__decode_from__gd20d(v0.@layout_3, v1.i256) {
+func inline(always) private %impl_trait_Answer__decode_from__gd20d(v0.@layout_3, v1.i256) {
     block0:
         jump block1;
 
@@ -535,17 +483,25 @@ func private %decode_from_bounded(v0.@layout_3, v1.i256, v2.i256) -> i256 {
 
     block1:
         v6.i256 = call %checked_frame_end v1 32.i256 v2;
-        v8.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_b229 v0 v1;
+        v8.i256 = call %decode_from__g72ab v0 v1;
         return v8;
 }
 
-func inline(always) private %decode_from_prechecked_head__g2f3f(v0.@layout_3, v1.i256, v2.i256) {
+func inline(always) private %impl_trait_GetX__decode_from__gd20d(v0.@layout_3, v1.i256) {
     block0:
         jump block1;
 
     block1:
-        call %impl_trait_Answer__decode_from__gd20d v0 v1;
         return;
+}
+
+func inline(always) private %decode_from__g72ab(v0.@layout_3, v1.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.i256 = call %impl_trait_CallData__word_at v0 v1;
+        return v4;
 }
 
 func inline(always) private %decode_from_prechecked_head__g6fcf(v0.@layout_3, v1.i256, v2.i256) -> @layout_3 {
@@ -563,6 +519,15 @@ func inline(always) private %decode_from_prechecked_head__g2d0f(v0.@layout_3, v1
 
     block1:
         call %impl_trait_GetX__decode_from__gd20d v0 v1;
+        return;
+}
+
+func inline(always) private %decode_from_prechecked_head__g2f3f(v0.@layout_3, v1.i256, v2.i256) {
+    block0:
+        jump block1;
+
+    block1:
+        call %impl_trait_Answer__decode_from__gd20d v0 v1;
         return;
 }
 
@@ -602,7 +567,7 @@ func inline(always) private %decode_payload__g407e(v0.objref<@layout_2>) -> i256
         jump block1;
 
     block1:
-        v2.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_3b1d v0;
+        v2.i256 = call %read_word v0;
         return v2;
 }
 
@@ -613,13 +578,13 @@ func inline(always) private %decode_runtime_args__gf173(v0.objref<@layout_5>) {
         jump block1;
 
     block1:
-        v3.@layout_3 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_58ca;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_2fcc v3;
+        v3.@layout_3 = call %input;
+        v5.i256 = call %impl_trait_CallData__len v3;
         mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
 
     block2:
-        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_2725;
+        call %abort;
         unreachable;
 
     block3:
@@ -643,13 +608,13 @@ func inline(always) private %decode_runtime_args__g235a(v0.objref<@layout_5>) {
         jump block1;
 
     block1:
-        v3.@layout_3 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_414c;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_c3b0 v3;
+        v3.@layout_3 = call %input;
+        v5.i256 = call %impl_trait_CallData__len v3;
         mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
 
     block2:
-        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_ee4e;
+        call %abort;
         unreachable;
 
     block3:
@@ -673,13 +638,13 @@ func inline(always) private %decode_runtime_args__g9e33(v0.objref<@layout_5>) ->
         jump block1;
 
     block1:
-        v3.@layout_3 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_024f;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_ab72 v3;
+        v3.@layout_3 = call %input;
+        v5.i256 = call %impl_trait_CallData__len v3;
         mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
 
     block2:
-        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_87bf;
+        call %abort;
         unreachable;
 
     block3:
@@ -710,7 +675,7 @@ func private %encode(v0.i256, v1.objref<@layout_0>) {
         jump block1;
 
     block1:
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_e5d7 v1 v0;
+        call %write_word v1 v0;
         return;
 }
 
@@ -723,10 +688,10 @@ func private %encode_field(v0.i256, v1.objref<@layout_0>, v2.i256) {
 
     block2:
         v5.i256 = call %impl_trait_SolEncoder__base v1;
-        v8.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_9950 v0;
+        v8.i256 = call %payload_size v0;
         v9.i256 = mload v2 i256;
         v10.i256 = sub v9 v5;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_dd9c v1 v10;
+        call %write_word v1 v10;
         v12.i256 = call %impl_trait_SolEncoder__pos v1;
         v13.i256 = mload v2 i256;
         call %impl_trait_SolEncoder__set_base v1 v13;
@@ -814,102 +779,16 @@ func private %encoder_new(v0.i256) -> @layout_0 {
         return v2;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_024f() -> @layout_3 {
+func private %input() -> @layout_3 {
     block0:
         jump block1;
 
     block1:
-        v0.@layout_3 = call %std__lib__evm__calldata__impl_CallData_8f43__new_45d4;
+        v0.@layout_3 = call %impl_CallData__new;
         return v0;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_414c() -> @layout_3 {
-    block0:
-        jump block1;
-
-    block1:
-        v0.@layout_3 = call %std__lib__evm__calldata__impl_CallData_8f43__new_c043;
-        return v0;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_58ca() -> @layout_3 {
-    block0:
-        jump block1;
-
-    block1:
-        v0.@layout_3 = call %std__lib__evm__calldata__impl_CallData_8f43__new_bdf6;
-        return v0;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_0523(v0.@layout_3) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v2.i256 = evm_calldata_size;
-        v5.i256 = extract_value v0 0.i256;
-        mstore v1 v2 i256;
-        v6.i256 = mload v1 i256;
-        v7.i1 = gt v5 v6;
-        br v7 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v9.i256 = extract_value v0 0.i256;
-        (v11.i256, v12.i1) = usubo v2 v9;
-        br v12 block5 block6;
-
-    block4:
-        v17.i256 = phi (0.i256 block2) (v11 block6);
-        return v17;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_2fcc(v0.@layout_3) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v2.i256 = evm_calldata_size;
-        v5.i256 = extract_value v0 0.i256;
-        mstore v1 v2 i256;
-        v6.i256 = mload v1 i256;
-        v7.i1 = gt v5 v6;
-        br v7 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v9.i256 = extract_value v0 0.i256;
-        (v11.i256, v12.i1) = usubo v2 v9;
-        br v12 block5 block6;
-
-    block4:
-        v17.i256 = phi (0.i256 block2) (v11 block6);
-        return v17;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_30f9(v0.objref<@layout_0>) -> i256 {
+func private %impl_trait_MemoryBytes__len(v0.objref<@layout_0>) -> i256 {
     block0:
         jump block1;
 
@@ -919,51 +798,7 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_30f9
         return v4;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_ab72(v0.@layout_3) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v2.i256 = evm_calldata_size;
-        v5.i256 = extract_value v0 0.i256;
-        mstore v1 v2 i256;
-        v6.i256 = mload v1 i256;
-        v7.i1 = gt v5 v6;
-        br v7 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v9.i256 = extract_value v0 0.i256;
-        (v11.i256, v12.i1) = usubo v2 v9;
-        br v12 block5 block6;
-
-    block4:
-        v17.i256 = phi (0.i256 block2) (v11 block6);
-        return v17;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_beb1(v0.objref<@layout_0>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 1.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_c3b0(v0.@layout_3) -> i256 {
+func inline(always) private %impl_trait_CallData__len(v0.@layout_3) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         jump block1;
@@ -1029,31 +864,7 @@ func private %impl_SolEncoder__new(v0.i256) -> @layout_0 {
         return v8;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_45d4() -> @layout_3 {
-    block0:
-        jump block1;
-
-    block1:
-        v1.constref<@layout_3> = const.ref $const_region_0;
-        v2.objref<@layout_3> = obj.alloc @layout_3;
-        obj.init.const v2 v1;
-        v3.@layout_3 = obj.load v2;
-        return v3;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_bdf6() -> @layout_3 {
-    block0:
-        jump block1;
-
-    block1:
-        v1.constref<@layout_3> = const.ref $const_region_0;
-        v2.objref<@layout_3> = obj.alloc @layout_3;
-        obj.init.const v2 v1;
-        v3.@layout_3 = obj.load v2;
-        return v3;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_c043() -> @layout_3 {
+func inline(always) private %impl_CallData__new() -> @layout_3 {
     block0:
         jump block1;
 
@@ -1076,15 +887,7 @@ func inline(always) private %impl_SolDecoder__new__g463e(v0.@layout_0) -> @layou
         return v7;
 }
 
-func private %core__lib__abi__trait_AbiSize__payload_size__ge513_9950(v0.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        return 32.i256;
-}
-
-func private %core__lib__abi__trait_AbiSize__payload_size__ge513_9950_0(v0.i256) -> i256 {
+func private %payload_size(v0.i256) -> i256 {
     block0:
         jump block1;
 
@@ -1113,7 +916,7 @@ func private %impl_trait_SolEncoder__pos(v0.objref<@layout_0>) -> i256 {
         return v4;
 }
 
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_0bb7(v0.objref<@layout_2>) -> i256 {
+func inline(always) private %read_word(v0.objref<@layout_2>) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         jump block1;
@@ -1124,7 +927,7 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         v6.@layout_0 = obj.load v5;
         v7.objref<@layout_1> = obj.proj v0 0.i256;
         v8.objref<@layout_0> = obj.proj v7 0.i256;
-        v9.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_30f9 v8;
+        v9.i256 = call %impl_trait_MemoryBytes__len v8;
         v10.objref<@layout_1> = obj.proj v0 0.i256;
         v12.objref<i256> = obj.proj v10 1.i256;
         v13.i256 = obj.load v12;
@@ -1146,7 +949,7 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         v32.i256 = obj.load v31;
         v33.objref<@layout_1> = obj.proj v0 0.i256;
         v34.objref<@layout_0> = obj.proj v33 0.i256;
-        v35.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_3fe6 v34 v32;
+        v35.i256 = call %impl_trait_MemoryBytes__word_at v34 v32;
         v37.objref<@layout_1> = obj.proj v0 0.i256;
         v38.objref<i256> = obj.proj v37 1.i256;
         obj.store v38 v15;
@@ -1171,81 +974,7 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         br v25 block2 block5;
 }
 
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_3b1d(v0.objref<@layout_2>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v4.objref<@layout_1> = obj.proj v0 0.i256;
-        v5.objref<@layout_0> = obj.proj v4 0.i256;
-        v6.@layout_0 = obj.load v5;
-        v7.objref<@layout_1> = obj.proj v0 0.i256;
-        v8.objref<@layout_0> = obj.proj v7 0.i256;
-        v9.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_beb1 v8;
-        v10.objref<@layout_1> = obj.proj v0 0.i256;
-        v12.objref<i256> = obj.proj v10 1.i256;
-        v13.i256 = obj.load v12;
-        (v15.i256, v16.i1) = uaddo v13 32.i256;
-        br v16 block6 block7;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v27.objref<@layout_1> = obj.proj v0 0.i256;
-        v28.objref<@layout_0> = obj.proj v27 0.i256;
-        v29.@layout_0 = obj.load v28;
-        v30.objref<@layout_1> = obj.proj v0 0.i256;
-        v31.objref<i256> = obj.proj v30 1.i256;
-        v32.i256 = obj.load v31;
-        v33.objref<@layout_1> = obj.proj v0 0.i256;
-        v34.objref<@layout_0> = obj.proj v33 0.i256;
-        v35.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_8d2c v34 v32;
-        v37.objref<@layout_1> = obj.proj v0 0.i256;
-        v38.objref<i256> = obj.proj v37 1.i256;
-        obj.store v38 v15;
-        return v35;
-
-    block5:
-        mstore v1 v9 i256;
-        v41.i256 = mload v1 i256;
-        v42.i1 = gt v15 v41;
-        br v42 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v22.objref<@layout_1> = obj.proj v0 0.i256;
-        v23.objref<i256> = obj.proj v22 1.i256;
-        v24.i256 = obj.load v23;
-        v25.i1 = lt v15 v24;
-        br v25 block2 block5;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_6da5(v0.i256, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert v0 v1;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_a97d(v0.i256, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert v0 v1;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_f892(v0.i256, v1.i256) {
+func private %revert(v0.i256, v1.i256) {
     block0:
         jump block1;
 
@@ -1303,7 +1032,18 @@ func private %store_word(v0.i256, v1.i256) {
         return;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_3fe6(v0.objref<@layout_0>, v1.i256) -> i256 {
+func inline(always) private %impl_trait_CallData__word_at(v0.@layout_3, v1.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
+}
+
+func private %impl_trait_MemoryBytes__word_at(v0.objref<@layout_0>, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -1315,66 +1055,7 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_
         return v8;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_6c3a(v0.@layout_3, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_8d2c(v0.objref<@layout_0>, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.objref<i256> = obj.proj v0 0.i256;
-        v5.i256 = obj.load v4;
-        v7.i256 = add v5 v1;
-        v8.i256 = mload v7 i256;
-        return v8;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_ef3a(v0.@layout_3, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_ef3a_0(v0.@layout_3, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v6.i256 = add v4 v1;
-        v7.i256 = evm_calldata_load v6;
-        return v7;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_dd9c(v0.objref<@layout_0>, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v4.objref<i256> = obj.proj v0 1.i256;
-        v5.i256 = obj.load v4;
-        mstore v5 v1 i256;
-        v9.i256 = add v5 32.i256;
-        v10.objref<i256> = obj.proj v0 1.i256;
-        obj.store v10 v9;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_e5d7(v0.objref<@layout_0>, v1.i256) {
+func private %write_word(v0.objref<@layout_0>, v1.i256) {
     block0:
         jump block1;
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/immutable_contract_field_init_set.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/immutable_contract_field_init_set.snap
@@ -1,22 +1,18 @@
 ---
 source: crates/codegen/tests/sonatina_ir.rs
-assertion_line: 449
 expression: output
 input_file: crates/codegen/tests/fixtures/immutable_contract_field_init_set.fe
 ---
 target = "evm-ethereum-osaka"
 
 type @layout_0 = {i256, i256};
-type @layout_1 = {i256, i256};
+type @layout_1 = {@layout_0, i256};
 type @layout_2 = {@layout_1, i256};
-type @layout_3 = {@layout_2, i256};
-type @layout_4 = {i256};
-type @layout_5 = {i256};
-type @layout_6 = {};
-type @layout_7 = {@layout_6};
-type @layout_8 = {i256, i256};
+type @layout_3 = {i256};
+type @layout_4 = {};
+type @layout_5 = {@layout_4};
 
-global private const @layout_4 $const_region_0 = {0};
+global private const @layout_3 $const_region_0 = {0};
 
 func private %__ImmutableContractFieldInitSet_init(v0.i256, v1.objref<i256>) {
     block0:
@@ -104,7 +100,7 @@ func private %impl_trait_SolEncoder__base(v0.objref<@layout_0>) -> i256 {
         return v4;
 }
 
-func private %base__g463e(v0.objref<@layout_3>) -> i256 {
+func private %base__g463e(v0.objref<@layout_2>) -> i256 {
     block0:
         jump block1;
 
@@ -116,8 +112,8 @@ func private %base__g463e(v0.objref<@layout_3>) -> i256 {
 
 func inline(always) private %contract_init_abi_ImmutableContractFieldInitSet() {
     block0:
-        v0.objref<@layout_1> = obj.alloc @layout_1;
-        v1.objref<@layout_3> = obj.alloc @layout_3;
+        v0.objref<@layout_0> = obj.alloc @layout_0;
+        v1.objref<@layout_2> = obj.alloc @layout_2;
         jump block1;
 
     block1:
@@ -155,12 +151,12 @@ func inline(always) private %contract_init_abi_ImmutableContractFieldInitSet() {
         obj.store v23 v20;
         v25.objref<i256> = obj.proj v0 1.i256;
         obj.store v25 v13;
-        v26.@layout_1 = obj.load v0;
-        v27.@layout_3 = call %decoder_new v26;
-        v28.objref<@layout_2> = obj.proj v1 0.i256;
-        v29.@layout_2 = extract_value v27 0.i256;
-        v30.objref<@layout_1> = obj.proj v28 0.i256;
-        v31.@layout_1 = extract_value v29 0.i256;
+        v26.@layout_0 = obj.load v0;
+        v27.@layout_2 = call %decoder_new v26;
+        v28.objref<@layout_1> = obj.proj v1 0.i256;
+        v29.@layout_1 = extract_value v27 0.i256;
+        v30.objref<@layout_0> = obj.proj v28 0.i256;
+        v31.@layout_0 = extract_value v29 0.i256;
         v32.objref<i256> = obj.proj v30 0.i256;
         v33.i256 = extract_value v31 0.i256;
         obj.store v32 v33;
@@ -173,7 +169,7 @@ func inline(always) private %contract_init_abi_ImmutableContractFieldInitSet() {
         v38.objref<i256> = obj.proj v1 1.i256;
         v39.i256 = extract_value v27 1.i256;
         obj.store v38 v39;
-        v40.@layout_5 = call %decode_payload__g3854 v1;
+        v40.@layout_3 = call %decode_payload__g3854 v1;
         v41.i256 = extract_value v40 0.i256;
         v43.*i8 = evm_malloc 32.i256;
         v44.i256 = ptr_to_int v43 i256;
@@ -236,12 +232,12 @@ func inline(always) private %contract_recv_abi_ImmutableContractFieldInitSet_1()
         evm_revert 0.i256 0.i256;
 
     block3:
-        v5.objref<@layout_7> = obj.alloc @layout_7;
+        v5.objref<@layout_5> = obj.alloc @layout_5;
         call %decode_runtime_args v5;
         v7.i256 = evm_code_size;
         v9.i256 = add v7 -32.i256;
         v10.i256 = call %__ImmutableContractFieldInitSet_recv_0_0 v9;
-        v11.@layout_8 = call %encode_single_root_alloc v10;
+        v11.@layout_0 = call %encode_single_root_alloc v10;
         v12.i256 = extract_value v11 0.i256;
         v14.i256 = extract_value v11 1.i256;
         evm_return v12 v14;
@@ -270,7 +266,7 @@ func private %contract_runtime_root_ImmutableContractFieldInitSet() {
         unreachable;
 }
 
-func inline(always) private %decode_field(v0.objref<@layout_3>) -> i256 {
+func inline(always) private %decode_field(v0.objref<@layout_2>) -> i256 {
     block0:
         jump block1;
 
@@ -278,7 +274,7 @@ func inline(always) private %decode_field(v0.objref<@layout_3>) -> i256 {
         br 0.i1 block2 block3;
 
     block2:
-        v3.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_f8bc v0;
+        v3.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_a1a4 v0;
         v4.i256 = call %base__g463e v0;
         v5.i256 = call %pos__g463e v0;
         (v6.i256, v7.i1) = uaddo v4 v3;
@@ -306,7 +302,7 @@ func inline(always) private %decode_field(v0.objref<@layout_3>) -> i256 {
         return v17;
 }
 
-func inline(always) private %decode_from(v0.@layout_4, v1.i256) {
+func inline(always) private %decode_from(v0.@layout_3, v1.i256) {
     block0:
         jump block1;
 
@@ -314,7 +310,7 @@ func inline(always) private %decode_from(v0.@layout_4, v1.i256) {
         return;
 }
 
-func inline(always) private %decode_from_prechecked_head(v0.@layout_4, v1.i256, v2.i256) {
+func inline(always) private %decode_from_prechecked_head(v0.@layout_3, v1.i256, v2.i256) {
     block0:
         jump block1;
 
@@ -323,33 +319,33 @@ func inline(always) private %decode_from_prechecked_head(v0.@layout_4, v1.i256, 
         return;
 }
 
-func private %decode_payload__g3854(v0.objref<@layout_3>) -> @layout_5 {
+func inline(always) private %decode_payload__g407e(v0.objref<@layout_2>) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v2.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_4465 v0;
+        return v2;
+}
+
+func private %decode_payload__g3854(v0.objref<@layout_2>) -> @layout_3 {
     block0:
         jump block1;
 
     block1:
         v2.i256 = call %decode_field v0;
-        v5.@layout_5 = insert_value undef.@layout_5 0.i256 v2;
+        v5.@layout_3 = insert_value undef.@layout_3 0.i256 v2;
         return v5;
 }
 
-func inline(always) private %decode_payload__g407e(v0.objref<@layout_3>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_9e55 v0;
-        return v2;
-}
-
-func inline(always) private %decode_runtime_args(v0.objref<@layout_7>) {
+func inline(always) private %decode_runtime_args(v0.objref<@layout_5>) {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.@layout_4 = call %input;
+        v3.@layout_3 = call %input;
         v5.i256 = call %impl_trait_CallData__len v3;
         mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
@@ -372,12 +368,12 @@ func inline(always) private %decode_runtime_args(v0.objref<@layout_7>) {
         br v15 block2 block3;
 }
 
-func private %decoder_new(v0.@layout_1) -> @layout_3 {
+func private %decoder_new(v0.@layout_0) -> @layout_2 {
     block0:
         jump block1;
 
     block1:
-        v2.@layout_3 = call %impl_SolDecoder__new__g463e v0;
+        v2.@layout_2 = call %impl_SolDecoder__new__g463e v0;
         return v2;
 }
 
@@ -386,7 +382,7 @@ func private %encode(v0.i256, v1.objref<@layout_0>) {
         jump block1;
 
     block1:
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_bfe9 v1 v0;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_7e37 v1 v0;
         return;
 }
 
@@ -402,7 +398,7 @@ func private %encode_field(v0.i256, v1.objref<@layout_0>, v2.i256) {
         v8.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_6b32 v0;
         v9.i256 = mload v2 i256;
         v10.i256 = sub v9 v5;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_8a32 v1 v10;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_738e v1 v10;
         v12.i256 = call %impl_trait_SolEncoder__pos v1;
         v13.i256 = mload v2 i256;
         call %impl_trait_SolEncoder__set_base v1 v13;
@@ -451,7 +447,7 @@ func private %encode_single_root(v0.i256, v1.objref<@layout_0>) {
         return;
 }
 
-func private %encode_single_root_alloc(v0.i256) -> @layout_8 {
+func private %encode_single_root_alloc(v0.i256) -> @layout_0 {
     block0:
         jump block1;
 
@@ -467,8 +463,8 @@ func private %encode_single_root_alloc(v0.i256) -> @layout_8 {
         obj.store v9 v10;
         v11.i256 = call %impl_trait_SolEncoder__base v4;
         call %encode_single_root v0 v4;
-        v14.@layout_8 = insert_value undef.@layout_8 0.i256 v11;
-        v15.@layout_8 = insert_value v14 1.i256 v2;
+        v14.@layout_0 = insert_value undef.@layout_0 0.i256 v11;
+        v15.@layout_0 = insert_value v14 1.i256 v2;
         return v15;
 }
 
@@ -490,16 +486,26 @@ func private %encoder_new(v0.i256) -> @layout_0 {
         return v2;
 }
 
-func private %input() -> @layout_4 {
+func private %input() -> @layout_3 {
     block0:
         jump block1;
 
     block1:
-        v0.@layout_4 = call %impl_CallData__new;
+        v0.@layout_3 = call %impl_CallData__new;
         return v0;
 }
 
-func inline(always) private %impl_trait_CallData__len(v0.@layout_4) -> i256 {
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_28a9(v0.objref<@layout_0>) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v3.objref<i256> = obj.proj v0 1.i256;
+        v4.i256 = obj.load v3;
+        return v4;
+}
+
+func inline(always) private %impl_trait_CallData__len(v0.@layout_3) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         jump block1;
@@ -533,7 +539,7 @@ func inline(always) private %impl_trait_CallData__len(v0.@layout_4) -> i256 {
         jump block4;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_e033(v0.objref<@layout_1>) -> i256 {
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_8127(v0.objref<@layout_0>) -> i256 {
     block0:
         jump block1;
 
@@ -543,46 +549,36 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_e033
         return v4;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_f424(v0.objref<@layout_1>) -> i256 {
+func inline(always) private %impl_SolDecoder__new__g463e(v0.@layout_0) -> @layout_2 {
     block0:
         jump block1;
 
     block1:
-        v3.objref<i256> = obj.proj v0 1.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
-func inline(always) private %impl_SolDecoder__new__g463e(v0.@layout_1) -> @layout_3 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.@layout_2 = call %impl_Cursor__new__g463e v0;
-        v5.@layout_3 = insert_value undef.@layout_3 0.i256 v2;
-        v7.@layout_3 = insert_value v5 1.i256 0.i256;
+        v2.@layout_1 = call %impl_Cursor__new__g463e v0;
+        v5.@layout_2 = insert_value undef.@layout_2 0.i256 v2;
+        v7.@layout_2 = insert_value v5 1.i256 0.i256;
         return v7;
 }
 
-func inline(always) private %impl_CallData__new() -> @layout_4 {
+func inline(always) private %impl_CallData__new() -> @layout_3 {
     block0:
         jump block1;
 
     block1:
-        v1.constref<@layout_4> = const.ref $const_region_0;
-        v2.objref<@layout_4> = obj.alloc @layout_4;
+        v1.constref<@layout_3> = const.ref $const_region_0;
+        v2.objref<@layout_3> = obj.alloc @layout_3;
         obj.init.const v2 v1;
-        v3.@layout_4 = obj.load v2;
+        v3.@layout_3 = obj.load v2;
         return v3;
 }
 
-func inline(always) private %impl_Cursor__new__g463e(v0.@layout_1) -> @layout_2 {
+func inline(always) private %impl_Cursor__new__g463e(v0.@layout_0) -> @layout_1 {
     block0:
         jump block1;
 
     block1:
-        v4.@layout_2 = insert_value undef.@layout_2 0.i256 v0;
-        v6.@layout_2 = insert_value v4 1.i256 0.i256;
+        v4.@layout_1 = insert_value undef.@layout_1 0.i256 v0;
+        v6.@layout_1 = insert_value v4 1.i256 0.i256;
         return v6;
 }
 
@@ -624,6 +620,17 @@ func private %core__lib__abi__trait_AbiSize__payload_size__ge513_6b32_0(v0.i256)
         return 32.i256;
 }
 
+func private %pos__g463e(v0.objref<@layout_2>) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v3.objref<@layout_1> = obj.proj v0 0.i256;
+        v5.objref<i256> = obj.proj v3 1.i256;
+        v6.i256 = obj.load v5;
+        return v6;
+}
+
 func private %impl_trait_SolEncoder__pos(v0.objref<@layout_0>) -> i256 {
     block0:
         jump block1;
@@ -634,30 +641,19 @@ func private %impl_trait_SolEncoder__pos(v0.objref<@layout_0>) -> i256 {
         return v4;
 }
 
-func private %pos__g463e(v0.objref<@layout_3>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<@layout_2> = obj.proj v0 0.i256;
-        v5.objref<i256> = obj.proj v3 1.i256;
-        v6.i256 = obj.load v5;
-        return v6;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_9e55(v0.objref<@layout_3>) -> i256 {
+func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_4465(v0.objref<@layout_2>) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v4.objref<@layout_2> = obj.proj v0 0.i256;
-        v5.objref<@layout_1> = obj.proj v4 0.i256;
-        v6.@layout_1 = obj.load v5;
-        v7.objref<@layout_2> = obj.proj v0 0.i256;
-        v8.objref<@layout_1> = obj.proj v7 0.i256;
-        v9.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_f424 v8;
-        v10.objref<@layout_2> = obj.proj v0 0.i256;
+        v4.objref<@layout_1> = obj.proj v0 0.i256;
+        v5.objref<@layout_0> = obj.proj v4 0.i256;
+        v6.@layout_0 = obj.load v5;
+        v7.objref<@layout_1> = obj.proj v0 0.i256;
+        v8.objref<@layout_0> = obj.proj v7 0.i256;
+        v9.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_8127 v8;
+        v10.objref<@layout_1> = obj.proj v0 0.i256;
         v12.objref<i256> = obj.proj v10 1.i256;
         v13.i256 = obj.load v12;
         (v15.i256, v16.i1) = uaddo v13 32.i256;
@@ -670,16 +666,16 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         jump block4;
 
     block4:
-        v27.objref<@layout_2> = obj.proj v0 0.i256;
-        v28.objref<@layout_1> = obj.proj v27 0.i256;
-        v29.@layout_1 = obj.load v28;
-        v30.objref<@layout_2> = obj.proj v0 0.i256;
+        v27.objref<@layout_1> = obj.proj v0 0.i256;
+        v28.objref<@layout_0> = obj.proj v27 0.i256;
+        v29.@layout_0 = obj.load v28;
+        v30.objref<@layout_1> = obj.proj v0 0.i256;
         v31.objref<i256> = obj.proj v30 1.i256;
         v32.i256 = obj.load v31;
-        v33.objref<@layout_2> = obj.proj v0 0.i256;
-        v34.objref<@layout_1> = obj.proj v33 0.i256;
-        v35.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_1e81 v34 v32;
-        v37.objref<@layout_2> = obj.proj v0 0.i256;
+        v33.objref<@layout_1> = obj.proj v0 0.i256;
+        v34.objref<@layout_0> = obj.proj v33 0.i256;
+        v35.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_d5f0 v34 v32;
+        v37.objref<@layout_1> = obj.proj v0 0.i256;
         v38.objref<i256> = obj.proj v37 1.i256;
         obj.store v38 v15;
         return v35;
@@ -696,26 +692,26 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         evm_revert 0.i256 36.i256;
 
     block7:
-        v22.objref<@layout_2> = obj.proj v0 0.i256;
+        v22.objref<@layout_1> = obj.proj v0 0.i256;
         v23.objref<i256> = obj.proj v22 1.i256;
         v24.i256 = obj.load v23;
         v25.i1 = lt v15 v24;
         br v25 block2 block5;
 }
 
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_f8bc(v0.objref<@layout_3>) -> i256 {
+func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_a1a4(v0.objref<@layout_2>) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v4.objref<@layout_2> = obj.proj v0 0.i256;
-        v5.objref<@layout_1> = obj.proj v4 0.i256;
-        v6.@layout_1 = obj.load v5;
-        v7.objref<@layout_2> = obj.proj v0 0.i256;
-        v8.objref<@layout_1> = obj.proj v7 0.i256;
-        v9.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_e033 v8;
-        v10.objref<@layout_2> = obj.proj v0 0.i256;
+        v4.objref<@layout_1> = obj.proj v0 0.i256;
+        v5.objref<@layout_0> = obj.proj v4 0.i256;
+        v6.@layout_0 = obj.load v5;
+        v7.objref<@layout_1> = obj.proj v0 0.i256;
+        v8.objref<@layout_0> = obj.proj v7 0.i256;
+        v9.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_28a9 v8;
+        v10.objref<@layout_1> = obj.proj v0 0.i256;
         v12.objref<i256> = obj.proj v10 1.i256;
         v13.i256 = obj.load v12;
         (v15.i256, v16.i1) = uaddo v13 32.i256;
@@ -728,16 +724,16 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         jump block4;
 
     block4:
-        v27.objref<@layout_2> = obj.proj v0 0.i256;
-        v28.objref<@layout_1> = obj.proj v27 0.i256;
-        v29.@layout_1 = obj.load v28;
-        v30.objref<@layout_2> = obj.proj v0 0.i256;
+        v27.objref<@layout_1> = obj.proj v0 0.i256;
+        v28.objref<@layout_0> = obj.proj v27 0.i256;
+        v29.@layout_0 = obj.load v28;
+        v30.objref<@layout_1> = obj.proj v0 0.i256;
         v31.objref<i256> = obj.proj v30 1.i256;
         v32.i256 = obj.load v31;
-        v33.objref<@layout_2> = obj.proj v0 0.i256;
-        v34.objref<@layout_1> = obj.proj v33 0.i256;
-        v35.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_9935 v34 v32;
-        v37.objref<@layout_2> = obj.proj v0 0.i256;
+        v33.objref<@layout_1> = obj.proj v0 0.i256;
+        v34.objref<@layout_0> = obj.proj v33 0.i256;
+        v35.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_b15d v34 v32;
+        v37.objref<@layout_1> = obj.proj v0 0.i256;
         v38.objref<i256> = obj.proj v37 1.i256;
         obj.store v38 v15;
         return v35;
@@ -754,7 +750,7 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         evm_revert 0.i256 36.i256;
 
     block7:
-        v22.objref<@layout_2> = obj.proj v0 0.i256;
+        v22.objref<@layout_1> = obj.proj v0 0.i256;
         v23.objref<i256> = obj.proj v22 1.i256;
         v24.i256 = obj.load v23;
         v25.i1 = lt v15 v24;
@@ -769,6 +765,16 @@ func private %revert(v0.i256, v1.i256) {
         evm_revert v0 v1;
 }
 
+func private %set_base__g463e(v0.objref<@layout_2>, v1.i256) {
+    block0:
+        jump block1;
+
+    block1:
+        v5.objref<i256> = obj.proj v0 1.i256;
+        obj.store v5 v1;
+        return;
+}
+
 func private %impl_trait_SolEncoder__set_base(v0.objref<@layout_0>, v1.i256) {
     block0:
         jump block1;
@@ -779,13 +785,14 @@ func private %impl_trait_SolEncoder__set_base(v0.objref<@layout_0>, v1.i256) {
         return;
 }
 
-func private %set_base__g463e(v0.objref<@layout_3>, v1.i256) {
+func private %set_pos__g463e(v0.objref<@layout_2>, v1.i256) {
     block0:
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 1.i256;
-        obj.store v5 v1;
+        v5.objref<@layout_1> = obj.proj v0 0.i256;
+        v7.objref<i256> = obj.proj v5 1.i256;
+        obj.store v7 v1;
         return;
 }
 
@@ -799,17 +806,6 @@ func private %impl_trait_SolEncoder__set_pos(v0.objref<@layout_0>, v1.i256) {
         return;
 }
 
-func private %set_pos__g463e(v0.objref<@layout_3>, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v5.objref<@layout_2> = obj.proj v0 0.i256;
-        v7.objref<i256> = obj.proj v5 1.i256;
-        obj.store v7 v1;
-        return;
-}
-
 func private %store_word(v0.i256, v1.i256) {
     block0:
         jump block1;
@@ -819,7 +815,7 @@ func private %store_word(v0.i256, v1.i256) {
         return;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_1e81(v0.objref<@layout_1>, v1.i256) -> i256 {
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_b15d(v0.objref<@layout_0>, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -831,7 +827,7 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_
         return v8;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_9935(v0.objref<@layout_1>, v1.i256) -> i256 {
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_d5f0(v0.objref<@layout_0>, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -843,7 +839,7 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_
         return v8;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_8a32(v0.objref<@layout_0>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_738e(v0.objref<@layout_0>, v1.i256) {
     block0:
         jump block1;
 
@@ -857,7 +853,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_8a32(v0
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_bfe9(v0.objref<@layout_0>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_7e37(v0.objref<@layout_0>, v1.i256) {
     block0:
         jump block1;
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/immutable_contract_field_init_set.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/immutable_contract_field_init_set.snap
@@ -40,7 +40,7 @@ func private %abi_field_size(v0.i256) -> i256 {
         jump block1;
 
     block1:
-        v2.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_6b32_0 v0;
+        v2.i256 = call %payload_size v0;
         br 0.i1 block2 block3;
 
     block2:
@@ -90,22 +90,22 @@ func inline(always) private %at(v0.i256) -> @layout_0 {
         return v6;
 }
 
-func private %impl_trait_SolEncoder__base(v0.objref<@layout_0>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 0.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
 func private %base__g463e(v0.objref<@layout_2>) -> i256 {
     block0:
         jump block1;
 
     block1:
         v3.objref<i256> = obj.proj v0 1.i256;
+        v4.i256 = obj.load v3;
+        return v4;
+}
+
+func private %impl_trait_SolEncoder__base(v0.objref<@layout_0>) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v3.objref<i256> = obj.proj v0 0.i256;
         v4.i256 = obj.load v3;
         return v4;
 }
@@ -274,7 +274,7 @@ func inline(always) private %decode_field(v0.objref<@layout_2>) -> i256 {
         br 0.i1 block2 block3;
 
     block2:
-        v3.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_a1a4 v0;
+        v3.i256 = call %read_word v0;
         v4.i256 = call %base__g463e v0;
         v5.i256 = call %pos__g463e v0;
         (v6.i256, v7.i1) = uaddo v4 v3;
@@ -319,15 +319,6 @@ func inline(always) private %decode_from_prechecked_head(v0.@layout_3, v1.i256, 
         return;
 }
 
-func inline(always) private %decode_payload__g407e(v0.objref<@layout_2>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_4465 v0;
-        return v2;
-}
-
 func private %decode_payload__g3854(v0.objref<@layout_2>) -> @layout_3 {
     block0:
         jump block1;
@@ -336,6 +327,15 @@ func private %decode_payload__g3854(v0.objref<@layout_2>) -> @layout_3 {
         v2.i256 = call %decode_field v0;
         v5.@layout_3 = insert_value undef.@layout_3 0.i256 v2;
         return v5;
+}
+
+func inline(always) private %decode_payload__g407e(v0.objref<@layout_2>) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v2.i256 = call %read_word v0;
+        return v2;
 }
 
 func inline(always) private %decode_runtime_args(v0.objref<@layout_5>) {
@@ -382,7 +382,7 @@ func private %encode(v0.i256, v1.objref<@layout_0>) {
         jump block1;
 
     block1:
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_7e37 v1 v0;
+        call %write_word v1 v0;
         return;
 }
 
@@ -395,10 +395,10 @@ func private %encode_field(v0.i256, v1.objref<@layout_0>, v2.i256) {
 
     block2:
         v5.i256 = call %impl_trait_SolEncoder__base v1;
-        v8.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_6b32 v0;
+        v8.i256 = call %payload_size v0;
         v9.i256 = mload v2 i256;
         v10.i256 = sub v9 v5;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_738e v1 v10;
+        call %write_word v1 v10;
         v12.i256 = call %impl_trait_SolEncoder__pos v1;
         v13.i256 = mload v2 i256;
         call %impl_trait_SolEncoder__set_base v1 v13;
@@ -495,7 +495,7 @@ func private %input() -> @layout_3 {
         return v0;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_28a9(v0.objref<@layout_0>) -> i256 {
+func private %impl_trait_MemoryBytes__len(v0.objref<@layout_0>) -> i256 {
     block0:
         jump block1;
 
@@ -539,16 +539,6 @@ func inline(always) private %impl_trait_CallData__len(v0.@layout_3) -> i256 {
         jump block4;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_8127(v0.objref<@layout_0>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 1.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
 func inline(always) private %impl_SolDecoder__new__g463e(v0.@layout_0) -> @layout_2 {
     block0:
         jump block1;
@@ -558,28 +548,6 @@ func inline(always) private %impl_SolDecoder__new__g463e(v0.@layout_0) -> @layou
         v5.@layout_2 = insert_value undef.@layout_2 0.i256 v2;
         v7.@layout_2 = insert_value v5 1.i256 0.i256;
         return v7;
-}
-
-func inline(always) private %impl_CallData__new() -> @layout_3 {
-    block0:
-        jump block1;
-
-    block1:
-        v1.constref<@layout_3> = const.ref $const_region_0;
-        v2.objref<@layout_3> = obj.alloc @layout_3;
-        obj.init.const v2 v1;
-        v3.@layout_3 = obj.load v2;
-        return v3;
-}
-
-func inline(always) private %impl_Cursor__new__g463e(v0.@layout_0) -> @layout_1 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.@layout_1 = insert_value undef.@layout_1 0.i256 v0;
-        v6.@layout_1 = insert_value v4 1.i256 0.i256;
-        return v6;
 }
 
 func private %impl_SolEncoder__new(v0.i256) -> @layout_0 {
@@ -604,15 +572,29 @@ func private %impl_SolEncoder__new(v0.i256) -> @layout_0 {
         return v8;
 }
 
-func private %core__lib__abi__trait_AbiSize__payload_size__ge513_6b32(v0.i256) -> i256 {
+func inline(always) private %impl_CallData__new() -> @layout_3 {
     block0:
         jump block1;
 
     block1:
-        return 32.i256;
+        v1.constref<@layout_3> = const.ref $const_region_0;
+        v2.objref<@layout_3> = obj.alloc @layout_3;
+        obj.init.const v2 v1;
+        v3.@layout_3 = obj.load v2;
+        return v3;
 }
 
-func private %core__lib__abi__trait_AbiSize__payload_size__ge513_6b32_0(v0.i256) -> i256 {
+func inline(always) private %impl_Cursor__new__g463e(v0.@layout_0) -> @layout_1 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.@layout_1 = insert_value undef.@layout_1 0.i256 v0;
+        v6.@layout_1 = insert_value v4 1.i256 0.i256;
+        return v6;
+}
+
+func private %payload_size(v0.i256) -> i256 {
     block0:
         jump block1;
 
@@ -641,7 +623,7 @@ func private %impl_trait_SolEncoder__pos(v0.objref<@layout_0>) -> i256 {
         return v4;
 }
 
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_4465(v0.objref<@layout_2>) -> i256 {
+func inline(always) private %read_word(v0.objref<@layout_2>) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         jump block1;
@@ -652,7 +634,7 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         v6.@layout_0 = obj.load v5;
         v7.objref<@layout_1> = obj.proj v0 0.i256;
         v8.objref<@layout_0> = obj.proj v7 0.i256;
-        v9.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_8127 v8;
+        v9.i256 = call %impl_trait_MemoryBytes__len v8;
         v10.objref<@layout_1> = obj.proj v0 0.i256;
         v12.objref<i256> = obj.proj v10 1.i256;
         v13.i256 = obj.load v12;
@@ -674,65 +656,7 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         v32.i256 = obj.load v31;
         v33.objref<@layout_1> = obj.proj v0 0.i256;
         v34.objref<@layout_0> = obj.proj v33 0.i256;
-        v35.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_d5f0 v34 v32;
-        v37.objref<@layout_1> = obj.proj v0 0.i256;
-        v38.objref<i256> = obj.proj v37 1.i256;
-        obj.store v38 v15;
-        return v35;
-
-    block5:
-        mstore v1 v9 i256;
-        v41.i256 = mload v1 i256;
-        v42.i1 = gt v15 v41;
-        br v42 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v22.objref<@layout_1> = obj.proj v0 0.i256;
-        v23.objref<i256> = obj.proj v22 1.i256;
-        v24.i256 = obj.load v23;
-        v25.i1 = lt v15 v24;
-        br v25 block2 block5;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_a1a4(v0.objref<@layout_2>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v4.objref<@layout_1> = obj.proj v0 0.i256;
-        v5.objref<@layout_0> = obj.proj v4 0.i256;
-        v6.@layout_0 = obj.load v5;
-        v7.objref<@layout_1> = obj.proj v0 0.i256;
-        v8.objref<@layout_0> = obj.proj v7 0.i256;
-        v9.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_28a9 v8;
-        v10.objref<@layout_1> = obj.proj v0 0.i256;
-        v12.objref<i256> = obj.proj v10 1.i256;
-        v13.i256 = obj.load v12;
-        (v15.i256, v16.i1) = uaddo v13 32.i256;
-        br v16 block6 block7;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v27.objref<@layout_1> = obj.proj v0 0.i256;
-        v28.objref<@layout_0> = obj.proj v27 0.i256;
-        v29.@layout_0 = obj.load v28;
-        v30.objref<@layout_1> = obj.proj v0 0.i256;
-        v31.objref<i256> = obj.proj v30 1.i256;
-        v32.i256 = obj.load v31;
-        v33.objref<@layout_1> = obj.proj v0 0.i256;
-        v34.objref<@layout_0> = obj.proj v33 0.i256;
-        v35.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_b15d v34 v32;
+        v35.i256 = call %word_at v34 v32;
         v37.objref<@layout_1> = obj.proj v0 0.i256;
         v38.objref<i256> = obj.proj v37 1.i256;
         obj.store v38 v15;
@@ -765,6 +689,16 @@ func private %revert(v0.i256, v1.i256) {
         evm_revert v0 v1;
 }
 
+func private %impl_trait_SolEncoder__set_base(v0.objref<@layout_0>, v1.i256) {
+    block0:
+        jump block1;
+
+    block1:
+        v5.objref<i256> = obj.proj v0 0.i256;
+        obj.store v5 v1;
+        return;
+}
+
 func private %set_base__g463e(v0.objref<@layout_2>, v1.i256) {
     block0:
         jump block1;
@@ -775,12 +709,12 @@ func private %set_base__g463e(v0.objref<@layout_2>, v1.i256) {
         return;
 }
 
-func private %impl_trait_SolEncoder__set_base(v0.objref<@layout_0>, v1.i256) {
+func private %impl_trait_SolEncoder__set_pos(v0.objref<@layout_0>, v1.i256) {
     block0:
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
+        v5.objref<i256> = obj.proj v0 1.i256;
         obj.store v5 v1;
         return;
 }
@@ -796,16 +730,6 @@ func private %set_pos__g463e(v0.objref<@layout_2>, v1.i256) {
         return;
 }
 
-func private %impl_trait_SolEncoder__set_pos(v0.objref<@layout_0>, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v5.objref<i256> = obj.proj v0 1.i256;
-        obj.store v5 v1;
-        return;
-}
-
 func private %store_word(v0.i256, v1.i256) {
     block0:
         jump block1;
@@ -815,7 +739,7 @@ func private %store_word(v0.i256, v1.i256) {
         return;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_b15d(v0.objref<@layout_0>, v1.i256) -> i256 {
+func private %word_at(v0.objref<@layout_0>, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -827,33 +751,7 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_
         return v8;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_d5f0(v0.objref<@layout_0>, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.objref<i256> = obj.proj v0 0.i256;
-        v5.i256 = obj.load v4;
-        v7.i256 = add v5 v1;
-        v8.i256 = mload v7 i256;
-        return v8;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_738e(v0.objref<@layout_0>, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v4.objref<i256> = obj.proj v0 1.i256;
-        v5.i256 = obj.load v4;
-        mstore v5 v1 i256;
-        v9.i256 = add v5 32.i256;
-        v10.objref<i256> = obj.proj v0 1.i256;
-        obj.store v10 v9;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_7e37(v0.objref<@layout_0>, v1.i256) {
+func private %write_word(v0.objref<@layout_0>, v1.i256) {
     block0:
         jump block1;
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/init_args_with_child_dep.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/init_args_with_child_dep.snap
@@ -48,27 +48,7 @@ func inline(always) private %at(v0.i256) -> @layout_0 {
         return v6;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_1e01(v0.objref<@layout_0>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 0.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_558b(v0.objref<@layout_0>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 0.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_ce73(v0.objref<@layout_2>) -> i256 {
+func private %base__g463e(v0.objref<@layout_2>) -> i256 {
     block0:
         jump block1;
 
@@ -78,12 +58,12 @@ func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_ce73(v
         return v4;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_fb1b(v0.objref<@layout_2>) -> i256 {
+func private %impl_trait_SolEncoder__base(v0.objref<@layout_0>) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v3.objref<i256> = obj.proj v0 1.i256;
+        v3.objref<i256> = obj.proj v0 0.i256;
         v4.i256 = obj.load v3;
         return v4;
 }
@@ -413,9 +393,9 @@ func inline(always) private %core__lib__abi__decode_field__g3854_3e1e(v0.objref<
         br 0.i1 block2 block3;
 
     block2:
-        v3.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_bc00 v0;
-        v4.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_ce73 v0;
-        v5.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g463e_5cb2 v0;
+        v3.i256 = call %read_word v0;
+        v4.i256 = call %base__g463e v0;
+        v5.i256 = call %pos v0;
         (v6.i256, v7.i1) = uaddo v4 v3;
         br v7 block5 block6;
 
@@ -423,7 +403,7 @@ func inline(always) private %core__lib__abi__decode_field__g3854_3e1e(v0.objref<
         jump block4;
 
     block4:
-        v23.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_payload__g407e_78fe v0;
+        v23.i256 = call %decode_payload__g407e v0;
         return v23;
 
     block5:
@@ -432,12 +412,12 @@ func inline(always) private %core__lib__abi__decode_field__g3854_3e1e(v0.objref<
         evm_revert 0.i256 36.i256;
 
     block6:
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_f899 v0 v6;
-        v15.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_ce73 v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_424a v0 v15;
-        v17.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_payload__g407e_78fe v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_f899 v0 v4;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_424a v0 v5;
+        call %set_base__g463e v0 v6;
+        v15.i256 = call %base__g463e v0;
+        call %set_pos__g463e v0 v15;
+        v17.i256 = call %decode_payload__g407e v0;
+        call %set_base__g463e v0 v4;
+        call %set_pos__g463e v0 v5;
         return v17;
 }
 
@@ -449,9 +429,9 @@ func inline(always) private %core__lib__abi__decode_field__g3854_c153(v0.objref<
         br 0.i1 block2 block3;
 
     block2:
-        v3.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_5955 v0;
-        v4.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_fb1b v0;
-        v5.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g463e_78fa v0;
+        v3.i256 = call %read_word v0;
+        v4.i256 = call %base__g463e v0;
+        v5.i256 = call %pos v0;
         (v6.i256, v7.i1) = uaddo v4 v3;
         br v7 block5 block6;
 
@@ -459,7 +439,7 @@ func inline(always) private %core__lib__abi__decode_field__g3854_c153(v0.objref<
         jump block4;
 
     block4:
-        v23.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_payload__g407e_d426 v0;
+        v23.i256 = call %decode_payload__g407e v0;
         return v23;
 
     block5:
@@ -468,12 +448,12 @@ func inline(always) private %core__lib__abi__decode_field__g3854_c153(v0.objref<
         evm_revert 0.i256 36.i256;
 
     block6:
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_37e4 v0 v6;
-        v15.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_fb1b v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_d16c v0 v15;
-        v17.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_payload__g407e_d426 v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_37e4 v0 v4;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_d16c v0 v5;
+        call %set_base__g463e v0 v6;
+        v15.i256 = call %base__g463e v0;
+        call %set_pos__g463e v0 v15;
+        v17.i256 = call %decode_payload__g407e v0;
+        call %set_base__g463e v0 v4;
+        call %set_pos__g463e v0 v5;
         return v17;
 }
 
@@ -487,21 +467,12 @@ func private %decode_payload__g3854(v0.objref<@layout_2>) -> @layout_3 {
         return v5;
 }
 
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_payload__g407e_78fe(v0.objref<@layout_2>) -> i256 {
+func inline(always) private %decode_payload__g407e(v0.objref<@layout_2>) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v2.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_4b2c v0;
-        return v2;
-}
-
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_payload__g407e_d426(v0.objref<@layout_2>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_2dec v0;
+        v2.i256 = call %read_word v0;
         return v2;
 }
 
@@ -543,7 +514,7 @@ func private %dynamic_payload_size(v0.i256) -> i256 {
         br 0.i1 block2 block3;
 
     block2:
-        v3.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_e959 v0;
+        v3.i256 = call %payload_size__ge513 v0;
         return v3;
 
     block3:
@@ -559,7 +530,7 @@ func inline(always) private %encode__g7769(v0.@layout_0, v1.objref<@layout_0>) {
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_1e01 v1;
+        v4.i256 = call %impl_trait_SolEncoder__base v1;
         v6.i256 = add v4 64.i256;
         mstore v2 v6 i256;
         v8.i256 = add v4 32.i256;
@@ -597,7 +568,7 @@ func inline(always) private %encode_alloc(v0.@layout_0) -> @layout_0 {
         v9.objref<i256> = obj.proj v4 1.i256;
         v10.i256 = extract_value v3 1.i256;
         obj.store v9 v10;
-        v11.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_558b v4;
+        v11.i256 = call %impl_trait_SolEncoder__base v4;
         call %encode__g7769 v0 v4;
         v14.@layout_0 = insert_value undef.@layout_0 0.i256 v11;
         v15.@layout_0 = insert_value v14 1.i256 v2;
@@ -621,7 +592,7 @@ func inline(always) private %encode_field_at(v0.i256, v1.objref<@layout_0>, v2.i
         br 0.i1 block2 block3;
 
     block2:
-        v8.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_fde5 v0;
+        v8.i256 = call %payload_size__ge513 v0;
         v11.i256 = mload v4 i256;
         v12.i256 = sub v11 v2;
         call %write_word_at v1 v3 v12;
@@ -673,37 +644,7 @@ func private %encoder_new(v0.i256) -> @layout_0 {
         return v2;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_528e(v0.objref<@layout_0>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 1.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_82aa(v0.objref<@layout_0>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 1.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_8b08(v0.objref<@layout_0>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 1.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_945c(v0.objref<@layout_0>) -> i256 {
+func private %len(v0.objref<@layout_0>) -> i256 {
     block0:
         jump block1;
 
@@ -777,6 +718,14 @@ func inline(always) private %std__lib__abi__sol__impl_SolDecoder_113c__new__g463
         return v7;
 }
 
+func private %payload_size__ge513(v0.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        return 32.i256;
+}
+
 func inline(always) private %payload_size__gbd8e(v0.@layout_0) -> i256 {
     block0:
         jump block1;
@@ -791,23 +740,7 @@ func inline(always) private %payload_size__gbd8e(v0.@layout_0) -> i256 {
         return v10;
 }
 
-func private %core__lib__abi__trait_AbiSize__payload_size__ge513_e959(v0.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        return 32.i256;
-}
-
-func private %core__lib__abi__trait_AbiSize__payload_size__ge513_fde5(v0.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        return 32.i256;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g463e_5cb2(v0.objref<@layout_2>) -> i256 {
+func private %pos(v0.objref<@layout_2>) -> i256 {
     block0:
         jump block1;
 
@@ -818,18 +751,7 @@ func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g463e_5cb2(v0
         return v6;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g463e_78fa(v0.objref<@layout_2>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<@layout_1> = obj.proj v0 0.i256;
-        v5.objref<i256> = obj.proj v3 1.i256;
-        v6.i256 = obj.load v5;
-        return v6;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_2dec(v0.objref<@layout_2>) -> i256 {
+func inline(always) private %read_word(v0.objref<@layout_2>) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         jump block1;
@@ -840,7 +762,7 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         v6.@layout_0 = obj.load v5;
         v7.objref<@layout_1> = obj.proj v0 0.i256;
         v8.objref<@layout_0> = obj.proj v7 0.i256;
-        v9.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_528e v8;
+        v9.i256 = call %len v8;
         v10.objref<@layout_1> = obj.proj v0 0.i256;
         v12.objref<i256> = obj.proj v10 1.i256;
         v13.i256 = obj.load v12;
@@ -862,7 +784,7 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         v32.i256 = obj.load v31;
         v33.objref<@layout_1> = obj.proj v0 0.i256;
         v34.objref<@layout_0> = obj.proj v33 0.i256;
-        v35.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_9f26 v34 v32;
+        v35.i256 = call %word_at v34 v32;
         v37.objref<@layout_1> = obj.proj v0 0.i256;
         v38.objref<i256> = obj.proj v37 1.i256;
         obj.store v38 v15;
@@ -885,190 +807,6 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         v24.i256 = obj.load v23;
         v25.i1 = lt v15 v24;
         br v25 block2 block5;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_4b2c(v0.objref<@layout_2>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v4.objref<@layout_1> = obj.proj v0 0.i256;
-        v5.objref<@layout_0> = obj.proj v4 0.i256;
-        v6.@layout_0 = obj.load v5;
-        v7.objref<@layout_1> = obj.proj v0 0.i256;
-        v8.objref<@layout_0> = obj.proj v7 0.i256;
-        v9.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_945c v8;
-        v10.objref<@layout_1> = obj.proj v0 0.i256;
-        v12.objref<i256> = obj.proj v10 1.i256;
-        v13.i256 = obj.load v12;
-        (v15.i256, v16.i1) = uaddo v13 32.i256;
-        br v16 block6 block7;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v27.objref<@layout_1> = obj.proj v0 0.i256;
-        v28.objref<@layout_0> = obj.proj v27 0.i256;
-        v29.@layout_0 = obj.load v28;
-        v30.objref<@layout_1> = obj.proj v0 0.i256;
-        v31.objref<i256> = obj.proj v30 1.i256;
-        v32.i256 = obj.load v31;
-        v33.objref<@layout_1> = obj.proj v0 0.i256;
-        v34.objref<@layout_0> = obj.proj v33 0.i256;
-        v35.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_5951 v34 v32;
-        v37.objref<@layout_1> = obj.proj v0 0.i256;
-        v38.objref<i256> = obj.proj v37 1.i256;
-        obj.store v38 v15;
-        return v35;
-
-    block5:
-        mstore v1 v9 i256;
-        v41.i256 = mload v1 i256;
-        v42.i1 = gt v15 v41;
-        br v42 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v22.objref<@layout_1> = obj.proj v0 0.i256;
-        v23.objref<i256> = obj.proj v22 1.i256;
-        v24.i256 = obj.load v23;
-        v25.i1 = lt v15 v24;
-        br v25 block2 block5;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_5955(v0.objref<@layout_2>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v4.objref<@layout_1> = obj.proj v0 0.i256;
-        v5.objref<@layout_0> = obj.proj v4 0.i256;
-        v6.@layout_0 = obj.load v5;
-        v7.objref<@layout_1> = obj.proj v0 0.i256;
-        v8.objref<@layout_0> = obj.proj v7 0.i256;
-        v9.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_82aa v8;
-        v10.objref<@layout_1> = obj.proj v0 0.i256;
-        v12.objref<i256> = obj.proj v10 1.i256;
-        v13.i256 = obj.load v12;
-        (v15.i256, v16.i1) = uaddo v13 32.i256;
-        br v16 block6 block7;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v27.objref<@layout_1> = obj.proj v0 0.i256;
-        v28.objref<@layout_0> = obj.proj v27 0.i256;
-        v29.@layout_0 = obj.load v28;
-        v30.objref<@layout_1> = obj.proj v0 0.i256;
-        v31.objref<i256> = obj.proj v30 1.i256;
-        v32.i256 = obj.load v31;
-        v33.objref<@layout_1> = obj.proj v0 0.i256;
-        v34.objref<@layout_0> = obj.proj v33 0.i256;
-        v35.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_778c v34 v32;
-        v37.objref<@layout_1> = obj.proj v0 0.i256;
-        v38.objref<i256> = obj.proj v37 1.i256;
-        obj.store v38 v15;
-        return v35;
-
-    block5:
-        mstore v1 v9 i256;
-        v41.i256 = mload v1 i256;
-        v42.i1 = gt v15 v41;
-        br v42 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v22.objref<@layout_1> = obj.proj v0 0.i256;
-        v23.objref<i256> = obj.proj v22 1.i256;
-        v24.i256 = obj.load v23;
-        v25.i1 = lt v15 v24;
-        br v25 block2 block5;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_bc00(v0.objref<@layout_2>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v4.objref<@layout_1> = obj.proj v0 0.i256;
-        v5.objref<@layout_0> = obj.proj v4 0.i256;
-        v6.@layout_0 = obj.load v5;
-        v7.objref<@layout_1> = obj.proj v0 0.i256;
-        v8.objref<@layout_0> = obj.proj v7 0.i256;
-        v9.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_8b08 v8;
-        v10.objref<@layout_1> = obj.proj v0 0.i256;
-        v12.objref<i256> = obj.proj v10 1.i256;
-        v13.i256 = obj.load v12;
-        (v15.i256, v16.i1) = uaddo v13 32.i256;
-        br v16 block6 block7;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v27.objref<@layout_1> = obj.proj v0 0.i256;
-        v28.objref<@layout_0> = obj.proj v27 0.i256;
-        v29.@layout_0 = obj.load v28;
-        v30.objref<@layout_1> = obj.proj v0 0.i256;
-        v31.objref<i256> = obj.proj v30 1.i256;
-        v32.i256 = obj.load v31;
-        v33.objref<@layout_1> = obj.proj v0 0.i256;
-        v34.objref<@layout_0> = obj.proj v33 0.i256;
-        v35.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_c21f v34 v32;
-        v37.objref<@layout_1> = obj.proj v0 0.i256;
-        v38.objref<i256> = obj.proj v37 1.i256;
-        obj.store v38 v15;
-        return v35;
-
-    block5:
-        mstore v1 v9 i256;
-        v41.i256 = mload v1 i256;
-        v42.i1 = gt v15 v41;
-        br v42 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v22.objref<@layout_1> = obj.proj v0 0.i256;
-        v23.objref<i256> = obj.proj v22 1.i256;
-        v24.i256 = obj.load v23;
-        v25.i1 = lt v15 v24;
-        br v25 block2 block5;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_37e4(v0.objref<@layout_2>, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v5.objref<i256> = obj.proj v0 1.i256;
-        obj.store v5 v1;
-        return;
 }
 
 func private %impl_trait_SolEncoder__set_base(v0.objref<@layout_0>, v1.i256) {
@@ -1081,24 +819,13 @@ func private %impl_trait_SolEncoder__set_base(v0.objref<@layout_0>, v1.i256) {
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_f899(v0.objref<@layout_2>, v1.i256) {
+func private %set_base__g463e(v0.objref<@layout_2>, v1.i256) {
     block0:
         jump block1;
 
     block1:
         v5.objref<i256> = obj.proj v0 1.i256;
         obj.store v5 v1;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_424a(v0.objref<@layout_2>, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v5.objref<@layout_1> = obj.proj v0 0.i256;
-        v7.objref<i256> = obj.proj v5 1.i256;
-        obj.store v7 v1;
         return;
 }
 
@@ -1112,7 +839,7 @@ func private %impl_trait_SolEncoder__set_pos(v0.objref<@layout_0>, v1.i256) {
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_d16c(v0.objref<@layout_2>, v1.i256) {
+func private %set_pos__g463e(v0.objref<@layout_2>, v1.i256) {
     block0:
         jump block1;
 
@@ -1132,43 +859,7 @@ func private %store_word(v0.i256, v1.i256) {
         return;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_5951(v0.objref<@layout_0>, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.objref<i256> = obj.proj v0 0.i256;
-        v5.i256 = obj.load v4;
-        v7.i256 = add v5 v1;
-        v8.i256 = mload v7 i256;
-        return v8;
-}
-
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_778c(v0.objref<@layout_0>, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.objref<i256> = obj.proj v0 0.i256;
-        v5.i256 = obj.load v4;
-        v7.i256 = add v5 v1;
-        v8.i256 = mload v7 i256;
-        return v8;
-}
-
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_9f26(v0.objref<@layout_0>, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.objref<i256> = obj.proj v0 0.i256;
-        v5.i256 = obj.load v4;
-        v7.i256 = add v5 v1;
-        v8.i256 = mload v7 i256;
-        return v8;
-}
-
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_c21f(v0.objref<@layout_0>, v1.i256) -> i256 {
+func private %word_at(v0.objref<@layout_0>, v1.i256) -> i256 {
     block0:
         jump block1;
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/init_args_with_child_dep.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/init_args_with_child_dep.snap
@@ -6,12 +6,9 @@ input_file: crates/codegen/tests/fixtures/init_args_with_child_dep.fe
 target = "evm-ethereum-osaka"
 
 type @layout_0 = {i256, i256};
-type @layout_1 = {i256, i256};
-type @layout_2 = {i256, i256};
-type @layout_3 = {@layout_2, i256};
-type @layout_4 = {@layout_3, i256};
-type @layout_5 = {i256};
-type @layout_6 = {i256};
+type @layout_1 = {@layout_0, i256};
+type @layout_2 = {@layout_1, i256};
+type @layout_3 = {i256};
 
 func private %__Child_init(v0.i256, v1.i256) {
     block0:
@@ -28,7 +25,7 @@ func private %__Parent_init(v0.i256) {
     block1:
         v4.@layout_0 = insert_value undef.@layout_0 0.i256 v0;
         v6.@layout_0 = insert_value v4 1.i256 v0;
-        v7.@layout_5 = call %create 0.i256 v6;
+        v7.@layout_3 = call %create 0.i256 v6;
         return;
 }
 
@@ -41,37 +38,17 @@ func private %abi_payload_size(v0.@layout_0) -> i256 {
         return v2;
 }
 
-func inline(always) private %at(v0.i256) -> @layout_1 {
+func inline(always) private %at(v0.i256) -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v4.@layout_1 = insert_value undef.@layout_1 0.i256 v0;
-        v6.@layout_1 = insert_value v4 1.i256 v0;
+        v4.@layout_0 = insert_value undef.@layout_0 0.i256 v0;
+        v6.@layout_0 = insert_value v4 1.i256 v0;
         return v6;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_1672(v0.objref<@layout_4>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 1.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_2b07(v0.objref<@layout_4>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 1.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_f240(v0.objref<@layout_1>) -> i256 {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_1e01(v0.objref<@layout_0>) -> i256 {
     block0:
         jump block1;
 
@@ -81,20 +58,40 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_f240(v0.objre
         return v4;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_f488(v0.objref<@layout_1>) -> i256 {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_558b(v0.objref<@layout_0>) -> i256 {
     block0:
         jump block1;
 
     block1:
         v3.objref<i256> = obj.proj v0 0.i256;
+        v4.i256 = obj.load v3;
+        return v4;
+}
+
+func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_ce73(v0.objref<@layout_2>) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v3.objref<i256> = obj.proj v0 1.i256;
+        v4.i256 = obj.load v3;
+        return v4;
+}
+
+func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_fb1b(v0.objref<@layout_2>) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v3.objref<i256> = obj.proj v0 1.i256;
         v4.i256 = obj.load v3;
         return v4;
 }
 
 func inline(always) private %contract_init_abi_Child() {
     block0:
-        v0.objref<@layout_2> = obj.alloc @layout_2;
-        v1.objref<@layout_4> = obj.alloc @layout_4;
+        v0.objref<@layout_0> = obj.alloc @layout_0;
+        v1.objref<@layout_2> = obj.alloc @layout_2;
         jump block1;
 
     block1:
@@ -132,12 +129,12 @@ func inline(always) private %contract_init_abi_Child() {
         obj.store v23 v20;
         v25.objref<i256> = obj.proj v0 1.i256;
         obj.store v25 v13;
-        v26.@layout_2 = obj.load v0;
-        v27.@layout_4 = call %std__lib__abi__sol__impl_trait_Sol_1f5f__decoder_new__g463e_6eaf_0 v26;
-        v28.objref<@layout_3> = obj.proj v1 0.i256;
-        v29.@layout_3 = extract_value v27 0.i256;
-        v30.objref<@layout_2> = obj.proj v28 0.i256;
-        v31.@layout_2 = extract_value v29 0.i256;
+        v26.@layout_0 = obj.load v0;
+        v27.@layout_2 = call %std__lib__abi__sol__impl_trait_Sol_1f5f__decoder_new__g463e_b6cb_0 v26;
+        v28.objref<@layout_1> = obj.proj v1 0.i256;
+        v29.@layout_1 = extract_value v27 0.i256;
+        v30.objref<@layout_0> = obj.proj v28 0.i256;
+        v31.@layout_0 = extract_value v29 0.i256;
         v32.objref<i256> = obj.proj v30 0.i256;
         v33.i256 = extract_value v31 0.i256;
         obj.store v32 v33;
@@ -159,8 +156,8 @@ func inline(always) private %contract_init_abi_Child() {
 
 func inline(always) private %contract_init_abi_Parent() {
     block0:
-        v0.objref<@layout_2> = obj.alloc @layout_2;
-        v1.objref<@layout_4> = obj.alloc @layout_4;
+        v0.objref<@layout_0> = obj.alloc @layout_0;
+        v1.objref<@layout_2> = obj.alloc @layout_2;
         jump block1;
 
     block1:
@@ -198,12 +195,12 @@ func inline(always) private %contract_init_abi_Parent() {
         obj.store v23 v20;
         v25.objref<i256> = obj.proj v0 1.i256;
         obj.store v25 v13;
-        v26.@layout_2 = obj.load v0;
-        v27.@layout_4 = call %std__lib__abi__sol__impl_trait_Sol_1f5f__decoder_new__g463e_6eaf v26;
-        v28.objref<@layout_3> = obj.proj v1 0.i256;
-        v29.@layout_3 = extract_value v27 0.i256;
-        v30.objref<@layout_2> = obj.proj v28 0.i256;
-        v31.@layout_2 = extract_value v29 0.i256;
+        v26.@layout_0 = obj.load v0;
+        v27.@layout_2 = call %std__lib__abi__sol__impl_trait_Sol_1f5f__decoder_new__g463e_b6cb v26;
+        v28.objref<@layout_1> = obj.proj v1 0.i256;
+        v29.@layout_1 = extract_value v27 0.i256;
+        v30.objref<@layout_0> = obj.proj v28 0.i256;
+        v31.@layout_0 = extract_value v29 0.i256;
         v32.objref<i256> = obj.proj v30 0.i256;
         v33.i256 = extract_value v31 0.i256;
         obj.store v32 v33;
@@ -216,7 +213,7 @@ func inline(always) private %contract_init_abi_Parent() {
         v38.objref<i256> = obj.proj v1 1.i256;
         v39.i256 = extract_value v27 1.i256;
         obj.store v38 v39;
-        v40.@layout_6 = call %decode_payload__g3854 v1;
+        v40.@layout_3 = call %decode_payload__g3854 v1;
         v41.i256 = extract_value v40 0.i256;
         call %__Parent_init v41;
         return;
@@ -329,7 +326,7 @@ func private %copy_words(v0.i256, v1.i256, v2.i256) {
         jump block2;
 }
 
-func private %create(v0.i256, v1.@layout_0) -> @layout_5 {
+func private %create(v0.i256, v1.@layout_0) -> @layout_3 {
     block0:
         jump block1;
 
@@ -342,7 +339,7 @@ func private %create(v0.i256, v1.@layout_0) -> @layout_5 {
         v7.*i8 = evm_malloc v2;
         v8.i256 = ptr_to_int v7 i256;
         evm_code_copy v8 v3 v2;
-        v12.@layout_5 = call %create_raw v0 v8 v2;
+        v12.@layout_3 = call %create_raw v0 v8 v2;
         jump block4;
 
     block3:
@@ -352,7 +349,7 @@ func private %create(v0.i256, v1.@layout_0) -> @layout_5 {
         br v19 block9 block10;
 
     block4:
-        v43.@layout_5 = phi (v12 block2) (v42 block12);
+        v43.@layout_3 = phi (v12 block2) (v42 block12);
         v44.i256 = extract_value v43 0.i256;
         v45.i1 = eq v44 0.i256;
         br v45 block6 block7;
@@ -394,21 +391,21 @@ func private %create(v0.i256, v1.@layout_0) -> @layout_5 {
         br v39 block9 block12;
 
     block12:
-        v42.@layout_5 = call %create_raw v0 v26 v38;
+        v42.@layout_3 = call %create_raw v0 v26 v38;
         jump block4;
 }
 
-func private %create_raw(v0.i256, v1.i256, v2.i256) -> @layout_5 {
+func private %create_raw(v0.i256, v1.i256, v2.i256) -> @layout_3 {
     block0:
         jump block1;
 
     block1:
         v6.i256 = evm_create v0 v1 v2;
-        v9.@layout_5 = insert_value undef.@layout_5 0.i256 v6;
+        v9.@layout_3 = insert_value undef.@layout_3 0.i256 v6;
         return v9;
 }
 
-func inline(always) private %core__lib__abi__decode_field__g3854_271d(v0.objref<@layout_4>) -> i256 {
+func inline(always) private %core__lib__abi__decode_field__g3854_3e1e(v0.objref<@layout_2>) -> i256 {
     block0:
         jump block1;
 
@@ -416,9 +413,9 @@ func inline(always) private %core__lib__abi__decode_field__g3854_271d(v0.objref<
         br 0.i1 block2 block3;
 
     block2:
-        v3.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_6997 v0;
-        v4.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_1672 v0;
-        v5.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g463e_5a37 v0;
+        v3.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_bc00 v0;
+        v4.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_ce73 v0;
+        v5.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g463e_5cb2 v0;
         (v6.i256, v7.i1) = uaddo v4 v3;
         br v7 block5 block6;
 
@@ -426,7 +423,7 @@ func inline(always) private %core__lib__abi__decode_field__g3854_271d(v0.objref<
         jump block4;
 
     block4:
-        v23.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_payload__g407e_92e8 v0;
+        v23.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_payload__g407e_78fe v0;
         return v23;
 
     block5:
@@ -435,16 +432,16 @@ func inline(always) private %core__lib__abi__decode_field__g3854_271d(v0.objref<
         evm_revert 0.i256 36.i256;
 
     block6:
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_e112 v0 v6;
-        v15.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_1672 v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_0c70 v0 v15;
-        v17.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_payload__g407e_92e8 v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_e112 v0 v4;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_0c70 v0 v5;
+        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_f899 v0 v6;
+        v15.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_ce73 v0;
+        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_424a v0 v15;
+        v17.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_payload__g407e_78fe v0;
+        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_f899 v0 v4;
+        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_424a v0 v5;
         return v17;
 }
 
-func inline(always) private %core__lib__abi__decode_field__g3854_e495(v0.objref<@layout_4>) -> i256 {
+func inline(always) private %core__lib__abi__decode_field__g3854_c153(v0.objref<@layout_2>) -> i256 {
     block0:
         jump block1;
 
@@ -452,9 +449,9 @@ func inline(always) private %core__lib__abi__decode_field__g3854_e495(v0.objref<
         br 0.i1 block2 block3;
 
     block2:
-        v3.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_c4ab v0;
-        v4.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_2b07 v0;
-        v5.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g463e_1111 v0;
+        v3.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_5955 v0;
+        v4.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_fb1b v0;
+        v5.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g463e_78fa v0;
         (v6.i256, v7.i1) = uaddo v4 v3;
         br v7 block5 block6;
 
@@ -462,7 +459,7 @@ func inline(always) private %core__lib__abi__decode_field__g3854_e495(v0.objref<
         jump block4;
 
     block4:
-        v23.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_payload__g407e_a9a2 v0;
+        v23.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_payload__g407e_d426 v0;
         return v23;
 
     block5:
@@ -471,70 +468,70 @@ func inline(always) private %core__lib__abi__decode_field__g3854_e495(v0.objref<
         evm_revert 0.i256 36.i256;
 
     block6:
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_bba9 v0 v6;
-        v15.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_2b07 v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_5886 v0 v15;
-        v17.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_payload__g407e_a9a2 v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_bba9 v0 v4;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_5886 v0 v5;
+        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_37e4 v0 v6;
+        v15.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_fb1b v0;
+        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_d16c v0 v15;
+        v17.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_payload__g407e_d426 v0;
+        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_37e4 v0 v4;
+        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_d16c v0 v5;
         return v17;
 }
 
-func private %decode_payload__g4770(v0.objref<@layout_4>) -> @layout_0 {
+func private %decode_payload__g3854(v0.objref<@layout_2>) -> @layout_3 {
     block0:
         jump block1;
 
     block1:
-        v2.i256 = call %core__lib__abi__decode_field__g3854_e495 v0;
-        v3.i256 = call %core__lib__abi__decode_field__g3854_e495 v0;
+        v2.i256 = call %core__lib__abi__decode_field__g3854_3e1e v0;
+        v5.@layout_3 = insert_value undef.@layout_3 0.i256 v2;
+        return v5;
+}
+
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_payload__g407e_78fe(v0.objref<@layout_2>) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v2.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_4b2c v0;
+        return v2;
+}
+
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_payload__g407e_d426(v0.objref<@layout_2>) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v2.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_2dec v0;
+        return v2;
+}
+
+func private %decode_payload__g4770(v0.objref<@layout_2>) -> @layout_0 {
+    block0:
+        jump block1;
+
+    block1:
+        v2.i256 = call %core__lib__abi__decode_field__g3854_c153 v0;
+        v3.i256 = call %core__lib__abi__decode_field__g3854_c153 v0;
         v6.@layout_0 = insert_value undef.@layout_0 0.i256 v2;
         v8.@layout_0 = insert_value v6 1.i256 v3;
         return v8;
 }
 
-func private %decode_payload__g3854(v0.objref<@layout_4>) -> @layout_6 {
+func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decoder_new__g463e_b6cb(v0.@layout_0) -> @layout_2 {
     block0:
         jump block1;
 
     block1:
-        v2.i256 = call %core__lib__abi__decode_field__g3854_271d v0;
-        v5.@layout_6 = insert_value undef.@layout_6 0.i256 v2;
-        return v5;
-}
-
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_payload__g407e_92e8(v0.objref<@layout_4>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_b4b0 v0;
+        v2.@layout_2 = call %std__lib__abi__sol__impl_SolDecoder_113c__new__g463e_ae17 v0;
         return v2;
 }
 
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_payload__g407e_a9a2(v0.objref<@layout_4>) -> i256 {
+func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decoder_new__g463e_b6cb_0(v0.@layout_0) -> @layout_2 {
     block0:
         jump block1;
 
     block1:
-        v2.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_4a6a v0;
-        return v2;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decoder_new__g463e_6eaf(v0.@layout_2) -> @layout_4 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.@layout_4 = call %std__lib__abi__sol__impl_SolDecoder_113c__new__g463e_7b57 v0;
-        return v2;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decoder_new__g463e_6eaf_0(v0.@layout_2) -> @layout_4 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.@layout_4 = call %std__lib__abi__sol__impl_SolDecoder_113c__new__g463e_7b57_0 v0;
+        v2.@layout_2 = call %std__lib__abi__sol__impl_SolDecoder_113c__new__g463e_ae17_0 v0;
         return v2;
 }
 
@@ -556,13 +553,13 @@ func private %dynamic_payload_size(v0.i256) -> i256 {
         return 0.i256;
 }
 
-func inline(always) private %encode__g7769(v0.@layout_0, v1.objref<@layout_1>) {
+func inline(always) private %encode__g7769(v0.@layout_0, v1.objref<@layout_0>) {
     block0:
         v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_f240 v1;
+        v4.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_1e01 v1;
         v6.i256 = add v4 64.i256;
         mstore v2 v6 i256;
         v8.i256 = add v4 32.i256;
@@ -592,22 +589,22 @@ func inline(always) private %encode_alloc(v0.@layout_0) -> @layout_0 {
 
     block1:
         v2.i256 = call %abi_payload_size v0;
-        v3.@layout_1 = call %encoder_new v2;
-        v4.objref<@layout_1> = obj.alloc @layout_1;
+        v3.@layout_0 = call %encoder_new v2;
+        v4.objref<@layout_0> = obj.alloc @layout_0;
         v6.objref<i256> = obj.proj v4 0.i256;
         v7.i256 = extract_value v3 0.i256;
         obj.store v6 v7;
         v9.objref<i256> = obj.proj v4 1.i256;
         v10.i256 = extract_value v3 1.i256;
         obj.store v9 v10;
-        v11.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_f488 v4;
+        v11.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_558b v4;
         call %encode__g7769 v0 v4;
         v14.@layout_0 = insert_value undef.@layout_0 0.i256 v11;
         v15.@layout_0 = insert_value v14 1.i256 v2;
         return v15;
 }
 
-func private %encode__g426c(v0.i256, v1.objref<@layout_1>) {
+func private %encode__g426c(v0.i256, v1.objref<@layout_0>) {
     block0:
         jump block1;
 
@@ -616,7 +613,7 @@ func private %encode__g426c(v0.i256, v1.objref<@layout_1>) {
         return;
 }
 
-func inline(always) private %encode_field_at(v0.i256, v1.objref<@layout_1>, v2.i256, v3.i256, v4.i256) {
+func inline(always) private %encode_field_at(v0.i256, v1.objref<@layout_0>, v2.i256, v3.i256, v4.i256) {
     block0:
         jump block1;
 
@@ -667,16 +664,16 @@ func private %encode_to_ptr(v0.i256, v1.i256) {
         return;
 }
 
-func private %encoder_new(v0.i256) -> @layout_1 {
+func private %encoder_new(v0.i256) -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v2.@layout_1 = call %impl_SolEncoder__new v0;
+        v2.@layout_0 = call %impl_SolEncoder__new v0;
         return v2;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_0d16(v0.objref<@layout_2>) -> i256 {
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_528e(v0.objref<@layout_0>) -> i256 {
     block0:
         jump block1;
 
@@ -686,7 +683,7 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_0d16
         return v4;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_2f12(v0.objref<@layout_2>) -> i256 {
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_82aa(v0.objref<@layout_0>) -> i256 {
     block0:
         jump block1;
 
@@ -696,7 +693,7 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_2f12
         return v4;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_4f49(v0.objref<@layout_2>) -> i256 {
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_8b08(v0.objref<@layout_0>) -> i256 {
     block0:
         jump block1;
 
@@ -706,7 +703,7 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_4f49
         return v4;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_d700(v0.objref<@layout_2>) -> i256 {
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_945c(v0.objref<@layout_0>) -> i256 {
     block0:
         jump block1;
 
@@ -716,7 +713,27 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_d700
         return v4;
 }
 
-func private %impl_SolEncoder__new(v0.i256) -> @layout_1 {
+func inline(always) private %core__lib__abi__impl_Cursor_1a04__new__g463e_0c08(v0.@layout_0) -> @layout_1 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.@layout_1 = insert_value undef.@layout_1 0.i256 v0;
+        v6.@layout_1 = insert_value v4 1.i256 0.i256;
+        return v6;
+}
+
+func inline(always) private %core__lib__abi__impl_Cursor_1a04__new__g463e_0c08_0(v0.@layout_0) -> @layout_1 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.@layout_1 = insert_value undef.@layout_1 0.i256 v0;
+        v6.@layout_1 = insert_value v4 1.i256 0.i256;
+        return v6;
+}
+
+func private %impl_SolEncoder__new(v0.i256) -> @layout_0 {
     block0:
         jump block1;
 
@@ -734,50 +751,30 @@ func private %impl_SolEncoder__new(v0.i256) -> @layout_1 {
 
     block4:
         v7.i256 = phi (0.i256 block2) (v6 block3);
-        v8.@layout_1 = call %at v7;
+        v8.@layout_0 = call %at v7;
         return v8;
 }
 
-func inline(always) private %std__lib__abi__sol__impl_SolDecoder_113c__new__g463e_7b57(v0.@layout_2) -> @layout_4 {
+func inline(always) private %std__lib__abi__sol__impl_SolDecoder_113c__new__g463e_ae17(v0.@layout_0) -> @layout_2 {
     block0:
         jump block1;
 
     block1:
-        v2.@layout_3 = call %core__lib__abi__impl_Cursor_1a04__new__g463e_aa29 v0;
-        v5.@layout_4 = insert_value undef.@layout_4 0.i256 v2;
-        v7.@layout_4 = insert_value v5 1.i256 0.i256;
+        v2.@layout_1 = call %core__lib__abi__impl_Cursor_1a04__new__g463e_0c08 v0;
+        v5.@layout_2 = insert_value undef.@layout_2 0.i256 v2;
+        v7.@layout_2 = insert_value v5 1.i256 0.i256;
         return v7;
 }
 
-func inline(always) private %std__lib__abi__sol__impl_SolDecoder_113c__new__g463e_7b57_0(v0.@layout_2) -> @layout_4 {
+func inline(always) private %std__lib__abi__sol__impl_SolDecoder_113c__new__g463e_ae17_0(v0.@layout_0) -> @layout_2 {
     block0:
         jump block1;
 
     block1:
-        v2.@layout_3 = call %core__lib__abi__impl_Cursor_1a04__new__g463e_aa29_0 v0;
-        v5.@layout_4 = insert_value undef.@layout_4 0.i256 v2;
-        v7.@layout_4 = insert_value v5 1.i256 0.i256;
+        v2.@layout_1 = call %core__lib__abi__impl_Cursor_1a04__new__g463e_0c08_0 v0;
+        v5.@layout_2 = insert_value undef.@layout_2 0.i256 v2;
+        v7.@layout_2 = insert_value v5 1.i256 0.i256;
         return v7;
-}
-
-func inline(always) private %core__lib__abi__impl_Cursor_1a04__new__g463e_aa29(v0.@layout_2) -> @layout_3 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.@layout_3 = insert_value undef.@layout_3 0.i256 v0;
-        v6.@layout_3 = insert_value v4 1.i256 0.i256;
-        return v6;
-}
-
-func inline(always) private %core__lib__abi__impl_Cursor_1a04__new__g463e_aa29_0(v0.@layout_2) -> @layout_3 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.@layout_3 = insert_value undef.@layout_3 0.i256 v0;
-        v6.@layout_3 = insert_value v4 1.i256 0.i256;
-        return v6;
 }
 
 func inline(always) private %payload_size__gbd8e(v0.@layout_0) -> i256 {
@@ -810,41 +807,41 @@ func private %core__lib__abi__trait_AbiSize__payload_size__ge513_fde5(v0.i256) -
         return 32.i256;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g463e_1111(v0.objref<@layout_4>) -> i256 {
+func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g463e_5cb2(v0.objref<@layout_2>) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v3.objref<@layout_3> = obj.proj v0 0.i256;
+        v3.objref<@layout_1> = obj.proj v0 0.i256;
         v5.objref<i256> = obj.proj v3 1.i256;
         v6.i256 = obj.load v5;
         return v6;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g463e_5a37(v0.objref<@layout_4>) -> i256 {
+func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g463e_78fa(v0.objref<@layout_2>) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v3.objref<@layout_3> = obj.proj v0 0.i256;
+        v3.objref<@layout_1> = obj.proj v0 0.i256;
         v5.objref<i256> = obj.proj v3 1.i256;
         v6.i256 = obj.load v5;
         return v6;
 }
 
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_4a6a(v0.objref<@layout_4>) -> i256 {
+func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_2dec(v0.objref<@layout_2>) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v4.objref<@layout_3> = obj.proj v0 0.i256;
-        v5.objref<@layout_2> = obj.proj v4 0.i256;
-        v6.@layout_2 = obj.load v5;
-        v7.objref<@layout_3> = obj.proj v0 0.i256;
-        v8.objref<@layout_2> = obj.proj v7 0.i256;
-        v9.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_d700 v8;
-        v10.objref<@layout_3> = obj.proj v0 0.i256;
+        v4.objref<@layout_1> = obj.proj v0 0.i256;
+        v5.objref<@layout_0> = obj.proj v4 0.i256;
+        v6.@layout_0 = obj.load v5;
+        v7.objref<@layout_1> = obj.proj v0 0.i256;
+        v8.objref<@layout_0> = obj.proj v7 0.i256;
+        v9.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_528e v8;
+        v10.objref<@layout_1> = obj.proj v0 0.i256;
         v12.objref<i256> = obj.proj v10 1.i256;
         v13.i256 = obj.load v12;
         (v15.i256, v16.i1) = uaddo v13 32.i256;
@@ -857,16 +854,16 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         jump block4;
 
     block4:
-        v27.objref<@layout_3> = obj.proj v0 0.i256;
-        v28.objref<@layout_2> = obj.proj v27 0.i256;
-        v29.@layout_2 = obj.load v28;
-        v30.objref<@layout_3> = obj.proj v0 0.i256;
+        v27.objref<@layout_1> = obj.proj v0 0.i256;
+        v28.objref<@layout_0> = obj.proj v27 0.i256;
+        v29.@layout_0 = obj.load v28;
+        v30.objref<@layout_1> = obj.proj v0 0.i256;
         v31.objref<i256> = obj.proj v30 1.i256;
         v32.i256 = obj.load v31;
-        v33.objref<@layout_3> = obj.proj v0 0.i256;
-        v34.objref<@layout_2> = obj.proj v33 0.i256;
-        v35.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_7a87 v34 v32;
-        v37.objref<@layout_3> = obj.proj v0 0.i256;
+        v33.objref<@layout_1> = obj.proj v0 0.i256;
+        v34.objref<@layout_0> = obj.proj v33 0.i256;
+        v35.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_9f26 v34 v32;
+        v37.objref<@layout_1> = obj.proj v0 0.i256;
         v38.objref<i256> = obj.proj v37 1.i256;
         obj.store v38 v15;
         return v35;
@@ -883,26 +880,26 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         evm_revert 0.i256 36.i256;
 
     block7:
-        v22.objref<@layout_3> = obj.proj v0 0.i256;
+        v22.objref<@layout_1> = obj.proj v0 0.i256;
         v23.objref<i256> = obj.proj v22 1.i256;
         v24.i256 = obj.load v23;
         v25.i1 = lt v15 v24;
         br v25 block2 block5;
 }
 
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_6997(v0.objref<@layout_4>) -> i256 {
+func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_4b2c(v0.objref<@layout_2>) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v4.objref<@layout_3> = obj.proj v0 0.i256;
-        v5.objref<@layout_2> = obj.proj v4 0.i256;
-        v6.@layout_2 = obj.load v5;
-        v7.objref<@layout_3> = obj.proj v0 0.i256;
-        v8.objref<@layout_2> = obj.proj v7 0.i256;
-        v9.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_0d16 v8;
-        v10.objref<@layout_3> = obj.proj v0 0.i256;
+        v4.objref<@layout_1> = obj.proj v0 0.i256;
+        v5.objref<@layout_0> = obj.proj v4 0.i256;
+        v6.@layout_0 = obj.load v5;
+        v7.objref<@layout_1> = obj.proj v0 0.i256;
+        v8.objref<@layout_0> = obj.proj v7 0.i256;
+        v9.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_945c v8;
+        v10.objref<@layout_1> = obj.proj v0 0.i256;
         v12.objref<i256> = obj.proj v10 1.i256;
         v13.i256 = obj.load v12;
         (v15.i256, v16.i1) = uaddo v13 32.i256;
@@ -915,16 +912,16 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         jump block4;
 
     block4:
-        v27.objref<@layout_3> = obj.proj v0 0.i256;
-        v28.objref<@layout_2> = obj.proj v27 0.i256;
-        v29.@layout_2 = obj.load v28;
-        v30.objref<@layout_3> = obj.proj v0 0.i256;
+        v27.objref<@layout_1> = obj.proj v0 0.i256;
+        v28.objref<@layout_0> = obj.proj v27 0.i256;
+        v29.@layout_0 = obj.load v28;
+        v30.objref<@layout_1> = obj.proj v0 0.i256;
         v31.objref<i256> = obj.proj v30 1.i256;
         v32.i256 = obj.load v31;
-        v33.objref<@layout_3> = obj.proj v0 0.i256;
-        v34.objref<@layout_2> = obj.proj v33 0.i256;
-        v35.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_f08f v34 v32;
-        v37.objref<@layout_3> = obj.proj v0 0.i256;
+        v33.objref<@layout_1> = obj.proj v0 0.i256;
+        v34.objref<@layout_0> = obj.proj v33 0.i256;
+        v35.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_5951 v34 v32;
+        v37.objref<@layout_1> = obj.proj v0 0.i256;
         v38.objref<i256> = obj.proj v37 1.i256;
         obj.store v38 v15;
         return v35;
@@ -941,26 +938,26 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         evm_revert 0.i256 36.i256;
 
     block7:
-        v22.objref<@layout_3> = obj.proj v0 0.i256;
+        v22.objref<@layout_1> = obj.proj v0 0.i256;
         v23.objref<i256> = obj.proj v22 1.i256;
         v24.i256 = obj.load v23;
         v25.i1 = lt v15 v24;
         br v25 block2 block5;
 }
 
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_b4b0(v0.objref<@layout_4>) -> i256 {
+func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_5955(v0.objref<@layout_2>) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v4.objref<@layout_3> = obj.proj v0 0.i256;
-        v5.objref<@layout_2> = obj.proj v4 0.i256;
-        v6.@layout_2 = obj.load v5;
-        v7.objref<@layout_3> = obj.proj v0 0.i256;
-        v8.objref<@layout_2> = obj.proj v7 0.i256;
-        v9.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_4f49 v8;
-        v10.objref<@layout_3> = obj.proj v0 0.i256;
+        v4.objref<@layout_1> = obj.proj v0 0.i256;
+        v5.objref<@layout_0> = obj.proj v4 0.i256;
+        v6.@layout_0 = obj.load v5;
+        v7.objref<@layout_1> = obj.proj v0 0.i256;
+        v8.objref<@layout_0> = obj.proj v7 0.i256;
+        v9.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_82aa v8;
+        v10.objref<@layout_1> = obj.proj v0 0.i256;
         v12.objref<i256> = obj.proj v10 1.i256;
         v13.i256 = obj.load v12;
         (v15.i256, v16.i1) = uaddo v13 32.i256;
@@ -973,16 +970,16 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         jump block4;
 
     block4:
-        v27.objref<@layout_3> = obj.proj v0 0.i256;
-        v28.objref<@layout_2> = obj.proj v27 0.i256;
-        v29.@layout_2 = obj.load v28;
-        v30.objref<@layout_3> = obj.proj v0 0.i256;
+        v27.objref<@layout_1> = obj.proj v0 0.i256;
+        v28.objref<@layout_0> = obj.proj v27 0.i256;
+        v29.@layout_0 = obj.load v28;
+        v30.objref<@layout_1> = obj.proj v0 0.i256;
         v31.objref<i256> = obj.proj v30 1.i256;
         v32.i256 = obj.load v31;
-        v33.objref<@layout_3> = obj.proj v0 0.i256;
-        v34.objref<@layout_2> = obj.proj v33 0.i256;
-        v35.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_9236 v34 v32;
-        v37.objref<@layout_3> = obj.proj v0 0.i256;
+        v33.objref<@layout_1> = obj.proj v0 0.i256;
+        v34.objref<@layout_0> = obj.proj v33 0.i256;
+        v35.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_778c v34 v32;
+        v37.objref<@layout_1> = obj.proj v0 0.i256;
         v38.objref<i256> = obj.proj v37 1.i256;
         obj.store v38 v15;
         return v35;
@@ -999,26 +996,26 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         evm_revert 0.i256 36.i256;
 
     block7:
-        v22.objref<@layout_3> = obj.proj v0 0.i256;
+        v22.objref<@layout_1> = obj.proj v0 0.i256;
         v23.objref<i256> = obj.proj v22 1.i256;
         v24.i256 = obj.load v23;
         v25.i1 = lt v15 v24;
         br v25 block2 block5;
 }
 
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_c4ab(v0.objref<@layout_4>) -> i256 {
+func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_bc00(v0.objref<@layout_2>) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v4.objref<@layout_3> = obj.proj v0 0.i256;
-        v5.objref<@layout_2> = obj.proj v4 0.i256;
-        v6.@layout_2 = obj.load v5;
-        v7.objref<@layout_3> = obj.proj v0 0.i256;
-        v8.objref<@layout_2> = obj.proj v7 0.i256;
-        v9.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_2f12 v8;
-        v10.objref<@layout_3> = obj.proj v0 0.i256;
+        v4.objref<@layout_1> = obj.proj v0 0.i256;
+        v5.objref<@layout_0> = obj.proj v4 0.i256;
+        v6.@layout_0 = obj.load v5;
+        v7.objref<@layout_1> = obj.proj v0 0.i256;
+        v8.objref<@layout_0> = obj.proj v7 0.i256;
+        v9.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_8b08 v8;
+        v10.objref<@layout_1> = obj.proj v0 0.i256;
         v12.objref<i256> = obj.proj v10 1.i256;
         v13.i256 = obj.load v12;
         (v15.i256, v16.i1) = uaddo v13 32.i256;
@@ -1031,16 +1028,16 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         jump block4;
 
     block4:
-        v27.objref<@layout_3> = obj.proj v0 0.i256;
-        v28.objref<@layout_2> = obj.proj v27 0.i256;
-        v29.@layout_2 = obj.load v28;
-        v30.objref<@layout_3> = obj.proj v0 0.i256;
+        v27.objref<@layout_1> = obj.proj v0 0.i256;
+        v28.objref<@layout_0> = obj.proj v27 0.i256;
+        v29.@layout_0 = obj.load v28;
+        v30.objref<@layout_1> = obj.proj v0 0.i256;
         v31.objref<i256> = obj.proj v30 1.i256;
         v32.i256 = obj.load v31;
-        v33.objref<@layout_3> = obj.proj v0 0.i256;
-        v34.objref<@layout_2> = obj.proj v33 0.i256;
-        v35.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_78ee v34 v32;
-        v37.objref<@layout_3> = obj.proj v0 0.i256;
+        v33.objref<@layout_1> = obj.proj v0 0.i256;
+        v34.objref<@layout_0> = obj.proj v33 0.i256;
+        v35.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_c21f v34 v32;
+        v37.objref<@layout_1> = obj.proj v0 0.i256;
         v38.objref<i256> = obj.proj v37 1.i256;
         obj.store v38 v15;
         return v35;
@@ -1057,14 +1054,24 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         evm_revert 0.i256 36.i256;
 
     block7:
-        v22.objref<@layout_3> = obj.proj v0 0.i256;
+        v22.objref<@layout_1> = obj.proj v0 0.i256;
         v23.objref<i256> = obj.proj v22 1.i256;
         v24.i256 = obj.load v23;
         v25.i1 = lt v15 v24;
         br v25 block2 block5;
 }
 
-func private %impl_trait_SolEncoder__set_base(v0.objref<@layout_1>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_37e4(v0.objref<@layout_2>, v1.i256) {
+    block0:
+        jump block1;
+
+    block1:
+        v5.objref<i256> = obj.proj v0 1.i256;
+        obj.store v5 v1;
+        return;
+}
+
+func private %impl_trait_SolEncoder__set_base(v0.objref<@layout_0>, v1.i256) {
     block0:
         jump block1;
 
@@ -1074,7 +1081,7 @@ func private %impl_trait_SolEncoder__set_base(v0.objref<@layout_1>, v1.i256) {
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_bba9(v0.objref<@layout_4>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_f899(v0.objref<@layout_2>, v1.i256) {
     block0:
         jump block1;
 
@@ -1084,45 +1091,35 @@ func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_bb
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_e112(v0.objref<@layout_4>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_424a(v0.objref<@layout_2>, v1.i256) {
     block0:
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 1.i256;
-        obj.store v5 v1;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_0c70(v0.objref<@layout_4>, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v5.objref<@layout_3> = obj.proj v0 0.i256;
+        v5.objref<@layout_1> = obj.proj v0 0.i256;
         v7.objref<i256> = obj.proj v5 1.i256;
         obj.store v7 v1;
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_5886(v0.objref<@layout_4>, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v5.objref<@layout_3> = obj.proj v0 0.i256;
-        v7.objref<i256> = obj.proj v5 1.i256;
-        obj.store v7 v1;
-        return;
-}
-
-func private %impl_trait_SolEncoder__set_pos(v0.objref<@layout_1>, v1.i256) {
+func private %impl_trait_SolEncoder__set_pos(v0.objref<@layout_0>, v1.i256) {
     block0:
         jump block1;
 
     block1:
         v5.objref<i256> = obj.proj v0 1.i256;
         obj.store v5 v1;
+        return;
+}
+
+func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_d16c(v0.objref<@layout_2>, v1.i256) {
+    block0:
+        jump block1;
+
+    block1:
+        v5.objref<@layout_1> = obj.proj v0 0.i256;
+        v7.objref<i256> = obj.proj v5 1.i256;
+        obj.store v7 v1;
         return;
 }
 
@@ -1135,7 +1132,7 @@ func private %store_word(v0.i256, v1.i256) {
         return;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_78ee(v0.objref<@layout_2>, v1.i256) -> i256 {
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_5951(v0.objref<@layout_0>, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -1147,7 +1144,7 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_
         return v8;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_7a87(v0.objref<@layout_2>, v1.i256) -> i256 {
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_778c(v0.objref<@layout_0>, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -1159,7 +1156,7 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_
         return v8;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_9236(v0.objref<@layout_2>, v1.i256) -> i256 {
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_9f26(v0.objref<@layout_0>, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -1171,7 +1168,7 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_
         return v8;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_f08f(v0.objref<@layout_2>, v1.i256) -> i256 {
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_c21f(v0.objref<@layout_0>, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -1183,7 +1180,7 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_
         return v8;
 }
 
-func private %write_word(v0.objref<@layout_1>, v1.i256) {
+func private %write_word(v0.objref<@layout_0>, v1.i256) {
     block0:
         jump block1;
 
@@ -1197,7 +1194,7 @@ func private %write_word(v0.objref<@layout_1>, v1.i256) {
         return;
 }
 
-func private %write_word_at(v0.objref<@layout_1>, v1.i256, v2.i256) {
+func private %write_word_at(v0.objref<@layout_0>, v1.i256, v2.i256) {
     block0:
         jump block1;
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/match_arm_return.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/match_arm_return.snap
@@ -6,8 +6,8 @@ input_file: crates/codegen/tests/fixtures/match_arm_return.fe
 target = "evm-ethereum-osaka"
 
 type @layout_0 = enum {
-    #A(i256),
-    #B,
+    #variant_0(i256),
+    #variant_1,
 };
 
 func private %f(v0.@layout_0) -> i256 {
@@ -20,8 +20,8 @@ func private %f(v0.@layout_0) -> i256 {
         br_table v3 (0.enumtag(@layout_0) block2) (1.enumtag(@layout_0) block3);
 
     block2:
-        enum.assert_variant v0 #A;
-        v8.i256 = enum.extract v0 #A 0.i256;
+        enum.assert_variant v0 #variant_0;
+        v8.i256 = enum.extract v0 #variant_0 0.i256;
         mstore v1 v8 i256;
         v9.i256 = mload v1 i256;
         return v9;
@@ -35,7 +35,7 @@ func private %main() -> i256 {
         jump block1;
 
     block1:
-        v0.@layout_0 = enum.make @layout_0 #B;
+        v0.@layout_0 = enum.make @layout_0 #variant_1;
         v1.i256 = call %f v0;
         return v1;
 }

--- a/crates/codegen/tests/fixtures/sonatina_ir/match_arm_return_comma.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/match_arm_return_comma.snap
@@ -6,8 +6,8 @@ input_file: crates/codegen/tests/fixtures/match_arm_return_comma.fe
 target = "evm-ethereum-osaka"
 
 type @layout_0 = enum {
-    #A(i256),
-    #B,
+    #variant_0(i256),
+    #variant_1,
 };
 
 func private %f(v0.@layout_0) -> i256 {
@@ -20,8 +20,8 @@ func private %f(v0.@layout_0) -> i256 {
         br_table v3 (0.enumtag(@layout_0) block2) (1.enumtag(@layout_0) block3);
 
     block2:
-        enum.assert_variant v0 #A;
-        v8.i256 = enum.extract v0 #A 0.i256;
+        enum.assert_variant v0 #variant_0;
+        v8.i256 = enum.extract v0 #variant_0 0.i256;
         mstore v1 v8 i256;
         v9.i256 = mload v1 i256;
         return v9;
@@ -35,7 +35,7 @@ func private %main() -> i256 {
         jump block1;
 
     block1:
-        v1.@layout_0 = enum.make @layout_0 #A 1.i256;
+        v1.@layout_0 = enum.make @layout_0 #variant_0 1.i256;
         v2.i256 = call %f v1;
         return v2;
 }

--- a/crates/codegen/tests/fixtures/sonatina_ir/match_enum.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/match_enum.snap
@@ -6,9 +6,9 @@ input_file: crates/codegen/tests/fixtures/match_enum.fe
 target = "evm-ethereum-osaka"
 
 type @layout_0 = enum {
-    #A,
-    #B,
-    #C,
+    #variant_0,
+    #variant_1,
+    #variant_2,
 };
 
 func private %main() -> i8 {
@@ -16,7 +16,7 @@ func private %main() -> i8 {
         jump block1;
 
     block1:
-        v0.@layout_0 = enum.make @layout_0 #B;
+        v0.@layout_0 = enum.make @layout_0 #variant_1;
         v1.i8 = call %match_enum v0;
         return v1;
 }

--- a/crates/codegen/tests/fixtures/sonatina_ir/match_enum_with_data.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/match_enum_with_data.snap
@@ -6,8 +6,8 @@ input_file: crates/codegen/tests/fixtures/match_enum_with_data.fe
 target = "evm-ethereum-osaka"
 
 type @layout_0 = enum {
-    #None,
-    #Some(i64),
+    #variant_0,
+    #variant_1(i64),
 };
 
 func private %main() -> i64 {
@@ -34,7 +34,7 @@ func private %make_some(v0.i64) -> @layout_0 {
         jump block1;
 
     block1:
-        v2.@layout_0 = enum.make @layout_0 #Some v0;
+        v2.@layout_0 = enum.make @layout_0 #variant_1 v0;
         return v2;
 }
 
@@ -51,8 +51,8 @@ func private %match_option(v0.@layout_0) -> i64 {
         return v5;
 
     block3:
-        enum.assert_variant v0 #Some;
-        v8.i64 = enum.extract v0 #Some 0.i256;
+        enum.assert_variant v0 #variant_1;
+        v8.i64 = enum.extract v0 #variant_1 0.i256;
         jump block2;
 
     block4:

--- a/crates/codegen/tests/fixtures/sonatina_ir/match_fn_call.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/match_fn_call.snap
@@ -5,25 +5,7 @@ input_file: crates/codegen/tests/fixtures/match_fn_call.fe
 ---
 target = "evm-ethereum-osaka"
 
-func private %std__lib__evm__effects__impl_trait_Evm_0098__calldataload_97e7(v0.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.i256 = evm_calldata_load v0;
-        return v2;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_0098__calldataload_97e7_0(v0.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.i256 = evm_calldata_load v0;
-        return v2;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_0098__calldataload_97e7_1(v0.i256) -> i256 {
+func private %calldataload(v0.i256) -> i256 {
     block0:
         jump block1;
 
@@ -115,7 +97,7 @@ func private %standalone_match_fn_call__match_fn_call__read_selector__gcd5c_044c
         jump block1;
 
     block1:
-        v1.i256 = call %std__lib__evm__effects__impl_trait_Evm_0098__calldataload_97e7 0.i256;
+        v1.i256 = call %calldataload 0.i256;
         v3.i256 = shr 224.i256 v1;
         return v3;
 }
@@ -125,7 +107,7 @@ func private %standalone_match_fn_call__match_fn_call__read_selector__gcd5c_5a44
         jump block1;
 
     block1:
-        v1.i256 = call %std__lib__evm__effects__impl_trait_Evm_0098__calldataload_97e7_0 0.i256;
+        v1.i256 = call %calldataload 0.i256;
         v3.i256 = shr 224.i256 v1;
         return v3;
 }
@@ -135,7 +117,7 @@ func private %standalone_match_fn_call__match_fn_call__read_selector__gcd5c_94d5
         jump block1;
 
     block1:
-        v1.i256 = call %std__lib__evm__effects__impl_trait_Evm_0098__calldataload_97e7_1 0.i256;
+        v1.i256 = call %calldataload 0.i256;
         v3.i256 = shr 224.i256 v1;
         return v3;
 }

--- a/crates/codegen/tests/fixtures/sonatina_ir/match_mixed_return.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/match_mixed_return.snap
@@ -6,8 +6,8 @@ input_file: crates/codegen/tests/fixtures/match_mixed_return.fe
 target = "evm-ethereum-osaka"
 
 type @layout_0 = enum {
-    #A,
-    #B,
+    #variant_0,
+    #variant_1,
 };
 
 func private %f(v0.@layout_0) -> i256 {
@@ -33,7 +33,7 @@ func private %main() -> i256 {
         jump block1;
 
     block1:
-        v0.@layout_0 = enum.make @layout_0 #B;
+        v0.@layout_0 = enum.make @layout_0 #variant_1;
         v1.i256 = call %f v0;
         return v1;
 }

--- a/crates/codegen/tests/fixtures/sonatina_ir/match_nested_default.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/match_nested_default.snap
@@ -7,16 +7,16 @@ target = "evm-ethereum-osaka"
 
 type @layout_3 = {i8, i8, i8, i8};
 type @layout_0 = enum {
-    #A,
-    #B,
-    #C,
+    #variant_0,
+    #variant_1,
+    #variant_2,
 };
 type @layout_1 = enum {
-    #First(@layout_0),
-    #Second(@layout_0),
+    #variant_0(@layout_0),
+    #variant_1(@layout_0),
 };
 type @layout_2 = enum {
-    #Wrap(@layout_1),
+    #variant_0(@layout_1),
 };
 
 func private %deeply_nested_wildcard(v0.@layout_2) -> i8 {
@@ -32,16 +32,16 @@ func private %deeply_nested_wildcard(v0.@layout_2) -> i8 {
         return v4;
 
     block3:
-        enum.assert_variant v0 #Wrap;
-        v7.@layout_1 = enum.extract v0 #Wrap 0.i256;
+        enum.assert_variant v0 #variant_0;
+        v7.@layout_1 = enum.extract v0 #variant_0 0.i256;
         v8.enumtag(@layout_1) = enum.tag v7;
         br_table v8 block5 (0.enumtag(@layout_1) block4);
 
     block4:
-        enum.assert_variant v0 #Wrap;
-        v11.@layout_1 = enum.extract v0 #Wrap 0.i256;
-        enum.assert_variant v11 #First;
-        v12.@layout_0 = enum.extract v11 #First 0.i256;
+        enum.assert_variant v0 #variant_0;
+        v11.@layout_1 = enum.extract v0 #variant_0 0.i256;
+        enum.assert_variant v11 #variant_0;
+        v12.@layout_0 = enum.extract v11 #variant_0 0.i256;
         v13.enumtag(@layout_0) = enum.tag v12;
         br_table v13 block7 (0.enumtag(@layout_0) block6);
 
@@ -68,8 +68,8 @@ func private %exhaustive_inner_outer_wildcard(v0.@layout_1) -> i8 {
         return v4;
 
     block3:
-        enum.assert_variant v0 #First;
-        v7.@layout_0 = enum.extract v0 #First 0.i256;
+        enum.assert_variant v0 #variant_0;
+        v7.@layout_0 = enum.extract v0 #variant_0 0.i256;
         v8.enumtag(@layout_0) = enum.tag v7;
         br_table v8 (0.enumtag(@layout_0) block5) (1.enumtag(@layout_0) block6) (2.enumtag(@layout_0) block7);
 
@@ -91,24 +91,24 @@ func private %main() -> @layout_3 {
         jump block1;
 
     block1:
-        v0.@layout_0 = enum.make @layout_0 #A;
-        v1.@layout_0 = enum.make @layout_0 #A;
-        v2.@layout_1 = enum.make @layout_1 #First v1;
+        v0.@layout_0 = enum.make @layout_0 #variant_0;
+        v1.@layout_0 = enum.make @layout_0 #variant_0;
+        v2.@layout_1 = enum.make @layout_1 #variant_0 v1;
         v3.i8 = call %nested_with_defaults v2;
-        v4.@layout_0 = enum.make @layout_0 #B;
-        v5.@layout_0 = enum.make @layout_0 #B;
-        v6.@layout_1 = enum.make @layout_1 #First v5;
+        v4.@layout_0 = enum.make @layout_0 #variant_1;
+        v5.@layout_0 = enum.make @layout_0 #variant_1;
+        v6.@layout_1 = enum.make @layout_1 #variant_0 v5;
         v7.i8 = call %outer_specific_inner_wildcard v6;
-        v8.@layout_0 = enum.make @layout_0 #C;
-        v9.@layout_0 = enum.make @layout_0 #C;
-        v10.@layout_1 = enum.make @layout_1 #Second v9;
-        v11.@layout_0 = enum.make @layout_0 #C;
-        v12.@layout_1 = enum.make @layout_1 #Second v11;
-        v13.@layout_2 = enum.make @layout_2 #Wrap v12;
+        v8.@layout_0 = enum.make @layout_0 #variant_2;
+        v9.@layout_0 = enum.make @layout_0 #variant_2;
+        v10.@layout_1 = enum.make @layout_1 #variant_1 v9;
+        v11.@layout_0 = enum.make @layout_0 #variant_2;
+        v12.@layout_1 = enum.make @layout_1 #variant_1 v11;
+        v13.@layout_2 = enum.make @layout_2 #variant_0 v12;
         v14.i8 = call %deeply_nested_wildcard v13;
-        v15.@layout_0 = enum.make @layout_0 #C;
-        v16.@layout_0 = enum.make @layout_0 #C;
-        v17.@layout_1 = enum.make @layout_1 #First v16;
+        v15.@layout_0 = enum.make @layout_0 #variant_2;
+        v16.@layout_0 = enum.make @layout_0 #variant_2;
+        v17.@layout_1 = enum.make @layout_1 #variant_0 v16;
         v18.i8 = call %exhaustive_inner_outer_wildcard v17;
         v21.@layout_3 = insert_value undef.@layout_3 0.i256 v3;
         v23.@layout_3 = insert_value v21 1.i256 v7;
@@ -139,14 +139,14 @@ func private %nested_with_defaults(v0.@layout_1) -> i8 {
         return v5;
 
     block3:
-        enum.assert_variant v0 #First;
-        v8.@layout_0 = enum.extract v0 #First 0.i256;
+        enum.assert_variant v0 #variant_0;
+        v8.@layout_0 = enum.extract v0 #variant_0 0.i256;
         v9.enumtag(@layout_0) = enum.tag v8;
         br_table v9 block6 (0.enumtag(@layout_0) block5);
 
     block4:
-        enum.assert_variant v0 #Second;
-        v12.@layout_0 = enum.extract v0 #Second 0.i256;
+        enum.assert_variant v0 #variant_1;
+        v12.@layout_0 = enum.extract v0 #variant_1 0.i256;
         v13.enumtag(@layout_0) = enum.tag v12;
         br_table v13 block8 (1.enumtag(@layout_0) block7);
 
@@ -176,8 +176,8 @@ func private %outer_specific_inner_wildcard(v0.@layout_1) -> i8 {
         return v4;
 
     block3:
-        enum.assert_variant v0 #First;
-        v7.@layout_0 = enum.extract v0 #First 0.i256;
+        enum.assert_variant v0 #variant_0;
+        v7.@layout_0 = enum.extract v0 #variant_0 0.i256;
         v8.enumtag(@layout_0) = enum.tag v7;
         br_table v8 block6 (0.enumtag(@layout_0) block5);
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/match_nested_enum.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/match_nested_enum.snap
@@ -1,18 +1,17 @@
 ---
 source: crates/codegen/tests/sonatina_ir.rs
-assertion_line: 455
 expression: output
 input_file: crates/codegen/tests/fixtures/match_nested_enum.fe
 ---
 target = "evm-ethereum-osaka"
 
 type @layout_0 = enum {
-    #Unit,
-    #Value(i8),
+    #variant_0,
+    #variant_1(i8),
 };
 type @layout_1 = enum {
-    #First(@layout_0),
-    #Second(i8),
+    #variant_0(@layout_0),
+    #variant_1(i8),
 };
 
 func private %main() -> i8 {
@@ -20,9 +19,9 @@ func private %main() -> i8 {
         jump block1;
 
     block1:
-        v1.@layout_0 = enum.make @layout_0 #Value 7.i8;
-        v2.@layout_0 = enum.make @layout_0 #Value 7.i8;
-        v3.@layout_1 = enum.make @layout_1 #First v2;
+        v1.@layout_0 = enum.make @layout_0 #variant_1 7.i8;
+        v2.@layout_0 = enum.make @layout_0 #variant_1 7.i8;
+        v3.@layout_1 = enum.make @layout_1 #variant_0 v2;
         v4.i8 = call %match_nested_enum v3;
         return v4;
 }
@@ -49,22 +48,22 @@ func private %match_nested_enum(v0.@layout_1) -> i8 {
         return v5;
 
     block3:
-        enum.assert_variant v0 #First;
-        v8.@layout_0 = enum.extract v0 #First 0.i256;
+        enum.assert_variant v0 #variant_0;
+        v8.@layout_0 = enum.extract v0 #variant_0 0.i256;
         v9.enumtag(@layout_0) = enum.tag v8;
         br_table v9 (0.enumtag(@layout_0) block5) (1.enumtag(@layout_0) block6);
 
     block4:
-        enum.assert_variant v0 #Second;
-        v13.i8 = enum.extract v0 #Second 0.i256;
+        enum.assert_variant v0 #variant_1;
+        v13.i8 = enum.extract v0 #variant_1 0.i256;
         jump block2;
 
     block5:
         jump block2;
 
     block6:
-        enum.assert_variant v8 #Value;
-        v16.i8 = enum.extract v8 #Value 0.i256;
+        enum.assert_variant v8 #variant_1;
+        v16.i8 = enum.extract v8 #variant_1 0.i256;
         jump block2;
 }
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/match_return.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/match_return.snap
@@ -6,8 +6,8 @@ input_file: crates/codegen/tests/fixtures/match_return.fe
 target = "evm-ethereum-osaka"
 
 type @layout_0 = enum {
-    #A,
-    #B,
+    #variant_0,
+    #variant_1,
 };
 
 func private %f(v0.@layout_0) {
@@ -32,7 +32,7 @@ func private %main() {
         jump block1;
 
     block1:
-        v0.@layout_0 = enum.make @layout_0 #A;
+        v0.@layout_0 = enum.make @layout_0 #variant_0;
         call %f v0;
         unreachable;
 }

--- a/crates/codegen/tests/fixtures/sonatina_ir/match_struct.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/match_struct.snap
@@ -6,19 +6,18 @@ input_file: crates/codegen/tests/fixtures/match_struct.fe
 target = "evm-ethereum-osaka"
 
 type @layout_0 = {i8, i8};
-type @layout_1 = {i8, i8};
 
-global private const @layout_1 $const_region_0 = {1, 2};
-global private const @layout_1 $const_region_1 = {0, 1};
+global private const @layout_0 $const_region_0 = {1, 2};
+global private const @layout_0 $const_region_1 = {0, 1};
 
 func private %main() -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v2.constref<@layout_1> = const.ref $const_region_0;
+        v2.constref<@layout_0> = const.ref $const_region_0;
         v3.i8 = call %match_struct_fields v2;
-        v5.constref<@layout_1> = const.ref $const_region_1;
+        v5.constref<@layout_0> = const.ref $const_region_1;
         v6.i8 = call %match_struct_wildcard v5;
         v9.@layout_0 = insert_value undef.@layout_0 0.i256 v3;
         v11.@layout_0 = insert_value v9 1.i256 v6;
@@ -34,7 +33,7 @@ func private %main_root() {
         evm_stop;
 }
 
-func private %match_struct_fields(v0.constref<@layout_1>) -> i8 {
+func private %match_struct_fields(v0.constref<@layout_0>) -> i8 {
     block0:
         v1.*i8 = alloca i8;
         v2.*i8 = alloca i8;
@@ -114,7 +113,7 @@ func private %match_struct_fields(v0.constref<@layout_1>) -> i8 {
         jump block2;
 }
 
-func private %match_struct_wildcard(v0.constref<@layout_1>) -> i8 {
+func private %match_struct_wildcard(v0.constref<@layout_0>) -> i8 {
     block0:
         jump block1;
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/match_wildcard.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/match_wildcard.snap
@@ -7,9 +7,9 @@ target = "evm-ethereum-osaka"
 
 type @layout_0 = {i8, i8, i8};
 type @layout_1 = enum {
-    #Red,
-    #Green,
-    #Blue,
+    #variant_0,
+    #variant_1,
+    #variant_2,
 };
 
 func private %main() -> @layout_0 {
@@ -17,10 +17,10 @@ func private %main() -> @layout_0 {
         jump block1;
 
     block1:
-        v0.@layout_1 = enum.make @layout_1 #Red;
+        v0.@layout_1 = enum.make @layout_1 #variant_0;
         v1.i8 = call %match_with_wildcard v0;
         v3.i8 = call %wildcard_not_last 1.i8;
-        v4.@layout_1 = enum.make @layout_1 #Green;
+        v4.@layout_1 = enum.make @layout_1 #variant_1;
         v5.i8 = call %multiple_before_wildcard v4;
         v8.@layout_0 = insert_value undef.@layout_0 0.i256 v1;
         v10.@layout_0 = insert_value v8 1.i256 v3;

--- a/crates/codegen/tests/fixtures/sonatina_ir/name_collisions.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/name_collisions.snap
@@ -311,7 +311,7 @@ func private %standalone_name_collisions__name_collisions__ret_param_collision_c
         return v3;
 }
 
-func private %standalone_name_collisions__name_collisions__impl_trait_MultiTraitImpl_5bd8__same_method_0552(v0.constref<@layout_0>) -> i32 {
+func private %impl_trait_MultiTraitImpl_5bd8__same_method(v0.constref<@layout_0>) -> i32 {
     block0:
         jump block1;
 
@@ -330,45 +330,7 @@ func private %standalone_name_collisions__name_collisions__impl_trait_MultiTrait
         return v6;
 }
 
-func private %standalone_name_collisions__name_collisions__impl_trait_MultiTraitImpl_5bd8__same_method_0552_0(v0.constref<@layout_0>) -> i32 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.constref<i32> = const.proj v0 0.i256;
-        v4.i32 = const.load v3;
-        (v6.i32, v7.i1) = uaddo v4 1.i32;
-        br v7 block2 block3;
-
-    block2:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block3:
-        return v6;
-}
-
-func private %standalone_name_collisions__name_collisions__impl_trait_MultiTraitImpl_b140__same_method_480f(v0.constref<@layout_0>) -> i32 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.constref<i32> = const.proj v0 0.i256;
-        v4.i32 = const.load v3;
-        (v6.i32, v7.i1) = uaddo v4 2.i32;
-        br v7 block2 block3;
-
-    block2:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block3:
-        return v6;
-}
-
-func private %standalone_name_collisions__name_collisions__impl_trait_MultiTraitImpl_b140__same_method_480f_0(v0.constref<@layout_0>) -> i32 {
+func private %impl_trait_MultiTraitImpl_b140__same_method(v0.constref<@layout_0>) -> i32 {
     block0:
         jump block1;
 
@@ -554,10 +516,10 @@ func private %standalone_name_collisions__name_collisions__test_trait_method_col
     block1:
         v1.constref<@layout_0> = const.ref $const_region_4;
         v2.constref<@layout_0> = const.ref $const_region_4;
-        v3.i32 = call %standalone_name_collisions__name_collisions__impl_trait_MultiTraitImpl_5bd8__same_method_0552 v2;
+        v3.i32 = call %impl_trait_MultiTraitImpl_5bd8__same_method v2;
         v4.constref<@layout_0> = const.ref $const_region_4;
         v5.constref<@layout_0> = const.ref $const_region_4;
-        v6.i32 = call %standalone_name_collisions__name_collisions__impl_trait_MultiTraitImpl_b140__same_method_480f v5;
+        v6.i32 = call %impl_trait_MultiTraitImpl_b140__same_method v5;
         (v7.i32, v8.i1) = uaddo v3 v6;
         br v8 block2 block3;
 
@@ -577,10 +539,10 @@ func private %standalone_name_collisions__name_collisions__test_trait_method_col
     block1:
         v1.constref<@layout_0> = const.ref $const_region_4;
         v2.constref<@layout_0> = const.ref $const_region_4;
-        v3.i32 = call %standalone_name_collisions__name_collisions__impl_trait_MultiTraitImpl_5bd8__same_method_0552_0 v2;
+        v3.i32 = call %impl_trait_MultiTraitImpl_5bd8__same_method v2;
         v4.constref<@layout_0> = const.ref $const_region_4;
         v5.constref<@layout_0> = const.ref $const_region_4;
-        v6.i32 = call %standalone_name_collisions__name_collisions__impl_trait_MultiTraitImpl_b140__same_method_480f_0 v5;
+        v6.i32 = call %impl_trait_MultiTraitImpl_b140__same_method v5;
         (v7.i32, v8.i1) = uaddo v3 v6;
         br v8 block2 block3;
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/name_collisions.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/name_collisions.snap
@@ -5,17 +5,14 @@ input_file: crates/codegen/tests/fixtures/name_collisions.fe
 ---
 target = "evm-ethereum-osaka"
 
-type @layout_0 = {i64};
-type @layout_1 = {i32};
-type @layout_2 = {i32};
-type @layout_3 = {i64};
-type @layout_4 = {i32};
+type @layout_0 = {i32};
+type @layout_1 = {i64};
 
-global private const @layout_1 $const_region_0 = {1};
-global private const @layout_0 $const_region_1 = {2};
-global private const @layout_2 $const_region_2 = {10};
-global private const @layout_3 $const_region_3 = {20};
-global private const @layout_4 $const_region_4 = {100};
+global private const @layout_0 $const_region_0 = {1};
+global private const @layout_1 $const_region_1 = {2};
+global private const @layout_0 $const_region_2 = {10};
+global private const @layout_1 $const_region_3 = {20};
+global private const @layout_0 $const_region_4 = {100};
 
 func private %standalone_name_collisions__name_collisions____u32_as_u256_56b3(v0.i32) -> i256 {
     block0:
@@ -105,7 +102,7 @@ func private %standalone_name_collisions__name_collisions__a_b__flattened_fn_ec8
         return 2.i32;
 }
 
-func private %standalone_name_collisions__name_collisions__generic_fn__gf088_02a1(v0.@layout_0) -> @layout_0 {
+func private %standalone_name_collisions__name_collisions__generic_fn__gb148_7f67(v0.@layout_0) -> @layout_0 {
     block0:
         jump block1;
 
@@ -113,7 +110,7 @@ func private %standalone_name_collisions__name_collisions__generic_fn__gf088_02a
         return v0;
 }
 
-func private %standalone_name_collisions__name_collisions__generic_fn__gf088_02a1_0(v0.@layout_0) -> @layout_0 {
+func private %standalone_name_collisions__name_collisions__generic_fn__gb148_7f67_0(v0.@layout_0) -> @layout_0 {
     block0:
         jump block1;
 
@@ -121,7 +118,7 @@ func private %standalone_name_collisions__name_collisions__generic_fn__gf088_02a
         return v0;
 }
 
-func private %standalone_name_collisions__name_collisions__generic_fn__gb148_5d90(v0.@layout_1) -> @layout_1 {
+func private %standalone_name_collisions__name_collisions__generic_fn__gf088_e9d1(v0.@layout_1) -> @layout_1 {
     block0:
         jump block1;
 
@@ -129,7 +126,7 @@ func private %standalone_name_collisions__name_collisions__generic_fn__gb148_5d9
         return v0;
 }
 
-func private %standalone_name_collisions__name_collisions__generic_fn__gb148_5d90_0(v0.@layout_1) -> @layout_1 {
+func private %standalone_name_collisions__name_collisions__generic_fn__gf088_e9d1_0(v0.@layout_1) -> @layout_1 {
     block0:
         jump block1;
 
@@ -204,45 +201,7 @@ func private %standalone_name_collisions__name_collisions__param_local_collision
         return v11;
 }
 
-func private %standalone_name_collisions__name_collisions__impl_a__impl_Widget_8971__process_7ed1(v0.constref<@layout_2>) -> i32 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.constref<i32> = const.proj v0 0.i256;
-        v4.i32 = const.load v3;
-        (v6.i32, v7.i1) = umulo v4 2.i32;
-        br v7 block2 block3;
-
-    block2:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block3:
-        return v6;
-}
-
-func private %standalone_name_collisions__name_collisions__impl_a__impl_Widget_8971__process_7ed1_0(v0.constref<@layout_2>) -> i32 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.constref<i32> = const.proj v0 0.i256;
-        v4.i32 = const.load v3;
-        (v6.i32, v7.i1) = umulo v4 2.i32;
-        br v7 block2 block3;
-
-    block2:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block3:
-        return v6;
-}
-
-func private %standalone_name_collisions__name_collisions__impl_b__impl_Widget_b0f7__process_cb50(v0.constref<@layout_3>) -> i64 {
+func private %standalone_name_collisions__name_collisions__impl_b__impl_Widget_b0f7__process_1462(v0.constref<@layout_1>) -> i64 {
     block0:
         jump block1;
 
@@ -261,7 +220,7 @@ func private %standalone_name_collisions__name_collisions__impl_b__impl_Widget_b
         return v6;
 }
 
-func private %standalone_name_collisions__name_collisions__impl_b__impl_Widget_b0f7__process_cb50_0(v0.constref<@layout_3>) -> i64 {
+func private %standalone_name_collisions__name_collisions__impl_b__impl_Widget_b0f7__process_1462_0(v0.constref<@layout_1>) -> i64 {
     block0:
         jump block1;
 
@@ -269,6 +228,44 @@ func private %standalone_name_collisions__name_collisions__impl_b__impl_Widget_b
         v3.constref<i64> = const.proj v0 0.i256;
         v4.i64 = const.load v3;
         (v6.i64, v7.i1) = umulo v4 3.i64;
+        br v7 block2 block3;
+
+    block2:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block3:
+        return v6;
+}
+
+func private %standalone_name_collisions__name_collisions__impl_a__impl_Widget_8971__process_9a37(v0.constref<@layout_0>) -> i32 {
+    block0:
+        jump block1;
+
+    block1:
+        v3.constref<i32> = const.proj v0 0.i256;
+        v4.i32 = const.load v3;
+        (v6.i32, v7.i1) = umulo v4 2.i32;
+        br v7 block2 block3;
+
+    block2:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block3:
+        return v6;
+}
+
+func private %standalone_name_collisions__name_collisions__impl_a__impl_Widget_8971__process_9a37_0(v0.constref<@layout_0>) -> i32 {
+    block0:
+        jump block1;
+
+    block1:
+        v3.constref<i32> = const.proj v0 0.i256;
+        v4.i32 = const.load v3;
+        (v6.i32, v7.i1) = umulo v4 2.i32;
         br v7 block2 block3;
 
     block2:
@@ -314,7 +311,7 @@ func private %standalone_name_collisions__name_collisions__ret_param_collision_c
         return v3;
 }
 
-func private %standalone_name_collisions__name_collisions__impl_trait_MultiTraitImpl_5bd8__same_method_133c(v0.constref<@layout_4>) -> i32 {
+func private %standalone_name_collisions__name_collisions__impl_trait_MultiTraitImpl_5bd8__same_method_0552(v0.constref<@layout_0>) -> i32 {
     block0:
         jump block1;
 
@@ -333,7 +330,7 @@ func private %standalone_name_collisions__name_collisions__impl_trait_MultiTrait
         return v6;
 }
 
-func private %standalone_name_collisions__name_collisions__impl_trait_MultiTraitImpl_5bd8__same_method_133c_0(v0.constref<@layout_4>) -> i32 {
+func private %standalone_name_collisions__name_collisions__impl_trait_MultiTraitImpl_5bd8__same_method_0552_0(v0.constref<@layout_0>) -> i32 {
     block0:
         jump block1;
 
@@ -352,7 +349,7 @@ func private %standalone_name_collisions__name_collisions__impl_trait_MultiTrait
         return v6;
 }
 
-func private %standalone_name_collisions__name_collisions__impl_trait_MultiTraitImpl_b140__same_method_66b3(v0.constref<@layout_4>) -> i32 {
+func private %standalone_name_collisions__name_collisions__impl_trait_MultiTraitImpl_b140__same_method_480f(v0.constref<@layout_0>) -> i32 {
     block0:
         jump block1;
 
@@ -371,7 +368,7 @@ func private %standalone_name_collisions__name_collisions__impl_trait_MultiTrait
         return v6;
 }
 
-func private %standalone_name_collisions__name_collisions__impl_trait_MultiTraitImpl_b140__same_method_66b3_0(v0.constref<@layout_4>) -> i32 {
+func private %standalone_name_collisions__name_collisions__impl_trait_MultiTraitImpl_b140__same_method_480f_0(v0.constref<@layout_0>) -> i32 {
     block0:
         jump block1;
 
@@ -413,18 +410,18 @@ func private %standalone_name_collisions__name_collisions__test_generic_type_col
         jump block1;
 
     block1:
-        v1.constref<@layout_1> = const.ref $const_region_0;
-        v2.constref<@layout_1> = const.ref $const_region_0;
-        v4.constref<@layout_0> = const.ref $const_region_1;
-        v5.constref<@layout_0> = const.ref $const_region_1;
-        v6.objref<@layout_1> = obj.alloc @layout_1;
+        v1.constref<@layout_0> = const.ref $const_region_0;
+        v2.constref<@layout_0> = const.ref $const_region_0;
+        v4.constref<@layout_1> = const.ref $const_region_1;
+        v5.constref<@layout_1> = const.ref $const_region_1;
+        v6.objref<@layout_0> = obj.alloc @layout_0;
         obj.init.const v6 v2;
-        v7.@layout_1 = obj.load v6;
-        v8.@layout_1 = call %standalone_name_collisions__name_collisions__generic_fn__gb148_5d90 v7;
-        v9.objref<@layout_0> = obj.alloc @layout_0;
+        v7.@layout_0 = obj.load v6;
+        v8.@layout_0 = call %standalone_name_collisions__name_collisions__generic_fn__gb148_7f67 v7;
+        v9.objref<@layout_1> = obj.alloc @layout_1;
         obj.init.const v9 v5;
-        v10.@layout_0 = obj.load v9;
-        v11.@layout_0 = call %standalone_name_collisions__name_collisions__generic_fn__gf088_02a1 v10;
+        v10.@layout_1 = obj.load v9;
+        v11.@layout_1 = call %standalone_name_collisions__name_collisions__generic_fn__gf088_e9d1 v10;
         return 42.i32;
 }
 
@@ -433,18 +430,18 @@ func private %standalone_name_collisions__name_collisions__test_generic_type_col
         jump block1;
 
     block1:
-        v1.constref<@layout_1> = const.ref $const_region_0;
-        v2.constref<@layout_1> = const.ref $const_region_0;
-        v4.constref<@layout_0> = const.ref $const_region_1;
-        v5.constref<@layout_0> = const.ref $const_region_1;
-        v6.objref<@layout_1> = obj.alloc @layout_1;
+        v1.constref<@layout_0> = const.ref $const_region_0;
+        v2.constref<@layout_0> = const.ref $const_region_0;
+        v4.constref<@layout_1> = const.ref $const_region_1;
+        v5.constref<@layout_1> = const.ref $const_region_1;
+        v6.objref<@layout_0> = obj.alloc @layout_0;
         obj.init.const v6 v2;
-        v7.@layout_1 = obj.load v6;
-        v8.@layout_1 = call %standalone_name_collisions__name_collisions__generic_fn__gb148_5d90_0 v7;
-        v9.objref<@layout_0> = obj.alloc @layout_0;
+        v7.@layout_0 = obj.load v6;
+        v8.@layout_0 = call %standalone_name_collisions__name_collisions__generic_fn__gb148_7f67_0 v7;
+        v9.objref<@layout_1> = obj.alloc @layout_1;
         obj.init.const v9 v5;
-        v10.@layout_0 = obj.load v9;
-        v11.@layout_0 = call %standalone_name_collisions__name_collisions__generic_fn__gf088_02a1_0 v10;
+        v10.@layout_1 = obj.load v9;
+        v11.@layout_1 = call %standalone_name_collisions__name_collisions__generic_fn__gf088_e9d1_0 v10;
         return 42.i32;
 }
 
@@ -453,12 +450,12 @@ func private %standalone_name_collisions__name_collisions__test_impl_method_coll
         jump block1;
 
     block1:
-        v1.constref<@layout_2> = const.ref $const_region_2;
-        v2.constref<@layout_2> = const.ref $const_region_2;
-        v4.constref<@layout_3> = const.ref $const_region_3;
-        v5.constref<@layout_3> = const.ref $const_region_3;
-        v6.i32 = call %standalone_name_collisions__name_collisions__impl_a__impl_Widget_8971__process_7ed1 v2;
-        v7.i64 = call %standalone_name_collisions__name_collisions__impl_b__impl_Widget_b0f7__process_cb50 v5;
+        v1.constref<@layout_0> = const.ref $const_region_2;
+        v2.constref<@layout_0> = const.ref $const_region_2;
+        v4.constref<@layout_1> = const.ref $const_region_3;
+        v5.constref<@layout_1> = const.ref $const_region_3;
+        v6.i32 = call %standalone_name_collisions__name_collisions__impl_a__impl_Widget_8971__process_9a37 v2;
+        v7.i64 = call %standalone_name_collisions__name_collisions__impl_b__impl_Widget_b0f7__process_1462 v5;
         return v6;
 }
 
@@ -467,12 +464,12 @@ func private %standalone_name_collisions__name_collisions__test_impl_method_coll
         jump block1;
 
     block1:
-        v1.constref<@layout_2> = const.ref $const_region_2;
-        v2.constref<@layout_2> = const.ref $const_region_2;
-        v4.constref<@layout_3> = const.ref $const_region_3;
-        v5.constref<@layout_3> = const.ref $const_region_3;
-        v6.i32 = call %standalone_name_collisions__name_collisions__impl_a__impl_Widget_8971__process_7ed1_0 v2;
-        v7.i64 = call %standalone_name_collisions__name_collisions__impl_b__impl_Widget_b0f7__process_cb50_0 v5;
+        v1.constref<@layout_0> = const.ref $const_region_2;
+        v2.constref<@layout_0> = const.ref $const_region_2;
+        v4.constref<@layout_1> = const.ref $const_region_3;
+        v5.constref<@layout_1> = const.ref $const_region_3;
+        v6.i32 = call %standalone_name_collisions__name_collisions__impl_a__impl_Widget_8971__process_9a37_0 v2;
+        v7.i64 = call %standalone_name_collisions__name_collisions__impl_b__impl_Widget_b0f7__process_1462_0 v5;
         return v6;
 }
 
@@ -555,12 +552,12 @@ func private %standalone_name_collisions__name_collisions__test_trait_method_col
         jump block1;
 
     block1:
-        v1.constref<@layout_4> = const.ref $const_region_4;
-        v2.constref<@layout_4> = const.ref $const_region_4;
-        v3.i32 = call %standalone_name_collisions__name_collisions__impl_trait_MultiTraitImpl_5bd8__same_method_133c v2;
-        v4.constref<@layout_4> = const.ref $const_region_4;
-        v5.constref<@layout_4> = const.ref $const_region_4;
-        v6.i32 = call %standalone_name_collisions__name_collisions__impl_trait_MultiTraitImpl_b140__same_method_66b3 v5;
+        v1.constref<@layout_0> = const.ref $const_region_4;
+        v2.constref<@layout_0> = const.ref $const_region_4;
+        v3.i32 = call %standalone_name_collisions__name_collisions__impl_trait_MultiTraitImpl_5bd8__same_method_0552 v2;
+        v4.constref<@layout_0> = const.ref $const_region_4;
+        v5.constref<@layout_0> = const.ref $const_region_4;
+        v6.i32 = call %standalone_name_collisions__name_collisions__impl_trait_MultiTraitImpl_b140__same_method_480f v5;
         (v7.i32, v8.i1) = uaddo v3 v6;
         br v8 block2 block3;
 
@@ -578,12 +575,12 @@ func private %standalone_name_collisions__name_collisions__test_trait_method_col
         jump block1;
 
     block1:
-        v1.constref<@layout_4> = const.ref $const_region_4;
-        v2.constref<@layout_4> = const.ref $const_region_4;
-        v3.i32 = call %standalone_name_collisions__name_collisions__impl_trait_MultiTraitImpl_5bd8__same_method_133c_0 v2;
-        v4.constref<@layout_4> = const.ref $const_region_4;
-        v5.constref<@layout_4> = const.ref $const_region_4;
-        v6.i32 = call %standalone_name_collisions__name_collisions__impl_trait_MultiTraitImpl_b140__same_method_66b3_0 v5;
+        v1.constref<@layout_0> = const.ref $const_region_4;
+        v2.constref<@layout_0> = const.ref $const_region_4;
+        v3.i32 = call %standalone_name_collisions__name_collisions__impl_trait_MultiTraitImpl_5bd8__same_method_0552_0 v2;
+        v4.constref<@layout_0> = const.ref $const_region_4;
+        v5.constref<@layout_0> = const.ref $const_region_4;
+        v6.i32 = call %standalone_name_collisions__name_collisions__impl_trait_MultiTraitImpl_b140__same_method_480f_0 v5;
         (v7.i32, v8.i1) = uaddo v3 v6;
         br v8 block2 block3;
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/nested_struct.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/nested_struct.snap
@@ -17,7 +17,7 @@ func private %abi_encode(v0.i256) {
 
     block1:
         call %mstore 0.i256 v0;
-        call %std__lib__evm__effects__impl_trait_Evm_0098__return_data_f7e3 0.i256 32.i256;
+        call %return_data 0.i256 32.i256;
         unreachable;
 }
 
@@ -58,7 +58,7 @@ func private %init() {
         v2.*i8 = evm_malloc v0;
         v3.i256 = ptr_to_int v2 i256;
         call %codecopy v3 v1 v0;
-        call %std__lib__evm__effects__impl_trait_Evm_0098__return_data_7adf_0 v3 v0;
+        call %return_data v3 v0;
         unreachable;
 }
 
@@ -133,23 +133,7 @@ func private %read_inner(v0.i256) -> i256 {
         return v9;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_0098__return_data_7adf(v0.i256, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        evm_return v0 v1;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_0098__return_data_7adf_0(v0.i256, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        evm_return v0 v1;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_0098__return_data_f7e3(v0.i256, v1.i256) {
+func private %return_data(v0.i256, v1.i256) {
     block0:
         jump block1;
 
@@ -188,7 +172,7 @@ func private %runtime() {
         unreachable;
 
     block5:
-        call %std__lib__evm__effects__impl_trait_Evm_0098__return_data_7adf 0.i256 0.i256;
+        call %return_data 0.i256 0.i256;
         unreachable;
 
     block6:

--- a/crates/codegen/tests/fixtures/sonatina_ir/nested_struct.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/nested_struct.snap
@@ -6,12 +6,10 @@ input_file: crates/codegen/tests/fixtures/nested_struct.fe
 target = "evm-ethereum-osaka"
 
 type @layout_0 = {i256};
-type @layout_1 = {i256};
-type @layout_2 = {@layout_1};
-type @layout_3 = {@layout_1};
+type @layout_1 = {@layout_0};
 
-global private const @layout_1 $const_region_0 = {0};
-global private const @layout_2 $const_region_1 = {{0}};
+global private const @layout_0 $const_region_0 = {0};
+global private const @layout_1 $const_region_1 = {{0}};
 
 func private %abi_encode(v0.i256) {
     block0:
@@ -87,18 +85,18 @@ func private %mem_read(v0.i256) -> i256 {
         jump block1;
 
     block1:
-        v2.constref<@layout_1> = const.ref $const_region_0;
-        v3.constref<@layout_2> = const.ref $const_region_1;
-        v5.@layout_1 = insert_value undef.@layout_1 0.i256 0.i256;
-        v6.objref<@layout_2> = obj.alloc @layout_2;
-        v7.objref<@layout_1> = obj.proj v6 0.i256;
+        v2.constref<@layout_0> = const.ref $const_region_0;
+        v3.constref<@layout_1> = const.ref $const_region_1;
+        v5.@layout_0 = insert_value undef.@layout_0 0.i256 0.i256;
+        v6.objref<@layout_1> = obj.alloc @layout_1;
+        v7.objref<@layout_0> = obj.proj v6 0.i256;
         v8.objref<i256> = obj.proj v7 0.i256;
         v9.i256 = extract_value v5 0.i256;
         obj.store v8 v9;
-        v11.objref<@layout_1> = obj.proj v6 0.i256;
+        v11.objref<@layout_0> = obj.proj v6 0.i256;
         v12.objref<i256> = obj.proj v11 0.i256;
         obj.store v12 v0;
-        v13.objref<@layout_1> = obj.proj v6 0.i256;
+        v13.objref<@layout_0> = obj.proj v6 0.i256;
         v14.objref<i256> = obj.proj v13 0.i256;
         v15.i256 = obj.load v14;
         return v15;
@@ -128,9 +126,9 @@ func private %read_inner(v0.i256) -> i256 {
 
     block1:
         v4.i256 = evm_sload v0;
-        v6.@layout_1 = insert_value undef.@layout_1 0.i256 v4;
-        v7.@layout_3 = insert_value undef.@layout_3 0.i256 v6;
-        v8.@layout_1 = extract_value v7 0.i256;
+        v6.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
+        v7.@layout_1 = insert_value undef.@layout_1 0.i256 v6;
+        v8.@layout_0 = extract_value v7 0.i256;
         v9.i256 = extract_value v8 0.i256;
         return v9;
 }

--- a/crates/codegen/tests/fixtures/sonatina_ir/newtype_storage_byplace_effect_arg.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/newtype_storage_byplace_effect_arg.snap
@@ -46,7 +46,7 @@ func private %abi_field_size(v0.i256) -> i256 {
         jump block1;
 
     block1:
-        v2.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_a5ce_0 v0;
+        v2.i256 = call %payload_size v0;
         br 0.i1 block2 block3;
 
     block2:
@@ -253,7 +253,7 @@ func private %encode(v0.i256, v1.objref<@layout_0>) {
         jump block1;
 
     block1:
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_06eb v1 v0;
+        call %write_word v1 v0;
         return;
 }
 
@@ -266,10 +266,10 @@ func private %encode_field(v0.i256, v1.objref<@layout_0>, v2.i256) {
 
     block2:
         v5.i256 = call %base v1;
-        v8.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_a5ce v0;
+        v8.i256 = call %payload_size v0;
         v9.i256 = mload v2 i256;
         v10.i256 = sub v9 v5;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_1bad v1 v10;
+        call %write_word v1 v10;
         v12.i256 = call %pos v1;
         v13.i256 = mload v2 i256;
         call %set_base v1 v13;
@@ -434,15 +434,7 @@ func inline(always) private %impl_CallData__new() -> @layout_1 {
         return v3;
 }
 
-func private %core__lib__abi__trait_AbiSize__payload_size__ge513_a5ce(v0.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        return 32.i256;
-}
-
-func private %core__lib__abi__trait_AbiSize__payload_size__ge513_a5ce_0(v0.i256) -> i256 {
+func private %payload_size(v0.i256) -> i256 {
     block0:
         jump block1;
 
@@ -497,21 +489,7 @@ func private %store_word(v0.i256, v1.i256) {
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_06eb(v0.objref<@layout_0>, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v4.objref<i256> = obj.proj v0 1.i256;
-        v5.i256 = obj.load v4;
-        mstore v5 v1 i256;
-        v9.i256 = add v5 32.i256;
-        v10.objref<i256> = obj.proj v0 1.i256;
-        obj.store v10 v9;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_1bad(v0.objref<@layout_0>, v1.i256) {
+func private %write_word(v0.objref<@layout_0>, v1.i256) {
     block0:
         jump block1;
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/newtype_storage_byplace_effect_arg.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/newtype_storage_byplace_effect_arg.snap
@@ -9,7 +9,6 @@ type @layout_0 = {i256, i256};
 type @layout_1 = {i256};
 type @layout_2 = {};
 type @layout_3 = {@layout_2};
-type @layout_4 = {i256, i256};
 
 global private const @layout_1 $const_region_0 = {0};
 
@@ -173,7 +172,7 @@ func inline(always) private %contract_recv_abi_NewtypeByPlaceEffectArg_1() {
         v5.objref<@layout_3> = obj.alloc @layout_3;
         call %decode_runtime_args v5;
         v8.i256 = call %__NewtypeByPlaceEffectArg_recv_0_0 1.i256 0.i256;
-        v9.@layout_4 = call %encode_single_root_alloc v8;
+        v9.@layout_0 = call %encode_single_root_alloc v8;
         v10.i256 = extract_value v9 0.i256;
         v11.i256 = extract_value v9 1.i256;
         evm_return v10 v11;
@@ -254,7 +253,7 @@ func private %encode(v0.i256, v1.objref<@layout_0>) {
         jump block1;
 
     block1:
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_8b2d v1 v0;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_06eb v1 v0;
         return;
 }
 
@@ -270,7 +269,7 @@ func private %encode_field(v0.i256, v1.objref<@layout_0>, v2.i256) {
         v8.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_a5ce v0;
         v9.i256 = mload v2 i256;
         v10.i256 = sub v9 v5;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_a98a v1 v10;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_1bad v1 v10;
         v12.i256 = call %pos v1;
         v13.i256 = mload v2 i256;
         call %set_base v1 v13;
@@ -319,7 +318,7 @@ func private %encode_single_root(v0.i256, v1.objref<@layout_0>) {
         return;
 }
 
-func private %encode_single_root_alloc(v0.i256) -> @layout_4 {
+func private %encode_single_root_alloc(v0.i256) -> @layout_0 {
     block0:
         jump block1;
 
@@ -335,8 +334,8 @@ func private %encode_single_root_alloc(v0.i256) -> @layout_4 {
         obj.store v9 v10;
         v11.i256 = call %base v4;
         call %encode_single_root v0 v4;
-        v14.@layout_4 = insert_value undef.@layout_4 0.i256 v11;
-        v15.@layout_4 = insert_value v14 1.i256 v2;
+        v14.@layout_0 = insert_value undef.@layout_0 0.i256 v11;
+        v15.@layout_0 = insert_value v14 1.i256 v2;
         return v15;
 }
 
@@ -498,7 +497,7 @@ func private %store_word(v0.i256, v1.i256) {
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_8b2d(v0.objref<@layout_0>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_06eb(v0.objref<@layout_0>, v1.i256) {
     block0:
         jump block1;
 
@@ -512,7 +511,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_8b2d(v0
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_a98a(v0.objref<@layout_0>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_1bad(v0.objref<@layout_0>, v1.i256) {
     block0:
         jump block1;
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/newtype_storage_field_mut_method_call.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/newtype_storage_field_mut_method_call.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/codegen/tests/sonatina_ir.rs
-assertion_line: 449
 expression: output
 input_file: crates/codegen/tests/fixtures/newtype_storage_field_mut_method_call.fe
 ---
@@ -10,7 +9,6 @@ type @layout_0 = {i256, i256};
 type @layout_1 = {i256};
 type @layout_2 = {};
 type @layout_3 = {@layout_2};
-type @layout_4 = {i256, i256};
 
 global private const @layout_1 $const_region_0 = {0};
 
@@ -163,7 +161,7 @@ func inline(always) private %contract_recv_abi_NewtypeStorageFieldMutMethodCall_
         v5.objref<@layout_3> = obj.alloc @layout_3;
         call %decode_runtime_args v5;
         v8.i256 = call %__NewtypeStorageFieldMutMethodCall_recv_0_0 1.i256;
-        v9.@layout_4 = call %encode_single_root_alloc v8;
+        v9.@layout_0 = call %encode_single_root_alloc v8;
         v10.i256 = extract_value v9 0.i256;
         v11.i256 = extract_value v9 1.i256;
         evm_return v10 v11;
@@ -244,7 +242,7 @@ func private %encode(v0.i256, v1.objref<@layout_0>) {
         jump block1;
 
     block1:
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_90ae v1 v0;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_5e95 v1 v0;
         return;
 }
 
@@ -260,7 +258,7 @@ func private %encode_field(v0.i256, v1.objref<@layout_0>, v2.i256) {
         v8.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_4e75 v0;
         v9.i256 = mload v2 i256;
         v10.i256 = sub v9 v5;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_9251 v1 v10;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_109b v1 v10;
         v12.i256 = call %pos v1;
         v13.i256 = mload v2 i256;
         call %set_base v1 v13;
@@ -309,7 +307,7 @@ func private %encode_single_root(v0.i256, v1.objref<@layout_0>) {
         return;
 }
 
-func private %encode_single_root_alloc(v0.i256) -> @layout_4 {
+func private %encode_single_root_alloc(v0.i256) -> @layout_0 {
     block0:
         jump block1;
 
@@ -325,8 +323,8 @@ func private %encode_single_root_alloc(v0.i256) -> @layout_4 {
         obj.store v9 v10;
         v11.i256 = call %base v4;
         call %encode_single_root v0 v4;
-        v14.@layout_4 = insert_value undef.@layout_4 0.i256 v11;
-        v15.@layout_4 = insert_value v14 1.i256 v2;
+        v14.@layout_0 = insert_value undef.@layout_0 0.i256 v11;
+        v15.@layout_0 = insert_value v14 1.i256 v2;
         return v15;
 }
 
@@ -488,7 +486,7 @@ func private %store_word(v0.i256, v1.i256) {
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_90ae(v0.objref<@layout_0>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_109b(v0.objref<@layout_0>, v1.i256) {
     block0:
         jump block1;
 
@@ -502,7 +500,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_90ae(v0
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_9251(v0.objref<@layout_0>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_5e95(v0.objref<@layout_0>, v1.i256) {
     block0:
         jump block1;
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/newtype_storage_field_mut_method_call.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/newtype_storage_field_mut_method_call.snap
@@ -35,7 +35,7 @@ func private %abi_field_size(v0.i256) -> i256 {
         jump block1;
 
     block1:
-        v2.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_4e75_0 v0;
+        v2.i256 = call %payload_size v0;
         br 0.i1 block2 block3;
 
     block2:
@@ -242,7 +242,7 @@ func private %encode(v0.i256, v1.objref<@layout_0>) {
         jump block1;
 
     block1:
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_5e95 v1 v0;
+        call %write_word v1 v0;
         return;
 }
 
@@ -255,10 +255,10 @@ func private %encode_field(v0.i256, v1.objref<@layout_0>, v2.i256) {
 
     block2:
         v5.i256 = call %base v1;
-        v8.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_4e75 v0;
+        v8.i256 = call %payload_size v0;
         v9.i256 = mload v2 i256;
         v10.i256 = sub v9 v5;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_109b v1 v10;
+        call %write_word v1 v10;
         v12.i256 = call %pos v1;
         v13.i256 = mload v2 i256;
         call %set_base v1 v13;
@@ -389,18 +389,6 @@ func inline(always) private %len(v0.@layout_1) -> i256 {
         jump block4;
 }
 
-func inline(always) private %impl_CallData__new() -> @layout_1 {
-    block0:
-        jump block1;
-
-    block1:
-        v1.constref<@layout_1> = const.ref $const_region_0;
-        v2.objref<@layout_1> = obj.alloc @layout_1;
-        obj.init.const v2 v1;
-        v3.@layout_1 = obj.load v2;
-        return v3;
-}
-
 func private %impl_SolEncoder__new(v0.i256) -> @layout_0 {
     block0:
         jump block1;
@@ -423,15 +411,19 @@ func private %impl_SolEncoder__new(v0.i256) -> @layout_0 {
         return v8;
 }
 
-func private %core__lib__abi__trait_AbiSize__payload_size__ge513_4e75(v0.i256) -> i256 {
+func inline(always) private %impl_CallData__new() -> @layout_1 {
     block0:
         jump block1;
 
     block1:
-        return 32.i256;
+        v1.constref<@layout_1> = const.ref $const_region_0;
+        v2.objref<@layout_1> = obj.alloc @layout_1;
+        obj.init.const v2 v1;
+        v3.@layout_1 = obj.load v2;
+        return v3;
 }
 
-func private %core__lib__abi__trait_AbiSize__payload_size__ge513_4e75_0(v0.i256) -> i256 {
+func private %payload_size(v0.i256) -> i256 {
     block0:
         jump block1;
 
@@ -486,21 +478,7 @@ func private %store_word(v0.i256, v1.i256) {
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_109b(v0.objref<@layout_0>, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v4.objref<i256> = obj.proj v0 1.i256;
-        v5.i256 = obj.load v4;
-        mstore v5 v1 i256;
-        v9.i256 = add v5 32.i256;
-        v10.objref<i256> = obj.proj v0 1.i256;
-        obj.store v10 v9;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_5e95(v0.objref<@layout_0>, v1.i256) {
+func private %write_word(v0.objref<@layout_0>, v1.i256) {
     block0:
         jump block1;
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/revert.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/revert.snap
@@ -10,8 +10,8 @@ func private %standalone_revert__revert__fail__gcd5c_35c3() {
         jump block1;
 
     block1:
-        call %std__lib__evm__effects__impl_trait_Evm_d0d8__mstore_401f 0.i256 42.i256;
-        call %std__lib__evm__effects__impl_trait_Evm_0098__revert_f9bb 0.i256 32.i256;
+        call %mstore 0.i256 42.i256;
+        call %revert 0.i256 32.i256;
         unreachable;
 }
 
@@ -20,8 +20,8 @@ func private %standalone_revert__revert__fail__gcd5c_cdbf() {
         jump block1;
 
     block1:
-        call %std__lib__evm__effects__impl_trait_Evm_d0d8__mstore_401f_0 0.i256 42.i256;
-        call %std__lib__evm__effects__impl_trait_Evm_0098__revert_f9bb_0 0.i256 32.i256;
+        call %mstore 0.i256 42.i256;
+        call %revert 0.i256 32.i256;
         unreachable;
 }
 
@@ -43,7 +43,7 @@ func private %main_root() {
         evm_stop;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_d0d8__mstore_401f(v0.i256, v1.i256) {
+func private %mstore(v0.i256, v1.i256) {
     block0:
         jump block1;
 
@@ -52,24 +52,7 @@ func private %std__lib__evm__effects__impl_trait_Evm_d0d8__mstore_401f(v0.i256, 
         return;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_d0d8__mstore_401f_0(v0.i256, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        mstore v0 v1 i256;
-        return;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_f9bb(v0.i256, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        evm_revert v0 v1;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_f9bb_0(v0.i256, v1.i256) {
+func private %revert(v0.i256, v1.i256) {
     block0:
         jump block1;
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/storage.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/storage.snap
@@ -18,7 +18,7 @@ func private %abi_encode(v0.i256) {
 
     block1:
         call %mstore 0.i256 v0;
-        call %std__lib__evm__effects__impl_trait_Evm_0098__return_data_f28e 0.i256 32.i256;
+        call %return_data 0.i256 32.i256;
         unreachable;
 }
 
@@ -151,7 +151,7 @@ func private %credit_bob(v0.i256, v1.i256, v2.i256) -> i256 {
         return v38;
 }
 
-func private %from_raw__gf198(v0.i256) -> @layout_0 {
+func private %from_raw__g9438(v0.i256) -> @layout_0 {
     block0:
         jump block1;
 
@@ -160,7 +160,7 @@ func private %from_raw__gf198(v0.i256) -> @layout_0 {
         return v4;
 }
 
-func private %from_raw__g9438(v0.i256) -> @layout_0 {
+func private %from_raw__gf198(v0.i256) -> @layout_0 {
     block0:
         jump block1;
 
@@ -179,7 +179,7 @@ func private %init() {
         v2.*i8 = evm_malloc v0;
         v3.i256 = ptr_to_int v2 i256;
         call %codecopy v3 v1 v0;
-        call %std__lib__evm__effects__impl_trait_Evm_0098__return_data_e8fc_0 v3 v0;
+        call %return_data v3 v0;
         unreachable;
 }
 
@@ -228,23 +228,7 @@ func private %raw__g9438(v0.@layout_0) -> i256 {
         return v3;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_0098__return_data_e8fc(v0.i256, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        evm_return v0 v1;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_0098__return_data_e8fc_0(v0.i256, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        evm_return v0 v1;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_0098__return_data_f28e(v0.i256, v1.i256) {
+func private %return_data(v0.i256, v1.i256) {
     block0:
         jump block1;
 
@@ -290,7 +274,7 @@ func private %runtime() {
         unreachable;
 
     block6:
-        call %std__lib__evm__effects__impl_trait_Evm_0098__return_data_e8fc 0.i256 0.i256;
+        call %return_data 0.i256 0.i256;
         unreachable;
 
     block7:
@@ -348,21 +332,21 @@ func private %runtime() {
         jump block17;
 }
 
-func private %stor_ptr__g2c78(v0.i256) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.@layout_0 = call %from_raw__g9438 v0;
-        return v2;
-}
-
 func private %stor_ptr__gd216(v0.i256) -> @layout_0 {
     block0:
         jump block1;
 
     block1:
         v2.@layout_0 = call %from_raw__gf198 v0;
+        return v2;
+}
+
+func private %stor_ptr__g2c78(v0.i256) -> @layout_0 {
+    block0:
+        jump block1;
+
+    block1:
+        v2.@layout_0 = call %from_raw__g9438 v0;
         return v2;
 }
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/storage.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/storage.snap
@@ -6,12 +6,10 @@ input_file: crates/codegen/tests/fixtures/storage.fe
 target = "evm-ethereum-osaka"
 
 type @layout_0 = {i256};
-type @layout_1 = {i256};
-type @layout_3 = {i256, i256};
-type @layout_4 = {i256};
-type @layout_2 = enum {
-    #Ok,
-    #Insufficient,
+type @layout_2 = {i256, i256};
+type @layout_1 = enum {
+    #variant_0,
+    #variant_1,
 };
 
 func private %abi_encode(v0.i256) {
@@ -38,19 +36,19 @@ func private %balance_of_raw(v0.i256, v1.i256) -> i256 {
 
     block3:
         v8.i256 = evm_sload v1;
-        v9.@layout_3 = insert_value undef.@layout_3 0.i256 v8;
+        v9.@layout_2 = insert_value undef.@layout_2 0.i256 v8;
         v11.i256 = add v1 1.i256;
         v12.i256 = evm_sload v11;
-        v13.@layout_3 = insert_value v9 1.i256 v12;
+        v13.@layout_2 = insert_value v9 1.i256 v12;
         v14.i256 = extract_value v13 0.i256;
         jump block2;
 
     block4:
         v17.i256 = evm_sload v1;
-        v18.@layout_3 = insert_value undef.@layout_3 0.i256 v17;
+        v18.@layout_2 = insert_value undef.@layout_2 0.i256 v17;
         v19.i256 = add v1 1.i256;
         v20.i256 = evm_sload v19;
-        v21.@layout_3 = insert_value v18 1.i256 v20;
+        v21.@layout_2 = insert_value v18 1.i256 v20;
         v22.i256 = extract_value v21 1.i256;
         jump block2;
 
@@ -82,10 +80,10 @@ func private %credit_alice(v0.i256, v1.i256, v2.i256) -> i256 {
 
     block1:
         v5.i256 = evm_sload v1;
-        v7.@layout_3 = insert_value undef.@layout_3 0.i256 v5;
+        v7.@layout_2 = insert_value undef.@layout_2 0.i256 v5;
         v9.i256 = add v1 1.i256;
         v10.i256 = evm_sload v9;
-        v11.@layout_3 = insert_value v7 1.i256 v10;
+        v11.@layout_2 = insert_value v7 1.i256 v10;
         v12.i256 = extract_value v11 0.i256;
         (v14.i256, v15.i1) = uaddo v12 v0;
         br v15 block2 block3;
@@ -98,7 +96,7 @@ func private %credit_alice(v0.i256, v1.i256, v2.i256) -> i256 {
     block3:
         evm_sstore v1 v14;
         v23.i256 = evm_sload v2;
-        v24.@layout_4 = insert_value undef.@layout_4 0.i256 v23;
+        v24.@layout_0 = insert_value undef.@layout_0 0.i256 v23;
         v25.i256 = extract_value v24 0.i256;
         (v27.i256, v28.i1) = uaddo v25 v0;
         br v28 block2 block4;
@@ -106,10 +104,10 @@ func private %credit_alice(v0.i256, v1.i256, v2.i256) -> i256 {
     block4:
         evm_sstore v2 v27;
         v32.i256 = evm_sload v1;
-        v33.@layout_3 = insert_value undef.@layout_3 0.i256 v32;
+        v33.@layout_2 = insert_value undef.@layout_2 0.i256 v32;
         v34.i256 = add v1 1.i256;
         v35.i256 = evm_sload v34;
-        v36.@layout_3 = insert_value v33 1.i256 v35;
+        v36.@layout_2 = insert_value v33 1.i256 v35;
         v37.i256 = extract_value v36 0.i256;
         return v37;
 }
@@ -120,10 +118,10 @@ func private %credit_bob(v0.i256, v1.i256, v2.i256) -> i256 {
 
     block1:
         v5.i256 = evm_sload v1;
-        v7.@layout_3 = insert_value undef.@layout_3 0.i256 v5;
+        v7.@layout_2 = insert_value undef.@layout_2 0.i256 v5;
         v9.i256 = add v1 1.i256;
         v10.i256 = evm_sload v9;
-        v11.@layout_3 = insert_value v7 1.i256 v10;
+        v11.@layout_2 = insert_value v7 1.i256 v10;
         v12.i256 = extract_value v11 1.i256;
         (v14.i256, v15.i1) = uaddo v12 v0;
         br v15 block2 block3;
@@ -137,7 +135,7 @@ func private %credit_bob(v0.i256, v1.i256, v2.i256) -> i256 {
         v21.i256 = add v1 1.i256;
         evm_sstore v21 v14;
         v24.i256 = evm_sload v2;
-        v25.@layout_4 = insert_value undef.@layout_4 0.i256 v24;
+        v25.@layout_0 = insert_value undef.@layout_0 0.i256 v24;
         v26.i256 = extract_value v25 0.i256;
         (v28.i256, v29.i1) = uaddo v26 v0;
         br v29 block2 block4;
@@ -145,10 +143,10 @@ func private %credit_bob(v0.i256, v1.i256, v2.i256) -> i256 {
     block4:
         evm_sstore v2 v28;
         v33.i256 = evm_sload v1;
-        v34.@layout_3 = insert_value undef.@layout_3 0.i256 v33;
+        v34.@layout_2 = insert_value undef.@layout_2 0.i256 v33;
         v35.i256 = add v1 1.i256;
         v36.i256 = evm_sload v35;
-        v37.@layout_3 = insert_value v34 1.i256 v36;
+        v37.@layout_2 = insert_value v34 1.i256 v36;
         v38.i256 = extract_value v37 1.i256;
         return v38;
 }
@@ -162,12 +160,12 @@ func private %from_raw__gf198(v0.i256) -> @layout_0 {
         return v4;
 }
 
-func private %from_raw__g9438(v0.i256) -> @layout_1 {
+func private %from_raw__g9438(v0.i256) -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v4.@layout_1 = insert_value undef.@layout_1 0.i256 v0;
+        v4.@layout_0 = insert_value undef.@layout_0 0.i256 v0;
         return v4;
 }
 
@@ -212,7 +210,7 @@ func private %mstore(v0.i256, v1.i256) {
         return;
 }
 
-func private %raw__g9438(v0.@layout_1) -> i256 {
+func private %raw__gf198(v0.@layout_0) -> i256 {
     block0:
         jump block1;
 
@@ -221,7 +219,7 @@ func private %raw__g9438(v0.@layout_1) -> i256 {
         return v3;
 }
 
-func private %raw__gf198(v0.@layout_0) -> i256 {
+func private %raw__g9438(v0.@layout_0) -> i256 {
     block0:
         jump block1;
 
@@ -259,7 +257,7 @@ func private %runtime() {
         jump block1;
 
     block1:
-        v1.@layout_1 = call %stor_ptr__g2c78 0.i256;
+        v1.@layout_0 = call %stor_ptr__g2c78 0.i256;
         v3.@layout_0 = call %stor_ptr__gd216 2.i256;
         v4.i256 = call %calldataload 0.i256;
         v6.i256 = shr 224.i256 v4;
@@ -331,31 +329,31 @@ func private %runtime() {
         jump block13;
 
     block15:
-        v46.@layout_2 = phi (v51 block16) (v55 block17);
+        v46.@layout_1 = phi (v51 block16) (v55 block17);
         v47.i256 = call %transfer_result_code v46;
         call %abi_encode v47;
         unreachable;
 
     block16:
         v49.i256 = call %raw__g9438 v1;
-        v51.@layout_2 = call %transfer_from_alice v19 v49;
+        v51.@layout_1 = call %transfer_from_alice v19 v49;
         jump block15;
 
     block17:
         v53.i256 = call %raw__g9438 v1;
-        v55.@layout_2 = call %transfer_from_bob v19 v53;
+        v55.@layout_1 = call %transfer_from_bob v19 v53;
         jump block15;
 
     block18:
         jump block17;
 }
 
-func private %stor_ptr__g2c78(v0.i256) -> @layout_1 {
+func private %stor_ptr__g2c78(v0.i256) -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v2.@layout_1 = call %from_raw__g9438 v0;
+        v2.@layout_0 = call %from_raw__g9438 v0;
         return v2;
 }
 
@@ -374,27 +372,27 @@ func private %total_supply(v0.i256) -> i256 {
 
     block1:
         v3.i256 = evm_sload v0;
-        v5.@layout_4 = insert_value undef.@layout_4 0.i256 v3;
+        v5.@layout_0 = insert_value undef.@layout_0 0.i256 v3;
         v6.i256 = extract_value v5 0.i256;
         return v6;
 }
 
-func private %transfer_from_alice(v0.i256, v1.i256) -> @layout_2 {
+func private %transfer_from_alice(v0.i256, v1.i256) -> @layout_1 {
     block0:
         jump block1;
 
     block1:
         v4.i256 = evm_sload v1;
-        v6.@layout_3 = insert_value undef.@layout_3 0.i256 v4;
+        v6.@layout_2 = insert_value undef.@layout_2 0.i256 v4;
         v8.i256 = add v1 1.i256;
         v9.i256 = evm_sload v8;
-        v10.@layout_3 = insert_value v6 1.i256 v9;
+        v10.@layout_2 = insert_value v6 1.i256 v9;
         v11.i256 = extract_value v10 0.i256;
         v13.i1 = lt v11 v0;
         br v13 block2 block3;
 
     block2:
-        v14.@layout_2 = enum.make @layout_2 #Insufficient;
+        v14.@layout_1 = enum.make @layout_1 #variant_1;
         return v14;
 
     block3:
@@ -402,10 +400,10 @@ func private %transfer_from_alice(v0.i256, v1.i256) -> @layout_2 {
 
     block4:
         v17.i256 = evm_sload v1;
-        v18.@layout_3 = insert_value undef.@layout_3 0.i256 v17;
+        v18.@layout_2 = insert_value undef.@layout_2 0.i256 v17;
         v19.i256 = add v1 1.i256;
         v20.i256 = evm_sload v19;
-        v21.@layout_3 = insert_value v18 1.i256 v20;
+        v21.@layout_2 = insert_value v18 1.i256 v20;
         v22.i256 = extract_value v21 0.i256;
         (v24.i256, v25.i1) = usubo v22 v0;
         br v25 block5 block6;
@@ -418,10 +416,10 @@ func private %transfer_from_alice(v0.i256, v1.i256) -> @layout_2 {
     block6:
         evm_sstore v1 v24;
         v32.i256 = evm_sload v1;
-        v33.@layout_3 = insert_value undef.@layout_3 0.i256 v32;
+        v33.@layout_2 = insert_value undef.@layout_2 0.i256 v32;
         v34.i256 = add v1 1.i256;
         v35.i256 = evm_sload v34;
-        v36.@layout_3 = insert_value v33 1.i256 v35;
+        v36.@layout_2 = insert_value v33 1.i256 v35;
         v37.i256 = extract_value v36 1.i256;
         (v39.i256, v40.i1) = uaddo v37 v0;
         br v40 block5 block7;
@@ -429,26 +427,26 @@ func private %transfer_from_alice(v0.i256, v1.i256) -> @layout_2 {
     block7:
         v42.i256 = add v1 1.i256;
         evm_sstore v42 v39;
-        v43.@layout_2 = enum.make @layout_2 #Ok;
+        v43.@layout_1 = enum.make @layout_1 #variant_0;
         return v43;
 }
 
-func private %transfer_from_bob(v0.i256, v1.i256) -> @layout_2 {
+func private %transfer_from_bob(v0.i256, v1.i256) -> @layout_1 {
     block0:
         jump block1;
 
     block1:
         v4.i256 = evm_sload v1;
-        v6.@layout_3 = insert_value undef.@layout_3 0.i256 v4;
+        v6.@layout_2 = insert_value undef.@layout_2 0.i256 v4;
         v8.i256 = add v1 1.i256;
         v9.i256 = evm_sload v8;
-        v10.@layout_3 = insert_value v6 1.i256 v9;
+        v10.@layout_2 = insert_value v6 1.i256 v9;
         v11.i256 = extract_value v10 1.i256;
         v13.i1 = lt v11 v0;
         br v13 block2 block3;
 
     block2:
-        v14.@layout_2 = enum.make @layout_2 #Insufficient;
+        v14.@layout_1 = enum.make @layout_1 #variant_1;
         return v14;
 
     block3:
@@ -456,10 +454,10 @@ func private %transfer_from_bob(v0.i256, v1.i256) -> @layout_2 {
 
     block4:
         v17.i256 = evm_sload v1;
-        v18.@layout_3 = insert_value undef.@layout_3 0.i256 v17;
+        v18.@layout_2 = insert_value undef.@layout_2 0.i256 v17;
         v19.i256 = add v1 1.i256;
         v20.i256 = evm_sload v19;
-        v21.@layout_3 = insert_value v18 1.i256 v20;
+        v21.@layout_2 = insert_value v18 1.i256 v20;
         v22.i256 = extract_value v21 1.i256;
         (v24.i256, v25.i1) = usubo v22 v0;
         br v25 block5 block6;
@@ -473,27 +471,27 @@ func private %transfer_from_bob(v0.i256, v1.i256) -> @layout_2 {
         v31.i256 = add v1 1.i256;
         evm_sstore v31 v24;
         v33.i256 = evm_sload v1;
-        v34.@layout_3 = insert_value undef.@layout_3 0.i256 v33;
+        v34.@layout_2 = insert_value undef.@layout_2 0.i256 v33;
         v35.i256 = add v1 1.i256;
         v36.i256 = evm_sload v35;
-        v37.@layout_3 = insert_value v34 1.i256 v36;
+        v37.@layout_2 = insert_value v34 1.i256 v36;
         v38.i256 = extract_value v37 0.i256;
         (v40.i256, v41.i1) = uaddo v38 v0;
         br v41 block5 block7;
 
     block7:
         evm_sstore v1 v40;
-        v43.@layout_2 = enum.make @layout_2 #Ok;
+        v43.@layout_1 = enum.make @layout_1 #variant_0;
         return v43;
 }
 
-func private %transfer_result_code(v0.@layout_2) -> i256 {
+func private %transfer_result_code(v0.@layout_1) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v2.enumtag(@layout_2) = enum.tag v0;
-        br_table v2 (0.enumtag(@layout_2) block3) (1.enumtag(@layout_2) block4);
+        v2.enumtag(@layout_1) = enum.tag v0;
+        br_table v2 (0.enumtag(@layout_1) block3) (1.enumtag(@layout_1) block4);
 
     block2:
         v5.i256 = phi (0.i256 block3) (1.i256 block4);

--- a/crates/codegen/tests/fixtures/sonatina_ir/storage_map.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/storage_map.snap
@@ -9,7 +9,6 @@ type @layout_0 = {i256, i256};
 type @layout_1 = {i256};
 type @layout_2 = {};
 type @layout_3 = {@layout_2};
-type @layout_4 = {i256, i256};
 
 global private const @layout_1 $const_region_0 = {0};
 
@@ -134,7 +133,7 @@ func inline(always) private %contract_recv_abi_C_0() {
         v5.objref<@layout_3> = obj.alloc @layout_3;
         call %decode_runtime_args v5;
         v7.i256 = call %__C_recv_0_0 0.i256;
-        v8.@layout_4 = call %encode_single_root_alloc v7;
+        v8.@layout_0 = call %encode_single_root_alloc v7;
         v9.i256 = extract_value v8 0.i256;
         v11.i256 = extract_value v8 1.i256;
         evm_return v9 v11;
@@ -215,7 +214,7 @@ func private %encode(v0.i256, v1.objref<@layout_0>) {
         jump block1;
 
     block1:
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_dff7 v1 v0;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_ec9b v1 v0;
         return;
 }
 
@@ -231,7 +230,7 @@ func private %encode_field(v0.i256, v1.objref<@layout_0>, v2.i256) {
         v8.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_3135 v0;
         v9.i256 = mload v2 i256;
         v10.i256 = sub v9 v5;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_e73a v1 v10;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_6fcb v1 v10;
         v12.i256 = call %pos v1;
         v13.i256 = mload v2 i256;
         call %set_base v1 v13;
@@ -280,7 +279,7 @@ func private %encode_single_root(v0.i256, v1.objref<@layout_0>) {
         return;
 }
 
-func private %encode_single_root_alloc(v0.i256) -> @layout_4 {
+func private %encode_single_root_alloc(v0.i256) -> @layout_0 {
     block0:
         jump block1;
 
@@ -296,8 +295,8 @@ func private %encode_single_root_alloc(v0.i256) -> @layout_4 {
         obj.store v9 v10;
         v11.i256 = call %base v4;
         call %encode_single_root v0 v4;
-        v14.@layout_4 = insert_value undef.@layout_4 0.i256 v11;
-        v15.@layout_4 = insert_value v14 1.i256 v2;
+        v14.@layout_0 = insert_value undef.@layout_0 0.i256 v11;
+        v15.@layout_0 = insert_value v14 1.i256 v2;
         return v15;
 }
 
@@ -621,7 +620,7 @@ func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__w
         return 32.i256;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_dff7(v0.objref<@layout_0>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_6fcb(v0.objref<@layout_0>, v1.i256) {
     block0:
         jump block1;
 
@@ -635,7 +634,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_dff7(v0
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_e73a(v0.objref<@layout_0>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_ec9b(v0.objref<@layout_0>, v1.i256) {
     block0:
         jump block1;
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/storage_map.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/storage_map.snap
@@ -27,7 +27,7 @@ func private %abi_field_size(v0.i256) -> i256 {
         jump block1;
 
     block1:
-        v2.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_3135_0 v0;
+        v2.i256 = call %payload_size v0;
         br 0.i1 block2 block3;
 
     block2:
@@ -214,7 +214,7 @@ func private %encode(v0.i256, v1.objref<@layout_0>) {
         jump block1;
 
     block1:
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_ec9b v1 v0;
+        call %write_word v1 v0;
         return;
 }
 
@@ -227,10 +227,10 @@ func private %encode_field(v0.i256, v1.objref<@layout_0>, v2.i256) {
 
     block2:
         v5.i256 = call %base v1;
-        v8.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_3135 v0;
+        v8.i256 = call %payload_size v0;
         v9.i256 = mload v2 i256;
         v10.i256 = sub v9 v5;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_6fcb v1 v10;
+        call %write_word v1 v10;
         v12.i256 = call %pos v1;
         v13.i256 = mload v2 i256;
         call %set_base v1 v13;
@@ -431,15 +431,7 @@ func inline(always) private %impl_CallData__new() -> @layout_1 {
         return v3;
 }
 
-func private %core__lib__abi__trait_AbiSize__payload_size__ge513_3135(v0.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        return 32.i256;
-}
-
-func private %core__lib__abi__trait_AbiSize__payload_size__ge513_3135_0(v0.i256) -> i256 {
+func private %payload_size(v0.i256) -> i256 {
     block0:
         jump block1;
 
@@ -540,7 +532,7 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot
     block1:
         v3.*i8 = evm_malloc 0.i256;
         v4.i256 = ptr_to_int v3 i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_2db6 v4 v0;
+        v6.i256 = call %write_key v4 v0;
         (v7.i256, v8.i1) = uaddo v4 v6;
         br v8 block2 block3;
 
@@ -566,7 +558,7 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot
     block1:
         v3.*i8 = evm_malloc 0.i256;
         v4.i256 = ptr_to_int v3 i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_2db6_0 v4 v0;
+        v6.i256 = call %write_key v4 v0;
         (v7.i256, v8.i1) = uaddo v4 v6;
         br v8 block2 block3;
 
@@ -602,7 +594,7 @@ func private %to_word(v0.i256) -> i256 {
         return v0;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_2db6(v0.i256, v1.i256) -> i256 {
+func inline(always) private %write_key(v0.i256, v1.i256) -> i256 {
     block0:
         jump block1;
 
@@ -611,30 +603,7 @@ func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__w
         return 32.i256;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_2db6_0(v0.i256, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        mstore v0 v1 i256;
-        return 32.i256;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_6fcb(v0.objref<@layout_0>, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v4.objref<i256> = obj.proj v0 1.i256;
-        v5.i256 = obj.load v4;
-        mstore v5 v1 i256;
-        v9.i256 = add v5 32.i256;
-        v10.objref<i256> = obj.proj v0 1.i256;
-        obj.store v10 v9;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_ec9b(v0.objref<@layout_0>, v1.i256) {
+func private %write_word(v0.objref<@layout_0>, v1.i256) {
     block0:
         jump block1;
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/storage_map_contract.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/storage_map_contract.snap
@@ -6,7 +6,6 @@ input_file: crates/codegen/tests/fixtures/storage_map_contract.fe
 target = "evm-ethereum-osaka"
 
 type @layout_0 = {i256};
-type @layout_1 = {i256};
 
 func private %abi_encode(v0.i256) {
     block0:
@@ -187,23 +186,23 @@ func private %new__g219d(v0.i256) -> @layout_0 {
         return v6;
 }
 
-func private %new__g10e6(v0.i256) -> @layout_1 {
+func private %new__g10e6(v0.i256) -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v2.@layout_1 = call %new_unchecked__gcbe1 v0;
+        v2.@layout_0 = call %new_unchecked__gcbe1 v0;
         v4.i256 = extract_value v2 0.i256;
-        v6.@layout_1 = insert_value undef.@layout_1 0.i256 v4;
+        v6.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
         return v6;
 }
 
-func private %new_unchecked__gcbe1(v0.i256) -> @layout_1 {
+func private %new_unchecked__gcbe1(v0.i256) -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v4.@layout_1 = insert_value undef.@layout_1 0.i256 v0;
+        v4.@layout_0 = insert_value undef.@layout_0 0.i256 v0;
         return v4;
 }
 
@@ -247,7 +246,7 @@ func private %runtime() {
     block1:
         v1.i256 = call %calldataload 0.i256;
         v3.i256 = shr 224.i256 v1;
-        v4.@layout_1 = call %new__g10e6 0.i256;
+        v4.@layout_0 = call %new__g10e6 0.i256;
         v5.i256 = extract_value v4 0.i256;
         v7.@layout_0 = call %new__g219d 1.i256;
         v8.i256 = extract_value v7 0.i256;

--- a/crates/codegen/tests/fixtures/sonatina_ir/storage_map_contract.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/storage_map_contract.snap
@@ -13,7 +13,7 @@ func private %abi_encode(v0.i256) {
 
     block1:
         call %mstore 0.i256 v0;
-        call %std__lib__evm__effects__impl_trait_Evm_0098__return_data_284c 0.i256 32.i256;
+        call %return_data 0.i256 32.i256;
         unreachable;
 }
 
@@ -35,23 +35,7 @@ func private %codecopy(v0.i256, v1.i256, v2.i256) {
         return;
 }
 
-func private %std__lib__evm__word__impl_trait_u256_1f9e__from_word_461b(v0.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        return v0;
-}
-
-func private %std__lib__evm__word__impl_trait_u256_1f9e__from_word_461b_0(v0.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        return v0;
-}
-
-func private %std__lib__evm__word__impl_trait_u256_1f9e__from_word_461b_1(v0.i256) -> i256 {
+func private %from_word(v0.i256) -> i256 {
     block0:
         jump block1;
 
@@ -110,7 +94,7 @@ func inline(always) private %get_unchecked__g7fdf(v0.i256, v1.i256) -> i256 {
 
     block1:
         v4.i256 = call %std__lib__evm__storage_map__storagemap_get_word_with_salt__ge513_a5dc v0 1.i256;
-        v5.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__from_word_461b v4;
+        v5.i256 = call %from_word v4;
         return v5;
 }
 
@@ -120,7 +104,7 @@ func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__g
 
     block1:
         v4.i256 = call %std__lib__evm__storage_map__storagemap_get_word_with_salt__ge513_a5dc_0 v0 0.i256;
-        v5.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__from_word_461b_0 v4;
+        v5.i256 = call %from_word v4;
         return v5;
 }
 
@@ -130,7 +114,7 @@ func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__g
 
     block1:
         v4.i256 = call %std__lib__evm__storage_map__storagemap_get_word_with_salt__ge513_a5dc_1 v0 0.i256;
-        v5.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__from_word_461b_1 v4;
+        v5.i256 = call %from_word v4;
         return v5;
 }
 
@@ -144,7 +128,7 @@ func private %init() {
         v2.*i8 = evm_malloc v0;
         v3.i256 = ptr_to_int v2 i256;
         call %codecopy v3 v1 v0;
-        call %std__lib__evm__effects__impl_trait_Evm_0098__return_data_ad81_0 v3 v0;
+        call %return_data v3 v0;
         unreachable;
 }
 
@@ -215,23 +199,7 @@ func private %new_unchecked__g7fdf(v0.i256) -> @layout_0 {
         return v4;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_0098__return_data_284c(v0.i256, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        evm_return v0 v1;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_0098__return_data_ad81(v0.i256, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        evm_return v0 v1;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_0098__return_data_ad81_0(v0.i256, v1.i256) {
+func private %return_data(v0.i256, v1.i256) {
     block0:
         jump block1;
 
@@ -288,7 +256,7 @@ func private %runtime() {
         unreachable;
 
     block7:
-        call %std__lib__evm__effects__impl_trait_Evm_0098__return_data_ad81 0.i256 0.i256;
+        call %return_data 0.i256 0.i256;
         unreachable;
 
     block8:
@@ -352,7 +320,7 @@ func inline(always) private %set_unchecked__gcbe1(v0.i256, v1.i256, v2.i256) {
         jump block1;
 
     block1:
-        v5.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__to_word_1ead_0 v1;
+        v5.i256 = call %to_word v1;
         call %std__lib__evm__storage_map__storagemap_set_word_with_salt__ge513_d78d_0 v0 0.i256 v5;
         return;
 }
@@ -362,7 +330,7 @@ func inline(always) private %set_unchecked__g7fdf(v0.i256, v1.i256, v2.i256) {
         jump block1;
 
     block1:
-        v5.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__to_word_1ead v1;
+        v5.i256 = call %to_word v1;
         call %std__lib__evm__storage_map__storagemap_set_word_with_salt__ge513_d78d v0 1.i256 v5;
         return;
 }
@@ -424,7 +392,7 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot
     block1:
         v3.*i8 = evm_malloc 0.i256;
         v4.i256 = ptr_to_int v3 i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_bd6c v4 v0;
+        v6.i256 = call %write_key v4 v0;
         (v7.i256, v8.i1) = uaddo v4 v6;
         br v8 block2 block3;
 
@@ -450,7 +418,7 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot
     block1:
         v3.*i8 = evm_malloc 0.i256;
         v4.i256 = ptr_to_int v3 i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_bd6c_0 v4 v0;
+        v6.i256 = call %write_key v4 v0;
         (v7.i256, v8.i1) = uaddo v4 v6;
         br v8 block2 block3;
 
@@ -476,7 +444,7 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot
     block1:
         v3.*i8 = evm_malloc 0.i256;
         v4.i256 = ptr_to_int v3 i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_bd6c_1 v4 v0;
+        v6.i256 = call %write_key v4 v0;
         (v7.i256, v8.i1) = uaddo v4 v6;
         br v8 block2 block3;
 
@@ -502,7 +470,7 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot
     block1:
         v3.*i8 = evm_malloc 0.i256;
         v4.i256 = ptr_to_int v3 i256;
-        v6.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_bd6c_2 v4 v0;
+        v6.i256 = call %write_key v4 v0;
         (v7.i256, v8.i1) = uaddo v4 v6;
         br v8 block2 block3;
 
@@ -521,15 +489,7 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot
         return v20;
 }
 
-func private %std__lib__evm__word__impl_trait_u256_1f9e__to_word_1ead(v0.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        return v0;
-}
-
-func private %std__lib__evm__word__impl_trait_u256_1f9e__to_word_1ead_0(v0.i256) -> i256 {
+func private %to_word(v0.i256) -> i256 {
     block0:
         jump block1;
 
@@ -572,34 +532,7 @@ func private %transfer(v0.i256, v1.i256, v2.i256, v3.i256) -> i256 {
         return 0.i256;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_bd6c(v0.i256, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        mstore v0 v1 i256;
-        return 32.i256;
-}
-
-func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_bd6c_0(v0.i256, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        mstore v0 v1 i256;
-        return 32.i256;
-}
-
-func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_bd6c_1(v0.i256, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        mstore v0 v1 i256;
-        return 32.i256;
-}
-
-func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_bd6c_2(v0.i256, v1.i256) -> i256 {
+func inline(always) private %write_key(v0.i256, v1.i256) -> i256 {
     block0:
         jump block1;
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/storage_packed_array.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/storage_packed_array.snap
@@ -9,10 +9,9 @@ type @layout_0 = {i256, i256};
 type @layout_1 = {i256};
 type @layout_2 = {};
 type @layout_3 = {@layout_2};
-type @layout_4 = {i256, i256};
-type @layout_5 = enum {
-    #Some(i256),
-    #None,
+type @layout_4 = enum {
+    #variant_0(i256),
+    #variant_1,
 };
 
 global private const @layout_1 $const_region_0 = {0};
@@ -140,7 +139,7 @@ func inline(always) private %contract_recv_abi_C_0() {
         v5.objref<@layout_3> = obj.alloc @layout_3;
         call %decode_runtime_args v5;
         v7.i256 = call %__C_recv_0_0;
-        v8.@layout_4 = call %encode_single_root_alloc v7;
+        v8.@layout_0 = call %encode_single_root_alloc v7;
         v9.i256 = extract_value v8 0.i256;
         v11.i256 = extract_value v8 1.i256;
         evm_return v9 v11;
@@ -221,7 +220,7 @@ func private %encode(v0.i256, v1.objref<@layout_0>) {
         jump block1;
 
     block1:
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_8250 v1 v0;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_8e90 v1 v0;
         return;
 }
 
@@ -237,7 +236,7 @@ func private %encode_field(v0.i256, v1.objref<@layout_0>, v2.i256) {
         v8.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_6965 v0;
         v9.i256 = mload v2 i256;
         v10.i256 = sub v9 v5;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_3bd7 v1 v10;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_2228 v1 v10;
         v12.i256 = call %pos v1;
         v13.i256 = mload v2 i256;
         call %set_base v1 v13;
@@ -286,7 +285,7 @@ func private %encode_single_root(v0.i256, v1.objref<@layout_0>) {
         return;
 }
 
-func private %encode_single_root_alloc(v0.i256) -> @layout_4 {
+func private %encode_single_root_alloc(v0.i256) -> @layout_0 {
     block0:
         jump block1;
 
@@ -302,8 +301,8 @@ func private %encode_single_root_alloc(v0.i256) -> @layout_4 {
         obj.store v9 v10;
         v11.i256 = call %base v4;
         call %encode_single_root v0 v4;
-        v14.@layout_4 = insert_value undef.@layout_4 0.i256 v11;
-        v15.@layout_4 = insert_value v14 1.i256 v2;
+        v14.@layout_0 = insert_value undef.@layout_0 0.i256 v11;
+        v15.@layout_0 = insert_value v14 1.i256 v2;
         return v15;
 }
 
@@ -460,7 +459,7 @@ func private %revert(v0.i256, v1.i256) {
         evm_revert v0 v1;
 }
 
-func private %search(v0.i256, v1.i256, v2.i256, v3.i256) -> @layout_5 {
+func private %search(v0.i256, v1.i256, v2.i256, v3.i256) -> @layout_4 {
     block0:
         v4.*i256 = alloca i256;
         v5.*i256 = alloca i256;
@@ -486,7 +485,7 @@ func private %search(v0.i256, v1.i256, v2.i256, v3.i256) -> @layout_5 {
         jump block5;
 
     block4:
-        v18.@layout_5 = enum.make @layout_5 #None;
+        v18.@layout_4 = enum.make @layout_4 #variant_1;
         return v18;
 
     block5:
@@ -512,7 +511,7 @@ func private %search(v0.i256, v1.i256, v2.i256, v3.i256) -> @layout_5 {
 
     block9:
         v33.i256 = mload v4 i256;
-        v34.@layout_5 = enum.make @layout_5 #Some v33;
+        v34.@layout_4 = enum.make @layout_4 #variant_0 v33;
         return v34;
 
     block10:
@@ -535,13 +534,13 @@ func private %search_status(v0.i256, v1.i256, v2.i256) -> i256 {
         jump block1;
 
     block1:
-        v7.@layout_5 = call %search v0 v1 v2 0.i256;
-        v8.enumtag(@layout_5) = enum.tag v7;
-        br_table v8 (0.enumtag(@layout_5) block2) (1.enumtag(@layout_5) block3);
+        v7.@layout_4 = call %search v0 v1 v2 0.i256;
+        v8.enumtag(@layout_4) = enum.tag v7;
+        br_table v8 (0.enumtag(@layout_4) block2) (1.enumtag(@layout_4) block3);
 
     block2:
-        enum.assert_variant v7 #Some;
-        v12.i256 = enum.extract v7 #Some 0.i256;
+        enum.assert_variant v7 #variant_0;
+        v12.i256 = enum.extract v7 #variant_0 0.i256;
         return v12;
 
     block3:
@@ -606,7 +605,7 @@ func private %store_word(v0.i256, v1.i256) {
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_3bd7(v0.objref<@layout_0>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_2228(v0.objref<@layout_0>, v1.i256) {
     block0:
         jump block1;
 
@@ -620,7 +619,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_3bd7(v0
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_8250(v0.objref<@layout_0>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_8e90(v0.objref<@layout_0>, v1.i256) {
     block0:
         jump block1;
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/storage_packed_array.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/storage_packed_array.snap
@@ -33,7 +33,7 @@ func private %abi_field_size(v0.i256) -> i256 {
         jump block1;
 
     block1:
-        v2.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_6965_0 v0;
+        v2.i256 = call %payload_size v0;
         br 0.i1 block2 block3;
 
     block2:
@@ -220,7 +220,7 @@ func private %encode(v0.i256, v1.objref<@layout_0>) {
         jump block1;
 
     block1:
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_8e90 v1 v0;
+        call %write_word v1 v0;
         return;
 }
 
@@ -233,10 +233,10 @@ func private %encode_field(v0.i256, v1.objref<@layout_0>, v2.i256) {
 
     block2:
         v5.i256 = call %base v1;
-        v8.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_6965 v0;
+        v8.i256 = call %payload_size v0;
         v9.i256 = mload v2 i256;
         v10.i256 = sub v9 v5;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_2228 v1 v10;
+        call %write_word v1 v10;
         v12.i256 = call %pos v1;
         v13.i256 = mload v2 i256;
         call %set_base v1 v13;
@@ -425,15 +425,7 @@ func inline(always) private %impl_CallData__new() -> @layout_1 {
         return v3;
 }
 
-func private %core__lib__abi__trait_AbiSize__payload_size__ge513_6965(v0.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        return 32.i256;
-}
-
-func private %core__lib__abi__trait_AbiSize__payload_size__ge513_6965_0(v0.i256) -> i256 {
+func private %payload_size(v0.i256) -> i256 {
     block0:
         jump block1;
 
@@ -605,21 +597,7 @@ func private %store_word(v0.i256, v1.i256) {
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_2228(v0.objref<@layout_0>, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v4.objref<i256> = obj.proj v0 1.i256;
-        v5.i256 = obj.load v4;
-        mstore v5 v1 i256;
-        v9.i256 = add v5 32.i256;
-        v10.objref<i256> = obj.proj v0 1.i256;
-        obj.store v10 v9;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_8e90(v0.objref<@layout_0>, v1.i256) {
+func private %write_word(v0.objref<@layout_0>, v1.i256) {
     block0:
         jump block1;
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/tstor_ptr_contract.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/tstor_ptr_contract.snap
@@ -9,7 +9,6 @@ type @layout_0 = {i256, i256};
 type @layout_1 = {i256};
 type @layout_2 = {};
 type @layout_3 = {@layout_2};
-type @layout_4 = {i256, i256};
 
 global private const @layout_1 $const_region_0 = {0};
 
@@ -159,7 +158,7 @@ func inline(always) private %contract_recv_abi_GuardContract_1() {
         v5.objref<@layout_3> = obj.alloc @layout_3;
         call %decode_runtime_args v5;
         v7.i1 = call %__GuardContract_recv_0_0 0.i256 0.i256;
-        v8.@layout_4 = call %encode_single_root_alloc v7;
+        v8.@layout_0 = call %encode_single_root_alloc v7;
         v9.i256 = extract_value v8 0.i256;
         v11.i256 = extract_value v8 1.i256;
         evm_return v9 v11;
@@ -243,11 +242,11 @@ func private %encode(v0.i1, v1.objref<@layout_0>) {
         br v0 block2 block3;
 
     block2:
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_9a9f v1 1.i256;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_9a67 v1 1.i256;
         jump block4;
 
     block3:
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_9a9f v1 0.i256;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_9a67 v1 0.i256;
         jump block4;
 
     block4:
@@ -266,7 +265,7 @@ func private %encode_field(v0.i1, v1.objref<@layout_0>, v2.i256) {
         v8.i256 = call %core__lib__abi__trait_AbiSize__payload_size__gda9b_f558 v0;
         v9.i256 = mload v2 i256;
         v10.i256 = sub v9 v5;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_74a3 v1 v10;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_ec67 v1 v10;
         v12.i256 = call %pos v1;
         v13.i256 = mload v2 i256;
         call %set_base v1 v13;
@@ -315,7 +314,7 @@ func private %encode_single_root(v0.i1, v1.objref<@layout_0>) {
         return;
 }
 
-func private %encode_single_root_alloc(v0.i1) -> @layout_4 {
+func private %encode_single_root_alloc(v0.i1) -> @layout_0 {
     block0:
         jump block1;
 
@@ -331,8 +330,8 @@ func private %encode_single_root_alloc(v0.i1) -> @layout_4 {
         obj.store v9 v10;
         v11.i256 = call %base v4;
         call %encode_single_root v0 v4;
-        v14.@layout_4 = insert_value undef.@layout_4 0.i256 v11;
-        v15.@layout_4 = insert_value v14 1.i256 v2;
+        v14.@layout_0 = insert_value undef.@layout_0 0.i256 v11;
+        v15.@layout_0 = insert_value v14 1.i256 v2;
         return v15;
 }
 
@@ -504,7 +503,7 @@ func private %store_word(v0.i256, v1.i256) {
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_74a3(v0.objref<@layout_0>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_9a67(v0.objref<@layout_0>, v1.i256) {
     block0:
         jump block1;
 
@@ -518,7 +517,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_74a3(v0
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_9a9f(v0.objref<@layout_0>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_ec67(v0.objref<@layout_0>, v1.i256) {
     block0:
         jump block1;
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/tstor_ptr_contract.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/tstor_ptr_contract.snap
@@ -51,7 +51,7 @@ func private %abi_field_size(v0.i1) -> i256 {
         jump block1;
 
     block1:
-        v2.i256 = call %core__lib__abi__trait_AbiSize__payload_size__gda9b_f558_0 v0;
+        v2.i256 = call %payload_size v0;
         br 0.i1 block2 block3;
 
     block2:
@@ -242,11 +242,11 @@ func private %encode(v0.i1, v1.objref<@layout_0>) {
         br v0 block2 block3;
 
     block2:
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_9a67 v1 1.i256;
+        call %write_word v1 1.i256;
         jump block4;
 
     block3:
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_9a67 v1 0.i256;
+        call %write_word v1 0.i256;
         jump block4;
 
     block4:
@@ -262,10 +262,10 @@ func private %encode_field(v0.i1, v1.objref<@layout_0>, v2.i256) {
 
     block2:
         v5.i256 = call %base v1;
-        v8.i256 = call %core__lib__abi__trait_AbiSize__payload_size__gda9b_f558 v0;
+        v8.i256 = call %payload_size v0;
         v9.i256 = mload v2 i256;
         v10.i256 = sub v9 v5;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_ec67 v1 v10;
+        call %write_word v1 v10;
         v12.i256 = call %pos v1;
         v13.i256 = mload v2 i256;
         call %set_base v1 v13;
@@ -440,15 +440,7 @@ func inline(always) private %impl_CallData__new() -> @layout_1 {
         return v3;
 }
 
-func private %core__lib__abi__trait_AbiSize__payload_size__gda9b_f558(v0.i1) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        return 32.i256;
-}
-
-func private %core__lib__abi__trait_AbiSize__payload_size__gda9b_f558_0(v0.i1) -> i256 {
+func private %payload_size(v0.i1) -> i256 {
     block0:
         jump block1;
 
@@ -503,21 +495,7 @@ func private %store_word(v0.i256, v1.i256) {
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_9a67(v0.objref<@layout_0>, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v4.objref<i256> = obj.proj v0 1.i256;
-        v5.i256 = obj.load v4;
-        mstore v5 v1 i256;
-        v9.i256 = add v5 32.i256;
-        v10.objref<i256> = obj.proj v0 1.i256;
-        obj.store v10 v9;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_ec67(v0.objref<@layout_0>, v1.i256) {
+func private %write_word(v0.objref<@layout_0>, v1.i256) {
     block0:
         jump block1;
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/tuple_return_contract.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/tuple_return_contract.snap
@@ -29,7 +29,7 @@ func private %abi_field_size(v0.@layout_1) -> i256 {
         jump block1;
 
     block1:
-        v2.i256 = call %core__lib__abi__impl_trait____ccb6__payload_size__g6d15_322c_0 v0;
+        v2.i256 = call %payload_size__g6d15 v0;
         br 0.i1 block2 block3;
 
     block2:
@@ -79,17 +79,7 @@ func inline(always) private %at(v0.i256) -> @layout_2 {
         return v6;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_9d39(v0.objref<@layout_2>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 0.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_9dac(v0.objref<@layout_2>) -> i256 {
+func private %base(v0.objref<@layout_2>) -> i256 {
     block0:
         jump block1;
 
@@ -221,7 +211,7 @@ func inline(always) private %decode_runtime_args(v0.objref<@layout_4>) {
         br v15 block2 block3;
 }
 
-func private %core__lib__abi__dynamic_payload_size__g67a8_864f(v0.@layout_0) -> i256 {
+func private %dynamic_payload_size__g67a8(v0.@layout_0) -> i256 {
     block0:
         jump block1;
 
@@ -229,7 +219,7 @@ func private %core__lib__abi__dynamic_payload_size__g67a8_864f(v0.@layout_0) -> 
         br 0.i1 block2 block3;
 
     block2:
-        v3.i256 = call %core__lib__abi__trait_AbiSize__payload_size__g67a8_5046 v0;
+        v3.i256 = call %payload_size__g67a8 v0;
         return v3;
 
     block3:
@@ -239,7 +229,7 @@ func private %core__lib__abi__dynamic_payload_size__g67a8_864f(v0.@layout_0) -> 
         return 0.i256;
 }
 
-func private %core__lib__abi__dynamic_payload_size__g67a8_864f_0(v0.@layout_0) -> i256 {
+func private %dynamic_payload_size__ge513(v0.i256) -> i256 {
     block0:
         jump block1;
 
@@ -247,7 +237,7 @@ func private %core__lib__abi__dynamic_payload_size__g67a8_864f_0(v0.@layout_0) -
         br 0.i1 block2 block3;
 
     block2:
-        v3.i256 = call %core__lib__abi__trait_AbiSize__payload_size__g67a8_5046_0 v0;
+        v3.i256 = call %payload_size__ge513 v0;
         return v3;
 
     block3:
@@ -255,51 +245,6 @@ func private %core__lib__abi__dynamic_payload_size__g67a8_864f_0(v0.@layout_0) -
 
     block4:
         return 0.i256;
-}
-
-func private %core__lib__abi__dynamic_payload_size__ge513_f973(v0.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        br 0.i1 block2 block3;
-
-    block2:
-        v3.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_c169 v0;
-        return v3;
-
-    block3:
-        jump block4;
-
-    block4:
-        return 0.i256;
-}
-
-func private %core__lib__abi__dynamic_payload_size__ge513_f973_0(v0.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        br 0.i1 block2 block3;
-
-    block2:
-        v3.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_c169_0 v0;
-        return v3;
-
-    block3:
-        jump block4;
-
-    block4:
-        return 0.i256;
-}
-
-func private %impl_trait_u256__encode__g426c(v0.i256, v1.objref<@layout_2>) {
-    block0:
-        jump block1;
-
-    block1:
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_5c61 v1 v0;
-        return;
 }
 
 func inline(always) private %encode__g4887(v0.@layout_1, v1.objref<@layout_2>) {
@@ -308,7 +253,7 @@ func inline(always) private %encode__g4887(v0.@layout_1, v1.objref<@layout_2>) {
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_9d39 v1;
+        v4.i256 = call %base v1;
         v6.i256 = add v4 64.i256;
         mstore v2 v6 i256;
         v8.i256 = add v4 32.i256;
@@ -319,7 +264,7 @@ func inline(always) private %encode__g4887(v0.@layout_1, v1.objref<@layout_2>) {
         v16.i256 = ptr_to_int v2 i256;
         call %encode_field_at__gf6b4 v15 v1 v4 v8 v16;
         v18.i256 = add v4 64.i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_a021_1 v1 v18;
+        call %set_pos v1 v18;
         return;
 }
 
@@ -329,7 +274,16 @@ func private %impl_trait_Address__encode__g426c(v0.@layout_0, v1.objref<@layout_
 
     block1:
         v4.i256 = extract_value v0 0.i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_6b8e v1 v4;
+        call %write_word v1 v4;
+        return;
+}
+
+func private %impl_trait_u256__encode__g426c(v0.i256, v1.objref<@layout_2>) {
+    block0:
+        jump block1;
+
+    block1:
+        call %write_word v1 v0;
         return;
 }
 
@@ -341,19 +295,19 @@ func private %encode_field(v0.@layout_1, v1.objref<@layout_2>, v2.i256) {
         br 0.i1 block2 block3;
 
     block2:
-        v5.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_9dac v1;
-        v8.i256 = call %core__lib__abi__impl_trait____ccb6__payload_size__g6d15_322c v0;
+        v5.i256 = call %base v1;
+        v8.i256 = call %payload_size__g6d15 v0;
         v9.i256 = mload v2 i256;
         v10.i256 = sub v9 v5;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_baef v1 v10;
+        call %write_word v1 v10;
         v12.i256 = call %pos v1;
         v13.i256 = mload v2 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_33b4 v1 v13;
+        call %set_base v1 v13;
         v15.i256 = mload v2 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_cc8d v1 v15;
+        call %set_pos v1 v15;
         call %encode__g4887 v0 v1;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_33b4 v1 v5;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_cc8d v1 v12;
+        call %set_base v1 v5;
+        call %set_pos v1 v12;
         v20.i256 = mload v2 i256;
         v21.i256 = add v20 v8;
         mstore v2 v21 i256;
@@ -369,7 +323,7 @@ func private %encode_field(v0.@layout_1, v1.objref<@layout_2>, v2.i256) {
         v24.i256 = call %pos v1;
         call %encode_to_ptr__g753b v0 v24;
         v28.i256 = add v24 64.i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_cc8d v1 v28;
+        call %set_pos v1 v28;
         return;
 
     block6:
@@ -388,16 +342,16 @@ func inline(always) private %encode_field_at__gf6b4(v0.@layout_0, v1.objref<@lay
         br 0.i1 block2 block3;
 
     block2:
-        v8.i256 = call %core__lib__abi__trait_AbiSize__payload_size__g67a8_95de v0;
+        v8.i256 = call %payload_size__g67a8 v0;
         v11.i256 = mload v4 i256;
         v12.i256 = sub v11 v2;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_at_6ace v1 v3 v12;
+        call %write_word_at v1 v3 v12;
         v15.i256 = mload v4 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_69e1 v1 v15;
+        call %set_base v1 v15;
         v17.i256 = mload v4 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_a021 v1 v17;
+        call %set_pos v1 v17;
         call %impl_trait_Address__encode__g426c v0 v1;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_69e1 v1 v2;
+        call %set_base v1 v2;
         v21.i256 = mload v4 i256;
         v22.i256 = add v21 v8;
         mstore v4 v22 i256;
@@ -410,14 +364,14 @@ func inline(always) private %encode_field_at__gf6b4(v0.@layout_0, v1.objref<@lay
         br 1.i1 block5 block6;
 
     block5:
-        call %std__lib__evm__effects__impl_trait_Address_ed76__encode_to_ptr__gf13e_14be v0 v3;
+        call %impl_trait_Address__encode_to_ptr__gf13e v0 v3;
         return;
 
     block6:
         jump block7;
 
     block7:
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_a021 v1 v3;
+        call %set_pos v1 v3;
         call %impl_trait_Address__encode__g426c v0 v1;
         return;
 }
@@ -430,16 +384,16 @@ func inline(always) private %encode_field_at__g2e64(v0.i256, v1.objref<@layout_2
         br 0.i1 block2 block3;
 
     block2:
-        v8.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_7c20 v0;
+        v8.i256 = call %payload_size__ge513 v0;
         v11.i256 = mload v4 i256;
         v12.i256 = sub v11 v2;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_at_6ace_0 v1 v3 v12;
+        call %write_word_at v1 v3 v12;
         v15.i256 = mload v4 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_69e1_0 v1 v15;
+        call %set_base v1 v15;
         v17.i256 = mload v4 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_a021_0 v1 v17;
+        call %set_pos v1 v17;
         call %impl_trait_u256__encode__g426c v0 v1;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_69e1_0 v1 v2;
+        call %set_base v1 v2;
         v21.i256 = mload v4 i256;
         v22.i256 = add v21 v8;
         mstore v4 v22 i256;
@@ -452,14 +406,14 @@ func inline(always) private %encode_field_at__g2e64(v0.i256, v1.objref<@layout_2
         br 1.i1 block5 block6;
 
     block5:
-        call %core__lib__abi__impl_trait_u256_d99e__encode_to_ptr__gf13e_3ddf v0 v3;
+        call %impl_trait_u256__encode_to_ptr__gf13e v0 v3;
         return;
 
     block6:
         jump block7;
 
     block7:
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_a021_0 v1 v3;
+        call %set_pos v1 v3;
         call %impl_trait_u256__encode__g426c v0 v1;
         return;
 }
@@ -470,7 +424,7 @@ func private %encode_single_root(v0.@layout_1, v1.objref<@layout_2>) {
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_9dac v1;
+        v4.i256 = call %base v1;
         v6.i256 = add v4 64.i256;
         mstore v2 v6 i256;
         v7.i256 = ptr_to_int v2 i256;
@@ -492,48 +446,19 @@ func private %encode_single_root_alloc(v0.@layout_1) -> @layout_2 {
         v9.objref<i256> = obj.proj v4 1.i256;
         v10.i256 = extract_value v3 1.i256;
         obj.store v9 v10;
-        v11.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_9dac v4;
+        v11.i256 = call %base v4;
         call %encode_single_root v0 v4;
         v14.@layout_2 = insert_value undef.@layout_2 0.i256 v11;
         v15.@layout_2 = insert_value v14 1.i256 v2;
         return v15;
 }
 
-func private %std__lib__evm__effects__impl_trait_Address_ed76__encode_to_ptr__gf13e_14be(v0.@layout_0, v1.i256) {
+func private %impl_trait_u256__encode_to_ptr__gf13e(v0.i256, v1.i256) {
     block0:
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__store_word_001d v1 v5;
-        return;
-}
-
-func private %std__lib__evm__effects__impl_trait_Address_ed76__encode_to_ptr__gf13e_14be_0(v0.@layout_0, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v5.i256 = extract_value v0 0.i256;
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__store_word_001d_0 v1 v5;
-        return;
-}
-
-func private %core__lib__abi__impl_trait_u256_d99e__encode_to_ptr__gf13e_3ddf(v0.i256, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__store_word_5688 v1 v0;
-        return;
-}
-
-func private %core__lib__abi__impl_trait_u256_d99e__encode_to_ptr__gf13e_3ddf_0(v0.i256, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__store_word_5688 v1 v0;
+        call %store_word v1 v0;
         return;
 }
 
@@ -543,10 +468,20 @@ func private %encode_to_ptr__g753b(v0.@layout_1, v1.i256) {
 
     block1:
         v4.i256 = extract_value v0 0.i256;
-        call %core__lib__abi__impl_trait_u256_d99e__encode_to_ptr__gf13e_3ddf_0 v4 v1;
+        call %impl_trait_u256__encode_to_ptr__gf13e v4 v1;
         v8.@layout_0 = extract_value v0 1.i256;
         v10.i256 = add v1 32.i256;
-        call %std__lib__evm__effects__impl_trait_Address_ed76__encode_to_ptr__gf13e_14be_0 v8 v10;
+        call %impl_trait_Address__encode_to_ptr__gf13e v8 v10;
+        return;
+}
+
+func private %impl_trait_Address__encode_to_ptr__gf13e(v0.@layout_0, v1.i256) {
+    block0:
+        jump block1;
+
+    block1:
+        v5.i256 = extract_value v0 0.i256;
+        call %store_word v1 v5;
         return;
 }
 
@@ -602,18 +537,6 @@ func inline(always) private %len(v0.@layout_0) -> i256 {
         jump block4;
 }
 
-func inline(always) private %impl_CallData__new() -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v1.constref<@layout_0> = const.ref $const_region_0;
-        v2.objref<@layout_0> = obj.alloc @layout_0;
-        obj.init.const v2 v1;
-        v3.@layout_0 = obj.load v2;
-        return v3;
-}
-
 func private %impl_SolEncoder__new(v0.i256) -> @layout_2 {
     block0:
         jump block1;
@@ -636,35 +559,33 @@ func private %impl_SolEncoder__new(v0.i256) -> @layout_2 {
         return v8;
 }
 
-func inline(always) private %core__lib__abi__impl_trait____ccb6__payload_size__g6d15_322c(v0.@layout_1) -> i256 {
+func inline(always) private %impl_CallData__new() -> @layout_0 {
+    block0:
+        jump block1;
+
+    block1:
+        v1.constref<@layout_0> = const.ref $const_region_0;
+        v2.objref<@layout_0> = obj.alloc @layout_0;
+        obj.init.const v2 v1;
+        v3.@layout_0 = obj.load v2;
+        return v3;
+}
+
+func inline(always) private %payload_size__g6d15(v0.@layout_1) -> i256 {
     block0:
         jump block1;
 
     block1:
         v4.i256 = extract_value v0 0.i256;
-        v5.i256 = call %core__lib__abi__dynamic_payload_size__ge513_f973 v4;
+        v5.i256 = call %dynamic_payload_size__ge513 v4;
         v6.i256 = add 64.i256 v5;
         v8.@layout_0 = extract_value v0 1.i256;
-        v9.i256 = call %core__lib__abi__dynamic_payload_size__g67a8_864f v8;
+        v9.i256 = call %dynamic_payload_size__g67a8 v8;
         v10.i256 = add v6 v9;
         return v10;
 }
 
-func inline(always) private %core__lib__abi__impl_trait____ccb6__payload_size__g6d15_322c_0(v0.@layout_1) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v5.i256 = call %core__lib__abi__dynamic_payload_size__ge513_f973_0 v4;
-        v6.i256 = add 64.i256 v5;
-        v8.@layout_0 = extract_value v0 1.i256;
-        v9.i256 = call %core__lib__abi__dynamic_payload_size__g67a8_864f_0 v8;
-        v10.i256 = add v6 v9;
-        return v10;
-}
-
-func private %core__lib__abi__trait_AbiSize__payload_size__g67a8_5046(v0.@layout_0) -> i256 {
+func private %payload_size__ge513(v0.i256) -> i256 {
     block0:
         jump block1;
 
@@ -672,39 +593,7 @@ func private %core__lib__abi__trait_AbiSize__payload_size__g67a8_5046(v0.@layout
         return 32.i256;
 }
 
-func private %core__lib__abi__trait_AbiSize__payload_size__g67a8_5046_0(v0.@layout_0) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        return 32.i256;
-}
-
-func private %core__lib__abi__trait_AbiSize__payload_size__ge513_7c20(v0.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        return 32.i256;
-}
-
-func private %core__lib__abi__trait_AbiSize__payload_size__g67a8_95de(v0.@layout_0) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        return 32.i256;
-}
-
-func private %core__lib__abi__trait_AbiSize__payload_size__ge513_c169(v0.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        return 32.i256;
-}
-
-func private %core__lib__abi__trait_AbiSize__payload_size__ge513_c169_0(v0.i256) -> i256 {
+func private %payload_size__g67a8(v0.@layout_0) -> i256 {
     block0:
         jump block1;
 
@@ -730,7 +619,7 @@ func private %revert(v0.i256, v1.i256) {
         evm_revert v0 v1;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_33b4(v0.objref<@layout_2>, v1.i256) {
+func private %set_base(v0.objref<@layout_2>, v1.i256) {
     block0:
         jump block1;
 
@@ -740,27 +629,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_33b4(v0.o
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_69e1(v0.objref<@layout_2>, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        obj.store v5 v1;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_69e1_0(v0.objref<@layout_2>, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        obj.store v5 v1;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_a021(v0.objref<@layout_2>, v1.i256) {
+func private %set_pos(v0.objref<@layout_2>, v1.i256) {
     block0:
         jump block1;
 
@@ -770,37 +639,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_a021(v0.ob
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_a021_0(v0.objref<@layout_2>, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v5.objref<i256> = obj.proj v0 1.i256;
-        obj.store v5 v1;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_a021_1(v0.objref<@layout_2>, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v5.objref<i256> = obj.proj v0 1.i256;
-        obj.store v5 v1;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_cc8d(v0.objref<@layout_2>, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v5.objref<i256> = obj.proj v0 1.i256;
-        obj.store v5 v1;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__store_word_001d(v0.i256, v1.i256) {
+func private %store_word(v0.i256, v1.i256) {
     block0:
         jump block1;
 
@@ -809,25 +648,7 @@ func private %std__lib__abi__sol__impl_trait_Sol_1f5f__store_word_001d(v0.i256, 
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__store_word_001d_0(v0.i256, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        mstore v0 v1 i256;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__store_word_5688(v0.i256, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        mstore v0 v1 i256;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_5c61(v0.objref<@layout_2>, v1.i256) {
+func private %write_word(v0.objref<@layout_2>, v1.i256) {
     block0:
         jump block1;
 
@@ -841,49 +662,12 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_5c61(v0
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_6b8e(v0.objref<@layout_2>, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v4.objref<i256> = obj.proj v0 1.i256;
-        v5.i256 = obj.load v4;
-        mstore v5 v1 i256;
-        v9.i256 = add v5 32.i256;
-        v10.objref<i256> = obj.proj v0 1.i256;
-        obj.store v10 v9;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_at_6ace(v0.objref<@layout_2>, v1.i256, v2.i256) {
+func private %write_word_at(v0.objref<@layout_2>, v1.i256, v2.i256) {
     block0:
         jump block1;
 
     block1:
         mstore v1 v2 i256;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_at_6ace_0(v0.objref<@layout_2>, v1.i256, v2.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        mstore v1 v2 i256;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_baef(v0.objref<@layout_2>, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v4.objref<i256> = obj.proj v0 1.i256;
-        v5.i256 = obj.load v4;
-        mstore v5 v1 i256;
-        v9.i256 = add v5 32.i256;
-        v10.objref<i256> = obj.proj v0 1.i256;
-        obj.store v10 v9;
         return;
 }
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/tuple_return_contract.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/tuple_return_contract.snap
@@ -8,13 +8,10 @@ target = "evm-ethereum-osaka"
 type @layout_0 = {i256};
 type @layout_1 = {i256, @layout_0};
 type @layout_2 = {i256, i256};
-type @layout_3 = {i256};
-type @layout_4 = {};
-type @layout_5 = {@layout_4};
-type @layout_6 = {i256, i256};
+type @layout_3 = {};
+type @layout_4 = {@layout_3};
 
-global private const @layout_3 $const_region_0 = {0};
-global private const @layout_0 $const_region_1 = {0};
+global private const @layout_0 $const_region_0 = {0};
 
 func private %__TupleReturnContract_recv_0_0() -> @layout_1 {
     block0:
@@ -32,7 +29,7 @@ func private %abi_field_size(v0.@layout_1) -> i256 {
         jump block1;
 
     block1:
-        v2.i256 = call %core__lib__abi__impl_trait____ccb6__payload_size__g6d15_e33b_0 v0;
+        v2.i256 = call %core__lib__abi__impl_trait____ccb6__payload_size__g6d15_322c_0 v0;
         br 0.i1 block2 block3;
 
     block2:
@@ -82,7 +79,7 @@ func inline(always) private %at(v0.i256) -> @layout_2 {
         return v6;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_8e95(v0.objref<@layout_2>) -> i256 {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_9d39(v0.objref<@layout_2>) -> i256 {
     block0:
         jump block1;
 
@@ -92,7 +89,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_8e95(v0.objre
         return v4;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_a403(v0.objref<@layout_2>) -> i256 {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_9dac(v0.objref<@layout_2>) -> i256 {
     block0:
         jump block1;
 
@@ -145,10 +142,10 @@ func inline(always) private %contract_recv_abi_TupleReturnContract_1() {
         evm_revert 0.i256 0.i256;
 
     block3:
-        v5.objref<@layout_5> = obj.alloc @layout_5;
+        v5.objref<@layout_4> = obj.alloc @layout_4;
         call %decode_runtime_args v5;
         v7.@layout_1 = call %__TupleReturnContract_recv_0_0;
-        v8.@layout_6 = call %encode_single_root_alloc v7;
+        v8.@layout_2 = call %encode_single_root_alloc v7;
         v9.i256 = extract_value v8 0.i256;
         v11.i256 = extract_value v8 1.i256;
         evm_return v9 v11;
@@ -177,7 +174,7 @@ func private %contract_runtime_root_TupleReturnContract() {
         unreachable;
 }
 
-func inline(always) private %decode_from(v0.@layout_3, v1.i256) {
+func inline(always) private %decode_from(v0.@layout_0, v1.i256) {
     block0:
         jump block1;
 
@@ -185,7 +182,7 @@ func inline(always) private %decode_from(v0.@layout_3, v1.i256) {
         return;
 }
 
-func inline(always) private %decode_from_prechecked_head(v0.@layout_3, v1.i256, v2.i256) {
+func inline(always) private %decode_from_prechecked_head(v0.@layout_0, v1.i256, v2.i256) {
     block0:
         jump block1;
 
@@ -194,14 +191,14 @@ func inline(always) private %decode_from_prechecked_head(v0.@layout_3, v1.i256, 
         return;
 }
 
-func inline(always) private %decode_runtime_args(v0.objref<@layout_5>) {
+func inline(always) private %decode_runtime_args(v0.objref<@layout_4>) {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.@layout_3 = call %input;
+        v3.@layout_0 = call %input;
         v5.i256 = call %len v3;
         mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
@@ -224,7 +221,7 @@ func inline(always) private %decode_runtime_args(v0.objref<@layout_5>) {
         br v15 block2 block3;
 }
 
-func private %core__lib__abi__dynamic_payload_size__g67a8_baae(v0.@layout_0) -> i256 {
+func private %core__lib__abi__dynamic_payload_size__g67a8_864f(v0.@layout_0) -> i256 {
     block0:
         jump block1;
 
@@ -232,7 +229,7 @@ func private %core__lib__abi__dynamic_payload_size__g67a8_baae(v0.@layout_0) -> 
         br 0.i1 block2 block3;
 
     block2:
-        v3.i256 = call %core__lib__abi__trait_AbiSize__payload_size__g67a8_75f0 v0;
+        v3.i256 = call %core__lib__abi__trait_AbiSize__payload_size__g67a8_5046 v0;
         return v3;
 
     block3:
@@ -242,7 +239,7 @@ func private %core__lib__abi__dynamic_payload_size__g67a8_baae(v0.@layout_0) -> 
         return 0.i256;
 }
 
-func private %core__lib__abi__dynamic_payload_size__g67a8_baae_0(v0.@layout_0) -> i256 {
+func private %core__lib__abi__dynamic_payload_size__g67a8_864f_0(v0.@layout_0) -> i256 {
     block0:
         jump block1;
 
@@ -250,7 +247,7 @@ func private %core__lib__abi__dynamic_payload_size__g67a8_baae_0(v0.@layout_0) -
         br 0.i1 block2 block3;
 
     block2:
-        v3.i256 = call %core__lib__abi__trait_AbiSize__payload_size__g67a8_75f0_0 v0;
+        v3.i256 = call %core__lib__abi__trait_AbiSize__payload_size__g67a8_5046_0 v0;
         return v3;
 
     block3:
@@ -296,13 +293,22 @@ func private %core__lib__abi__dynamic_payload_size__ge513_f973_0(v0.i256) -> i25
         return 0.i256;
 }
 
+func private %impl_trait_u256__encode__g426c(v0.i256, v1.objref<@layout_2>) {
+    block0:
+        jump block1;
+
+    block1:
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_5c61 v1 v0;
+        return;
+}
+
 func inline(always) private %encode__g4887(v0.@layout_1, v1.objref<@layout_2>) {
     block0:
         v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_8e95 v1;
+        v4.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_9d39 v1;
         v6.i256 = add v4 64.i256;
         mstore v2 v6 i256;
         v8.i256 = add v4 32.i256;
@@ -313,16 +319,7 @@ func inline(always) private %encode__g4887(v0.@layout_1, v1.objref<@layout_2>) {
         v16.i256 = ptr_to_int v2 i256;
         call %encode_field_at__gf6b4 v15 v1 v4 v8 v16;
         v18.i256 = add v4 64.i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_0d08_1 v1 v18;
-        return;
-}
-
-func private %impl_trait_u256__encode__g426c(v0.i256, v1.objref<@layout_2>) {
-    block0:
-        jump block1;
-
-    block1:
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_a864 v1 v0;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_a021_1 v1 v18;
         return;
 }
 
@@ -332,7 +329,7 @@ func private %impl_trait_Address__encode__g426c(v0.@layout_0, v1.objref<@layout_
 
     block1:
         v4.i256 = extract_value v0 0.i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_e52b v1 v4;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_6b8e v1 v4;
         return;
 }
 
@@ -344,19 +341,19 @@ func private %encode_field(v0.@layout_1, v1.objref<@layout_2>, v2.i256) {
         br 0.i1 block2 block3;
 
     block2:
-        v5.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_a403 v1;
-        v8.i256 = call %core__lib__abi__impl_trait____ccb6__payload_size__g6d15_e33b v0;
+        v5.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_9dac v1;
+        v8.i256 = call %core__lib__abi__impl_trait____ccb6__payload_size__g6d15_322c v0;
         v9.i256 = mload v2 i256;
         v10.i256 = sub v9 v5;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_4363 v1 v10;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_baef v1 v10;
         v12.i256 = call %pos v1;
         v13.i256 = mload v2 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_80f4 v1 v13;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_33b4 v1 v13;
         v15.i256 = mload v2 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_516e v1 v15;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_cc8d v1 v15;
         call %encode__g4887 v0 v1;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_80f4 v1 v5;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_516e v1 v12;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_33b4 v1 v5;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_cc8d v1 v12;
         v20.i256 = mload v2 i256;
         v21.i256 = add v20 v8;
         mstore v2 v21 i256;
@@ -372,7 +369,7 @@ func private %encode_field(v0.@layout_1, v1.objref<@layout_2>, v2.i256) {
         v24.i256 = call %pos v1;
         call %encode_to_ptr__g753b v0 v24;
         v28.i256 = add v24 64.i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_516e v1 v28;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_cc8d v1 v28;
         return;
 
     block6:
@@ -391,16 +388,16 @@ func inline(always) private %encode_field_at__gf6b4(v0.@layout_0, v1.objref<@lay
         br 0.i1 block2 block3;
 
     block2:
-        v8.i256 = call %core__lib__abi__trait_AbiSize__payload_size__g67a8_7cab v0;
+        v8.i256 = call %core__lib__abi__trait_AbiSize__payload_size__g67a8_95de v0;
         v11.i256 = mload v4 i256;
         v12.i256 = sub v11 v2;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_at_9d2f v1 v3 v12;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_at_6ace v1 v3 v12;
         v15.i256 = mload v4 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_3ff5 v1 v15;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_69e1 v1 v15;
         v17.i256 = mload v4 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_0d08 v1 v17;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_a021 v1 v17;
         call %impl_trait_Address__encode__g426c v0 v1;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_3ff5 v1 v2;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_69e1 v1 v2;
         v21.i256 = mload v4 i256;
         v22.i256 = add v21 v8;
         mstore v4 v22 i256;
@@ -413,14 +410,14 @@ func inline(always) private %encode_field_at__gf6b4(v0.@layout_0, v1.objref<@lay
         br 1.i1 block5 block6;
 
     block5:
-        call %std__lib__evm__effects__impl_trait_Address_ed76__encode_to_ptr__gf13e_8bc3 v0 v3;
+        call %std__lib__evm__effects__impl_trait_Address_ed76__encode_to_ptr__gf13e_14be v0 v3;
         return;
 
     block6:
         jump block7;
 
     block7:
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_0d08 v1 v3;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_a021 v1 v3;
         call %impl_trait_Address__encode__g426c v0 v1;
         return;
 }
@@ -436,13 +433,13 @@ func inline(always) private %encode_field_at__g2e64(v0.i256, v1.objref<@layout_2
         v8.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_7c20 v0;
         v11.i256 = mload v4 i256;
         v12.i256 = sub v11 v2;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_at_9d2f_0 v1 v3 v12;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_at_6ace_0 v1 v3 v12;
         v15.i256 = mload v4 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_3ff5_0 v1 v15;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_69e1_0 v1 v15;
         v17.i256 = mload v4 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_0d08_0 v1 v17;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_a021_0 v1 v17;
         call %impl_trait_u256__encode__g426c v0 v1;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_3ff5_0 v1 v2;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_69e1_0 v1 v2;
         v21.i256 = mload v4 i256;
         v22.i256 = add v21 v8;
         mstore v4 v22 i256;
@@ -462,7 +459,7 @@ func inline(always) private %encode_field_at__g2e64(v0.i256, v1.objref<@layout_2
         jump block7;
 
     block7:
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_0d08_0 v1 v3;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_a021_0 v1 v3;
         call %impl_trait_u256__encode__g426c v0 v1;
         return;
 }
@@ -473,7 +470,7 @@ func private %encode_single_root(v0.@layout_1, v1.objref<@layout_2>) {
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_a403 v1;
+        v4.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_9dac v1;
         v6.i256 = add v4 64.i256;
         mstore v2 v6 i256;
         v7.i256 = ptr_to_int v2 i256;
@@ -481,7 +478,7 @@ func private %encode_single_root(v0.@layout_1, v1.objref<@layout_2>) {
         return;
 }
 
-func private %encode_single_root_alloc(v0.@layout_1) -> @layout_6 {
+func private %encode_single_root_alloc(v0.@layout_1) -> @layout_2 {
     block0:
         jump block1;
 
@@ -495,11 +492,31 @@ func private %encode_single_root_alloc(v0.@layout_1) -> @layout_6 {
         v9.objref<i256> = obj.proj v4 1.i256;
         v10.i256 = extract_value v3 1.i256;
         obj.store v9 v10;
-        v11.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_a403 v4;
+        v11.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_9dac v4;
         call %encode_single_root v0 v4;
-        v14.@layout_6 = insert_value undef.@layout_6 0.i256 v11;
-        v15.@layout_6 = insert_value v14 1.i256 v2;
+        v14.@layout_2 = insert_value undef.@layout_2 0.i256 v11;
+        v15.@layout_2 = insert_value v14 1.i256 v2;
         return v15;
+}
+
+func private %std__lib__evm__effects__impl_trait_Address_ed76__encode_to_ptr__gf13e_14be(v0.@layout_0, v1.i256) {
+    block0:
+        jump block1;
+
+    block1:
+        v5.i256 = extract_value v0 0.i256;
+        call %std__lib__abi__sol__impl_trait_Sol_1f5f__store_word_001d v1 v5;
+        return;
+}
+
+func private %std__lib__evm__effects__impl_trait_Address_ed76__encode_to_ptr__gf13e_14be_0(v0.@layout_0, v1.i256) {
+    block0:
+        jump block1;
+
+    block1:
+        v5.i256 = extract_value v0 0.i256;
+        call %std__lib__abi__sol__impl_trait_Sol_1f5f__store_word_001d_0 v1 v5;
+        return;
 }
 
 func private %core__lib__abi__impl_trait_u256_d99e__encode_to_ptr__gf13e_3ddf(v0.i256, v1.i256) {
@@ -529,27 +546,7 @@ func private %encode_to_ptr__g753b(v0.@layout_1, v1.i256) {
         call %core__lib__abi__impl_trait_u256_d99e__encode_to_ptr__gf13e_3ddf_0 v4 v1;
         v8.@layout_0 = extract_value v0 1.i256;
         v10.i256 = add v1 32.i256;
-        call %std__lib__evm__effects__impl_trait_Address_ed76__encode_to_ptr__gf13e_8bc3_0 v8 v10;
-        return;
-}
-
-func private %std__lib__evm__effects__impl_trait_Address_ed76__encode_to_ptr__gf13e_8bc3(v0.@layout_0, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v5.i256 = extract_value v0 0.i256;
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__store_word_001d v1 v5;
-        return;
-}
-
-func private %std__lib__evm__effects__impl_trait_Address_ed76__encode_to_ptr__gf13e_8bc3_0(v0.@layout_0, v1.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        v5.i256 = extract_value v0 0.i256;
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__store_word_001d_0 v1 v5;
+        call %std__lib__evm__effects__impl_trait_Address_ed76__encode_to_ptr__gf13e_14be_0 v8 v10;
         return;
 }
 
@@ -562,16 +559,16 @@ func private %encoder_new(v0.i256) -> @layout_2 {
         return v2;
 }
 
-func private %input() -> @layout_3 {
+func private %input() -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v0.@layout_3 = call %impl_CallData__new;
+        v0.@layout_0 = call %impl_CallData__new;
         return v0;
 }
 
-func inline(always) private %len(v0.@layout_3) -> i256 {
+func inline(always) private %len(v0.@layout_0) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         jump block1;
@@ -605,15 +602,15 @@ func inline(always) private %len(v0.@layout_3) -> i256 {
         jump block4;
 }
 
-func inline(always) private %impl_CallData__new() -> @layout_3 {
+func inline(always) private %impl_CallData__new() -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v1.constref<@layout_3> = const.ref $const_region_0;
-        v2.objref<@layout_3> = obj.alloc @layout_3;
+        v1.constref<@layout_0> = const.ref $const_region_0;
+        v2.objref<@layout_0> = obj.alloc @layout_0;
         obj.init.const v2 v1;
-        v3.@layout_3 = obj.load v2;
+        v3.@layout_0 = obj.load v2;
         return v3;
 }
 
@@ -639,7 +636,35 @@ func private %impl_SolEncoder__new(v0.i256) -> @layout_2 {
         return v8;
 }
 
-func private %core__lib__abi__trait_AbiSize__payload_size__g67a8_75f0(v0.@layout_0) -> i256 {
+func inline(always) private %core__lib__abi__impl_trait____ccb6__payload_size__g6d15_322c(v0.@layout_1) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.i256 = extract_value v0 0.i256;
+        v5.i256 = call %core__lib__abi__dynamic_payload_size__ge513_f973 v4;
+        v6.i256 = add 64.i256 v5;
+        v8.@layout_0 = extract_value v0 1.i256;
+        v9.i256 = call %core__lib__abi__dynamic_payload_size__g67a8_864f v8;
+        v10.i256 = add v6 v9;
+        return v10;
+}
+
+func inline(always) private %core__lib__abi__impl_trait____ccb6__payload_size__g6d15_322c_0(v0.@layout_1) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.i256 = extract_value v0 0.i256;
+        v5.i256 = call %core__lib__abi__dynamic_payload_size__ge513_f973_0 v4;
+        v6.i256 = add 64.i256 v5;
+        v8.@layout_0 = extract_value v0 1.i256;
+        v9.i256 = call %core__lib__abi__dynamic_payload_size__g67a8_864f_0 v8;
+        v10.i256 = add v6 v9;
+        return v10;
+}
+
+func private %core__lib__abi__trait_AbiSize__payload_size__g67a8_5046(v0.@layout_0) -> i256 {
     block0:
         jump block1;
 
@@ -647,7 +672,7 @@ func private %core__lib__abi__trait_AbiSize__payload_size__g67a8_75f0(v0.@layout
         return 32.i256;
 }
 
-func private %core__lib__abi__trait_AbiSize__payload_size__g67a8_75f0_0(v0.@layout_0) -> i256 {
+func private %core__lib__abi__trait_AbiSize__payload_size__g67a8_5046_0(v0.@layout_0) -> i256 {
     block0:
         jump block1;
 
@@ -663,7 +688,7 @@ func private %core__lib__abi__trait_AbiSize__payload_size__ge513_7c20(v0.i256) -
         return 32.i256;
 }
 
-func private %core__lib__abi__trait_AbiSize__payload_size__g67a8_7cab(v0.@layout_0) -> i256 {
+func private %core__lib__abi__trait_AbiSize__payload_size__g67a8_95de(v0.@layout_0) -> i256 {
     block0:
         jump block1;
 
@@ -687,34 +712,6 @@ func private %core__lib__abi__trait_AbiSize__payload_size__ge513_c169_0(v0.i256)
         return 32.i256;
 }
 
-func inline(always) private %core__lib__abi__impl_trait____ccb6__payload_size__g6d15_e33b(v0.@layout_1) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v5.i256 = call %core__lib__abi__dynamic_payload_size__ge513_f973 v4;
-        v6.i256 = add 64.i256 v5;
-        v8.@layout_0 = extract_value v0 1.i256;
-        v9.i256 = call %core__lib__abi__dynamic_payload_size__g67a8_baae v8;
-        v10.i256 = add v6 v9;
-        return v10;
-}
-
-func inline(always) private %core__lib__abi__impl_trait____ccb6__payload_size__g6d15_e33b_0(v0.@layout_1) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = extract_value v0 0.i256;
-        v5.i256 = call %core__lib__abi__dynamic_payload_size__ge513_f973_0 v4;
-        v6.i256 = add 64.i256 v5;
-        v8.@layout_0 = extract_value v0 1.i256;
-        v9.i256 = call %core__lib__abi__dynamic_payload_size__g67a8_baae_0 v8;
-        v10.i256 = add v6 v9;
-        return v10;
-}
-
 func private %pos(v0.objref<@layout_2>) -> i256 {
     block0:
         jump block1;
@@ -733,7 +730,7 @@ func private %revert(v0.i256, v1.i256) {
         evm_revert v0 v1;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_3ff5(v0.objref<@layout_2>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_33b4(v0.objref<@layout_2>, v1.i256) {
     block0:
         jump block1;
 
@@ -743,7 +740,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_3ff5(v0.o
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_3ff5_0(v0.objref<@layout_2>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_69e1(v0.objref<@layout_2>, v1.i256) {
     block0:
         jump block1;
 
@@ -753,7 +750,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_3ff5_0(v0
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_80f4(v0.objref<@layout_2>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_69e1_0(v0.objref<@layout_2>, v1.i256) {
     block0:
         jump block1;
 
@@ -763,7 +760,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_80f4(v0.o
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_0d08(v0.objref<@layout_2>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_a021(v0.objref<@layout_2>, v1.i256) {
     block0:
         jump block1;
 
@@ -773,7 +770,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_0d08(v0.ob
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_0d08_0(v0.objref<@layout_2>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_a021_0(v0.objref<@layout_2>, v1.i256) {
     block0:
         jump block1;
 
@@ -783,7 +780,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_0d08_0(v0.
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_0d08_1(v0.objref<@layout_2>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_a021_1(v0.objref<@layout_2>, v1.i256) {
     block0:
         jump block1;
 
@@ -793,7 +790,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_0d08_1(v0.
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_516e(v0.objref<@layout_2>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_cc8d(v0.objref<@layout_2>, v1.i256) {
     block0:
         jump block1;
 
@@ -830,7 +827,7 @@ func private %std__lib__abi__sol__impl_trait_Sol_1f5f__store_word_5688(v0.i256, 
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_4363(v0.objref<@layout_2>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_5c61(v0.objref<@layout_2>, v1.i256) {
     block0:
         jump block1;
 
@@ -844,7 +841,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_4363(v0
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_a864(v0.objref<@layout_2>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_6b8e(v0.objref<@layout_2>, v1.i256) {
     block0:
         jump block1;
 
@@ -858,7 +855,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_a864(v0
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_at_9d2f(v0.objref<@layout_2>, v1.i256, v2.i256) {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_at_6ace(v0.objref<@layout_2>, v1.i256, v2.i256) {
     block0:
         jump block1;
 
@@ -867,7 +864,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_at_9d2f
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_at_9d2f_0(v0.objref<@layout_2>, v1.i256, v2.i256) {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_at_6ace_0(v0.objref<@layout_2>, v1.i256, v2.i256) {
     block0:
         jump block1;
 
@@ -876,7 +873,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_at_9d2f
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_e52b(v0.objref<@layout_2>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_baef(v0.objref<@layout_2>, v1.i256) {
     block0:
         jump block1;
 
@@ -895,7 +892,7 @@ func private %zero() -> @layout_0 {
         jump block1;
 
     block1:
-        v1.constref<@layout_0> = const.ref $const_region_1;
+        v1.constref<@layout_0> = const.ref $const_region_0;
         v2.objref<@layout_0> = obj.alloc @layout_0;
         obj.init.const v2 v1;
         v3.@layout_0 = obj.load v2;
@@ -911,6 +908,5 @@ object @TupleReturnContract {
     section runtime {
         entry %contract_runtime_root_TupleReturnContract;
         data $const_region_0;
-        data $const_region_1;
     }
 }

--- a/crates/codegen/tests/fixtures/sonatina_ir/tuple_single_element_peeling.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/tuple_single_element_peeling.snap
@@ -9,8 +9,6 @@ type @layout_0 = {i256, i256, i256, i8};
 type @layout_1 = {i1};
 type @layout_2 = {i256};
 type @layout_3 = {@layout_2};
-type @layout_4 = {i256};
-type @layout_5 = {@layout_4};
 
 global private const @layout_1 $const_region_0 = {1};
 
@@ -94,9 +92,9 @@ func private %tuple_single_struct_newtype_nested(v0.i256) -> i256 {
         jump block1;
 
     block1:
-        v4.@layout_4 = insert_value undef.@layout_4 0.i256 v0;
-        v6.@layout_5 = insert_value undef.@layout_5 0.i256 v4;
-        v7.@layout_4 = extract_value v6 0.i256;
+        v4.@layout_2 = insert_value undef.@layout_2 0.i256 v0;
+        v6.@layout_3 = insert_value undef.@layout_3 0.i256 v4;
+        v7.@layout_2 = extract_value v6 0.i256;
         v8.i256 = extract_value v7 0.i256;
         return v8;
 }

--- a/crates/codegen/tests/fixtures/sonatina_ir/wrapping_saturating.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/wrapping_saturating.snap
@@ -52,21 +52,21 @@ func private %impl_trait_u64__saturating_add(v0.i64, v1.i64) -> i64 {
         return v4;
 }
 
-func private %impl_trait_u64__saturating_mul(v0.i64, v1.i64) -> i64 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i64 = umulsat v0 v1;
-        return v4;
-}
-
 func private %impl_trait_u256__saturating_mul(v0.i256, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
         v4.i256 = umulsat v0 v1;
+        return v4;
+}
+
+func private %impl_trait_u64__saturating_mul(v0.i64, v1.i64) -> i64 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.i64 = umulsat v0 v1;
         return v4;
 }
 
@@ -116,21 +116,21 @@ func private %impl_trait_u256__saturating_sub(v0.i256, v1.i256) -> i256 {
         return v4;
 }
 
-func private %impl_trait_u64__wrapping_add(v0.i64, v1.i64) -> i64 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i64 = add v0 v1;
-        return v4;
-}
-
 func private %impl_trait_u256__wrapping_add(v0.i256, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
         v4.i256 = add v0 v1;
+        return v4;
+}
+
+func private %impl_trait_u64__wrapping_add(v0.i64, v1.i64) -> i64 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.i64 = add v0 v1;
         return v4;
 }
 
@@ -180,21 +180,21 @@ func private %wrapping_ops_u64(v0.i64, v1.i64) -> @layout_0 {
         return v13;
 }
 
-func private %impl_trait_u64__wrapping_sub(v0.i64, v1.i64) -> i64 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i64 = sub v0 v1;
-        return v4;
-}
-
 func private %impl_trait_u256__wrapping_sub(v0.i256, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
         v4.i256 = sub v0 v1;
+        return v4;
+}
+
+func private %impl_trait_u64__wrapping_sub(v0.i64, v1.i64) -> i64 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.i64 = sub v0 v1;
         return v4;
 }
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/zero_sized_aggregates.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/zero_sized_aggregates.snap
@@ -8,11 +8,10 @@ target = "evm-ethereum-osaka"
 
 type @layout_0 = {};
 type @layout_1 = {@layout_0, i256};
-type @layout_2 = {@layout_0, i256};
 
 global private const @layout_1 $const_region_0 = {{}, 1};
 global private const @layout_1 $const_region_1 = {{}, 7};
-global private const @layout_2 $const_region_2 = {{}, 5};
+global private const @layout_1 $const_region_2 = {{}, 5};
 
 func private %empty_field_assign() {
     block0:
@@ -58,8 +57,8 @@ func private %tuple_with_empty() -> i256 {
         jump block1;
 
     block1:
-        v1.constref<@layout_2> = const.ref $const_region_2;
-        v2.constref<@layout_2> = const.ref $const_region_2;
+        v1.constref<@layout_1> = const.ref $const_region_2;
+        v2.constref<@layout_1> = const.ref $const_region_2;
         return 5.i256;
 }
 

--- a/crates/codegen/tests/runtime_handle_preservation.rs
+++ b/crates/codegen/tests/runtime_handle_preservation.rs
@@ -292,7 +292,14 @@ fn provider_root_trait_receivers_preserve_concrete_runtime_layouts() {
             let Layout::Struct(layout_data) = layout.data(&db) else {
                 panic!("storage receiver should use the concrete Pair layout:\n{body:#?}");
             };
-            assert_eq!(layout_data.source_ty.pretty_print(&db).to_string(), "Pair");
+            assert_eq!(layout_data.fields.len(), 2);
+            assert!(
+                layout_data
+                    .fields
+                    .iter()
+                    .all(|field| matches!(field, RuntimeClass::Scalar(_))),
+                "Pair layout should carry two scalar fields:\n{layout_data:#?}",
+            );
 
             let (callee, arg) = body
                 .blocks
@@ -376,7 +383,14 @@ fn view_receiver_with_storage_aggregate_keeps_receiver_runtime_visible() {
             let Layout::Struct(layout_data) = layout.data(&db) else {
                 panic!("view receiver should point at the stored Pair layout:\n{body:#?}");
             };
-            assert_eq!(layout_data.source_ty.pretty_print(&db).to_string(), "Pair");
+            assert_eq!(layout_data.fields.len(), 2);
+            assert!(
+                layout_data
+                    .fields
+                    .iter()
+                    .all(|field| matches!(field, RuntimeClass::Scalar(_))),
+                "Pair layout should carry two scalar fields:\n{layout_data:#?}",
+            );
             assert!(
                 body.blocks
                     .iter()
@@ -1779,9 +1793,9 @@ fn test_readonly_with_provider() {
 }
 
 #[test]
-fn borrow_typed_aggregate_literals_lower_without_const_shape_mismatch() {
+fn borrow_typed_aggregate_literals_can_lower_as_const_refs() {
     with_runtime_package!(
-        "borrow_typed_aggregate_literals_lower_without_const_shape_mismatch.fe",
+        "borrow_typed_aggregate_literals_can_lower_as_const_refs.fe",
         r#"fn first(xs: ref [u256; 2]) -> u256 {
     xs[0]
 }
@@ -1790,34 +1804,61 @@ fn entry() -> u256 {
     first([10, 20])
 }"#,
         |db, package| {
-            let debug = package
+            let first = package
                 .functions(&db)
                 .iter()
-                .map(|function| {
-                    let body = function.instance(&db).body(&db);
-                    format!("{}:\n{body:#?}", function.symbol(&db))
+                .copied()
+                .find(|function| function.symbol(&db) == "first")
+                .expect("first runtime function")
+                .instance(&db);
+            let entry = package
+                .functions(&db)
+                .iter()
+                .copied()
+                .find(|function| function.symbol(&db) == "entry")
+                .expect("entry runtime function");
+            let body = entry.instance(&db).body(&db);
+            let first_args = body
+                .blocks
+                .iter()
+                .flat_map(|block| block.stmts.iter())
+                .filter_map(|stmt| match stmt {
+                    RStmt::Assign {
+                        expr: RExpr::Call { callee, args },
+                        ..
+                    } if *callee == first => Some(args[0]),
+                    _ => None,
                 })
                 .collect::<Vec<_>>();
 
+            assert_eq!(
+                first_args.len(),
+                1,
+                "entry should call first exactly once:\n{body:#?}"
+            );
             assert!(
-                package.functions(&db).iter().any(|function| {
-                    let body = function.instance(&db).body(&db);
-                    body.blocks
-                        .iter()
-                        .flat_map(|block| block.stmts.iter())
-                        .any(|stmt| {
-                            matches!(
-                                stmt,
-                                RStmt::Assign {
-                                    expr: RExpr::MaterializeToObject { .. }
-                                        | RExpr::AllocObject { .. },
-                                    ..
-                                }
-                            )
-                        })
-                }),
-                "borrow-typed aggregate literals should materialize through normal object/value lowering:\n{}",
-                debug.join("\n\n")
+                matches!(
+                    body.value_class(first_args[0]),
+                    Some(RuntimeClass::Ref {
+                        kind: RefKind::Const,
+                        ..
+                    })
+                ),
+                "borrow-typed aggregate literal should be passed as a const ref:\n{body:#?}"
+            );
+            assert!(
+                !body
+                    .blocks
+                    .iter()
+                    .flat_map(|block| block.stmts.iter())
+                    .any(|stmt| matches!(
+                        stmt,
+                        RStmt::Assign {
+                            expr: RExpr::MaterializeToObject { .. } | RExpr::AllocObject { .. },
+                            ..
+                        }
+                    )),
+                "borrow-typed aggregate literal should not materialize before the call:\n{body:#?}"
             );
         }
     );

--- a/crates/fe/tests/fixtures/fe_test/trait_default_body_via_assumption.fe
+++ b/crates/fe/tests/fixtures/fe_test/trait_default_body_via_assumption.fe
@@ -1,0 +1,100 @@
+// Regression coverage for the canonical `ImplEnv` built when a trait method
+// resolves to a concrete impl (see `ImplEnv::for_resolved_trait_method`). That
+// env carries only the resolving witness and drops the caller's assumptions, so
+// a trait *default body* reached through a generic param receiver (an
+// "assumption implementor") must stay provable from the trait's own bounds plus
+// that single witness alone.
+
+// --- default body dispatching to a supertrait method ---
+
+trait Base {
+    fn base_value(self) -> u256
+}
+
+trait Derived: Base {
+    // Default body: calls a supertrait method on `self`. Resolving this call
+    // needs `Self: Base`, which is not the witness itself (`Self: Derived`) but
+    // must be elaborated from it -- with no caller assumptions available.
+    fn doubled(self) -> u256 {
+        self.base_value() * 2
+    }
+}
+
+struct Token {
+    amount: u256,
+}
+
+impl Copy for Token {}
+
+impl Base for Token {
+    fn base_value(self) -> u256 {
+        self.amount
+    }
+}
+
+// Only an empty `impl Derived`, so `doubled` resolves to the trait default body.
+impl Derived for Token {}
+
+// Param receiver: the `Derived` (and elaborated `Base`) bound is supplied purely
+// as a caller assumption. After monomorphization the call lands in the default
+// body of `Derived::doubled`.
+fn run_doubled<T: Derived>(_ t: T) -> u256 {
+    t.doubled()
+}
+
+#[test]
+fn default_body_supertrait_call_via_assumption() {
+    let token = Token { amount: 21 }
+    assert(run_doubled(token) == 42)
+}
+
+// --- default body dispatching to another required method of the same trait ---
+
+trait Counter {
+    fn seed(self) -> u256
+
+    // Default body: calls a sibling required method that the impl provides.
+    fn next(self) -> u256 {
+        self.seed() + 1
+    }
+}
+
+struct Ticket {
+    n: u256,
+}
+
+impl Copy for Ticket {}
+
+impl Counter for Ticket {
+    fn seed(self) -> u256 {
+        self.n
+    }
+}
+
+fn run_next<T: Counter>(_ t: T) -> u256 {
+    t.next()
+}
+
+#[test]
+fn default_body_sibling_call_via_assumption() {
+    let ticket = Ticket { n: 100 }
+    assert(run_next(ticket) == 101)
+}
+
+// --- nested generic forwarding before the default body resolves ---
+
+// `outer` only knows `T: Derived` as an assumption and forwards to `inner`,
+// which re-derives the same bound before finally reaching the default body.
+fn forward_inner<U: Derived>(_ u: U) -> u256 {
+    u.doubled()
+}
+
+fn forward_outer<T: Derived>(_ t: T) -> u256 {
+    forward_inner(t)
+}
+
+#[test]
+fn default_body_nested_forwarding_via_assumption() {
+    let token = Token { amount: 5 }
+    assert(forward_outer(token) == 10)
+}

--- a/crates/hir/src/analysis/semantic/instance/const_ref.rs
+++ b/crates/hir/src/analysis/semantic/instance/const_ref.rs
@@ -116,12 +116,7 @@ fn semantic_callee_key_with_assumptions<'db>(
     );
 
     let impl_env = if let Some(witness) = resolved_trait_witness {
-        ImplEnv::new(
-            db,
-            owner.scope(),
-            PredicateListId::empty_list(db),
-            vec![witness],
-        )
+        ImplEnv::for_resolved_trait_method(db, owner, witness)
     } else {
         let mut witnesses: IndexSet<_> = impl_env.witnesses(db).iter().copied().collect();
         if let Some(witness) = callable.trait_inst() {

--- a/crates/hir/src/analysis/semantic/instance/const_ref.rs
+++ b/crates/hir/src/analysis/semantic/instance/const_ref.rs
@@ -12,7 +12,8 @@ use crate::{
             const_ty::inherent_const_body_and_impl_args,
             effects::place_effect_provider_param_index_map,
             trait_def::{
-                assoc_const_body_and_impl_args_for_trait_inst, resolve_trait_method_instance,
+                assoc_const_body_and_impl_args_for_trait_inst, complete_resolved_trait_method_args,
+                resolve_trait_method_instance,
             },
             trait_resolution::{PredicateListId, TraitSolveCx},
             ty_check::{
@@ -76,6 +77,7 @@ fn semantic_callee_key_with_assumptions<'db>(
     provider_resolution_mode: ProviderResolutionMode,
 ) -> Option<SemanticInstanceKey<'db>> {
     let impl_env = caller_key.impl_env(db);
+    let mut resolved_trait_witness = None;
     let (owner, mut subst_args) = match callable.callable_def() {
         CallableDef::Func(func) => {
             let mut subst_args = callable.generic_args().to_vec();
@@ -88,13 +90,14 @@ fn semantic_callee_key_with_assumptions<'db>(
                     inst,
                     name,
                 ) {
-                let trait_arg_len = inst.args(db).len();
-                let mut resolved_args = impl_args;
-                let tail = subst_args
-                    .get(trait_arg_len..)
-                    .unwrap_or(subst_args.as_slice());
-                resolved_args.extend_from_slice(tail);
-                subst_args = resolved_args;
+                subst_args = complete_resolved_trait_method_args(
+                    db,
+                    impl_func,
+                    impl_args,
+                    &subst_args,
+                    inst.args(db).len(),
+                );
+                resolved_trait_witness = Some(inst);
                 BodyOwner::Func(impl_func)
             } else {
                 BodyOwner::Func(func)
@@ -112,16 +115,25 @@ fn semantic_callee_key_with_assumptions<'db>(
         provider_resolution_mode,
     );
 
-    let mut witnesses: IndexSet<_> = impl_env.witnesses(db).iter().copied().collect();
-    if let Some(witness) = callable.trait_inst() {
-        witnesses.insert(witness);
-    }
-    let impl_env = ImplEnv::new(
-        db,
-        impl_env.normalization_scope(db),
-        assumptions,
-        witnesses.into_iter().collect::<Vec<_>>(),
-    );
+    let impl_env = if let Some(witness) = resolved_trait_witness {
+        ImplEnv::new(
+            db,
+            owner.scope(),
+            PredicateListId::empty_list(db),
+            vec![witness],
+        )
+    } else {
+        let mut witnesses: IndexSet<_> = impl_env.witnesses(db).iter().copied().collect();
+        if let Some(witness) = callable.trait_inst() {
+            witnesses.insert(witness);
+        }
+        ImplEnv::new(
+            db,
+            impl_env.normalization_scope(db),
+            assumptions,
+            witnesses.into_iter().collect::<Vec<_>>(),
+        )
+    };
 
     Some(SemanticInstanceKey::new(
         db,

--- a/crates/hir/src/analysis/semantic/instance/template.rs
+++ b/crates/hir/src/analysis/semantic/instance/template.rs
@@ -80,6 +80,23 @@ impl<'db> ImplEnv<'db> {
             Vec::new(),
         )
     }
+
+    /// Canonical environment for a trait method that has been resolved to a
+    /// concrete impl body: the impl body's own scope, no caller assumptions,
+    /// and just the single resolving witness. Keeping this independent of the
+    /// caller lets identical resolved instances deduplicate.
+    pub fn for_resolved_trait_method(
+        db: &'db dyn HirAnalysisDb,
+        owner: BodyOwner<'db>,
+        witness: TraitInstId<'db>,
+    ) -> Self {
+        Self::new(
+            db,
+            owner.scope(),
+            PredicateListId::empty_list(db),
+            vec![witness],
+        )
+    }
 }
 
 #[salsa::interned]

--- a/crates/hir/src/analysis/ty/trait_def.rs
+++ b/crates/hir/src/analysis/ty/trait_def.rs
@@ -30,6 +30,7 @@ use super::{
         normalize_trait_inst_preserving_validity,
     },
     ty_def::{TyBase, TyData, TyId},
+    ty_lower::collect_generic_params,
     ty_lower::layout_param_root_uses,
     unify::UnificationTable,
     visitor::{TyVisitable, TyVisitor},
@@ -485,6 +486,22 @@ pub fn resolve_trait_method_instance<'db>(
         Selection::NotFound => return None,
     };
     resolved.method_instance(db, method)
+}
+
+pub fn complete_resolved_trait_method_args<'db>(
+    db: &'db dyn HirAnalysisDb,
+    impl_func: Func<'db>,
+    mut impl_args: Vec<TyId<'db>>,
+    caller_args: &[TyId<'db>],
+    trait_arg_len: usize,
+) -> Vec<TyId<'db>> {
+    let expected_len = collect_generic_params(db, impl_func.into())
+        .params(db)
+        .len();
+    let missing_len = expected_len.saturating_sub(impl_args.len());
+    let tail = caller_args.get(trait_arg_len..).unwrap_or(caller_args);
+    impl_args.extend(tail.iter().copied().take(missing_len));
+    impl_args
 }
 
 /// Returns all implementors for the given `ty` whose constraints are fully proven.

--- a/crates/mir/src/runtime/ir.rs
+++ b/crates/mir/src/runtime/ir.rs
@@ -508,7 +508,6 @@ impl<'db> LayoutId<'db> {
             LayoutKey::Struct(layout) => Layout::Struct(layout.clone()),
             LayoutKey::Array(layout) => Layout::Array(layout.clone()),
             LayoutKey::Enum(layout) => Layout::Enum(EnumLayout {
-                source_ty: layout.source_ty,
                 tag: ScalarClass {
                     repr: enum_tag_repr(layout.variants.len()),
                     role: ScalarRole::EnumTag { enum_layout: self },
@@ -535,7 +534,6 @@ pub enum Layout<'db> {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Update)]
 pub struct StructLayout<'db> {
-    pub source_ty: TyId<'db>,
     pub fields: Box<[RuntimeClass<'db>]>,
 }
 
@@ -551,27 +549,23 @@ impl<'db> StructLayout<'db> {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Update)]
 pub struct ArrayLayout<'db> {
-    pub source_ty: TyId<'db>,
     pub elem: RuntimeClass<'db>,
     pub len: u64,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Update)]
 pub struct EnumLayout<'db> {
-    pub source_ty: TyId<'db>,
     pub tag: ScalarClass<'db>,
     pub variants: Box<[EnumVariantLayout<'db>]>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Update)]
 pub struct EnumLayoutKey<'db> {
-    pub source_ty: TyId<'db>,
     pub variants: Box<[EnumVariantLayout<'db>]>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Update)]
 pub struct EnumVariantLayout<'db> {
-    pub name: String,
     pub fields: Box<[RuntimeClass<'db>]>,
 }
 

--- a/crates/mir/src/runtime/lower/abi.rs
+++ b/crates/mir/src/runtime/lower/abi.rs
@@ -132,13 +132,7 @@ pub(crate) fn runtime_abi_plan<'db>(
             .chain(evidence.iter().map(|result| result.class.clone()))
             .collect::<Vec<_>>()
             .into_boxed_slice();
-        let layout = LayoutId::new(
-            db,
-            LayoutKey::Struct(StructLayout {
-                source_ty: semantic.key(db).typed_body(db).result_ty(),
-                fields,
-            }),
-        );
+        let layout = LayoutId::new(db, LayoutKey::Struct(StructLayout { fields }));
         (Some(RuntimeClass::AggregateValue { layout }), Some(layout))
     };
 

--- a/crates/mir/src/runtime/lower/arg_selector.rs
+++ b/crates/mir/src/runtime/lower/arg_selector.rs
@@ -474,7 +474,7 @@ impl<'a, 'carriers, 'roots, 'cache, 'db> RuntimeArgSelector<'a, 'carriers, 'root
         boundary: &StagedBoundary<'db>,
     ) -> Option<SelectedRuntimeArg<'db>> {
         let boundary = self.specialized_boundary(local, boundary);
-        self.select_runtime_boundary_compatible_value(local, &boundary)
+        self.select_runtime_boundary_compatible_value_for_places(local, &boundary, true)
     }
 
     fn select_free_boundary_compatible_value(

--- a/crates/mir/src/runtime/lower/body.rs
+++ b/crates/mir/src/runtime/lower/body.rs
@@ -69,9 +69,9 @@ use super::{
         snapshot_source_place,
     },
     consts::{
-        aggregate_const_ref_class, aggregate_const_ref_region, const_scalar_for_class,
-        const_scalar_from_value, enum_tag_scalar, evaluated_const_ref_value, lower_const_region,
-        reified_const_ref_value_for_ty,
+        aggregate_const_ref_class, aggregate_const_ref_region, collect_const_ref_regions,
+        const_scalar_for_class, const_scalar_from_value, enum_tag_scalar,
+        evaluated_const_ref_value, lower_const_region,
     },
     conversion::{RuntimeConversionEmitter, RuntimeConversionError, emit_runtime_coercion},
     infer::{InferenceResult, LocalStateInferer, RuntimeLocalLowering, merge_runtime_class},
@@ -282,30 +282,6 @@ fn expr_requires_runtime_eval_when_erased(expr: &NExpr<'_>) -> bool {
         | NExpr::CodeRegionOffset { .. }
         | NExpr::CodeRegionLen { .. } => false,
     }
-}
-
-fn collect_const_ref_regions<'db>(
-    db: &'db dyn MirDb,
-    env: RuntimeTypeEnv<'db>,
-    body: &NormalizedSemanticBody<'db>,
-) -> HashSet<ConstRegionId<'db>> {
-    body.blocks
-        .iter()
-        .flat_map(|block| block.stmts.iter())
-        .filter_map(|stmt| {
-            let NSStmtKind::Assign { dst, expr } = &stmt.kind else {
-                return None;
-            };
-            let NExpr::Const(SConst::Ref(cref)) = expr else {
-                return None;
-            };
-            aggregate_const_ref_region(
-                db,
-                env,
-                reified_const_ref_value_for_ty(db, body.owner, *cref, body.locals[dst.index()].ty),
-            )
-        })
-        .collect()
 }
 
 pub(super) struct RmirEmitter<'db> {
@@ -4880,33 +4856,31 @@ impl<'db> RmirEmitter<'db> {
             }
             RuntimeConversionError::Cycle { source, target } => ("cyclic", source, target),
         };
-        let layout_source_ty = |layout: LayoutId<'db>| match layout.data(self.db) {
-            crate::runtime::Layout::Struct(data) => {
-                data.source_ty.pretty_print(self.db).to_string()
-            }
-            crate::runtime::Layout::Array(data) => data.source_ty.pretty_print(self.db).to_string(),
-            crate::runtime::Layout::Enum(data) => data.source_ty.pretty_print(self.db).to_string(),
+        let layout_kind = |layout: LayoutId<'db>| match layout.data(self.db) {
+            crate::runtime::Layout::Struct(data) => format!("struct/{}", data.fields.len()),
+            crate::runtime::Layout::Array(data) => format!("array/{}", data.len),
+            crate::runtime::Layout::Enum(data) => format!("enum/{}", data.variants.len()),
         };
         let source_layout = match &source {
             RuntimeClass::Ref { .. } => source
                 .aggregate_layout()
-                .map(|layout| (layout, layout.data(self.db), layout_source_ty(layout))),
+                .map(|layout| (layout, layout.data(self.db), layout_kind(layout))),
             RuntimeClass::AggregateValue { layout }
             | RuntimeClass::RawAddr {
                 target: Some(layout),
                 ..
-            } => Some((*layout, layout.data(self.db), layout_source_ty(*layout))),
+            } => Some((*layout, layout.data(self.db), layout_kind(*layout))),
             RuntimeClass::Scalar(_) | RuntimeClass::RawAddr { target: None, .. } => None,
         };
         let target_layout = match &target {
             RuntimeClass::Ref { .. } => target
                 .aggregate_layout()
-                .map(|layout| (layout, layout.data(self.db), layout_source_ty(layout))),
+                .map(|layout| (layout, layout.data(self.db), layout_kind(layout))),
             RuntimeClass::AggregateValue { layout }
             | RuntimeClass::RawAddr {
                 target: Some(layout),
                 ..
-            } => Some((*layout, layout.data(self.db), layout_source_ty(*layout))),
+            } => Some((*layout, layout.data(self.db), layout_kind(*layout))),
             RuntimeClass::Scalar(_) | RuntimeClass::RawAddr { target: None, .. } => None,
         };
         let owner = self
@@ -5767,13 +5741,20 @@ impl<'db> RmirEmitter<'db> {
     }
 
     fn const_lowering_ty(&self, fallback: TyId<'db>, target: &RuntimeClass<'db>) -> TyId<'db> {
-        target
-            .aggregate_layout()
-            .map_or(fallback, |layout| match layout.data(self.db) {
-                crate::runtime::Layout::Struct(layout) => layout.source_ty,
-                crate::runtime::Layout::Array(layout) => layout.source_ty,
-                crate::runtime::Layout::Enum(layout) => layout.source_ty,
-            })
+        if target.aggregate_layout().is_none() {
+            return fallback;
+        }
+        let mut ty = fallback;
+        while let Some(inner) = ty.as_view(self.db) {
+            ty = inner;
+        }
+        if let Some((_, inner)) = ty.as_borrow(self.db) {
+            ty = inner;
+            while let Some(inner) = ty.as_view(self.db) {
+                ty = inner;
+            }
+        }
+        ty
     }
 }
 

--- a/crates/mir/src/runtime/lower/body.rs
+++ b/crates/mir/src/runtime/lower/body.rs
@@ -5744,17 +5744,18 @@ impl<'db> RmirEmitter<'db> {
         if target.aggregate_layout().is_none() {
             return fallback;
         }
+        // Recover the underlying aggregate value type by peeling any
+        // view/borrow wrappers off the declared type.
         let mut ty = fallback;
-        while let Some(inner) = ty.as_view(self.db) {
-            ty = inner;
-        }
-        if let Some((_, inner)) = ty.as_borrow(self.db) {
-            ty = inner;
-            while let Some(inner) = ty.as_view(self.db) {
+        loop {
+            if let Some(inner) = ty.as_view(self.db) {
                 ty = inner;
+            } else if let Some((_, inner)) = ty.as_borrow(self.db) {
+                ty = inner;
+            } else {
+                return ty;
             }
         }
-        ty
     }
 }
 

--- a/crates/mir/src/runtime/lower/boundary.rs
+++ b/crates/mir/src/runtime/lower/boundary.rs
@@ -1018,7 +1018,6 @@ mod tests {
         LayoutId::new(
             db,
             LayoutKey::Struct(StructLayout {
-                source_ty: TyId::unit(db),
                 fields: vec![word_class()].into(),
             }),
         )
@@ -1028,9 +1027,7 @@ mod tests {
         let enum_layout = LayoutId::new(
             db,
             LayoutKey::Enum(EnumLayoutKey {
-                source_ty: TyId::unit(db),
                 variants: vec![EnumVariantLayout {
-                    name: "Variant".to_string(),
                     fields: vec![word_class()].into(),
                 }]
                 .into(),

--- a/crates/mir/src/runtime/lower/classify.rs
+++ b/crates/mir/src/runtime/lower/classify.rs
@@ -3420,12 +3420,12 @@ uses (slot: Slot<u256>)
                     layout.data(&db)
                 );
             };
-            assert_eq!(layout_data.source_ty, binding_ty);
             // The wrapped value plus the zero-sized `TSlot<bool>` lock field.
             assert_eq!(
                 layout_data.fields.len(),
                 2,
-                "guarded_balances Mutex layout should expose the wrapped value and lock fields for arm {arm_idx}"
+                "guarded_balances Mutex layout should expose the wrapped value and lock fields for arm {arm_idx}; binding_ty={}",
+                binding_ty.pretty_print(&db),
             );
 
             assert!(

--- a/crates/mir/src/runtime/lower/classify.rs
+++ b/crates/mir/src/runtime/lower/classify.rs
@@ -16,7 +16,9 @@ use hir::analysis::{
         corelib::runtime_builtin_func_kind,
         normalize::normalize_ty,
         provider::registered_root_providers,
-        trait_def::{TraitInstId, resolve_trait_method_instance},
+        trait_def::{
+            TraitInstId, complete_resolved_trait_method_args, resolve_trait_method_instance,
+        },
         trait_resolution::{PredicateListId, TraitSolveCx},
         ty_check::{BodyOwner, EffectParamSite, EffectPassMode, LocalBinding, ParamSite},
         ty_def::{CapabilityKind, TyData, TyId},
@@ -2279,7 +2281,7 @@ pub(crate) fn resolve_runtime_call_key<'db>(
         original_inst
     };
     let assumptions = runtime_callee_assumptions(db, caller_key, caller_typed_body);
-    let Some((impl_func, mut impl_args)) = resolve_trait_method_instance(
+    let Some((impl_func, impl_args)) = resolve_trait_method_instance(
         db,
         TraitSolveCx::new(db, caller_key.impl_env(db).normalization_scope(db))
             .with_assumptions(assumptions),
@@ -2295,17 +2297,13 @@ pub(crate) fn resolve_runtime_call_key<'db>(
                 .unwrap_or_else(|| "<none>".to_string()),
         )));
     };
-    let trait_arg_len = concrete_inst.args(db).len();
-    let tail = callee_key
-        .subst(db)
-        .generic_args(db)
-        .get(trait_arg_len..)
-        .unwrap_or(callee_key.subst(db).generic_args(db).as_slice());
-    impl_args.extend_from_slice(tail);
-    let mut witnesses = IndexSet::new();
-    witnesses.extend(caller_key.impl_env(db).witnesses(db).iter().copied());
-    witnesses.extend(impl_env.witnesses(db).iter().copied());
-    witnesses.insert(concrete_inst);
+    let impl_args = complete_resolved_trait_method_args(
+        db,
+        impl_func,
+        impl_args,
+        callee_key.subst(db).generic_args(db),
+        concrete_inst.args(db).len(),
+    );
     Ok(SemanticInstanceKey::new(
         db,
         BodyOwner::Func(impl_func),
@@ -2313,9 +2311,9 @@ pub(crate) fn resolve_runtime_call_key<'db>(
         hir::analysis::semantic::EffectProviderSubst::empty(db),
         ImplEnv::new(
             db,
-            caller_key.impl_env(db).normalization_scope(db),
-            assumptions,
-            witnesses.into_iter().collect::<Vec<_>>(),
+            BodyOwner::Func(impl_func).scope(),
+            PredicateListId::empty_list(db),
+            vec![concrete_inst],
         ),
     ))
 }

--- a/crates/mir/src/runtime/lower/classify.rs
+++ b/crates/mir/src/runtime/lower/classify.rs
@@ -2304,17 +2304,13 @@ pub(crate) fn resolve_runtime_call_key<'db>(
         callee_key.subst(db).generic_args(db),
         concrete_inst.args(db).len(),
     );
+    let owner = BodyOwner::Func(impl_func);
     Ok(SemanticInstanceKey::new(
         db,
-        BodyOwner::Func(impl_func),
+        owner,
         GenericSubst::new(db, impl_args),
         hir::analysis::semantic::EffectProviderSubst::empty(db),
-        ImplEnv::new(
-            db,
-            BodyOwner::Func(impl_func).scope(),
-            PredicateListId::empty_list(db),
-            vec![concrete_inst],
-        ),
+        ImplEnv::for_resolved_trait_method(db, owner, concrete_inst),
     ))
 }
 

--- a/crates/mir/src/runtime/lower/consts.rs
+++ b/crates/mir/src/runtime/lower/consts.rs
@@ -1,8 +1,12 @@
+use std::collections::HashSet;
+
+use cranelift_entity::EntityRef;
 use hir::analysis::{
     semantic::{
-        SemConstId, SemConstScalar, SemConstValue, SemanticConstRef, SemanticInstance,
-        VariantIndex, eval_const_ref, normalize_int_to_shape, reify_runtime_const_for_ty,
-        sem_const_ty,
+        NExpr, SConst, SemConstId, SemConstScalar, SemConstValue, SemanticConstRef,
+        SemanticInstance, VariantIndex,
+        borrowck::{NSStmtKind, NormalizedSemanticBody},
+        eval_const_ref, normalize_int_to_shape, reify_runtime_const_for_ty, sem_const_ty,
     },
     ty::const_ty::{ConstTyData, EvaluatedConstTy, evaluate_type_level_int_const_expr},
     ty::ty_def::{TyData, TyId},
@@ -39,6 +43,30 @@ pub(super) fn reified_const_ref_value_for_ty<'db>(
 ) -> SemConstId<'db> {
     let value = evaluated_const_ref_value(db, cref);
     reify_runtime_const_for_ty(db, semantic, expected_ty, value).unwrap_or(value)
+}
+
+pub(super) fn collect_const_ref_regions<'db>(
+    db: &'db dyn MirDb,
+    env: RuntimeTypeEnv<'db>,
+    body: &NormalizedSemanticBody<'db>,
+) -> HashSet<ConstRegionId<'db>> {
+    body.blocks
+        .iter()
+        .flat_map(|block| block.stmts.iter())
+        .filter_map(|stmt| {
+            let NSStmtKind::Assign { dst, expr } = &stmt.kind else {
+                return None;
+            };
+            let NExpr::Const(SConst::Ref(cref)) = expr else {
+                return None;
+            };
+            aggregate_const_ref_region(
+                db,
+                env,
+                reified_const_ref_value_for_ty(db, body.owner, *cref, body.locals[dst.index()].ty),
+            )
+        })
+        .collect()
 }
 
 pub(super) fn runtime_const_value_class<'db>(

--- a/crates/mir/src/runtime/lower/conversion.rs
+++ b/crates/mir/src/runtime/lower/conversion.rs
@@ -681,7 +681,6 @@ fn is_plain_word_scalar(scalar: &ScalarClass<'_>) -> bool {
 #[cfg(test)]
 mod tests {
     use driver::DriverDataBase;
-    use hir::analysis::ty::ty_def::TyId;
 
     use super::*;
     use crate::runtime::{EnumLayoutKey, EnumVariantLayout, LayoutKey, StructLayout};
@@ -700,19 +699,16 @@ mod tests {
         LayoutId::new(
             db,
             LayoutKey::Struct(StructLayout {
-                source_ty: TyId::unit(db),
                 fields: vec![word_class()].into(),
             }),
         )
     }
 
-    fn test_enum_layout<'db>(db: &'db dyn MirDb, source_ty: TyId<'db>) -> LayoutId<'db> {
+    fn test_enum_layout<'db>(db: &'db dyn MirDb) -> LayoutId<'db> {
         LayoutId::new(
             db,
             LayoutKey::Enum(EnumLayoutKey {
-                source_ty,
                 variants: vec![EnumVariantLayout {
-                    name: "Value".to_string(),
                     fields: vec![word_class()].into(),
                 }]
                 .into(),
@@ -930,10 +926,10 @@ mod tests {
     }
 
     #[test]
-    fn compatible_nominal_enum_values_rebuild_the_target_representation() {
+    fn structurally_identical_enum_values_need_no_conversion() {
         let db = DriverDataBase::default();
-        let source_layout = test_enum_layout(&db, TyId::unit(&db));
-        let target_layout = test_enum_layout(&db, TyId::u256(&db));
+        let source_layout = test_enum_layout(&db);
+        let target_layout = test_enum_layout(&db);
         let source = RuntimeClass::AggregateValue {
             layout: source_layout,
         };
@@ -941,17 +937,8 @@ mod tests {
             layout: target_layout,
         };
 
-        assert!(source.shares_runtime_rep_with(&db, &target));
-        let plan = RuntimeConversionPlanner::plan(&db, source, target.clone()).unwrap();
-        assert_eq!(
-            plan.steps.as_ref(),
-            &[
-                RuntimeConversionStep::AllocObjectCopy {
-                    class: RuntimeClass::object_ref(target_layout),
-                    layout: target_layout,
-                },
-                RuntimeConversionStep::LoadRef { class: target },
-            ]
-        );
+        assert_eq!(source_layout, target_layout);
+        let plan = RuntimeConversionPlanner::plan(&db, source, target).unwrap();
+        assert!(plan.steps.is_empty());
     }
 }

--- a/crates/mir/src/runtime/lower/infer.rs
+++ b/crates/mir/src/runtime/lower/infer.rs
@@ -1353,26 +1353,21 @@ fn merge_layouts<'db>(
         return Some(current);
     }
     match (current.data(db), desired.data(db)) {
-        (Layout::Array(current), Layout::Array(desired))
-            if current.source_ty == desired.source_ty && current.len == desired.len =>
-        {
+        (Layout::Array(current), Layout::Array(desired)) if current.len == desired.len => {
             Some(LayoutId::new(
                 db,
                 LayoutKey::Array(ArrayLayout {
-                    source_ty: current.source_ty,
                     elem: merge_runtime_class(db, &current.elem, &desired.elem)?,
                     len: current.len,
                 }),
             ))
         }
         (Layout::Struct(current), Layout::Struct(desired))
-            if current.source_ty == desired.source_ty
-                && current.fields.len() == desired.fields.len() =>
+            if current.fields.len() == desired.fields.len() =>
         {
             Some(LayoutId::new(
                 db,
                 LayoutKey::Struct(StructLayout {
-                    source_ty: current.source_ty,
                     fields: current
                         .fields
                         .iter()
@@ -1384,13 +1379,11 @@ fn merge_layouts<'db>(
             ))
         }
         (Layout::Enum(current), Layout::Enum(desired))
-            if current.source_ty == desired.source_ty
-                && current.variants.len() == desired.variants.len() =>
+            if current.variants.len() == desired.variants.len() =>
         {
             Some(LayoutId::new(
                 db,
                 LayoutKey::Enum(EnumLayoutKey {
-                    source_ty: current.source_ty,
                     variants: current
                         .variants
                         .iter()
@@ -1398,7 +1391,6 @@ fn merge_layouts<'db>(
                         .map(|(current, desired)| {
                             (current.fields.len() == desired.fields.len()).then_some(
                                 EnumVariantLayout {
-                                    name: current.name.clone(),
                                     fields: current
                                         .fields
                                         .iter()
@@ -1507,22 +1499,15 @@ mod tests {
     use super::*;
     use crate::runtime::{ScalarClass, ScalarRepr, ScalarRole};
 
-    fn test_enum_layout<'db>(
-        db: &'db dyn MirDb,
-        source_ty: TyId<'db>,
-        payload: RuntimeClass<'db>,
-    ) -> LayoutId<'db> {
+    fn test_enum_layout<'db>(db: &'db dyn MirDb, payload: RuntimeClass<'db>) -> LayoutId<'db> {
         LayoutId::new(
             db,
             LayoutKey::Enum(EnumLayoutKey {
-                source_ty,
                 variants: vec![
                     EnumVariantLayout {
-                        name: "Some".to_string(),
                         fields: vec![payload].into(),
                     },
                     EnumVariantLayout {
-                        name: "None".to_string(),
                         fields: vec![].into(),
                     },
                 ]
@@ -1542,7 +1527,6 @@ mod tests {
         LayoutId::new(
             db,
             LayoutKey::Struct(StructLayout {
-                source_ty: TyId::unit(db),
                 fields: vec![word.clone(), word].into(),
             }),
         )
@@ -1565,7 +1549,6 @@ mod tests {
     fn provider_enum_classes<'db>(
         db: &'db DriverDataBase,
     ) -> (RuntimeClass<'db>, RuntimeClass<'db>) {
-        let source_ty = TyId::unit(db);
         let pointee = RuntimeClass::Scalar(ScalarClass {
             repr: ScalarRepr::Int {
                 bits: 256,
@@ -1576,7 +1559,6 @@ mod tests {
         let provider = |provider_ty, space, pointee| RuntimeClass::AggregateValue {
             layout: test_enum_layout(
                 db,
-                source_ty,
                 RuntimeClass::Ref {
                     pointee: Box::new(pointee),
                     kind: RefKind::Provider { provider_ty, space },

--- a/crates/mir/src/runtime/lower/layout.rs
+++ b/crates/mir/src/runtime/lower/layout.rs
@@ -34,7 +34,6 @@ pub(crate) fn layout_for_ty_in_env<'db>(
         return LayoutId::new(
             db,
             LayoutKey::Array(ArrayLayout {
-                source_ty: ty,
                 elem: stored_class_for_ty_in_env(db, env, elem),
                 len: ty.array_len(db).expect("array length") as u64,
             }),
@@ -43,7 +42,6 @@ pub(crate) fn layout_for_ty_in_env<'db>(
     LayoutId::new(
         db,
         LayoutKey::Struct(StructLayout {
-            source_ty: ty,
             fields: ty
                 .field_types(db)
                 .into_iter()
@@ -85,7 +83,6 @@ pub(crate) fn layout_for_aggregate_instance_in_env<'db>(
         return LayoutId::new(
             db,
             LayoutKey::Array(ArrayLayout {
-                source_ty: ty,
                 elem,
                 len: len as u64,
             }),
@@ -100,7 +97,6 @@ pub(crate) fn layout_for_aggregate_instance_in_env<'db>(
     LayoutId::new(
         db,
         LayoutKey::Struct(StructLayout {
-            source_ty: ty,
             fields: field_classes.to_vec().into_boxed_slice(),
         }),
     )
@@ -121,7 +117,6 @@ pub(crate) fn layout_for_enum_variant_instance_in_env<'db>(
     LayoutId::new(
         db,
         LayoutKey::Enum(EnumLayoutKey {
-            source_ty: enum_ty,
             variants: enum_
                 .variants(db)
                 .enumerate()
@@ -149,10 +144,6 @@ pub(crate) fn layout_for_enum_variant_instance_in_env<'db>(
                         default_fields
                     };
                     EnumVariantLayout {
-                        name: enum_variant
-                            .name(db)
-                            .map(|name| name.data(db).to_string())
-                            .unwrap_or_else(|| format!("variant_{idx}")),
                         fields: fields.into(),
                     }
                 })
@@ -207,14 +198,9 @@ fn enum_layout_key<'db>(
     let enum_ = ty.as_enum(db).expect("enum layout requested for non-enum");
     let args = ty.generic_args(db);
     EnumLayoutKey {
-        source_ty: ty,
         variants: enum_
             .variants(db)
             .map(|variant| EnumVariantLayout {
-                name: variant
-                    .name(db)
-                    .map(|name| name.data(db).to_string())
-                    .unwrap_or_else(|| format!("variant_{}", variant.idx)),
                 fields: variant
                     .field_tys(db)
                     .into_iter()

--- a/crates/mir/src/runtime/lower/returns.rs
+++ b/crates/mir/src/runtime/lower/returns.rs
@@ -872,8 +872,24 @@ pub contract C {
             .copied()
             .find(|function| function.symbol(&db).contains("try_lock"))
             .expect("missing specialized try_lock runtime function");
-        let ret = function
-            .instance(&db)
+        let instance = function.instance(&db);
+        let semantic = instance
+            .key(&db)
+            .semantic(&db)
+            .expect("try_lock should be a semantic runtime instance");
+        let return_ty = semantic.key(&db).typed_body(&db).result_ty();
+        let option_enum = return_ty
+            .as_enum(&db)
+            .expect("try_lock should return Option");
+        let some_variant_idx = option_enum
+            .variants(&db)
+            .position(|variant| {
+                variant
+                    .name(&db)
+                    .is_some_and(|name| name.data(&db) == "Some")
+            })
+            .expect("Option should include Some");
+        let ret = instance
             .interface_signature(&db)
             .ret
             .expect("try_lock should return a runtime-visible Option");
@@ -885,8 +901,7 @@ pub contract C {
         };
         let some_variant = enum_layout
             .variants
-            .iter()
-            .find(|variant| variant.name == "Some")
+            .get(some_variant_idx)
             .expect("Option layout should include Some");
 
         assert!(

--- a/crates/mir/src/runtime/package.rs
+++ b/crates/mir/src/runtime/package.rs
@@ -2230,8 +2230,7 @@ fn layout_sort_key<'db>(db: &'db dyn MirDb, layout: LayoutId<'db>) -> String {
 fn layout_sort_key_query<'db>(db: &'db dyn MirDb, layout: LayoutId<'db>) -> String {
     match layout.key(db) {
         LayoutKey::Struct(layout) => format!(
-            "struct:{}:[{}]",
-            type_identity(db, layout.source_ty),
+            "struct:[{}]",
             layout
                 .fields
                 .iter()
@@ -2240,20 +2239,18 @@ fn layout_sort_key_query<'db>(db: &'db dyn MirDb, layout: LayoutId<'db>) -> Stri
                 .join(",")
         ),
         LayoutKey::Array(layout) => format!(
-            "array:{}:{}:{}",
-            type_identity(db, layout.source_ty),
+            "array:{}:{}",
             runtime_class_sort_key(db, &layout.elem),
             layout.len
         ),
         LayoutKey::Enum(layout) => format!(
-            "enum:{}:[{}]",
-            type_identity(db, layout.source_ty),
+            "enum:[{}]",
             layout
                 .variants
                 .iter()
-                .map(|variant| format!(
-                    "{}:[{}]",
-                    variant.name,
+                .enumerate()
+                .map(|(idx, variant)| format!(
+                    "{idx}:[{}]",
                     variant
                         .fields
                         .iter()

--- a/crates/mir/src/runtime/place.rs
+++ b/crates/mir/src/runtime/place.rs
@@ -606,8 +606,7 @@ pub(crate) fn project_field_class<'db>(
     project_field(&program, class.clone(), field).unwrap_or_else(|_| {
         match class.aggregate_layout().map(|layout| layout.data(db)) {
             Some(crate::runtime::Layout::Struct(layout)) => panic!(
-                "invalid field projection: field={field:?} source_ty={} fields={:?} class={class:?}",
-                layout.source_ty.pretty_print(db),
+                "invalid field projection: field={field:?} fields={:?} class={class:?}",
                 layout.fields,
             ),
             _ => panic!("invalid field projection class"),

--- a/crates/mir/src/runtime/pretty.rs
+++ b/crates/mir/src/runtime/pretty.rs
@@ -1037,13 +1037,9 @@ fn format_ref_view<'db>(db: &'db dyn MirDb, view: &RefView<'db>) -> String {
 
 fn format_layout<'db>(db: &'db dyn MirDb, layout: LayoutId<'db>) -> String {
     match layout.data(db) {
-        Layout::Struct(layout) => format!("struct {}", layout.source_ty.pretty_print(db)),
-        Layout::Array(layout) => format!(
-            "array {} x {}",
-            layout.source_ty.pretty_print(db),
-            layout.len
-        ),
-        Layout::Enum(layout) => format!("enum {}", layout.source_ty.pretty_print(db)),
+        Layout::Struct(layout) => format!("struct/{}", layout.fields.len()),
+        Layout::Array(layout) => format!("array/{}", layout.len),
+        Layout::Enum(layout) => format!("enum/{}", layout.variants.len()),
     }
 }
 
@@ -1054,7 +1050,7 @@ fn format_variant<'db>(db: &'db dyn MirDb, variant: VariantId<'db>) -> String {
             layout
                 .variants
                 .get(variant.index as usize)
-                .map(|variant_layout| variant_layout.name.clone())
+                .map(|_| format!("variant_{}", variant.index))
         })
         .unwrap_or_else(|| format!("#{}", variant.index))
 }

--- a/newsfragments/1465.performance.md
+++ b/newsfragments/1465.performance.md
@@ -1,0 +1,1 @@
+Functions are now deduplicated in MIR after monomorphization. This reduces compile time for large projects.


### PR DESCRIPTION
- **Structural layout dedup**
  Drop source_ty from struct/array/enum layouts and name from enum variants, so structurally-identical layouts collapse to a single LayoutId. Variant selection is by index, so the dropped names were cosmetic. This is the bulk of the snapshot churn (layouts/variants now render as struct/N, variant_N, etc.).
- **Canonical resolved-trait-method instances**
  When a trait method resolves to a concrete impl, build a canonical ImplEnv (impl scope, single resolving witness, no caller assumptions) and cap method args at the impl's generic-param count, so the same resolved method dedupes across callers regardless of call-site context.

Also includes a small refactor (shared ImplEnv::for_resolved_trait_method constructor, simplified const_lowering_ty) and a regression fixture confirming trait default bodies reached through a generic param receiver still resolve under the canonical env.

Practical impact is faster compile times for large projects:
(fe test total runtime)
bountiful: 13.38s -> 4.61s
zk-kit: 58.08s -> 45.40s
chz: 17.37s -> 16.05s