### PR TITLE
sonatina 7711422

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6434,7 +6434,7 @@ dependencies = [
 [[package]]
 name = "sonatina-codegen"
 version = "0.0.3-alpha"
-source = "git+https://github.com/fe-lang/sonatina?rev=ed7c4f1#ed7c4f1a28240f9284f3c615cadf1eb032d11581"
+source = "git+https://github.com/fe-lang/sonatina?rev=7711422#77114223d8ef82a898bdaab36398d661564ee4ea"
 dependencies = [
  "bit-set",
  "cranelift-entity 0.126.2",
@@ -6454,7 +6454,7 @@ dependencies = [
 [[package]]
 name = "sonatina-ir"
 version = "0.0.3-alpha"
-source = "git+https://github.com/fe-lang/sonatina?rev=ed7c4f1#ed7c4f1a28240f9284f3c615cadf1eb032d11581"
+source = "git+https://github.com/fe-lang/sonatina?rev=7711422#77114223d8ef82a898bdaab36398d661564ee4ea"
 dependencies = [
  "bit-set",
  "bitflags 2.11.0",
@@ -6477,7 +6477,7 @@ dependencies = [
 [[package]]
 name = "sonatina-macros"
 version = "0.0.3-alpha"
-source = "git+https://github.com/fe-lang/sonatina?rev=ed7c4f1#ed7c4f1a28240f9284f3c615cadf1eb032d11581"
+source = "git+https://github.com/fe-lang/sonatina?rev=7711422#77114223d8ef82a898bdaab36398d661564ee4ea"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6487,7 +6487,7 @@ dependencies = [
 [[package]]
 name = "sonatina-parser"
 version = "0.0.3-alpha"
-source = "git+https://github.com/fe-lang/sonatina?rev=ed7c4f1#ed7c4f1a28240f9284f3c615cadf1eb032d11581"
+source = "git+https://github.com/fe-lang/sonatina?rev=7711422#77114223d8ef82a898bdaab36398d661564ee4ea"
 dependencies = [
  "annotate-snippets",
  "bimap",
@@ -6508,7 +6508,7 @@ dependencies = [
 [[package]]
 name = "sonatina-triple"
 version = "0.0.3-alpha"
-source = "git+https://github.com/fe-lang/sonatina?rev=ed7c4f1#ed7c4f1a28240f9284f3c615cadf1eb032d11581"
+source = "git+https://github.com/fe-lang/sonatina?rev=7711422#77114223d8ef82a898bdaab36398d661564ee4ea"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -6516,7 +6516,7 @@ dependencies = [
 [[package]]
 name = "sonatina-verifier"
 version = "0.0.3-alpha"
-source = "git+https://github.com/fe-lang/sonatina?rev=ed7c4f1#ed7c4f1a28240f9284f3c615cadf1eb032d11581"
+source = "git+https://github.com/fe-lang/sonatina?rev=7711422#77114223d8ef82a898bdaab36398d661564ee4ea"
 dependencies = [
  "cranelift-entity 0.126.2",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,10 +49,10 @@ tracing-tree = "0.4.0"
 wasm-bindgen-test = "0.3"
 semver = "1.0.26"
 petgraph = "0.8"
-sonatina-ir = { git = "https://github.com/fe-lang/sonatina", rev = "ed7c4f1" }
-sonatina-triple = { git = "https://github.com/fe-lang/sonatina", rev = "ed7c4f1" }
-sonatina-codegen = { git = "https://github.com/fe-lang/sonatina", rev = "ed7c4f1" }
-sonatina-verifier = { git = "https://github.com/fe-lang/sonatina", rev = "ed7c4f1" }
+sonatina-ir = { git = "https://github.com/fe-lang/sonatina", rev = "7711422" }
+sonatina-triple = { git = "https://github.com/fe-lang/sonatina", rev = "7711422" }
+sonatina-codegen = { git = "https://github.com/fe-lang/sonatina", rev = "7711422" }
+sonatina-verifier = { git = "https://github.com/fe-lang/sonatina", rev = "7711422" }
 
 [profile.dev]
 # Set to 0 to make the build faster and debugging more difficult.

--- a/newsfragments/1470.bugfix.md
+++ b/newsfragments/1470.bugfix.md
@@ -1,0 +1,3 @@
+Sonatina:
+  - Fix unchecked signed EVM division and remainder for narrow signed integer types.
+  - Fix EVM codegen for spilled phi values so control-flow joins do not let one edge's object storage clobber another edge's phi source.

--- a/newsfragments/1470.performance.md
+++ b/newsfragments/1470.performance.md
@@ -1,0 +1,5 @@
+Sonatina:
+  - EVM lowering now goes via a "machine EVM" instruction set, with additional
+    optimizations and better stack and memory management.
+  - Improve inlining for small specialized helpers, especially helpers with known callsite arguments or scalarizable object arguments.
+  - Sink pure computations into the branch or join block where their results are used, reducing unnecessary work and stack pressure.


### PR DESCRIPTION
  - Fix unchecked signed EVM division and remainder for narrow signed integer types.
  - Fix EVM codegen for spilled phi values so control-flow joins do not let one edge's object storage clobber another edge's phi source.
  - EVM lowering now goes via a "machine EVM" instruction set, with additional
    optimizations and better stack and memory management.
  - Improve inlining for small specialized helpers, especially helpers with known callsite arguments or scalarizable object arguments.
  - Sink pure computations into the branch or join block where their results are used, reducing unnecessary work and stack pressure.

```
Largest improvements
====================
verifier     test_plonkVerifyGas()                                      327448 ->    324667  -2781 (-0.85%)
verifier     testGas_fe_plonkVerify()                                   327429 ->    324648  -2781 (-0.85%)
verifier     test_plonkVerify()                                         329640 ->    326859  -2781 (-0.84%)
governance   test_equivalence_redelegate()                              152664 ->    150708  -1956 (-1.28%)
governance   test_equivalence_propose_and_vote()                        406974 ->    405223  -1751 (-0.43%)
governance   test_equivalence_delegateVoteWeight()                      402995 ->    401340  -1655 (-0.41%)
governance   test_equivalence_doubleVotePrevention()                    298215 ->    296909  -1306 (-0.44%)
governance   test_equivalence_execute()                                 358116 ->    356893  -1223 (-0.34%)
governance   test_equivalence_proposalCount()                           318493 ->    317361  -1132 (-0.36%)
governance   test_equivalence_delegation()                              137105 ->    135983  -1122 (-0.82%)
governance   test_equivalence_execute_fails_quorum()                    375926 ->    374812  -1114 (-0.30%)
poseidon     test_equivalence_1_2()                                      67302 ->     66303  -999 (-1.48%)
poseidon     testGas_fe_poseidon()                                       32978 ->     31979  -999 (-3.03%)
poseidon     test_equivalence_0_0()                                      67342 ->     66343  -999 (-1.48%)
amm          test_swap_sequence_eq()                                     50003 ->     49116  -887 (-1.77%)
governance   test_equivalence_votingPeriodEnforcement()                 197846 ->    197072  -774 (-0.39%)
amm          test_invariant_k_never_decreases()                          24049 ->     23382  -667 (-2.77%)
ec           test_ecAdd_ecMul_consistency()                              13503 ->     12952  -551 (-4.08%)
governance   testGas_fe_vote()                                           54257 ->     53725  -532 (-0.98%)
erc20        testGas_fe_transfer()                                       57069 ->     56539  -530 (-0.93%)

Largest regressions
===================
escrow       testGas_fe_getBalance()                                      4234 ->      4239  +5 (+0.12%)
escrow       test_equivalence_deposit_balance()                         104636 ->    104641  +5 (+0.00%)
reverts      test_fe_checked_overflow_reverts_with_solidity_panic()       8512 ->      8516  +4 (+0.05%)
```