### PR TITLE
abi optimizations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6434,7 +6434,7 @@ dependencies = [
 [[package]]
 name = "sonatina-codegen"
 version = "0.0.3-alpha"
-source = "git+https://github.com/fe-lang/sonatina?rev=7711422#77114223d8ef82a898bdaab36398d661564ee4ea"
+source = "git+https://github.com/fe-lang/sonatina?rev=f4b5b31#f4b5b31e554472f9fae65625ae3f440c98482ad9"
 dependencies = [
  "bit-set",
  "cranelift-entity 0.126.2",
@@ -6454,7 +6454,7 @@ dependencies = [
 [[package]]
 name = "sonatina-ir"
 version = "0.0.3-alpha"
-source = "git+https://github.com/fe-lang/sonatina?rev=7711422#77114223d8ef82a898bdaab36398d661564ee4ea"
+source = "git+https://github.com/fe-lang/sonatina?rev=f4b5b31#f4b5b31e554472f9fae65625ae3f440c98482ad9"
 dependencies = [
  "bit-set",
  "bitflags 2.11.0",
@@ -6477,7 +6477,7 @@ dependencies = [
 [[package]]
 name = "sonatina-macros"
 version = "0.0.3-alpha"
-source = "git+https://github.com/fe-lang/sonatina?rev=7711422#77114223d8ef82a898bdaab36398d661564ee4ea"
+source = "git+https://github.com/fe-lang/sonatina?rev=f4b5b31#f4b5b31e554472f9fae65625ae3f440c98482ad9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6487,7 +6487,7 @@ dependencies = [
 [[package]]
 name = "sonatina-parser"
 version = "0.0.3-alpha"
-source = "git+https://github.com/fe-lang/sonatina?rev=7711422#77114223d8ef82a898bdaab36398d661564ee4ea"
+source = "git+https://github.com/fe-lang/sonatina?rev=f4b5b31#f4b5b31e554472f9fae65625ae3f440c98482ad9"
 dependencies = [
  "annotate-snippets",
  "bimap",
@@ -6508,7 +6508,7 @@ dependencies = [
 [[package]]
 name = "sonatina-triple"
 version = "0.0.3-alpha"
-source = "git+https://github.com/fe-lang/sonatina?rev=7711422#77114223d8ef82a898bdaab36398d661564ee4ea"
+source = "git+https://github.com/fe-lang/sonatina?rev=f4b5b31#f4b5b31e554472f9fae65625ae3f440c98482ad9"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -6516,7 +6516,7 @@ dependencies = [
 [[package]]
 name = "sonatina-verifier"
 version = "0.0.3-alpha"
-source = "git+https://github.com/fe-lang/sonatina?rev=7711422#77114223d8ef82a898bdaab36398d661564ee4ea"
+source = "git+https://github.com/fe-lang/sonatina?rev=f4b5b31#f4b5b31e554472f9fae65625ae3f440c98482ad9"
 dependencies = [
  "cranelift-entity 0.126.2",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,10 +49,10 @@ tracing-tree = "0.4.0"
 wasm-bindgen-test = "0.3"
 semver = "1.0.26"
 petgraph = "0.8"
-sonatina-ir = { git = "https://github.com/fe-lang/sonatina", rev = "7711422" }
-sonatina-triple = { git = "https://github.com/fe-lang/sonatina", rev = "7711422" }
-sonatina-codegen = { git = "https://github.com/fe-lang/sonatina", rev = "7711422" }
-sonatina-verifier = { git = "https://github.com/fe-lang/sonatina", rev = "7711422" }
+sonatina-ir = { git = "https://github.com/fe-lang/sonatina", rev = "f4b5b31" }
+sonatina-triple = { git = "https://github.com/fe-lang/sonatina", rev = "f4b5b31" }
+sonatina-codegen = { git = "https://github.com/fe-lang/sonatina", rev = "f4b5b31" }
+sonatina-verifier = { git = "https://github.com/fe-lang/sonatina", rev = "f4b5b31" }
 
 [profile.dev]
 # Set to 0 to make the build faster and debugging more difficult.

--- a/crates/codegen/tests/fixtures/sonatina_ir/by_ref_trait_provider_storage_bug.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/by_ref_trait_provider_storage_bug.snap
@@ -7,14 +7,12 @@ target = "evm-ethereum-osaka"
 
 type @layout_0 = {i256, i256};
 type @layout_1 = {i256};
-type @layout_2 = {@layout_1, i256};
-type @layout_3 = {@layout_2, i256};
-type @layout_4 = {};
-type @layout_5 = {@layout_4};
-type @layout_6 = {i256, i256};
-type @layout_7 = {i256, i256};
+type @layout_2 = {};
+type @layout_3 = {@layout_2};
+type @layout_4 = {i256, i256};
+type @layout_5 = {i256, i256};
 
-global private const @layout_7 $const_region_0 = {40, 2};
+global private const @layout_5 $const_region_0 = {40, 2};
 global private const @layout_1 $const_region_1 = {0};
 
 func private %__ByRefTraitProviderStorageBug_init(v0.i256) {
@@ -22,10 +20,10 @@ func private %__ByRefTraitProviderStorageBug_init(v0.i256) {
         jump block1;
 
     block1:
-        v3.constref<@layout_7> = const.ref $const_region_0;
-        v4.objref<@layout_7> = obj.alloc @layout_7;
+        v3.constref<@layout_5> = const.ref $const_region_0;
+        v4.objref<@layout_5> = obj.alloc @layout_5;
         obj.init.const v4 v3;
-        v5.@layout_7 = obj.load v4;
+        v5.@layout_5 = obj.load v4;
         v8.i256 = extract_value v5 0.i256;
         evm_sstore v0 v8;
         v10.i256 = extract_value v5 1.i256;
@@ -85,6 +83,15 @@ func private %abi_single_root_size(v0.i256) -> i256 {
         return v3;
 }
 
+func private %abort() {
+    block0:
+        jump block1;
+
+    block1:
+        call %revert 0.i256 0.i256;
+        unreachable;
+}
+
 func private %base(v0.objref<@layout_0>) -> i256 {
     block0:
         jump block1;
@@ -139,10 +146,10 @@ func private %contract_recv_abi_ByRefTraitProviderStorageBug_1() {
         evm_revert 0.i256 0.i256;
 
     block3:
-        v5.objref<@layout_5> = obj.alloc @layout_5;
+        v5.objref<@layout_3> = obj.alloc @layout_3;
         call %decode_runtime_args v5;
         v7.i256 = call %__ByRefTraitProviderStorageBug_recv_0_0 0.i256;
-        v8.@layout_6 = call %encode_single_root_alloc v7;
+        v8.@layout_4 = call %encode_single_root_alloc v7;
         v9.i256 = extract_value v8 0.i256;
         v11.i256 = extract_value v8 1.i256;
         evm_return v9 v11;
@@ -171,48 +178,71 @@ func private %contract_runtime_root_ByRefTraitProviderStorageBug() {
         unreachable;
 }
 
-func inline(always) private %decode_payload(v0.objref<@layout_3>) {
-    block0:
-        jump block1;
-
-    block1:
-        return;
-}
-
-func inline(always) private %decode_runtime_args(v0.objref<@layout_5>) {
-    block0:
-        jump block1;
-
-    block1:
-        v1.@layout_3 = call %runtime_decoder;
-        v2.objref<@layout_3> = obj.alloc @layout_3;
-        v4.objref<@layout_2> = obj.proj v2 0.i256;
-        v5.@layout_2 = extract_value v1 0.i256;
-        v6.objref<@layout_1> = obj.proj v4 0.i256;
-        v7.@layout_1 = extract_value v5 0.i256;
-        v8.objref<i256> = obj.proj v6 0.i256;
-        v9.i256 = extract_value v7 0.i256;
-        obj.store v8 v9;
-        v11.objref<i256> = obj.proj v4 1.i256;
-        v12.i256 = extract_value v5 1.i256;
-        obj.store v11 v12;
-        v13.objref<i256> = obj.proj v2 1.i256;
-        v14.i256 = extract_value v1 1.i256;
-        obj.store v13 v14;
-        call %decode_payload v2;
-        return;
-}
-
-func private %decoder_with_base(v0.@layout_1, v1.i256) -> @layout_3 {
+func inline(always) private %decode_from(v0.@layout_1, v1.i256) {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v5.@layout_3 = call %with_base v0 v3;
-        return v5;
+        return;
+}
+
+func inline(always) private %decode_runtime_args(v0.objref<@layout_3>) {
+    block0:
+        v1.*i256 = alloca i256;
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v5.@layout_1 = call %input;
+        v7.i256 = call %len v5;
+        mstore v1 v7 i256;
+        v8.i256 = mload v1 i256;
+        mstore v2 v8 i256;
+        v9.i256 = mload v2 i256;
+        v10.i1 = gt 4.i256 v9;
+        br v10 block2 block3;
+
+    block2:
+        call %abort;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        br 1.i1 block5 block6;
+
+    block5:
+        mstore v3 4.i256 i256;
+        br 0.i1 block8 block11;
+
+    block6:
+        jump block7;
+
+    block7:
+        call %decode_from v5 4.i256;
+        return;
+
+    block8:
+        call %abort;
+        unreachable;
+
+    block9:
+        jump block10;
+
+    block10:
+        jump block7;
+
+    block11:
+        v17.i256 = mload v1 i256;
+        mstore v4 v17 i256;
+        v19.i256 = mload v4 i256;
+        v20.i1 = gt 4.i256 v19;
+        br v20 block8 block9;
 }
 
 func private %encode(v0.i256, v1.objref<@layout_0>) {
@@ -285,7 +315,7 @@ func private %encode_single_root(v0.i256, v1.objref<@layout_0>) {
         return;
 }
 
-func private %encode_single_root_alloc(v0.i256) -> @layout_6 {
+func private %encode_single_root_alloc(v0.i256) -> @layout_4 {
     block0:
         jump block1;
 
@@ -301,12 +331,12 @@ func private %encode_single_root_alloc(v0.i256) -> @layout_6 {
         obj.store v9 v10;
         v11.i256 = call %base v4;
         call %encode_single_root v0 v4;
-        v13.objref<@layout_6> = obj.alloc @layout_6;
+        v13.objref<@layout_4> = obj.alloc @layout_4;
         v14.objref<i256> = obj.proj v13 0.i256;
         obj.store v14 v11;
         v15.objref<i256> = obj.proj v13 1.i256;
         obj.store v15 v2;
-        v16.@layout_6 = obj.load v13;
+        v16.@layout_4 = obj.load v13;
         return v16;
 }
 
@@ -334,26 +364,6 @@ func private %encoder_new(v0.i256) -> @layout_0 {
         return v3;
 }
 
-func inline(always) private %fork(v0.@layout_2, v1.i256) -> @layout_2 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v5.@layout_1 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.objref<@layout_2> = obj.alloc @layout_2;
-        v8.objref<@layout_1> = obj.proj v7 0.i256;
-        v9.objref<i256> = obj.proj v8 0.i256;
-        v10.i256 = extract_value v5 0.i256;
-        obj.store v9 v10;
-        v12.objref<i256> = obj.proj v7 1.i256;
-        obj.store v12 v6;
-        v13.@layout_2 = obj.load v7;
-        return v13;
-}
-
 func private %input() -> @layout_1 {
     block0:
         jump block1;
@@ -361,6 +371,44 @@ func private %input() -> @layout_1 {
     block1:
         v0.@layout_1 = call %impl_CallData__new;
         return v0;
+}
+
+func inline(always) private %len(v0.@layout_1) -> i256 {
+    block0:
+        v1.*i256 = alloca i256;
+        v2.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v3.i256 = evm_calldata_size;
+        mstore v1 v3 i256;
+        v6.i256 = extract_value v0 0.i256;
+        v7.i256 = mload v1 i256;
+        mstore v2 v7 i256;
+        v8.i256 = mload v2 i256;
+        v9.i1 = gt v6 v8;
+        br v9 block2 block3;
+
+    block2:
+        jump block4;
+
+    block3:
+        v11.i256 = extract_value v0 0.i256;
+        v12.i256 = mload v1 i256;
+        (v13.i256, v14.i1) = usubo v12 v11;
+        br v14 block5 block6;
+
+    block4:
+        v19.i256 = phi (0.i256 block2) (v13 block6);
+        return v19;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        jump block4;
 }
 
 func inline(always) private %impl_CallData__new() -> @layout_1 {
@@ -373,22 +421,6 @@ func inline(always) private %impl_CallData__new() -> @layout_1 {
         obj.init.const v2 v1;
         v3.@layout_1 = obj.load v2;
         return v3;
-}
-
-func inline(always) private %new__gd20d(v0.@layout_1) -> @layout_2 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.objref<@layout_2> = obj.alloc @layout_2;
-        v4.objref<@layout_1> = obj.proj v2 0.i256;
-        v5.objref<i256> = obj.proj v4 0.i256;
-        v6.i256 = extract_value v0 0.i256;
-        obj.store v5 v6;
-        v8.objref<i256> = obj.proj v2 1.i256;
-        obj.store v8 0.i256;
-        v9.@layout_2 = obj.load v2;
-        return v9;
 }
 
 func private %impl_SolEncoder__new(v0.i256) -> @layout_0 {
@@ -452,14 +484,18 @@ func private %pos(v0.objref<@layout_0>) -> i256 {
         return v4;
 }
 
-func inline(always) private %runtime_decoder() -> @layout_3 {
+func private %revert(v0.i256, v1.i256) {
     block0:
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        mstore v2 v0 i256;
+        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v0.@layout_1 = call %input;
-        v2.@layout_3 = call %decoder_with_base v0 4.i256;
-        return v2;
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v3 i256;
+        evm_revert v4 v5;
 }
 
 func private %set_base(v0.objref<@layout_0>, v1.i256) {
@@ -530,33 +566,6 @@ func private %use_ctx(v0.i256) -> i256 {
     block1:
         v2.i256 = call %sum v0;
         return v2;
-}
-
-func inline(always) private %with_base(v0.@layout_1, v1.i256) -> @layout_3 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v4.@layout_2 = call %new__gd20d v0;
-        v5.i256 = mload v2 i256;
-        v6.@layout_2 = call %fork v4 v5;
-        v7.i256 = mload v2 i256;
-        v8.objref<@layout_3> = obj.alloc @layout_3;
-        v10.objref<@layout_2> = obj.proj v8 0.i256;
-        v11.objref<@layout_1> = obj.proj v10 0.i256;
-        v12.@layout_1 = extract_value v6 0.i256;
-        v13.objref<i256> = obj.proj v11 0.i256;
-        v14.i256 = extract_value v12 0.i256;
-        obj.store v13 v14;
-        v16.objref<i256> = obj.proj v10 1.i256;
-        v17.i256 = extract_value v6 1.i256;
-        obj.store v16 v17;
-        v18.objref<i256> = obj.proj v8 1.i256;
-        obj.store v18 v7;
-        v19.@layout_3 = obj.load v8;
-        return v19;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_7682(v0.objref<@layout_0>, v1.i256) {

--- a/crates/codegen/tests/fixtures/sonatina_ir/by_ref_trait_provider_storage_bug.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/by_ref_trait_provider_storage_bug.snap
@@ -206,23 +206,34 @@ func inline(always) private %decode_from(v0.@layout_1, v1.i256) {
         return;
 }
 
+func inline(always) private %decode_from_checked_head(v0.@layout_1, v1.i256, v2.i256) {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v4 i256;
+        v7.i256 = mload v3 i256;
+        call %decode_from v0 v7;
+        return;
+}
+
 func inline(always) private %decode_runtime_args(v0.objref<@layout_3>) {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
         v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v5.@layout_1 = call %input;
-        v7.i256 = call %len v5;
-        mstore v1 v7 i256;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt 4.i256 v9;
-        br v10 block2 block3;
+        v4.@layout_1 = call %input;
+        v6.i256 = call %len v4;
+        mstore v1 v6 i256;
+        mstore v2 4.i256 i256;
+        br 0.i1 block2 block5;
 
     block2:
         call %abort;
@@ -232,35 +243,16 @@ func inline(always) private %decode_runtime_args(v0.objref<@layout_3>) {
         jump block4;
 
     block4:
-        br 1.i1 block5 block6;
-
-    block5:
-        mstore v3 4.i256 i256;
-        br 0.i1 block8 block11;
-
-    block6:
-        jump block7;
-
-    block7:
-        call %decode_from v5 4.i256;
+        v11.i256 = mload v1 i256;
+        call %decode_from_checked_head v4 4.i256 v11;
         return;
 
-    block8:
-        call %abort;
-        unreachable;
-
-    block9:
-        jump block10;
-
-    block10:
-        jump block7;
-
-    block11:
-        v17.i256 = mload v1 i256;
-        mstore v4 v17 i256;
-        v19.i256 = mload v4 i256;
-        v20.i1 = gt 4.i256 v19;
-        br v20 block8 block9;
+    block5:
+        v13.i256 = mload v1 i256;
+        mstore v3 v13 i256;
+        v15.i256 = mload v3 i256;
+        v16.i1 = gt 4.i256 v15;
+        br v16 block2 block3;
 }
 
 func private %encode(v0.i256, v1.objref<@layout_0>) {

--- a/crates/codegen/tests/fixtures/sonatina_ir/by_ref_trait_provider_storage_bug.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/by_ref_trait_provider_storage_bug.snap
@@ -92,6 +92,24 @@ func private %abort() {
         unreachable;
 }
 
+func inline(always) private %at(v0.i256) -> @layout_0 {
+    block0:
+        v1.*i256 = alloca i256;
+        mstore v1 v0 i256;
+        jump block1;
+
+    block1:
+        v2.i256 = mload v1 i256;
+        v3.i256 = mload v1 i256;
+        v4.objref<@layout_0> = obj.alloc @layout_0;
+        v6.objref<i256> = obj.proj v4 0.i256;
+        obj.store v6 v2;
+        v8.objref<i256> = obj.proj v4 1.i256;
+        obj.store v8 v3;
+        v9.@layout_0 = obj.load v4;
+        return v9;
+}
+
 func private %base(v0.objref<@layout_0>) -> i256 {
     block0:
         jump block1;
@@ -445,13 +463,8 @@ func private %impl_SolEncoder__new(v0.i256) -> @layout_0 {
 
     block4:
         v8.i256 = phi (0.i256 block2) (v7 block3);
-        v9.objref<@layout_0> = obj.alloc @layout_0;
-        v10.objref<i256> = obj.proj v9 0.i256;
-        obj.store v10 v8;
-        v12.objref<i256> = obj.proj v9 1.i256;
-        obj.store v12 v8;
-        v13.@layout_0 = obj.load v9;
-        return v13;
+        v9.@layout_0 = call %at v8;
+        return v9;
 }
 
 func private %core__lib__abi__trait_AbiSize__payload_size__ge513_83d5(v0.i256) -> i256 {

--- a/crates/codegen/tests/fixtures/sonatina_ir/by_ref_trait_provider_storage_bug.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/by_ref_trait_provider_storage_bug.snap
@@ -206,7 +206,7 @@ func inline(always) private %decode_from(v0.@layout_1, v1.i256) {
         return;
 }
 
-func inline(always) private %decode_from_checked_head(v0.@layout_1, v1.i256, v2.i256) {
+func inline(always) private %decode_from_prechecked_head(v0.@layout_1, v1.i256, v2.i256) {
     block0:
         v3.*i256 = alloca i256;
         v4.*i256 = alloca i256;
@@ -244,7 +244,7 @@ func inline(always) private %decode_runtime_args(v0.objref<@layout_3>) {
 
     block4:
         v11.i256 = mload v1 i256;
-        call %decode_from_checked_head v4 4.i256 v11;
+        call %decode_from_prechecked_head v4 4.i256 v11;
         return;
 
     block5:

--- a/crates/codegen/tests/fixtures/sonatina_ir/create_contract.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/create_contract.snap
@@ -898,6 +898,36 @@ func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__
         return v5;
 }
 
+func inline(always) private %decode_from_checked_head__gbecb(v0.@layout_6, v1.i256, v2.i256) -> @layout_8 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v4 i256;
+        v7.i256 = mload v3 i256;
+        v8.@layout_8 = call %impl_trait_Deploy__decode_from__gd20d v0 v7;
+        return v8;
+}
+
+func inline(always) private %decode_from_checked_head__g4e6c(v0.@layout_6, v1.i256, v2.i256) -> @layout_7 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v4 i256;
+        v7.i256 = mload v3 i256;
+        v8.@layout_7 = call %impl_trait_Deploy2__decode_from__gd20d v0 v7;
+        return v8;
+}
+
 func inline(always) private %impl_trait_Deploy__decode_from__gd20d(v0.@layout_6, v1.i256) -> @layout_8 {
     block0:
         v2.*i256 = alloca i256;
@@ -959,18 +989,14 @@ func inline(always) private %decode_runtime_args__gadcc(v0.objref<@layout_10>) -
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
         v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v5.@layout_6 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_b215;
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_847d v5;
-        mstore v1 v7 i256;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt 4.i256 v9;
-        br v10 block2 block3;
+        v4.@layout_6 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_b215;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_847d v4;
+        mstore v1 v6 i256;
+        mstore v2 4.i256 i256;
+        br 0.i1 block2 block5;
 
     block2:
         call %std__lib__evm__effects__impl_trait_Evm_c913__abort_9c27;
@@ -980,35 +1006,16 @@ func inline(always) private %decode_runtime_args__gadcc(v0.objref<@layout_10>) -
         jump block4;
 
     block4:
-        br 1.i1 block5 block6;
+        v12.i256 = mload v1 i256;
+        v13.@layout_7 = call %decode_from_checked_head__g4e6c v4 4.i256 v12;
+        return v13;
 
     block5:
-        mstore v3 4.i256 i256;
-        br 0.i1 block8 block11;
-
-    block6:
-        jump block7;
-
-    block7:
-        v17.@layout_7 = call %impl_trait_Deploy2__decode_from__gd20d v5 4.i256;
-        return v17;
-
-    block8:
-        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_9c27;
-        unreachable;
-
-    block9:
-        jump block10;
-
-    block10:
-        jump block7;
-
-    block11:
-        v18.i256 = mload v1 i256;
-        mstore v4 v18 i256;
-        v20.i256 = mload v4 i256;
-        v21.i1 = gt 100.i256 v20;
-        br v21 block8 block9;
+        v14.i256 = mload v1 i256;
+        mstore v3 v14 i256;
+        v16.i256 = mload v3 i256;
+        v17.i1 = gt 100.i256 v16;
+        br v17 block2 block3;
 }
 
 func inline(always) private %decode_runtime_args__gbdfb(v0.objref<@layout_10>) -> @layout_8 {
@@ -1016,18 +1023,14 @@ func inline(always) private %decode_runtime_args__gbdfb(v0.objref<@layout_10>) -
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
         v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v5.@layout_6 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_2b2c;
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_8db5 v5;
-        mstore v1 v7 i256;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt 4.i256 v9;
-        br v10 block2 block3;
+        v4.@layout_6 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_2b2c;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_8db5 v4;
+        mstore v1 v6 i256;
+        mstore v2 4.i256 i256;
+        br 0.i1 block2 block5;
 
     block2:
         call %std__lib__evm__effects__impl_trait_Evm_c913__abort_0b80;
@@ -1037,35 +1040,16 @@ func inline(always) private %decode_runtime_args__gbdfb(v0.objref<@layout_10>) -
         jump block4;
 
     block4:
-        br 1.i1 block5 block6;
+        v12.i256 = mload v1 i256;
+        v13.@layout_8 = call %decode_from_checked_head__gbecb v4 4.i256 v12;
+        return v13;
 
     block5:
-        mstore v3 4.i256 i256;
-        br 0.i1 block8 block11;
-
-    block6:
-        jump block7;
-
-    block7:
-        v17.@layout_8 = call %impl_trait_Deploy__decode_from__gd20d v5 4.i256;
-        return v17;
-
-    block8:
-        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_0b80;
-        unreachable;
-
-    block9:
-        jump block10;
-
-    block10:
-        jump block7;
-
-    block11:
-        v18.i256 = mload v1 i256;
-        mstore v4 v18 i256;
-        v20.i256 = mload v4 i256;
-        v21.i1 = gt 68.i256 v20;
-        br v21 block8 block9;
+        v14.i256 = mload v1 i256;
+        mstore v3 v14 i256;
+        v16.i256 = mload v3 i256;
+        v17.i1 = gt 68.i256 v16;
+        br v17 block2 block3;
 }
 
 func private %decoder_new(v0.@layout_3) -> @layout_5 {

--- a/crates/codegen/tests/fixtures/sonatina_ir/create_contract.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/create_contract.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/codegen/tests/sonatina_ir.rs
-assertion_line: 403
 expression: output
 input_file: crates/codegen/tests/fixtures/create_contract.fe
 ---
@@ -9,18 +8,16 @@ target = "evm-ethereum-osaka"
 type @layout_0 = {i256};
 type @layout_1 = {i256, i256};
 type @layout_2 = {i256, i256};
-type @layout_3 = {i256};
+type @layout_3 = {i256, i256};
 type @layout_4 = {@layout_3, i256};
 type @layout_5 = {@layout_4, i256};
-type @layout_6 = {i256, i256};
-type @layout_7 = {@layout_6, i256};
-type @layout_8 = {@layout_7, i256};
-type @layout_9 = {i256, i256, i256};
-type @layout_10 = {i256, i256};
-type @layout_11 = {};
-type @layout_12 = {@layout_11};
+type @layout_6 = {i256};
+type @layout_7 = {i256, i256, i256};
+type @layout_8 = {i256, i256};
+type @layout_9 = {};
+type @layout_10 = {@layout_9};
 
-global private const @layout_3 $const_region_0 = {0};
+global private const @layout_6 $const_region_0 = {0};
 
 func private %__Child_init(v0.i256, v1.i256, v2.i256) {
     block0:
@@ -114,17 +111,25 @@ func private %abi_single_root_size(v0.@layout_0) -> i256 {
         return v2;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_0639(v0.objref<@layout_2>) -> i256 {
+func private %std__lib__evm__effects__impl_trait_Evm_c913__abort_0b80() {
     block0:
         jump block1;
 
     block1:
-        v3.objref<i256> = obj.proj v0 0.i256;
-        v4.i256 = obj.load v3;
-        return v4;
+        call %std__lib__evm__effects__impl_trait_Evm_0098__revert_286a 0.i256 0.i256;
+        unreachable;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_0639_0(v0.objref<@layout_2>) -> i256 {
+func private %std__lib__evm__effects__impl_trait_Evm_c913__abort_9c27() {
+    block0:
+        jump block1;
+
+    block1:
+        call %std__lib__evm__effects__impl_trait_Evm_0098__revert_6bdb 0.i256 0.i256;
+        unreachable;
+}
+
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_0639(v0.objref<@layout_2>) -> i256 {
     block0:
         jump block1;
 
@@ -154,27 +159,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_5cdf(v0.objre
         return v4;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_6749(v0.objref<@layout_5>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 1.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_b6d6(v0.objref<@layout_5>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 1.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
-func private %base__g463e(v0.objref<@layout_8>) -> i256 {
+func private %base__g463e(v0.objref<@layout_5>) -> i256 {
     block0:
         jump block1;
 
@@ -186,8 +171,8 @@ func private %base__g463e(v0.objref<@layout_8>) -> i256 {
 
 func private %contract_init_abi_Child() {
     block0:
-        v0.objref<@layout_6> = obj.alloc @layout_6;
-        v1.objref<@layout_8> = obj.alloc @layout_8;
+        v0.objref<@layout_3> = obj.alloc @layout_3;
+        v1.objref<@layout_5> = obj.alloc @layout_5;
         jump block1;
 
     block1:
@@ -225,12 +210,12 @@ func private %contract_init_abi_Child() {
         obj.store v23 v20;
         v25.objref<i256> = obj.proj v0 1.i256;
         obj.store v25 v13;
-        v26.@layout_6 = obj.load v0;
-        v27.@layout_8 = call %decoder_new v26;
-        v28.objref<@layout_7> = obj.proj v1 0.i256;
-        v29.@layout_7 = extract_value v27 0.i256;
-        v30.objref<@layout_6> = obj.proj v28 0.i256;
-        v31.@layout_6 = extract_value v29 0.i256;
+        v26.@layout_3 = obj.load v0;
+        v27.@layout_5 = call %decoder_new v26;
+        v28.objref<@layout_4> = obj.proj v1 0.i256;
+        v29.@layout_4 = extract_value v27 0.i256;
+        v30.objref<@layout_3> = obj.proj v28 0.i256;
+        v31.@layout_3 = extract_value v29 0.i256;
         v32.objref<i256> = obj.proj v30 0.i256;
         v33.i256 = extract_value v31 0.i256;
         obj.store v32 v33;
@@ -305,8 +290,8 @@ func private %contract_recv_abi_Factory_1() {
         evm_revert 0.i256 0.i256;
 
     block3:
-        v5.objref<@layout_12> = obj.alloc @layout_12;
-        v6.@layout_10 = call %decode_runtime_args__gbdfb v5;
+        v5.objref<@layout_10> = obj.alloc @layout_10;
+        v6.@layout_8 = call %decode_runtime_args__gbdfb v5;
         v7.i256 = extract_value v6 0.i256;
         v9.i256 = extract_value v6 1.i256;
         v10.@layout_0 = call %__Factory_recv_0_0 v7 v9;
@@ -330,8 +315,8 @@ func private %contract_recv_abi_Factory_2() {
         evm_revert 0.i256 0.i256;
 
     block3:
-        v5.objref<@layout_12> = obj.alloc @layout_12;
-        v6.@layout_9 = call %decode_runtime_args__gadcc v5;
+        v5.objref<@layout_10> = obj.alloc @layout_10;
+        v6.@layout_7 = call %decode_runtime_args__gadcc v5;
         v7.i256 = extract_value v6 0.i256;
         v9.i256 = extract_value v6 1.i256;
         v11.i256 = extract_value v6 2.i256;
@@ -701,79 +686,7 @@ func private %create_raw(v0.i256, v1.i256, v2.i256) -> @layout_0 {
         return v13;
 }
 
-func inline(always) private %core__lib__abi__decode_field__g7400_017a(v0.objref<@layout_5>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        br 0.i1 block2 block3;
-
-    block2:
-        v3.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_d553 v0;
-        v4.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_6749 v0;
-        v5.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g8f43_c492 v0;
-        (v6.i256, v7.i1) = uaddo v4 v3;
-        br v7 block5 block6;
-
-    block3:
-        jump block4;
-
-    block4:
-        v23.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_payload__g574e_a410 v0;
-        return v23;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_7c4b v0 v6;
-        v15.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_6749 v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_a1ae v0 v15;
-        v17.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_payload__g574e_a410 v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_7c4b v0 v4;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_a1ae v0 v5;
-        return v17;
-}
-
-func inline(always) private %core__lib__abi__decode_field__g7400_c049(v0.objref<@layout_5>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        br 0.i1 block2 block3;
-
-    block2:
-        v3.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_eb70 v0;
-        v4.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_b6d6 v0;
-        v5.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g8f43_9b4c v0;
-        (v6.i256, v7.i1) = uaddo v4 v3;
-        br v7 block5 block6;
-
-    block3:
-        jump block4;
-
-    block4:
-        v23.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_payload__g574e_2100 v0;
-        return v23;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_f205 v0 v6;
-        v15.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_b6d6 v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_0b40 v0 v15;
-        v17.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_payload__g574e_2100 v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_f205 v0 v4;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_0b40 v0 v5;
-        return v17;
-}
-
-func inline(always) private %decode_field__g3854(v0.objref<@layout_8>) -> i256 {
+func inline(always) private %decode_field(v0.objref<@layout_5>) -> i256 {
     block0:
         jump block1;
 
@@ -809,66 +722,184 @@ func inline(always) private %decode_field__g3854(v0.objref<@layout_8>) -> i256 {
         return v17;
 }
 
-func inline(always) private %impl_trait_Deploy2__decode_payload__g3a69(v0.objref<@layout_5>) -> @layout_9 {
+func inline(always) private %core__lib__abi__decode_field_from__g5385_8113(v0.@layout_6, v1.i256, v2.i256) -> i256 {
     block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v2.i256 = call %core__lib__abi__decode_field__g7400_017a v0;
-        v3.i256 = call %core__lib__abi__decode_field__g7400_017a v0;
-        v4.i256 = call %core__lib__abi__decode_field__g7400_017a v0;
-        v5.objref<@layout_9> = obj.alloc @layout_9;
-        v7.objref<i256> = obj.proj v5 0.i256;
-        obj.store v7 v2;
-        v9.objref<i256> = obj.proj v5 1.i256;
-        obj.store v9 v3;
-        v11.objref<i256> = obj.proj v5 2.i256;
-        obj.store v11 v4;
-        v12.@layout_9 = obj.load v5;
-        return v12;
+        br 0.i1 block2 block3;
+
+    block2:
+        v7.i256 = mload v4 i256;
+        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_32d2 v0 v7;
+        v9.i256 = mload v3 i256;
+        (v10.i256, v11.i1) = uaddo v9 v8;
+        br v11 block5 block6;
+
+    block3:
+        jump block4;
+
+    block4:
+        v20.i256 = mload v4 i256;
+        v21.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_3180 v0 v20;
+        return v21;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        v18.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_3180 v0 v10;
+        return v18;
 }
 
-func inline(always) private %impl_trait_Deploy__decode_payload__g3a69(v0.objref<@layout_5>) -> @layout_10 {
+func inline(always) private %core__lib__abi__decode_field_from__g5385_bea4(v0.@layout_6, v1.i256, v2.i256) -> i256 {
     block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v2.i256 = call %core__lib__abi__decode_field__g7400_c049 v0;
-        v3.i256 = call %core__lib__abi__decode_field__g7400_c049 v0;
-        v4.objref<@layout_10> = obj.alloc @layout_10;
-        v6.objref<i256> = obj.proj v4 0.i256;
-        obj.store v6 v2;
-        v8.objref<i256> = obj.proj v4 1.i256;
-        obj.store v8 v3;
-        v9.@layout_10 = obj.load v4;
-        return v9;
+        br 0.i1 block2 block3;
+
+    block2:
+        v7.i256 = mload v4 i256;
+        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3368 v0 v7;
+        v9.i256 = mload v3 i256;
+        (v10.i256, v11.i1) = uaddo v9 v8;
+        br v11 block5 block6;
+
+    block3:
+        jump block4;
+
+    block4:
+        v20.i256 = mload v4 i256;
+        v21.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8640 v0 v20;
+        return v21;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        v18.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8640 v0 v10;
+        return v18;
 }
 
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_payload__g574e_2100(v0.objref<@layout_5>) -> i256 {
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_3180(v0.@layout_6, v1.i256) -> i256 {
     block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v2.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_3732 v0;
-        return v2;
+        v4.i256 = mload v2 i256;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_8c36 v0 v4;
+        return v5;
 }
 
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_payload__g574e_a410(v0.objref<@layout_5>) -> i256 {
+func inline(always) private %impl_trait_Deploy2__decode_from__gd20d(v0.@layout_6, v1.i256) -> @layout_7 {
     block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v2.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_e23c v0;
-        return v2;
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v2 i256;
+        v6.i256 = call %core__lib__abi__decode_field_from__g5385_bea4 v0 v4 v5;
+        v7.i256 = mload v2 i256;
+        v8.i256 = mload v2 i256;
+        (v10.i256, v11.i1) = uaddo v8 32.i256;
+        br v11 block2 block3;
+
+    block2:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block3:
+        v19.i256 = call %core__lib__abi__decode_field_from__g5385_bea4 v0 v7 v10;
+        v21.i256 = mload v2 i256;
+        v22.i256 = mload v2 i256;
+        (v23.i256, v24.i1) = uaddo v22 32.i256;
+        br v24 block2 block4;
+
+    block4:
+        (v25.i256, v26.i1) = uaddo v23 32.i256;
+        br v26 block2 block5;
+
+    block5:
+        v29.i256 = call %core__lib__abi__decode_field_from__g5385_bea4 v0 v21 v25;
+        v30.objref<@layout_7> = obj.alloc @layout_7;
+        v32.objref<i256> = obj.proj v30 0.i256;
+        obj.store v32 v6;
+        v35.objref<i256> = obj.proj v30 1.i256;
+        obj.store v35 v19;
+        v37.objref<i256> = obj.proj v30 2.i256;
+        obj.store v37 v29;
+        v38.@layout_7 = obj.load v30;
+        return v38;
 }
 
-func private %decode_payload__g4770(v0.objref<@layout_8>) -> @layout_1 {
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8640(v0.@layout_6, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b2da v0 v4;
+        return v5;
+}
+
+func inline(always) private %impl_trait_Deploy__decode_from__gd20d(v0.@layout_6, v1.i256) -> @layout_8 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v2 i256;
+        v6.i256 = call %core__lib__abi__decode_field_from__g5385_8113 v0 v4 v5;
+        v7.i256 = mload v2 i256;
+        v8.i256 = mload v2 i256;
+        (v10.i256, v11.i1) = uaddo v8 32.i256;
+        br v11 block2 block3;
+
+    block2:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block3:
+        v19.i256 = call %core__lib__abi__decode_field_from__g5385_8113 v0 v7 v10;
+        v20.objref<@layout_8> = obj.alloc @layout_8;
+        v22.objref<i256> = obj.proj v20 0.i256;
+        obj.store v22 v6;
+        v24.objref<i256> = obj.proj v20 1.i256;
+        obj.store v24 v19;
+        v25.@layout_8 = obj.load v20;
+        return v25;
+}
+
+func private %decode_payload__g4770(v0.objref<@layout_5>) -> @layout_1 {
     block0:
         jump block1;
 
     block1:
-        v2.i256 = call %decode_field__g3854 v0;
-        v3.i256 = call %decode_field__g3854 v0;
+        v2.i256 = call %decode_field v0;
+        v3.i256 = call %decode_field v0;
         v4.objref<@layout_1> = obj.alloc @layout_1;
         v6.objref<i256> = obj.proj v4 0.i256;
         obj.store v6 v2;
@@ -878,7 +909,7 @@ func private %decode_payload__g4770(v0.objref<@layout_8>) -> @layout_1 {
         return v9;
 }
 
-func inline(always) private %decode_payload__g407e(v0.objref<@layout_8>) -> i256 {
+func inline(always) private %decode_payload__g407e(v0.objref<@layout_5>) -> i256 {
     block0:
         jump block1;
 
@@ -887,85 +918,127 @@ func inline(always) private %decode_payload__g407e(v0.objref<@layout_8>) -> i256
         return v2;
 }
 
-func inline(always) private %decode_runtime_args__gadcc(v0.objref<@layout_12>) -> @layout_9 {
+func inline(always) private %decode_runtime_args__gadcc(v0.objref<@layout_10>) -> @layout_7 {
     block0:
+        v1.*i256 = alloca i256;
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v1.@layout_5 = call %core__lib__contracts__trait_ContractHost__runtime_decoder__g736d_a560;
-        v2.objref<@layout_5> = obj.alloc @layout_5;
-        v4.objref<@layout_4> = obj.proj v2 0.i256;
-        v5.@layout_4 = extract_value v1 0.i256;
-        v6.objref<@layout_3> = obj.proj v4 0.i256;
-        v7.@layout_3 = extract_value v5 0.i256;
-        v8.objref<i256> = obj.proj v6 0.i256;
-        v9.i256 = extract_value v7 0.i256;
-        obj.store v8 v9;
-        v11.objref<i256> = obj.proj v4 1.i256;
-        v12.i256 = extract_value v5 1.i256;
-        obj.store v11 v12;
-        v13.objref<i256> = obj.proj v2 1.i256;
-        v14.i256 = extract_value v1 1.i256;
-        obj.store v13 v14;
-        v15.@layout_9 = call %impl_trait_Deploy2__decode_payload__g3a69 v2;
-        return v15;
+        v5.@layout_6 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_b215;
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_847d v5;
+        mstore v1 v7 i256;
+        v8.i256 = mload v1 i256;
+        mstore v2 v8 i256;
+        v9.i256 = mload v2 i256;
+        v10.i1 = gt 4.i256 v9;
+        br v10 block2 block3;
+
+    block2:
+        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_9c27;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        br 1.i1 block5 block6;
+
+    block5:
+        mstore v3 4.i256 i256;
+        br 0.i1 block8 block11;
+
+    block6:
+        jump block7;
+
+    block7:
+        v17.@layout_7 = call %impl_trait_Deploy2__decode_from__gd20d v5 4.i256;
+        return v17;
+
+    block8:
+        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_9c27;
+        unreachable;
+
+    block9:
+        jump block10;
+
+    block10:
+        jump block7;
+
+    block11:
+        v18.i256 = mload v1 i256;
+        mstore v4 v18 i256;
+        v20.i256 = mload v4 i256;
+        v21.i1 = gt 100.i256 v20;
+        br v21 block8 block9;
 }
 
-func inline(always) private %decode_runtime_args__gbdfb(v0.objref<@layout_12>) -> @layout_10 {
+func inline(always) private %decode_runtime_args__gbdfb(v0.objref<@layout_10>) -> @layout_8 {
     block0:
+        v1.*i256 = alloca i256;
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v1.@layout_5 = call %core__lib__contracts__trait_ContractHost__runtime_decoder__g736d_60a1;
-        v2.objref<@layout_5> = obj.alloc @layout_5;
-        v4.objref<@layout_4> = obj.proj v2 0.i256;
-        v5.@layout_4 = extract_value v1 0.i256;
-        v6.objref<@layout_3> = obj.proj v4 0.i256;
-        v7.@layout_3 = extract_value v5 0.i256;
-        v8.objref<i256> = obj.proj v6 0.i256;
-        v9.i256 = extract_value v7 0.i256;
-        obj.store v8 v9;
-        v11.objref<i256> = obj.proj v4 1.i256;
-        v12.i256 = extract_value v5 1.i256;
-        obj.store v11 v12;
-        v13.objref<i256> = obj.proj v2 1.i256;
-        v14.i256 = extract_value v1 1.i256;
-        obj.store v13 v14;
-        v15.@layout_10 = call %impl_trait_Deploy__decode_payload__g3a69 v2;
-        return v15;
+        v5.@layout_6 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_2b2c;
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_8db5 v5;
+        mstore v1 v7 i256;
+        v8.i256 = mload v1 i256;
+        mstore v2 v8 i256;
+        v9.i256 = mload v2 i256;
+        v10.i1 = gt 4.i256 v9;
+        br v10 block2 block3;
+
+    block2:
+        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_0b80;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        br 1.i1 block5 block6;
+
+    block5:
+        mstore v3 4.i256 i256;
+        br 0.i1 block8 block11;
+
+    block6:
+        jump block7;
+
+    block7:
+        v17.@layout_8 = call %impl_trait_Deploy__decode_from__gd20d v5 4.i256;
+        return v17;
+
+    block8:
+        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_0b80;
+        unreachable;
+
+    block9:
+        jump block10;
+
+    block10:
+        jump block7;
+
+    block11:
+        v18.i256 = mload v1 i256;
+        mstore v4 v18 i256;
+        v20.i256 = mload v4 i256;
+        v21.i1 = gt 68.i256 v20;
+        br v21 block8 block9;
 }
 
-func private %decoder_new(v0.@layout_6) -> @layout_8 {
+func private %decoder_new(v0.@layout_3) -> @layout_5 {
     block0:
         jump block1;
 
     block1:
-        v2.@layout_8 = call %impl_SolDecoder__new__g463e v0;
+        v2.@layout_5 = call %impl_SolDecoder__new__g463e v0;
         return v2;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decoder_with_base__gd20d_b1d3(v0.@layout_3, v1.i256) -> @layout_5 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v5.@layout_5 = call %std__lib__abi__sol__impl_SolDecoder_113c__with_base__gd20d_1dc8 v0 v3;
-        return v5;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decoder_with_base__gd20d_b4ac(v0.@layout_3, v1.i256) -> @layout_5 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v5.@layout_5 = call %std__lib__abi__sol__impl_SolDecoder_113c__with_base__gd20d_8ee4 v0 v3;
-        return v5;
 }
 
 func private %dynamic_payload_size(v0.i256) -> i256 {
@@ -1002,7 +1075,7 @@ func private %encode__g7769(v0.@layout_1, v1.objref<@layout_2>) {
         jump block1;
 
     block1:
-        v11.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_0639_0 v1;
+        v11.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_0639 v1;
         (v13.i256, v14.i1) = uaddo v11 64.i256;
         br v14 block2 block3;
 
@@ -1269,65 +1342,25 @@ func private %std__lib__abi__sol__impl_trait_Sol_1f5f__encoder_new_c533(v0.i256)
         return v3;
 }
 
-func inline(always) private %core__lib__abi__impl_Cursor_1a04__fork__gd20d_2f47(v0.@layout_4, v1.i256) -> @layout_4 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v5.@layout_3 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.objref<@layout_4> = obj.alloc @layout_4;
-        v8.objref<@layout_3> = obj.proj v7 0.i256;
-        v9.objref<i256> = obj.proj v8 0.i256;
-        v10.i256 = extract_value v5 0.i256;
-        obj.store v9 v10;
-        v12.objref<i256> = obj.proj v7 1.i256;
-        obj.store v12 v6;
-        v13.@layout_4 = obj.load v7;
-        return v13;
-}
-
-func inline(always) private %core__lib__abi__impl_Cursor_1a04__fork__gd20d_d139(v0.@layout_4, v1.i256) -> @layout_4 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v5.@layout_3 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.objref<@layout_4> = obj.alloc @layout_4;
-        v8.objref<@layout_3> = obj.proj v7 0.i256;
-        v9.objref<i256> = obj.proj v8 0.i256;
-        v10.i256 = extract_value v5 0.i256;
-        obj.store v9 v10;
-        v12.objref<i256> = obj.proj v7 1.i256;
-        obj.store v12 v6;
-        v13.@layout_4 = obj.load v7;
-        return v13;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_46c6() -> @layout_3 {
+func private %std__lib__evm__effects__impl_trait_Evm_c913__input_2b2c() -> @layout_6 {
     block0:
         jump block1;
 
     block1:
-        v0.@layout_3 = call %std__lib__evm__calldata__impl_CallData_8f43__new_9839;
+        v0.@layout_6 = call %std__lib__evm__calldata__impl_CallData_8f43__new_b558;
         return v0;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_b116() -> @layout_3 {
+func private %std__lib__evm__effects__impl_trait_Evm_c913__input_b215() -> @layout_6 {
     block0:
         jump block1;
 
     block1:
-        v0.@layout_3 = call %std__lib__evm__calldata__impl_CallData_8f43__new_f68d;
+        v0.@layout_6 = call %std__lib__evm__calldata__impl_CallData_8f43__new_4d25;
         return v0;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_0b55(v0.objref<@layout_3>) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_847d(v0.@layout_6) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
@@ -1336,27 +1369,25 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
     block1:
         v3.i256 = evm_calldata_size;
         mstore v1 v3 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        v7.i256 = obj.load v6;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt v7 v9;
-        br v10 block2 block3;
+        v6.i256 = extract_value v0 0.i256;
+        v7.i256 = mload v1 i256;
+        mstore v2 v7 i256;
+        v8.i256 = mload v2 i256;
+        v9.i1 = gt v6 v8;
+        br v9 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v12.objref<i256> = obj.proj v0 0.i256;
-        v13.i256 = obj.load v12;
-        v14.i256 = mload v1 i256;
-        (v15.i256, v16.i1) = usubo v14 v13;
-        br v16 block5 block6;
+        v11.i256 = extract_value v0 0.i256;
+        v12.i256 = mload v1 i256;
+        (v13.i256, v14.i1) = usubo v12 v11;
+        br v14 block5 block6;
 
     block4:
-        v21.i256 = phi (0.i256 block2) (v15 block6);
-        return v21;
+        v19.i256 = phi (0.i256 block2) (v13 block6);
+        return v19;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -1367,87 +1398,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         jump block4;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_20b8(v0.objref<@layout_3>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        v7.i256 = obj.load v6;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt v7 v9;
-        br v10 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v12.objref<i256> = obj.proj v0 0.i256;
-        v13.i256 = obj.load v12;
-        v14.i256 = mload v1 i256;
-        (v15.i256, v16.i1) = usubo v14 v13;
-        br v16 block5 block6;
-
-    block4:
-        v21.i256 = phi (0.i256 block2) (v15 block6);
-        return v21;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_35e0(v0.objref<@layout_3>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        v7.i256 = obj.load v6;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt v7 v9;
-        br v10 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v12.objref<i256> = obj.proj v0 0.i256;
-        v13.i256 = obj.load v12;
-        v14.i256 = mload v1 i256;
-        (v15.i256, v16.i1) = usubo v14 v13;
-        br v16 block5 block6;
-
-    block4:
-        v21.i256 = phi (0.i256 block2) (v15 block6);
-        return v21;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_8584(v0.objref<@layout_6>) -> i256 {
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_8584(v0.objref<@layout_3>) -> i256 {
     block0:
         jump block1;
 
@@ -1457,17 +1408,7 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_8584
         return v4;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_bf50(v0.objref<@layout_6>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 1.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_d349(v0.objref<@layout_3>) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_8db5(v0.@layout_6) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
@@ -1476,27 +1417,25 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
     block1:
         v3.i256 = evm_calldata_size;
         mstore v1 v3 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        v7.i256 = obj.load v6;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt v7 v9;
-        br v10 block2 block3;
+        v6.i256 = extract_value v0 0.i256;
+        v7.i256 = mload v1 i256;
+        mstore v2 v7 i256;
+        v8.i256 = mload v2 i256;
+        v9.i1 = gt v6 v8;
+        br v9 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v12.objref<i256> = obj.proj v0 0.i256;
-        v13.i256 = obj.load v12;
-        v14.i256 = mload v1 i256;
-        (v15.i256, v16.i1) = usubo v14 v13;
-        br v16 block5 block6;
+        v11.i256 = extract_value v0 0.i256;
+        v12.i256 = mload v1 i256;
+        (v13.i256, v14.i1) = usubo v12 v11;
+        br v14 block5 block6;
 
     block4:
-        v21.i256 = phi (0.i256 block2) (v15 block6);
-        return v21;
+        v19.i256 = phi (0.i256 block2) (v13 block6);
+        return v19;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -1507,13 +1446,23 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         jump block4;
 }
 
-func inline(always) private %impl_Cursor__new__g463e(v0.@layout_6) -> @layout_7 {
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_bf50(v0.objref<@layout_3>) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v2.objref<@layout_7> = obj.alloc @layout_7;
-        v4.objref<@layout_6> = obj.proj v2 0.i256;
+        v3.objref<i256> = obj.proj v0 1.i256;
+        v4.i256 = obj.load v3;
+        return v4;
+}
+
+func inline(always) private %impl_Cursor__new__g463e(v0.@layout_3) -> @layout_4 {
+    block0:
+        jump block1;
+
+    block1:
+        v2.objref<@layout_4> = obj.alloc @layout_4;
+        v4.objref<@layout_3> = obj.proj v2 0.i256;
         v5.objref<i256> = obj.proj v4 0.i256;
         v6.i256 = extract_value v0 0.i256;
         obj.store v5 v6;
@@ -1522,8 +1471,20 @@ func inline(always) private %impl_Cursor__new__g463e(v0.@layout_6) -> @layout_7 
         obj.store v8 v9;
         v10.objref<i256> = obj.proj v2 1.i256;
         obj.store v10 0.i256;
-        v11.@layout_7 = obj.load v2;
+        v11.@layout_4 = obj.load v2;
         return v11;
+}
+
+func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_4d25() -> @layout_6 {
+    block0:
+        jump block1;
+
+    block1:
+        v1.constref<@layout_6> = const.ref $const_region_0;
+        v2.objref<@layout_6> = obj.alloc @layout_6;
+        obj.init.const v2 v1;
+        v3.@layout_6 = obj.load v2;
+        return v3;
 }
 
 func private %std__lib__abi__sol__impl_SolEncoder_ce34__new_61f8(v0.i256) -> @layout_2 {
@@ -1557,34 +1518,6 @@ func private %std__lib__abi__sol__impl_SolEncoder_ce34__new_61f8(v0.i256) -> @la
         return v13;
 }
 
-func inline(always) private %core__lib__abi__impl_Cursor_1a04__new__gd20d_74da(v0.@layout_3) -> @layout_4 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.objref<@layout_4> = obj.alloc @layout_4;
-        v4.objref<@layout_3> = obj.proj v2 0.i256;
-        v5.objref<i256> = obj.proj v4 0.i256;
-        v6.i256 = extract_value v0 0.i256;
-        obj.store v5 v6;
-        v8.objref<i256> = obj.proj v2 1.i256;
-        obj.store v8 0.i256;
-        v9.@layout_4 = obj.load v2;
-        return v9;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_9839() -> @layout_3 {
-    block0:
-        jump block1;
-
-    block1:
-        v1.constref<@layout_3> = const.ref $const_region_0;
-        v2.objref<@layout_3> = obj.alloc @layout_3;
-        obj.init.const v2 v1;
-        v3.@layout_3 = obj.load v2;
-        return v3;
-}
-
 func private %std__lib__abi__sol__impl_SolEncoder_ce34__new_aa27(v0.i256) -> @layout_2 {
     block0:
         v1.*i256 = alloca i256;
@@ -1616,44 +1549,28 @@ func private %std__lib__abi__sol__impl_SolEncoder_ce34__new_aa27(v0.i256) -> @la
         return v13;
 }
 
-func inline(always) private %core__lib__abi__impl_Cursor_1a04__new__gd20d_ed1c(v0.@layout_3) -> @layout_4 {
+func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_b558() -> @layout_6 {
     block0:
         jump block1;
 
     block1:
-        v2.objref<@layout_4> = obj.alloc @layout_4;
-        v4.objref<@layout_3> = obj.proj v2 0.i256;
-        v5.objref<i256> = obj.proj v4 0.i256;
-        v6.i256 = extract_value v0 0.i256;
-        obj.store v5 v6;
-        v8.objref<i256> = obj.proj v2 1.i256;
-        obj.store v8 0.i256;
-        v9.@layout_4 = obj.load v2;
-        return v9;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_f68d() -> @layout_3 {
-    block0:
-        jump block1;
-
-    block1:
-        v1.constref<@layout_3> = const.ref $const_region_0;
-        v2.objref<@layout_3> = obj.alloc @layout_3;
+        v1.constref<@layout_6> = const.ref $const_region_0;
+        v2.objref<@layout_6> = obj.alloc @layout_6;
         obj.init.const v2 v1;
-        v3.@layout_3 = obj.load v2;
+        v3.@layout_6 = obj.load v2;
         return v3;
 }
 
-func inline(always) private %impl_SolDecoder__new__g463e(v0.@layout_6) -> @layout_8 {
+func inline(always) private %impl_SolDecoder__new__g463e(v0.@layout_3) -> @layout_5 {
     block0:
         jump block1;
 
     block1:
-        v2.@layout_7 = call %impl_Cursor__new__g463e v0;
-        v4.objref<@layout_8> = obj.alloc @layout_8;
-        v5.objref<@layout_7> = obj.proj v4 0.i256;
-        v6.objref<@layout_6> = obj.proj v5 0.i256;
-        v7.@layout_6 = extract_value v2 0.i256;
+        v2.@layout_4 = call %impl_Cursor__new__g463e v0;
+        v4.objref<@layout_5> = obj.alloc @layout_5;
+        v5.objref<@layout_4> = obj.proj v4 0.i256;
+        v6.objref<@layout_3> = obj.proj v5 0.i256;
+        v7.@layout_3 = extract_value v2 0.i256;
         v8.objref<i256> = obj.proj v6 0.i256;
         v9.i256 = extract_value v7 0.i256;
         obj.store v8 v9;
@@ -1665,7 +1582,7 @@ func inline(always) private %impl_SolDecoder__new__g463e(v0.@layout_6) -> @layou
         obj.store v13 v14;
         v15.objref<i256> = obj.proj v4 1.i256;
         obj.store v15 0.i256;
-        v16.@layout_8 = obj.load v4;
+        v16.@layout_5 = obj.load v4;
         return v16;
 }
 
@@ -1740,29 +1657,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_65f2(v0.objref
         return v4;
 }
 
-func private %pos__g463e(v0.objref<@layout_8>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<@layout_7> = obj.proj v0 0.i256;
-        v5.objref<i256> = obj.proj v3 1.i256;
-        v6.i256 = obj.load v5;
-        return v6;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g8f43_9b4c(v0.objref<@layout_5>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<@layout_4> = obj.proj v0 0.i256;
-        v5.objref<i256> = obj.proj v3 1.i256;
-        v6.i256 = obj.load v5;
-        return v6;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g8f43_c492(v0.objref<@layout_5>) -> i256 {
+func private %pos__g463e(v0.objref<@layout_5>) -> i256 {
     block0:
         jump block1;
 
@@ -1783,81 +1678,20 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_de88(v0.objref
         return v4;
 }
 
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_0984(v0.objref<@layout_8>) -> i256 {
+func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_0984(v0.objref<@layout_5>) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v5.objref<@layout_7> = obj.proj v0 0.i256;
-        v6.objref<@layout_6> = obj.proj v5 0.i256;
-        v7.@layout_6 = obj.load v6;
-        v8.objref<@layout_7> = obj.proj v0 0.i256;
-        v9.objref<@layout_6> = obj.proj v8 0.i256;
+        v5.objref<@layout_4> = obj.proj v0 0.i256;
+        v6.objref<@layout_3> = obj.proj v5 0.i256;
+        v7.@layout_3 = obj.load v6;
+        v8.objref<@layout_4> = obj.proj v0 0.i256;
+        v9.objref<@layout_3> = obj.proj v8 0.i256;
         v10.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_bf50 v9;
         mstore v1 v10 i256;
-        v11.objref<@layout_7> = obj.proj v0 0.i256;
-        v13.objref<i256> = obj.proj v11 1.i256;
-        v14.i256 = obj.load v13;
-        (v16.i256, v17.i1) = uaddo v14 32.i256;
-        br v17 block6 block7;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v28.objref<@layout_7> = obj.proj v0 0.i256;
-        v29.objref<@layout_6> = obj.proj v28 0.i256;
-        v30.@layout_6 = obj.load v29;
-        v31.objref<@layout_7> = obj.proj v0 0.i256;
-        v32.objref<i256> = obj.proj v31 1.i256;
-        v33.i256 = obj.load v32;
-        v34.objref<@layout_7> = obj.proj v0 0.i256;
-        v35.objref<@layout_6> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_14ee v35 v33;
-        v38.objref<@layout_7> = obj.proj v0 0.i256;
-        v39.objref<i256> = obj.proj v38 1.i256;
-        obj.store v39 v16;
-        return v36;
-
-    block5:
-        v40.i256 = mload v1 i256;
-        mstore v2 v40 i256;
-        v42.i256 = mload v2 i256;
-        v43.i1 = gt v16 v42;
-        br v43 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v23.objref<@layout_7> = obj.proj v0 0.i256;
-        v24.objref<i256> = obj.proj v23 1.i256;
-        v25.i256 = obj.load v24;
-        v26.i1 = lt v16 v25;
-        br v26 block2 block5;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_3732(v0.objref<@layout_5>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v5.objref<@layout_4> = obj.proj v0 0.i256;
-        v6.objref<@layout_3> = obj.proj v5 0.i256;
-        v7.@layout_3 = obj.load v6;
-        v8.objref<@layout_4> = obj.proj v0 0.i256;
-        v9.objref<@layout_3> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_20b8 v9;
-        mstore v1 v10 i256;
         v11.objref<@layout_4> = obj.proj v0 0.i256;
         v13.objref<i256> = obj.proj v11 1.i256;
         v14.i256 = obj.load v13;
@@ -1879,7 +1713,7 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         v33.i256 = obj.load v32;
         v34.objref<@layout_4> = obj.proj v0 0.i256;
         v35.objref<@layout_3> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_749b v35 v33;
+        v36.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_14ee v35 v33;
         v38.objref<@layout_4> = obj.proj v0 0.i256;
         v39.objref<i256> = obj.proj v38 1.i256;
         obj.store v39 v16;
@@ -1905,21 +1739,21 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         br v26 block2 block5;
 }
 
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_8dbd(v0.objref<@layout_8>) -> i256 {
+func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_8dbd(v0.objref<@layout_5>) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v5.objref<@layout_7> = obj.proj v0 0.i256;
-        v6.objref<@layout_6> = obj.proj v5 0.i256;
-        v7.@layout_6 = obj.load v6;
-        v8.objref<@layout_7> = obj.proj v0 0.i256;
-        v9.objref<@layout_6> = obj.proj v8 0.i256;
+        v5.objref<@layout_4> = obj.proj v0 0.i256;
+        v6.objref<@layout_3> = obj.proj v5 0.i256;
+        v7.@layout_3 = obj.load v6;
+        v8.objref<@layout_4> = obj.proj v0 0.i256;
+        v9.objref<@layout_3> = obj.proj v8 0.i256;
         v10.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_8584 v9;
         mstore v1 v10 i256;
-        v11.objref<@layout_7> = obj.proj v0 0.i256;
+        v11.objref<@layout_4> = obj.proj v0 0.i256;
         v13.objref<i256> = obj.proj v11 1.i256;
         v14.i256 = obj.load v13;
         (v16.i256, v17.i1) = uaddo v14 32.i256;
@@ -1932,76 +1766,15 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         jump block4;
 
     block4:
-        v28.objref<@layout_7> = obj.proj v0 0.i256;
-        v29.objref<@layout_6> = obj.proj v28 0.i256;
-        v30.@layout_6 = obj.load v29;
-        v31.objref<@layout_7> = obj.proj v0 0.i256;
+        v28.objref<@layout_4> = obj.proj v0 0.i256;
+        v29.objref<@layout_3> = obj.proj v28 0.i256;
+        v30.@layout_3 = obj.load v29;
+        v31.objref<@layout_4> = obj.proj v0 0.i256;
         v32.objref<i256> = obj.proj v31 1.i256;
         v33.i256 = obj.load v32;
-        v34.objref<@layout_7> = obj.proj v0 0.i256;
-        v35.objref<@layout_6> = obj.proj v34 0.i256;
+        v34.objref<@layout_4> = obj.proj v0 0.i256;
+        v35.objref<@layout_3> = obj.proj v34 0.i256;
         v36.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_231d v35 v33;
-        v38.objref<@layout_7> = obj.proj v0 0.i256;
-        v39.objref<i256> = obj.proj v38 1.i256;
-        obj.store v39 v16;
-        return v36;
-
-    block5:
-        v40.i256 = mload v1 i256;
-        mstore v2 v40 i256;
-        v42.i256 = mload v2 i256;
-        v43.i1 = gt v16 v42;
-        br v43 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v23.objref<@layout_7> = obj.proj v0 0.i256;
-        v24.objref<i256> = obj.proj v23 1.i256;
-        v25.i256 = obj.load v24;
-        v26.i1 = lt v16 v25;
-        br v26 block2 block5;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_d553(v0.objref<@layout_5>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v5.objref<@layout_4> = obj.proj v0 0.i256;
-        v6.objref<@layout_3> = obj.proj v5 0.i256;
-        v7.@layout_3 = obj.load v6;
-        v8.objref<@layout_4> = obj.proj v0 0.i256;
-        v9.objref<@layout_3> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_35e0 v9;
-        mstore v1 v10 i256;
-        v11.objref<@layout_4> = obj.proj v0 0.i256;
-        v13.objref<i256> = obj.proj v11 1.i256;
-        v14.i256 = obj.load v13;
-        (v16.i256, v17.i1) = uaddo v14 32.i256;
-        br v17 block6 block7;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v28.objref<@layout_4> = obj.proj v0 0.i256;
-        v29.objref<@layout_3> = obj.proj v28 0.i256;
-        v30.@layout_3 = obj.load v29;
-        v31.objref<@layout_4> = obj.proj v0 0.i256;
-        v32.objref<i256> = obj.proj v31 1.i256;
-        v33.i256 = obj.load v32;
-        v34.objref<@layout_4> = obj.proj v0 0.i256;
-        v35.objref<@layout_3> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_8f1b v35 v33;
         v38.objref<@layout_4> = obj.proj v0 0.i256;
         v39.objref<i256> = obj.proj v38 1.i256;
         obj.store v39 v16;
@@ -2027,146 +1800,32 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         br v26 block2 block5;
 }
 
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_e23c(v0.objref<@layout_5>) -> i256 {
+func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_286a(v0.i256, v1.i256) {
     block0:
-        v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        mstore v2 v0 i256;
+        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<@layout_4> = obj.proj v0 0.i256;
-        v6.objref<@layout_3> = obj.proj v5 0.i256;
-        v7.@layout_3 = obj.load v6;
-        v8.objref<@layout_4> = obj.proj v0 0.i256;
-        v9.objref<@layout_3> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_d349 v9;
-        mstore v1 v10 i256;
-        v11.objref<@layout_4> = obj.proj v0 0.i256;
-        v13.objref<i256> = obj.proj v11 1.i256;
-        v14.i256 = obj.load v13;
-        (v16.i256, v17.i1) = uaddo v14 32.i256;
-        br v17 block6 block7;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v28.objref<@layout_4> = obj.proj v0 0.i256;
-        v29.objref<@layout_3> = obj.proj v28 0.i256;
-        v30.@layout_3 = obj.load v29;
-        v31.objref<@layout_4> = obj.proj v0 0.i256;
-        v32.objref<i256> = obj.proj v31 1.i256;
-        v33.i256 = obj.load v32;
-        v34.objref<@layout_4> = obj.proj v0 0.i256;
-        v35.objref<@layout_3> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_dd03 v35 v33;
-        v38.objref<@layout_4> = obj.proj v0 0.i256;
-        v39.objref<i256> = obj.proj v38 1.i256;
-        obj.store v39 v16;
-        return v36;
-
-    block5:
-        v40.i256 = mload v1 i256;
-        mstore v2 v40 i256;
-        v42.i256 = mload v2 i256;
-        v43.i1 = gt v16 v42;
-        br v43 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v23.objref<@layout_4> = obj.proj v0 0.i256;
-        v24.objref<i256> = obj.proj v23 1.i256;
-        v25.i256 = obj.load v24;
-        v26.i1 = lt v16 v25;
-        br v26 block2 block5;
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v3 i256;
+        evm_revert v4 v5;
 }
 
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_eb70(v0.objref<@layout_5>) -> i256 {
+func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_6bdb(v0.i256, v1.i256) {
     block0:
-        v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        mstore v2 v0 i256;
+        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<@layout_4> = obj.proj v0 0.i256;
-        v6.objref<@layout_3> = obj.proj v5 0.i256;
-        v7.@layout_3 = obj.load v6;
-        v8.objref<@layout_4> = obj.proj v0 0.i256;
-        v9.objref<@layout_3> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_0b55 v9;
-        mstore v1 v10 i256;
-        v11.objref<@layout_4> = obj.proj v0 0.i256;
-        v13.objref<i256> = obj.proj v11 1.i256;
-        v14.i256 = obj.load v13;
-        (v16.i256, v17.i1) = uaddo v14 32.i256;
-        br v17 block6 block7;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v28.objref<@layout_4> = obj.proj v0 0.i256;
-        v29.objref<@layout_3> = obj.proj v28 0.i256;
-        v30.@layout_3 = obj.load v29;
-        v31.objref<@layout_4> = obj.proj v0 0.i256;
-        v32.objref<i256> = obj.proj v31 1.i256;
-        v33.i256 = obj.load v32;
-        v34.objref<@layout_4> = obj.proj v0 0.i256;
-        v35.objref<@layout_3> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_2a2a v35 v33;
-        v38.objref<@layout_4> = obj.proj v0 0.i256;
-        v39.objref<i256> = obj.proj v38 1.i256;
-        obj.store v39 v16;
-        return v36;
-
-    block5:
-        v40.i256 = mload v1 i256;
-        mstore v2 v40 i256;
-        v42.i256 = mload v2 i256;
-        v43.i1 = gt v16 v42;
-        br v43 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v23.objref<@layout_4> = obj.proj v0 0.i256;
-        v24.objref<i256> = obj.proj v23 1.i256;
-        v25.i256 = obj.load v24;
-        v26.i1 = lt v16 v25;
-        br v26 block2 block5;
-}
-
-func inline(always) private %core__lib__contracts__trait_ContractHost__runtime_decoder__g736d_60a1() -> @layout_5 {
-    block0:
-        jump block1;
-
-    block1:
-        v0.@layout_3 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_46c6;
-        v2.@layout_5 = call %std__lib__abi__sol__impl_trait_Sol_1f5f__decoder_with_base__gd20d_b1d3 v0 4.i256;
-        return v2;
-}
-
-func inline(always) private %core__lib__contracts__trait_ContractHost__runtime_decoder__g736d_a560() -> @layout_5 {
-    block0:
-        jump block1;
-
-    block1:
-        v0.@layout_3 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_b116;
-        v2.@layout_5 = call %std__lib__abi__sol__impl_trait_Sol_1f5f__decoder_with_base__gd20d_b4ac v0 4.i256;
-        return v2;
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v3 i256;
+        evm_revert v4 v5;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_3f4d(v0.objref<@layout_2>, v1.i256) {
@@ -2182,20 +1841,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_3f4d(v0.o
         return;
 }
 
-func private %set_base__g463e(v0.objref<@layout_8>, v1.i256) {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 1.i256;
-        obj.store v6 v3;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_7c4b(v0.objref<@layout_5>, v1.i256) {
+func private %set_base__g463e(v0.objref<@layout_5>, v1.i256) {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -2221,20 +1867,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_b006(v0.o
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_f205(v0.objref<@layout_5>, v1.i256) {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 1.i256;
-        obj.store v6 v3;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_0b40(v0.objref<@layout_5>, v1.i256) {
+func private %set_pos__g463e(v0.objref<@layout_5>, v1.i256) {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -2243,20 +1876,6 @@ func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_0b4
     block1:
         v3.i256 = mload v2 i256;
         v6.objref<@layout_4> = obj.proj v0 0.i256;
-        v8.objref<i256> = obj.proj v6 1.i256;
-        obj.store v8 v3;
-        return;
-}
-
-func private %set_pos__g463e(v0.objref<@layout_8>, v1.i256) {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<@layout_7> = obj.proj v0 0.i256;
         v8.objref<i256> = obj.proj v6 1.i256;
         obj.store v8 v3;
         return;
@@ -2272,20 +1891,6 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_863e(v0.ob
         v3.i256 = mload v2 i256;
         v6.objref<i256> = obj.proj v0 1.i256;
         obj.store v6 v3;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_a1ae(v0.objref<@layout_5>, v1.i256) {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<@layout_4> = obj.proj v0 0.i256;
-        v8.objref<i256> = obj.proj v6 1.i256;
-        obj.store v8 v3;
         return;
 }
 
@@ -2332,61 +1937,7 @@ func private %std__lib__abi__sol__impl_trait_Sol_1f5f__store_word_d9ea(v0.i256, 
         return;
 }
 
-func inline(always) private %std__lib__abi__sol__impl_SolDecoder_113c__with_base__gd20d_1dc8(v0.@layout_3, v1.i256) -> @layout_5 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v4.@layout_4 = call %core__lib__abi__impl_Cursor_1a04__new__gd20d_ed1c v0;
-        v5.i256 = mload v2 i256;
-        v6.@layout_4 = call %core__lib__abi__impl_Cursor_1a04__fork__gd20d_2f47 v4 v5;
-        v7.i256 = mload v2 i256;
-        v8.objref<@layout_5> = obj.alloc @layout_5;
-        v10.objref<@layout_4> = obj.proj v8 0.i256;
-        v11.objref<@layout_3> = obj.proj v10 0.i256;
-        v12.@layout_3 = extract_value v6 0.i256;
-        v13.objref<i256> = obj.proj v11 0.i256;
-        v14.i256 = extract_value v12 0.i256;
-        obj.store v13 v14;
-        v16.objref<i256> = obj.proj v10 1.i256;
-        v17.i256 = extract_value v6 1.i256;
-        obj.store v16 v17;
-        v18.objref<i256> = obj.proj v8 1.i256;
-        obj.store v18 v7;
-        v19.@layout_5 = obj.load v8;
-        return v19;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_SolDecoder_113c__with_base__gd20d_8ee4(v0.@layout_3, v1.i256) -> @layout_5 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v4.@layout_4 = call %core__lib__abi__impl_Cursor_1a04__new__gd20d_74da v0;
-        v5.i256 = mload v2 i256;
-        v6.@layout_4 = call %core__lib__abi__impl_Cursor_1a04__fork__gd20d_d139 v4 v5;
-        v7.i256 = mload v2 i256;
-        v8.objref<@layout_5> = obj.alloc @layout_5;
-        v10.objref<@layout_4> = obj.proj v8 0.i256;
-        v11.objref<@layout_3> = obj.proj v10 0.i256;
-        v12.@layout_3 = extract_value v6 0.i256;
-        v13.objref<i256> = obj.proj v11 0.i256;
-        v14.i256 = extract_value v12 0.i256;
-        obj.store v13 v14;
-        v16.objref<i256> = obj.proj v10 1.i256;
-        v17.i256 = extract_value v6 1.i256;
-        obj.store v16 v17;
-        v18.objref<i256> = obj.proj v8 1.i256;
-        obj.store v18 v7;
-        v19.@layout_5 = obj.load v8;
-        return v19;
-}
-
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_14ee(v0.objref<@layout_6>, v1.i256) -> i256 {
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_14ee(v0.objref<@layout_3>, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -2401,7 +1952,7 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_
         return v9;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_231d(v0.objref<@layout_6>, v1.i256) -> i256 {
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_231d(v0.objref<@layout_3>, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -2416,64 +1967,60 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_
         return v9;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_2a2a(v0.objref<@layout_3>, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_32d2(v0.@layout_6, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = evm_calldata_load v8;
-        return v9;
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_749b(v0.objref<@layout_3>, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3368(v0.@layout_6, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = evm_calldata_load v8;
-        return v9;
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_8f1b(v0.objref<@layout_3>, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_8c36(v0.@layout_6, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = evm_calldata_load v8;
-        return v9;
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_dd03(v0.objref<@layout_3>, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b2da(v0.@layout_6, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = evm_calldata_load v8;
-        return v9;
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_1f5e(v0.objref<@layout_2>, v1.i256) {

--- a/crates/codegen/tests/fixtures/sonatina_ir/create_contract.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/create_contract.snap
@@ -1515,7 +1515,7 @@ func private %encode_abi_payload(v0.@layout_1) -> @layout_1 {
         return v2;
 }
 
-func private %encode_alloc(v0.@layout_1) -> @layout_1 {
+func inline(always) private %encode_alloc(v0.@layout_1) -> @layout_1 {
     block0:
         jump block1;
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/create_contract.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/create_contract.snap
@@ -129,6 +129,42 @@ func private %std__lib__evm__effects__impl_trait_Evm_c913__abort_9c27() {
         unreachable;
 }
 
+func inline(always) private %std__lib__abi__sol__impl_SolEncoder_ce34__at_4eb0(v0.i256) -> @layout_2 {
+    block0:
+        v1.*i256 = alloca i256;
+        mstore v1 v0 i256;
+        jump block1;
+
+    block1:
+        v2.i256 = mload v1 i256;
+        v3.i256 = mload v1 i256;
+        v4.objref<@layout_2> = obj.alloc @layout_2;
+        v6.objref<i256> = obj.proj v4 0.i256;
+        obj.store v6 v2;
+        v8.objref<i256> = obj.proj v4 1.i256;
+        obj.store v8 v3;
+        v9.@layout_2 = obj.load v4;
+        return v9;
+}
+
+func inline(always) private %std__lib__abi__sol__impl_SolEncoder_ce34__at_9565(v0.i256) -> @layout_2 {
+    block0:
+        v1.*i256 = alloca i256;
+        mstore v1 v0 i256;
+        jump block1;
+
+    block1:
+        v2.i256 = mload v1 i256;
+        v3.i256 = mload v1 i256;
+        v4.objref<@layout_2> = obj.alloc @layout_2;
+        v6.objref<i256> = obj.proj v4 0.i256;
+        obj.store v6 v2;
+        v8.objref<i256> = obj.proj v4 1.i256;
+        obj.store v8 v3;
+        v9.@layout_2 = obj.load v4;
+        return v9;
+}
+
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_0639(v0.objref<@layout_2>) -> i256 {
     block0:
         jump block1;
@@ -1062,7 +1098,7 @@ func private %dynamic_payload_size(v0.i256) -> i256 {
         return 0.i256;
 }
 
-func private %encode__g7769(v0.@layout_1, v1.objref<@layout_2>) {
+func inline(always) private %encode__g7769(v0.@layout_1, v1.objref<@layout_2>) {
     block0:
         v2.objref<@layout_1> = obj.alloc @layout_1;
         v3.*i256 = alloca i256;
@@ -1076,24 +1112,19 @@ func private %encode__g7769(v0.@layout_1, v1.objref<@layout_2>) {
 
     block1:
         v11.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_0639 v1;
-        (v13.i256, v14.i1) = uaddo v11 64.i256;
-        br v14 block2 block3;
-
-    block2:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block3:
+        v13.i256 = add v11 64.i256;
         mstore v3 v13 i256;
-        v19.objref<i256> = obj.proj v2 0.i256;
-        v20.i256 = obj.load v19;
+        v15.i256 = add v11 32.i256;
+        v16.objref<i256> = obj.proj v2 0.i256;
+        v17.i256 = obj.load v16;
+        v18.i256 = ptr_to_int v3 i256;
+        call %encode_field_at v17 v1 v11 v11 v18;
+        v20.objref<i256> = obj.proj v2 1.i256;
+        v21.i256 = obj.load v20;
         v22.i256 = ptr_to_int v3 i256;
-        call %encode_field__g2e64 v20 v1 v22;
-        v24.objref<i256> = obj.proj v2 1.i256;
-        v25.i256 = obj.load v24;
-        v26.i256 = ptr_to_int v3 i256;
-        call %encode_field__g2e64 v25 v1 v26;
+        call %encode_field_at v21 v1 v11 v15 v22;
+        v24.i256 = add v11 64.i256;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_863e v1 v24;
         return;
 }
 
@@ -1155,54 +1186,7 @@ func private %encode_alloc(v0.@layout_1) -> @layout_1 {
         return v16;
 }
 
-func private %encode_field__g2e64(v0.i256, v1.objref<@layout_2>, v2.i256) {
-    block0:
-        jump block1;
-
-    block1:
-        br 0.i1 block2 block3;
-
-    block2:
-        v5.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_0639 v1;
-        v8.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_ccad v0;
-        v9.i256 = mload v2 i256;
-        v10.i256 = sub v9 v5;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_1f5e v1 v10;
-        v12.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_65f2 v1;
-        v13.i256 = mload v2 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_3f4d v1 v13;
-        v15.i256 = mload v2 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_863e v1 v15;
-        call %impl_trait_u256__encode__g426c v0 v1;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_3f4d v1 v5;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_863e v1 v12;
-        v20.i256 = mload v2 i256;
-        v21.i256 = add v20 v8;
-        mstore v2 v21 i256;
-        return;
-
-    block3:
-        jump block4;
-
-    block4:
-        br 1.i1 block5 block6;
-
-    block5:
-        v24.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_65f2 v1;
-        call %impl_trait_u256__encode_to_ptr__gf13e v0 v24;
-        v28.i256 = add v24 32.i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_863e v1 v28;
-        return;
-
-    block6:
-        jump block7;
-
-    block7:
-        call %impl_trait_u256__encode__g426c v0 v1;
-        return;
-}
-
-func private %encode_field__gf6b4(v0.@layout_0, v1.objref<@layout_2>, v2.i256) {
+func private %encode_field(v0.@layout_0, v1.objref<@layout_2>, v2.i256) {
     block0:
         jump block1;
 
@@ -1215,7 +1199,7 @@ func private %encode_field__gf6b4(v0.@layout_0, v1.objref<@layout_2>, v2.i256) {
         v9.i256 = mload v2 i256;
         v10.i256 = sub v9 v5;
         call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_528a v1 v10;
-        v12.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_de88 v1;
+        v12.i256 = call %impl_trait_SolEncoder__pos v1;
         v13.i256 = mload v2 i256;
         call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_b006 v1 v13;
         v15.i256 = mload v2 i256;
@@ -1235,7 +1219,7 @@ func private %encode_field__gf6b4(v0.@layout_0, v1.objref<@layout_2>, v2.i256) {
         br 1.i1 block5 block6;
 
     block5:
-        v24.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_de88 v1;
+        v24.i256 = call %impl_trait_SolEncoder__pos v1;
         call %impl_trait_Address__encode_to_ptr__gf13e v0 v24;
         v28.i256 = add v24 32.i256;
         call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_d061 v1 v28;
@@ -1249,6 +1233,57 @@ func private %encode_field__gf6b4(v0.@layout_0, v1.objref<@layout_2>, v2.i256) {
         return;
 }
 
+func inline(always) private %encode_field_at(v0.i256, v1.objref<@layout_2>, v2.i256, v3.i256, v4.i256) {
+    block0:
+        v5.*i256 = alloca i256;
+        v6.*i256 = alloca i256;
+        mstore v5 v2 i256;
+        mstore v6 v3 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v10.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_ccad v0;
+        v11.i256 = mload v6 i256;
+        v12.i256 = mload v5 i256;
+        v13.i256 = mload v4 i256;
+        v14.i256 = sub v13 v12;
+        call %write_word_at v1 v11 v14;
+        v17.i256 = mload v4 i256;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_3f4d v1 v17;
+        v19.i256 = mload v4 i256;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_863e v1 v19;
+        call %impl_trait_u256__encode__g426c v0 v1;
+        v22.i256 = mload v5 i256;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_3f4d v1 v22;
+        v24.i256 = mload v4 i256;
+        v25.i256 = add v24 v10;
+        mstore v4 v25 i256;
+        return;
+
+    block3:
+        jump block4;
+
+    block4:
+        br 1.i1 block5 block6;
+
+    block5:
+        v27.i256 = mload v6 i256;
+        call %impl_trait_u256__encode_to_ptr__gf13e v0 v27;
+        return;
+
+    block6:
+        jump block7;
+
+    block7:
+        v30.i256 = mload v6 i256;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_863e v1 v30;
+        call %impl_trait_u256__encode__g426c v0 v1;
+        return;
+}
+
 func private %encode_single_root(v0.@layout_0, v1.objref<@layout_2>) {
     block0:
         v2.*i256 = alloca i256;
@@ -1259,7 +1294,7 @@ func private %encode_single_root(v0.@layout_0, v1.objref<@layout_2>) {
         v6.i256 = add v4 32.i256;
         mstore v2 v6 i256;
         v7.i256 = ptr_to_int v2 i256;
-        call %encode_field__gf6b4 v0 v1 v7;
+        call %encode_field v0 v1 v7;
         return;
 }
 
@@ -1509,13 +1544,8 @@ func private %std__lib__abi__sol__impl_SolEncoder_ce34__new_61f8(v0.i256) -> @la
 
     block4:
         v8.i256 = phi (0.i256 block2) (v7 block3);
-        v9.objref<@layout_2> = obj.alloc @layout_2;
-        v10.objref<i256> = obj.proj v9 0.i256;
-        obj.store v10 v8;
-        v12.objref<i256> = obj.proj v9 1.i256;
-        obj.store v12 v8;
-        v13.@layout_2 = obj.load v9;
-        return v13;
+        v9.@layout_2 = call %std__lib__abi__sol__impl_SolEncoder_ce34__at_4eb0 v8;
+        return v9;
 }
 
 func private %std__lib__abi__sol__impl_SolEncoder_ce34__new_aa27(v0.i256) -> @layout_2 {
@@ -1540,13 +1570,8 @@ func private %std__lib__abi__sol__impl_SolEncoder_ce34__new_aa27(v0.i256) -> @la
 
     block4:
         v8.i256 = phi (0.i256 block2) (v7 block3);
-        v9.objref<@layout_2> = obj.alloc @layout_2;
-        v10.objref<i256> = obj.proj v9 0.i256;
-        obj.store v10 v8;
-        v12.objref<i256> = obj.proj v9 1.i256;
-        obj.store v12 v8;
-        v13.@layout_2 = obj.load v9;
-        return v13;
+        v9.@layout_2 = call %std__lib__abi__sol__impl_SolEncoder_ce34__at_9565 v8;
+        return v9;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_b558() -> @layout_6 {
@@ -1586,29 +1611,18 @@ func inline(always) private %impl_SolDecoder__new__g463e(v0.@layout_3) -> @layou
         return v16;
 }
 
-func private %payload_size__gbd8e(v0.@layout_1) -> i256 {
+func inline(always) private %payload_size__gbd8e(v0.@layout_1) -> i256 {
     block0:
         jump block1;
 
     block1:
         v4.i256 = extract_value v0 0.i256;
         v5.i256 = call %dynamic_payload_size v4;
-        (v6.i256, v7.i1) = uaddo 64.i256 v5;
-        br v7 block2 block3;
-
-    block2:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block3:
-        v14.i256 = extract_value v0 1.i256;
-        v15.i256 = call %dynamic_payload_size v14;
-        (v16.i256, v17.i1) = uaddo v6 v15;
-        br v17 block2 block4;
-
-    block4:
-        return v16;
+        v6.i256 = add 64.i256 v5;
+        v8.i256 = extract_value v0 1.i256;
+        v9.i256 = call %dynamic_payload_size v8;
+        v10.i256 = add v6 v9;
+        return v10;
 }
 
 func private %core__lib__abi__trait_AbiSize__payload_size__g67a8_7f10(v0.@layout_0) -> i256 {
@@ -1647,16 +1661,6 @@ func private %core__lib__abi__trait_AbiSize__payload_size__ge513_ccad(v0.i256) -
         return 32.i256;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_65f2(v0.objref<@layout_2>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 1.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
 func private %pos__g463e(v0.objref<@layout_5>) -> i256 {
     block0:
         jump block1;
@@ -1668,7 +1672,7 @@ func private %pos__g463e(v0.objref<@layout_5>) -> i256 {
         return v6;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_de88(v0.objref<@layout_2>) -> i256 {
+func private %impl_trait_SolEncoder__pos(v0.objref<@layout_2>) -> i256 {
     block0:
         jump block1;
 
@@ -2023,23 +2027,6 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v8;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_1f5e(v0.objref<@layout_2>, v1.i256) {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v5.objref<i256> = obj.proj v0 1.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        mstore v6 v7 i256;
-        v10.i256 = add v6 32.i256;
-        v11.objref<i256> = obj.proj v0 1.i256;
-        obj.store v11 v10;
-        return;
-}
-
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_2c07(v0.objref<@layout_2>, v1.i256) {
     block0:
         v2.*i256 = alloca i256;
@@ -2088,6 +2075,21 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_528a(v0
         v10.i256 = add v6 32.i256;
         v11.objref<i256> = obj.proj v0 1.i256;
         obj.store v11 v10;
+        return;
+}
+
+func private %write_word_at(v0.objref<@layout_2>, v1.i256, v2.i256) {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v3 i256;
+        v6.i256 = mload v4 i256;
+        mstore v5 v6 i256;
         return;
 }
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/create_contract.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/create_contract.snap
@@ -898,36 +898,6 @@ func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__
         return v5;
 }
 
-func inline(always) private %decode_from_checked_head__gbecb(v0.@layout_6, v1.i256, v2.i256) -> @layout_8 {
-    block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
-        jump block1;
-
-    block1:
-        v5.i256 = mload v4 i256;
-        v7.i256 = mload v3 i256;
-        v8.@layout_8 = call %impl_trait_Deploy__decode_from__gd20d v0 v7;
-        return v8;
-}
-
-func inline(always) private %decode_from_checked_head__g4e6c(v0.@layout_6, v1.i256, v2.i256) -> @layout_7 {
-    block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
-        jump block1;
-
-    block1:
-        v5.i256 = mload v4 i256;
-        v7.i256 = mload v3 i256;
-        v8.@layout_7 = call %impl_trait_Deploy2__decode_from__gd20d v0 v7;
-        return v8;
-}
-
 func inline(always) private %impl_trait_Deploy__decode_from__gd20d(v0.@layout_6, v1.i256) -> @layout_8 {
     block0:
         v2.*i256 = alloca i256;
@@ -957,6 +927,36 @@ func inline(always) private %impl_trait_Deploy__decode_from__gd20d(v0.@layout_6,
         obj.store v24 v19;
         v25.@layout_8 = obj.load v20;
         return v25;
+}
+
+func inline(always) private %decode_from_prechecked_head__g4e6c(v0.@layout_6, v1.i256, v2.i256) -> @layout_7 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v4 i256;
+        v7.i256 = mload v3 i256;
+        v8.@layout_7 = call %impl_trait_Deploy2__decode_from__gd20d v0 v7;
+        return v8;
+}
+
+func inline(always) private %decode_from_prechecked_head__gbecb(v0.@layout_6, v1.i256, v2.i256) -> @layout_8 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v4 i256;
+        v7.i256 = mload v3 i256;
+        v8.@layout_8 = call %impl_trait_Deploy__decode_from__gd20d v0 v7;
+        return v8;
 }
 
 func private %decode_payload__g4770(v0.objref<@layout_5>) -> @layout_1 {
@@ -1007,7 +1007,7 @@ func inline(always) private %decode_runtime_args__gadcc(v0.objref<@layout_10>) -
 
     block4:
         v12.i256 = mload v1 i256;
-        v13.@layout_7 = call %decode_from_checked_head__g4e6c v4 4.i256 v12;
+        v13.@layout_7 = call %decode_from_prechecked_head__g4e6c v4 4.i256 v12;
         return v13;
 
     block5:
@@ -1041,7 +1041,7 @@ func inline(always) private %decode_runtime_args__gbdfb(v0.objref<@layout_10>) -
 
     block4:
         v12.i256 = mload v1 i256;
-        v13.@layout_8 = call %decode_from_checked_head__gbecb v4 4.i256 v12;
+        v13.@layout_8 = call %decode_from_prechecked_head__gbecb v4 4.i256 v12;
         return v13;
 
     block5:

--- a/crates/codegen/tests/fixtures/sonatina_ir/create_contract.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/create_contract.snap
@@ -165,6 +165,16 @@ func inline(always) private %std__lib__abi__sol__impl_SolEncoder_ce34__at_9565(v
         return v9;
 }
 
+func private %base__g463e(v0.objref<@layout_5>) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v3.objref<i256> = obj.proj v0 1.i256;
+        v4.i256 = obj.load v3;
+        return v4;
+}
+
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_0639(v0.objref<@layout_2>) -> i256 {
     block0:
         jump block1;
@@ -195,14 +205,158 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_5cdf(v0.objre
         return v4;
 }
 
-func private %base__g463e(v0.objref<@layout_5>) -> i256 {
+func inline(always) private %core__lib__abi__checked_frame_end__gf13e_056e(v0.i256, v1.i256, v2.i256) -> i256 {
     block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        mstore v3 v0 i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
         jump block1;
 
     block1:
-        v3.objref<i256> = obj.proj v0 1.i256;
-        v4.i256 = obj.load v3;
-        return v4;
+        v6.i256 = mload v3 i256;
+        v7.i256 = mload v4 i256;
+        (v8.i256, v9.i1) = uaddo v6 v7;
+        br v9 block6 block7;
+
+    block2:
+        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_7064;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        return v8;
+
+    block5:
+        v19.i256 = mload v5 i256;
+        v20.i1 = gt v8 v19;
+        br v20 block2 block3;
+
+    block6:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block7:
+        v15.i256 = mload v3 i256;
+        v16.i1 = lt v8 v15;
+        br v16 block2 block5;
+}
+
+func inline(always) private %core__lib__abi__checked_frame_end__gf13e_352b(v0.i256, v1.i256, v2.i256) -> i256 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        mstore v3 v0 i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        jump block1;
+
+    block1:
+        v6.i256 = mload v3 i256;
+        v7.i256 = mload v4 i256;
+        (v8.i256, v9.i1) = uaddo v6 v7;
+        br v9 block6 block7;
+
+    block2:
+        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_e3bb;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        return v8;
+
+    block5:
+        v19.i256 = mload v5 i256;
+        v20.i1 = gt v8 v19;
+        br v20 block2 block3;
+
+    block6:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block7:
+        v15.i256 = mload v3 i256;
+        v16.i1 = lt v8 v15;
+        br v16 block2 block5;
+}
+
+func inline(always) private %core__lib__abi__checked_tail__gf13e_4046(v0.i256, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        mstore v2 v0 i256;
+        mstore v3 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v3 i256;
+        (v6.i256, v7.i1) = uaddo v4 v5;
+        br v7 block5 block6;
+
+    block2:
+        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_43bf;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        return v6;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        v13.i256 = mload v2 i256;
+        v14.i1 = lt v6 v13;
+        br v14 block2 block3;
+}
+
+func inline(always) private %core__lib__abi__checked_tail__gf13e_4919(v0.i256, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        mstore v2 v0 i256;
+        mstore v3 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v3 i256;
+        (v6.i256, v7.i1) = uaddo v4 v5;
+        br v7 block5 block6;
+
+    block2:
+        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_8b22;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        return v6;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        v13.i256 = mload v2 i256;
+        v14.i1 = lt v6 v13;
+        br v14 block2 block3;
 }
 
 func private %contract_init_abi_Child() {
@@ -722,6 +876,38 @@ func private %create_raw(v0.i256, v1.i256, v2.i256) -> @layout_0 {
         return v13;
 }
 
+func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_43bf() {
+    block0:
+        jump block1;
+
+    block1:
+        evm_revert 0.i256 0.i256;
+}
+
+func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_7064() {
+    block0:
+        jump block1;
+
+    block1:
+        evm_revert 0.i256 0.i256;
+}
+
+func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_8b22() {
+    block0:
+        jump block1;
+
+    block1:
+        evm_revert 0.i256 0.i256;
+}
+
+func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_e3bb() {
+    block0:
+        jump block1;
+
+    block1:
+        evm_revert 0.i256 0.i256;
+}
+
 func inline(always) private %decode_field(v0.objref<@layout_5>) -> i256 {
     block0:
         jump block1;
@@ -730,7 +916,7 @@ func inline(always) private %decode_field(v0.objref<@layout_5>) -> i256 {
         br 0.i1 block2 block3;
 
     block2:
-        v3.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_0984 v0;
+        v3.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_272f v0;
         v4.i256 = call %base__g463e v0;
         v5.i256 = call %pos__g463e v0;
         (v6.i256, v7.i1) = uaddo v4 v3;
@@ -758,7 +944,7 @@ func inline(always) private %decode_field(v0.objref<@layout_5>) -> i256 {
         return v17;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from__g5385_8113(v0.@layout_6, v1.i256, v2.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_field_from__g5385_0636(v0.@layout_6, v1.i256, v2.i256) -> i256 {
     block0:
         v3.*i256 = alloca i256;
         v4.*i256 = alloca i256;
@@ -781,7 +967,7 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_8113(v0.@l
 
     block4:
         v20.i256 = mload v4 i256;
-        v21.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_3180 v0 v20;
+        v21.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_3180_0 v0 v20;
         return v21;
 
     block5:
@@ -790,11 +976,11 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_8113(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v18.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_3180 v0 v10;
+        v18.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_3180_0 v0 v10;
         return v18;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from__g5385_bea4(v0.@layout_6, v1.i256, v2.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_field_from__g5385_5caf(v0.@layout_6, v1.i256, v2.i256) -> i256 {
     block0:
         v3.*i256 = alloca i256;
         v4.*i256 = alloca i256;
@@ -817,7 +1003,7 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_bea4(v0.@l
 
     block4:
         v20.i256 = mload v4 i256;
-        v21.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8640 v0 v20;
+        v21.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8640_0 v0 v20;
         return v21;
 
     block5:
@@ -826,8 +1012,70 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_bea4(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v18.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8640 v0 v10;
+        v18.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8640_0 v0 v10;
         return v18;
+}
+
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_0f32(v0.@layout_6, v1.i256, v2.i256, v3.i256) -> i256 {
+    block0:
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        v6.*i256 = alloca i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        mstore v6 v3 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v9.i256 = mload v5 i256;
+        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3368 v0 v9;
+        v11.i256 = mload v4 i256;
+        v12.i256 = call %core__lib__abi__checked_tail__gf13e_4046 v11 v10;
+        v13.i256 = mload v6 i256;
+        v14.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_7fc6 v0 v12 v13;
+        return v14;
+
+    block3:
+        jump block4;
+
+    block4:
+        v16.i256 = mload v5 i256;
+        v17.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8640_0 v0 v16;
+        return v17;
+}
+
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_f107(v0.@layout_6, v1.i256, v2.i256, v3.i256) -> i256 {
+    block0:
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        v6.*i256 = alloca i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        mstore v6 v3 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v9.i256 = mload v5 i256;
+        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_32d2 v0 v9;
+        v11.i256 = mload v4 i256;
+        v12.i256 = call %core__lib__abi__checked_tail__gf13e_4919 v11 v10;
+        v13.i256 = mload v6 i256;
+        v14.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_7780 v0 v12 v13;
+        return v14;
+
+    block3:
+        jump block4;
+
+    block4:
+        v16.i256 = mload v5 i256;
+        v17.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_3180_0 v0 v16;
+        return v17;
 }
 
 func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_3180(v0.@layout_6, v1.i256) -> i256 {
@@ -842,7 +1090,7 @@ func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__
         return v5;
 }
 
-func inline(always) private %impl_trait_Deploy2__decode_from__gd20d(v0.@layout_6, v1.i256) -> @layout_7 {
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_3180_0(v0.@layout_6, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -850,12 +1098,25 @@ func inline(always) private %impl_trait_Deploy2__decode_from__gd20d(v0.@layout_6
 
     block1:
         v4.i256 = mload v2 i256;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_8c36_0 v0 v4;
+        return v5;
+}
+
+func inline(always) private %impl_trait_Deploy2__decode_from__gd20d(v0.@layout_6, v1.i256) -> @layout_7 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_6f75 v0;
         v5.i256 = mload v2 i256;
-        v6.i256 = call %core__lib__abi__decode_field_from__g5385_bea4 v0 v4 v5;
-        v7.i256 = mload v2 i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = call %core__lib__abi__decode_msg_field_from__g5385_f1db v0 v5 v6 v4;
         v8.i256 = mload v2 i256;
-        (v10.i256, v11.i1) = uaddo v8 32.i256;
-        br v11 block2 block3;
+        v9.i256 = mload v2 i256;
+        (v11.i256, v12.i1) = uaddo v9 32.i256;
+        br v12 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -863,27 +1124,27 @@ func inline(always) private %impl_trait_Deploy2__decode_from__gd20d(v0.@layout_6
         evm_revert 0.i256 36.i256;
 
     block3:
-        v19.i256 = call %core__lib__abi__decode_field_from__g5385_bea4 v0 v7 v10;
-        v21.i256 = mload v2 i256;
-        v22.i256 = mload v2 i256;
-        (v23.i256, v24.i1) = uaddo v22 32.i256;
-        br v24 block2 block4;
+        v21.i256 = call %core__lib__abi__decode_msg_field_from__g5385_f1db v0 v8 v11 v4;
+        v23.i256 = mload v2 i256;
+        v24.i256 = mload v2 i256;
+        (v25.i256, v26.i1) = uaddo v24 32.i256;
+        br v26 block2 block4;
 
     block4:
-        (v25.i256, v26.i1) = uaddo v23 32.i256;
-        br v26 block2 block5;
+        (v27.i256, v28.i1) = uaddo v25 32.i256;
+        br v28 block2 block5;
 
     block5:
-        v29.i256 = call %core__lib__abi__decode_field_from__g5385_bea4 v0 v21 v25;
-        v30.objref<@layout_7> = obj.alloc @layout_7;
-        v32.objref<i256> = obj.proj v30 0.i256;
-        obj.store v32 v6;
-        v35.objref<i256> = obj.proj v30 1.i256;
-        obj.store v35 v19;
-        v37.objref<i256> = obj.proj v30 2.i256;
-        obj.store v37 v29;
-        v38.@layout_7 = obj.load v30;
-        return v38;
+        v32.i256 = call %core__lib__abi__decode_msg_field_from__g5385_f1db v0 v23 v27 v4;
+        v33.objref<@layout_7> = obj.alloc @layout_7;
+        v35.objref<i256> = obj.proj v33 0.i256;
+        obj.store v35 v7;
+        v38.objref<i256> = obj.proj v33 1.i256;
+        obj.store v38 v21;
+        v40.objref<i256> = obj.proj v33 2.i256;
+        obj.store v40 v32;
+        v41.@layout_7 = obj.load v33;
+        return v41;
 }
 
 func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8640(v0.@layout_6, v1.i256) -> i256 {
@@ -898,7 +1159,7 @@ func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__
         return v5;
 }
 
-func inline(always) private %impl_trait_Deploy__decode_from__gd20d(v0.@layout_6, v1.i256) -> @layout_8 {
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8640_0(v0.@layout_6, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -906,12 +1167,59 @@ func inline(always) private %impl_trait_Deploy__decode_from__gd20d(v0.@layout_6,
 
     block1:
         v4.i256 = mload v2 i256;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b2da_0 v0 v4;
+        return v5;
+}
+
+func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_7780(v0.@layout_6, v1.i256, v2.i256) -> i256 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v3 i256;
+        v7.i256 = mload v4 i256;
+        v8.i256 = call %core__lib__abi__checked_frame_end__gf13e_352b v5 32.i256 v7;
+        v10.i256 = mload v3 i256;
+        v11.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_3180 v0 v10;
+        return v11;
+}
+
+func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_7fc6(v0.@layout_6, v1.i256, v2.i256) -> i256 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v3 i256;
+        v7.i256 = mload v4 i256;
+        v8.i256 = call %core__lib__abi__checked_frame_end__gf13e_056e v5 32.i256 v7;
+        v10.i256 = mload v3 i256;
+        v11.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8640 v0 v10;
+        return v11;
+}
+
+func inline(always) private %impl_trait_Deploy__decode_from__gd20d(v0.@layout_6, v1.i256) -> @layout_8 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_2577 v0;
         v5.i256 = mload v2 i256;
-        v6.i256 = call %core__lib__abi__decode_field_from__g5385_8113 v0 v4 v5;
-        v7.i256 = mload v2 i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = call %core__lib__abi__decode_msg_field_from__g5385_790c v0 v5 v6 v4;
         v8.i256 = mload v2 i256;
-        (v10.i256, v11.i1) = uaddo v8 32.i256;
-        br v11 block2 block3;
+        v9.i256 = mload v2 i256;
+        (v11.i256, v12.i1) = uaddo v9 32.i256;
+        br v12 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -919,14 +1227,14 @@ func inline(always) private %impl_trait_Deploy__decode_from__gd20d(v0.@layout_6,
         evm_revert 0.i256 36.i256;
 
     block3:
-        v19.i256 = call %core__lib__abi__decode_field_from__g5385_8113 v0 v7 v10;
-        v20.objref<@layout_8> = obj.alloc @layout_8;
-        v22.objref<i256> = obj.proj v20 0.i256;
-        obj.store v22 v6;
-        v24.objref<i256> = obj.proj v20 1.i256;
-        obj.store v24 v19;
-        v25.@layout_8 = obj.load v20;
-        return v25;
+        v21.i256 = call %core__lib__abi__decode_msg_field_from__g5385_790c v0 v8 v11 v4;
+        v22.objref<@layout_8> = obj.alloc @layout_8;
+        v24.objref<i256> = obj.proj v22 0.i256;
+        obj.store v24 v7;
+        v26.objref<i256> = obj.proj v22 1.i256;
+        obj.store v26 v21;
+        v27.@layout_8 = obj.load v22;
+        return v27;
 }
 
 func inline(always) private %decode_from_prechecked_head__g4e6c(v0.@layout_6, v1.i256, v2.i256) -> @layout_7 {
@@ -959,6 +1267,77 @@ func inline(always) private %decode_from_prechecked_head__gbecb(v0.@layout_6, v1
         return v8;
 }
 
+func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_790c(v0.@layout_6, v1.i256, v2.i256, v3.i256) -> i256 {
+    block0:
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        v6.*i256 = alloca i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        mstore v6 v3 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v9.i256 = mload v4 i256;
+        v10.i256 = mload v5 i256;
+        v11.i256 = mload v6 i256;
+        v12.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_f107 v0 v9 v10 v11;
+        return v12;
+
+    block3:
+        jump block4;
+
+    block4:
+        v13.i256 = mload v6 i256;
+        v15.i256 = mload v4 i256;
+        v16.i256 = mload v5 i256;
+        v17.i256 = call %core__lib__abi__decode_field_from__g5385_0636 v0 v15 v16;
+        return v17;
+}
+
+func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_f1db(v0.@layout_6, v1.i256, v2.i256, v3.i256) -> i256 {
+    block0:
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        v6.*i256 = alloca i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        mstore v6 v3 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v9.i256 = mload v4 i256;
+        v10.i256 = mload v5 i256;
+        v11.i256 = mload v6 i256;
+        v12.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_0f32 v0 v9 v10 v11;
+        return v12;
+
+    block3:
+        jump block4;
+
+    block4:
+        v13.i256 = mload v6 i256;
+        v15.i256 = mload v4 i256;
+        v16.i256 = mload v5 i256;
+        v17.i256 = call %core__lib__abi__decode_field_from__g5385_5caf v0 v15 v16;
+        return v17;
+}
+
+func inline(always) private %decode_payload__g407e(v0.objref<@layout_5>) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v2.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_7adc v0;
+        return v2;
+}
+
 func private %decode_payload__g4770(v0.objref<@layout_5>) -> @layout_1 {
     block0:
         jump block1;
@@ -973,15 +1352,6 @@ func private %decode_payload__g4770(v0.objref<@layout_5>) -> @layout_1 {
         obj.store v8 v3;
         v9.@layout_1 = obj.load v4;
         return v9;
-}
-
-func inline(always) private %decode_payload__g407e(v0.objref<@layout_5>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_8dbd v0;
-        return v2;
 }
 
 func inline(always) private %decode_runtime_args__gadcc(v0.objref<@layout_10>) -> @layout_7 {
@@ -1379,6 +1749,102 @@ func private %std__lib__evm__effects__impl_trait_Evm_c913__input_b215() -> @layo
         return v0;
 }
 
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_1fd5(v0.objref<@layout_3>) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v3.objref<i256> = obj.proj v0 1.i256;
+        v4.i256 = obj.load v3;
+        return v4;
+}
+
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_2577(v0.@layout_6) -> i256 {
+    block0:
+        v1.*i256 = alloca i256;
+        v2.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v3.i256 = evm_calldata_size;
+        mstore v1 v3 i256;
+        v6.i256 = extract_value v0 0.i256;
+        v7.i256 = mload v1 i256;
+        mstore v2 v7 i256;
+        v8.i256 = mload v2 i256;
+        v9.i1 = gt v6 v8;
+        br v9 block2 block3;
+
+    block2:
+        jump block4;
+
+    block3:
+        v11.i256 = extract_value v0 0.i256;
+        v12.i256 = mload v1 i256;
+        (v13.i256, v14.i1) = usubo v12 v11;
+        br v14 block5 block6;
+
+    block4:
+        v19.i256 = phi (0.i256 block2) (v13 block6);
+        return v19;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        jump block4;
+}
+
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_3e84(v0.objref<@layout_3>) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v3.objref<i256> = obj.proj v0 1.i256;
+        v4.i256 = obj.load v3;
+        return v4;
+}
+
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_6f75(v0.@layout_6) -> i256 {
+    block0:
+        v1.*i256 = alloca i256;
+        v2.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v3.i256 = evm_calldata_size;
+        mstore v1 v3 i256;
+        v6.i256 = extract_value v0 0.i256;
+        v7.i256 = mload v1 i256;
+        mstore v2 v7 i256;
+        v8.i256 = mload v2 i256;
+        v9.i1 = gt v6 v8;
+        br v9 block2 block3;
+
+    block2:
+        jump block4;
+
+    block3:
+        v11.i256 = extract_value v0 0.i256;
+        v12.i256 = mload v1 i256;
+        (v13.i256, v14.i1) = usubo v12 v11;
+        br v14 block5 block6;
+
+    block4:
+        v19.i256 = phi (0.i256 block2) (v13 block6);
+        return v19;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        jump block4;
+}
+
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_847d(v0.@layout_6) -> i256 {
     block0:
         v1.*i256 = alloca i256;
@@ -1417,16 +1883,6 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         jump block4;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_8584(v0.objref<@layout_3>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 1.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_8db5(v0.@layout_6) -> i256 {
     block0:
         v1.*i256 = alloca i256;
@@ -1463,16 +1919,6 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
 
     block6:
         jump block4;
-}
-
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_bf50(v0.objref<@layout_3>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 1.i256;
-        v4.i256 = obj.load v3;
-        return v4;
 }
 
 func inline(always) private %impl_Cursor__new__g463e(v0.@layout_3) -> @layout_4 {
@@ -1666,7 +2112,7 @@ func private %impl_trait_SolEncoder__pos(v0.objref<@layout_2>) -> i256 {
         return v4;
 }
 
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_0984(v0.objref<@layout_5>) -> i256 {
+func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_272f(v0.objref<@layout_5>) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
@@ -1678,7 +2124,7 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         v7.@layout_3 = obj.load v6;
         v8.objref<@layout_4> = obj.proj v0 0.i256;
         v9.objref<@layout_3> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_bf50 v9;
+        v10.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_1fd5 v9;
         mstore v1 v10 i256;
         v11.objref<@layout_4> = obj.proj v0 0.i256;
         v13.objref<i256> = obj.proj v11 1.i256;
@@ -1701,7 +2147,7 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         v33.i256 = obj.load v32;
         v34.objref<@layout_4> = obj.proj v0 0.i256;
         v35.objref<@layout_3> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_14ee v35 v33;
+        v36.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_d5b9 v35 v33;
         v38.objref<@layout_4> = obj.proj v0 0.i256;
         v39.objref<i256> = obj.proj v38 1.i256;
         obj.store v39 v16;
@@ -1727,7 +2173,7 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         br v26 block2 block5;
 }
 
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_8dbd(v0.objref<@layout_5>) -> i256 {
+func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_7adc(v0.objref<@layout_5>) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
@@ -1739,7 +2185,7 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         v7.@layout_3 = obj.load v6;
         v8.objref<@layout_4> = obj.proj v0 0.i256;
         v9.objref<@layout_3> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_8584 v9;
+        v10.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_3e84 v9;
         mstore v1 v10 i256;
         v11.objref<@layout_4> = obj.proj v0 0.i256;
         v13.objref<i256> = obj.proj v11 1.i256;
@@ -1762,7 +2208,7 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         v33.i256 = obj.load v32;
         v34.objref<@layout_4> = obj.proj v0 0.i256;
         v35.objref<@layout_3> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_231d v35 v33;
+        v36.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_3db5 v35 v33;
         v38.objref<@layout_4> = obj.proj v0 0.i256;
         v39.objref<i256> = obj.proj v38 1.i256;
         obj.store v39 v16;
@@ -1855,20 +2301,6 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_b006(v0.o
         return;
 }
 
-func private %set_pos__g463e(v0.objref<@layout_5>, v1.i256) {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<@layout_4> = obj.proj v0 0.i256;
-        v8.objref<i256> = obj.proj v6 1.i256;
-        obj.store v8 v3;
-        return;
-}
-
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_863e(v0.objref<@layout_2>, v1.i256) {
     block0:
         v2.*i256 = alloca i256;
@@ -1892,6 +2324,20 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_d061(v0.ob
         v3.i256 = mload v2 i256;
         v6.objref<i256> = obj.proj v0 1.i256;
         obj.store v6 v3;
+        return;
+}
+
+func private %set_pos__g463e(v0.objref<@layout_5>, v1.i256) {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v3.i256 = mload v2 i256;
+        v6.objref<@layout_4> = obj.proj v0 0.i256;
+        v8.objref<i256> = obj.proj v6 1.i256;
+        obj.store v8 v3;
         return;
 }
 
@@ -1925,36 +2371,6 @@ func private %std__lib__abi__sol__impl_trait_Sol_1f5f__store_word_d9ea(v0.i256, 
         return;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_14ee(v0.objref<@layout_3>, v1.i256) -> i256 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = mload v8 i256;
-        return v9;
-}
-
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_231d(v0.objref<@layout_3>, v1.i256) -> i256 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = mload v8 i256;
-        return v9;
-}
-
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_32d2(v0.@layout_6, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
@@ -1983,7 +2399,36 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v8;
 }
 
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_3db5(v0.objref<@layout_3>, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v5.objref<i256> = obj.proj v0 0.i256;
+        v6.i256 = obj.load v5;
+        v7.i256 = mload v2 i256;
+        v8.i256 = add v6 v7;
+        v9.i256 = mload v8 i256;
+        return v9;
+}
+
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_8c36(v0.@layout_6, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
+}
+
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_8c36_0(v0.@layout_6, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -2009,6 +2454,35 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         v7.i256 = add v5 v6;
         v8.i256 = evm_calldata_load v7;
         return v8;
+}
+
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b2da_0(v0.@layout_6, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
+}
+
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_d5b9(v0.objref<@layout_3>, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v5.objref<i256> = obj.proj v0 0.i256;
+        v6.i256 = obj.load v5;
+        v7.i256 = mload v2 i256;
+        v8.i256 = add v6 v7;
+        v9.i256 = mload v8 i256;
+        return v9;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_2c07(v0.objref<@layout_2>, v1.i256) {

--- a/crates/codegen/tests/fixtures/sonatina_ir/effect_handle_field_deref.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/effect_handle_field_deref.snap
@@ -483,51 +483,6 @@ func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__
         return v5;
 }
 
-func inline(always) private %decode_from_checked_head__ge273(v0.@layout_2, v1.i256, v2.i256) -> @layout_4 {
-    block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
-        jump block1;
-
-    block1:
-        v5.i256 = mload v4 i256;
-        v7.i256 = mload v3 i256;
-        v8.@layout_4 = call %impl_trait_ReadViaHolder__decode_from__gd20d v0 v7;
-        return v8;
-}
-
-func inline(always) private %decode_from_checked_head__g1d15(v0.@layout_2, v1.i256, v2.i256) -> @layout_5 {
-    block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
-        jump block1;
-
-    block1:
-        v5.i256 = mload v4 i256;
-        v7.i256 = mload v3 i256;
-        v8.@layout_5 = call %impl_trait_SeedSlot__decode_from__gd20d v0 v7;
-        return v8;
-}
-
-func inline(always) private %decode_from_checked_head__gdaee(v0.@layout_2, v1.i256, v2.i256) -> @layout_3 {
-    block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
-        jump block1;
-
-    block1:
-        v5.i256 = mload v4 i256;
-        v7.i256 = mload v3 i256;
-        v8.@layout_3 = call %impl_trait_BumpMover__decode_from__gd20d v0 v7;
-        return v8;
-}
-
 func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f0a9(v0.@layout_2, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
@@ -583,6 +538,51 @@ func inline(always) private %impl_trait_SeedSlot__decode_from__gd20d(v0.@layout_
         return v25;
 }
 
+func inline(always) private %decode_from_prechecked_head__gdaee(v0.@layout_2, v1.i256, v2.i256) -> @layout_3 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v4 i256;
+        v7.i256 = mload v3 i256;
+        v8.@layout_3 = call %impl_trait_BumpMover__decode_from__gd20d v0 v7;
+        return v8;
+}
+
+func inline(always) private %decode_from_prechecked_head__ge273(v0.@layout_2, v1.i256, v2.i256) -> @layout_4 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v4 i256;
+        v7.i256 = mload v3 i256;
+        v8.@layout_4 = call %impl_trait_ReadViaHolder__decode_from__gd20d v0 v7;
+        return v8;
+}
+
+func inline(always) private %decode_from_prechecked_head__g1d15(v0.@layout_2, v1.i256, v2.i256) -> @layout_5 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v4 i256;
+        v7.i256 = mload v3 i256;
+        v8.@layout_5 = call %impl_trait_SeedSlot__decode_from__gd20d v0 v7;
+        return v8;
+}
+
 func inline(always) private %decode_runtime_args__g5aad(v0.objref<@layout_7>) -> @layout_5 {
     block0:
         v1.*i256 = alloca i256;
@@ -606,7 +606,7 @@ func inline(always) private %decode_runtime_args__g5aad(v0.objref<@layout_7>) ->
 
     block4:
         v12.i256 = mload v1 i256;
-        v13.@layout_5 = call %decode_from_checked_head__g1d15 v4 4.i256 v12;
+        v13.@layout_5 = call %decode_from_prechecked_head__g1d15 v4 4.i256 v12;
         return v13;
 
     block5:
@@ -640,7 +640,7 @@ func inline(always) private %decode_runtime_args__g01e9(v0.objref<@layout_7>) ->
 
     block4:
         v12.i256 = mload v1 i256;
-        v13.@layout_4 = call %decode_from_checked_head__ge273 v4 4.i256 v12;
+        v13.@layout_4 = call %decode_from_prechecked_head__ge273 v4 4.i256 v12;
         return v13;
 
     block5:
@@ -674,7 +674,7 @@ func inline(always) private %decode_runtime_args__g0392(v0.objref<@layout_7>) ->
 
     block4:
         v12.i256 = mload v1 i256;
-        v13.@layout_3 = call %decode_from_checked_head__gdaee v4 4.i256 v12;
+        v13.@layout_3 = call %decode_from_prechecked_head__gdaee v4 4.i256 v12;
         return v13;
 
     block5:

--- a/crates/codegen/tests/fixtures/sonatina_ir/effect_handle_field_deref.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/effect_handle_field_deref.snap
@@ -195,6 +195,237 @@ func private %bump(v0.objref<@layout_1>, v1.i256) -> i256 {
         return v19;
 }
 
+func inline(always) private %core__lib__abi__checked_frame_end__gf13e_6c9f(v0.i256, v1.i256, v2.i256) -> i256 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        mstore v3 v0 i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        jump block1;
+
+    block1:
+        v6.i256 = mload v3 i256;
+        v7.i256 = mload v4 i256;
+        (v8.i256, v9.i1) = uaddo v6 v7;
+        br v9 block6 block7;
+
+    block2:
+        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_5569;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        return v8;
+
+    block5:
+        v19.i256 = mload v5 i256;
+        v20.i1 = gt v8 v19;
+        br v20 block2 block3;
+
+    block6:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block7:
+        v15.i256 = mload v3 i256;
+        v16.i1 = lt v8 v15;
+        br v16 block2 block5;
+}
+
+func inline(always) private %core__lib__abi__checked_frame_end__gf13e_7613(v0.i256, v1.i256, v2.i256) -> i256 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        mstore v3 v0 i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        jump block1;
+
+    block1:
+        v6.i256 = mload v3 i256;
+        v7.i256 = mload v4 i256;
+        (v8.i256, v9.i1) = uaddo v6 v7;
+        br v9 block6 block7;
+
+    block2:
+        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_1efd;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        return v8;
+
+    block5:
+        v19.i256 = mload v5 i256;
+        v20.i1 = gt v8 v19;
+        br v20 block2 block3;
+
+    block6:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block7:
+        v15.i256 = mload v3 i256;
+        v16.i1 = lt v8 v15;
+        br v16 block2 block5;
+}
+
+func inline(always) private %core__lib__abi__checked_frame_end__gf13e_d188(v0.i256, v1.i256, v2.i256) -> i256 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        mstore v3 v0 i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        jump block1;
+
+    block1:
+        v6.i256 = mload v3 i256;
+        v7.i256 = mload v4 i256;
+        (v8.i256, v9.i1) = uaddo v6 v7;
+        br v9 block6 block7;
+
+    block2:
+        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_928c;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        return v8;
+
+    block5:
+        v19.i256 = mload v5 i256;
+        v20.i1 = gt v8 v19;
+        br v20 block2 block3;
+
+    block6:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block7:
+        v15.i256 = mload v3 i256;
+        v16.i1 = lt v8 v15;
+        br v16 block2 block5;
+}
+
+func inline(always) private %core__lib__abi__checked_tail__gf13e_3857(v0.i256, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        mstore v2 v0 i256;
+        mstore v3 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v3 i256;
+        (v6.i256, v7.i1) = uaddo v4 v5;
+        br v7 block5 block6;
+
+    block2:
+        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_bd08;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        return v6;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        v13.i256 = mload v2 i256;
+        v14.i1 = lt v6 v13;
+        br v14 block2 block3;
+}
+
+func inline(always) private %core__lib__abi__checked_tail__gf13e_931a(v0.i256, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        mstore v2 v0 i256;
+        mstore v3 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v3 i256;
+        (v6.i256, v7.i1) = uaddo v4 v5;
+        br v7 block5 block6;
+
+    block2:
+        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_9d46;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        return v6;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        v13.i256 = mload v2 i256;
+        v14.i1 = lt v6 v13;
+        br v14 block2 block3;
+}
+
+func inline(always) private %core__lib__abi__checked_tail__gf13e_c189(v0.i256, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        mstore v2 v0 i256;
+        mstore v3 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v3 i256;
+        (v6.i256, v7.i1) = uaddo v4 v5;
+        br v7 block5 block6;
+
+    block2:
+        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_a064;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        return v6;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        v13.i256 = mload v2 i256;
+        v14.i1 = lt v6 v13;
+        br v14 block2 block3;
+}
+
 func private %contract_init_abi_EffectHandleFieldDeref() {
     block0:
         jump block1;
@@ -329,79 +560,55 @@ func private %contract_runtime_root_EffectHandleFieldDeref() {
         unreachable;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from__g5385_27c8(v0.@layout_2, v1.i256, v2.i256) -> i256 {
+func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_1efd() {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        br 0.i1 block2 block3;
-
-    block2:
-        v7.i256 = mload v4 i256;
-        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_7c41 v0 v7;
-        v9.i256 = mload v3 i256;
-        (v10.i256, v11.i1) = uaddo v9 v8;
-        br v11 block5 block6;
-
-    block3:
-        jump block4;
-
-    block4:
-        v20.i256 = mload v4 i256;
-        v21.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_a878 v0 v20;
-        return v21;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        v18.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_a878 v0 v10;
-        return v18;
+        evm_revert 0.i256 0.i256;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from__g5385_54a8(v0.@layout_2, v1.i256, v2.i256) -> i256 {
+func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_5569() {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        br 0.i1 block2 block3;
-
-    block2:
-        v7.i256 = mload v4 i256;
-        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_dee9 v0 v7;
-        v9.i256 = mload v3 i256;
-        (v10.i256, v11.i1) = uaddo v9 v8;
-        br v11 block5 block6;
-
-    block3:
-        jump block4;
-
-    block4:
-        v20.i256 = mload v4 i256;
-        v21.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f0a9 v0 v20;
-        return v21;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        v18.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f0a9 v0 v10;
-        return v18;
+        evm_revert 0.i256 0.i256;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from__g5385_7f7d(v0.@layout_2, v1.i256, v2.i256) -> i256 {
+func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_928c() {
+    block0:
+        jump block1;
+
+    block1:
+        evm_revert 0.i256 0.i256;
+}
+
+func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_9d46() {
+    block0:
+        jump block1;
+
+    block1:
+        evm_revert 0.i256 0.i256;
+}
+
+func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_a064() {
+    block0:
+        jump block1;
+
+    block1:
+        evm_revert 0.i256 0.i256;
+}
+
+func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_bd08() {
+    block0:
+        jump block1;
+
+    block1:
+        evm_revert 0.i256 0.i256;
+}
+
+func inline(always) private %core__lib__abi__decode_field_from__g5385_1cc8(v0.@layout_2, v1.i256, v2.i256) -> i256 {
     block0:
         v3.*i256 = alloca i256;
         v4.*i256 = alloca i256;
@@ -424,7 +631,7 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_7f7d(v0.@l
 
     block4:
         v20.i256 = mload v4 i256;
-        v21.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f4af v0 v20;
+        v21.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f4af_0 v0 v20;
         return v21;
 
     block5:
@@ -433,8 +640,173 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_7f7d(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v18.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f4af v0 v10;
+        v18.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f4af_0 v0 v10;
         return v18;
+}
+
+func inline(always) private %core__lib__abi__decode_field_from__g5385_23bd(v0.@layout_2, v1.i256, v2.i256) -> i256 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v7.i256 = mload v4 i256;
+        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_dee9 v0 v7;
+        v9.i256 = mload v3 i256;
+        (v10.i256, v11.i1) = uaddo v9 v8;
+        br v11 block5 block6;
+
+    block3:
+        jump block4;
+
+    block4:
+        v20.i256 = mload v4 i256;
+        v21.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f0a9_0 v0 v20;
+        return v21;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        v18.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f0a9_0 v0 v10;
+        return v18;
+}
+
+func inline(always) private %core__lib__abi__decode_field_from__g5385_48de(v0.@layout_2, v1.i256, v2.i256) -> i256 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v7.i256 = mload v4 i256;
+        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_7c41 v0 v7;
+        v9.i256 = mload v3 i256;
+        (v10.i256, v11.i1) = uaddo v9 v8;
+        br v11 block5 block6;
+
+    block3:
+        jump block4;
+
+    block4:
+        v20.i256 = mload v4 i256;
+        v21.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_a878_0 v0 v20;
+        return v21;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        v18.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_a878_0 v0 v10;
+        return v18;
+}
+
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_61db(v0.@layout_2, v1.i256, v2.i256, v3.i256) -> i256 {
+    block0:
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        v6.*i256 = alloca i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        mstore v6 v3 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v9.i256 = mload v5 i256;
+        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_dee9 v0 v9;
+        v11.i256 = mload v4 i256;
+        v12.i256 = call %core__lib__abi__checked_tail__gf13e_3857 v11 v10;
+        v13.i256 = mload v6 i256;
+        v14.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_dae2 v0 v12 v13;
+        return v14;
+
+    block3:
+        jump block4;
+
+    block4:
+        v16.i256 = mload v5 i256;
+        v17.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f0a9_0 v0 v16;
+        return v17;
+}
+
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_d7e7(v0.@layout_2, v1.i256, v2.i256, v3.i256) -> i256 {
+    block0:
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        v6.*i256 = alloca i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        mstore v6 v3 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v9.i256 = mload v5 i256;
+        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_7c41 v0 v9;
+        v11.i256 = mload v4 i256;
+        v12.i256 = call %core__lib__abi__checked_tail__gf13e_c189 v11 v10;
+        v13.i256 = mload v6 i256;
+        v14.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_2684 v0 v12 v13;
+        return v14;
+
+    block3:
+        jump block4;
+
+    block4:
+        v16.i256 = mload v5 i256;
+        v17.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_a878_0 v0 v16;
+        return v17;
+}
+
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_f2f8(v0.@layout_2, v1.i256, v2.i256, v3.i256) -> i256 {
+    block0:
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        v6.*i256 = alloca i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        mstore v6 v3 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v9.i256 = mload v5 i256;
+        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_7303 v0 v9;
+        v11.i256 = mload v4 i256;
+        v12.i256 = call %core__lib__abi__checked_tail__gf13e_931a v11 v10;
+        v13.i256 = mload v6 i256;
+        v14.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_89cb v0 v12 v13;
+        return v14;
+
+    block3:
+        jump block4;
+
+    block4:
+        v16.i256 = mload v5 i256;
+        v17.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f4af_0 v0 v16;
+        return v17;
 }
 
 func inline(always) private %impl_trait_BumpMover__decode_from__gd20d(v0.@layout_2, v1.i256) -> @layout_3 {
@@ -444,14 +816,15 @@ func inline(always) private %impl_trait_BumpMover__decode_from__gd20d(v0.@layout
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_9e81 v0;
         v5.i256 = mload v2 i256;
-        v6.i256 = call %core__lib__abi__decode_field_from__g5385_7f7d v0 v4 v5;
-        v7.objref<@layout_3> = obj.alloc @layout_3;
-        v9.objref<i256> = obj.proj v7 0.i256;
-        obj.store v9 v6;
-        v10.@layout_3 = obj.load v7;
-        return v10;
+        v6.i256 = mload v2 i256;
+        v7.i256 = call %core__lib__abi__decode_msg_field_from__g5385_5108 v0 v5 v6 v4;
+        v8.objref<@layout_3> = obj.alloc @layout_3;
+        v10.objref<i256> = obj.proj v8 0.i256;
+        obj.store v10 v7;
+        v11.@layout_3 = obj.load v8;
+        return v11;
 }
 
 func inline(always) private %impl_trait_ReadViaHolder__decode_from__gd20d(v0.@layout_2, v1.i256) -> @layout_4 {
@@ -461,14 +834,15 @@ func inline(always) private %impl_trait_ReadViaHolder__decode_from__gd20d(v0.@la
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_392e v0;
         v5.i256 = mload v2 i256;
-        v6.i256 = call %core__lib__abi__decode_field_from__g5385_27c8 v0 v4 v5;
-        v7.objref<@layout_4> = obj.alloc @layout_4;
-        v9.objref<i256> = obj.proj v7 0.i256;
-        obj.store v9 v6;
-        v10.@layout_4 = obj.load v7;
-        return v10;
+        v6.i256 = mload v2 i256;
+        v7.i256 = call %core__lib__abi__decode_msg_field_from__g5385_7d42 v0 v5 v6 v4;
+        v8.objref<@layout_4> = obj.alloc @layout_4;
+        v10.objref<i256> = obj.proj v8 0.i256;
+        obj.store v10 v7;
+        v11.@layout_4 = obj.load v8;
+        return v11;
 }
 
 func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_a878(v0.@layout_2, v1.i256) -> i256 {
@@ -483,6 +857,69 @@ func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__
         return v5;
 }
 
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_a878_0(v0.@layout_2, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_9c31_0 v0 v4;
+        return v5;
+}
+
+func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_2684(v0.@layout_2, v1.i256, v2.i256) -> i256 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v3 i256;
+        v7.i256 = mload v4 i256;
+        v8.i256 = call %core__lib__abi__checked_frame_end__gf13e_6c9f v5 32.i256 v7;
+        v10.i256 = mload v3 i256;
+        v11.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_a878 v0 v10;
+        return v11;
+}
+
+func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_89cb(v0.@layout_2, v1.i256, v2.i256) -> i256 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v3 i256;
+        v7.i256 = mload v4 i256;
+        v8.i256 = call %core__lib__abi__checked_frame_end__gf13e_d188 v5 32.i256 v7;
+        v10.i256 = mload v3 i256;
+        v11.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f4af v0 v10;
+        return v11;
+}
+
+func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_dae2(v0.@layout_2, v1.i256, v2.i256) -> i256 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v3 i256;
+        v7.i256 = mload v4 i256;
+        v8.i256 = call %core__lib__abi__checked_frame_end__gf13e_7613 v5 32.i256 v7;
+        v10.i256 = mload v3 i256;
+        v11.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f0a9 v0 v10;
+        return v11;
+}
+
 func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f0a9(v0.@layout_2, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
@@ -492,6 +929,18 @@ func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__
     block1:
         v4.i256 = mload v2 i256;
         v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_950e v0 v4;
+        return v5;
+}
+
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f0a9_0(v0.@layout_2, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_950e_0 v0 v4;
         return v5;
 }
 
@@ -507,7 +956,7 @@ func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__
         return v5;
 }
 
-func inline(always) private %impl_trait_SeedSlot__decode_from__gd20d(v0.@layout_2, v1.i256) -> @layout_5 {
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f4af_0(v0.@layout_2, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -515,12 +964,25 @@ func inline(always) private %impl_trait_SeedSlot__decode_from__gd20d(v0.@layout_
 
     block1:
         v4.i256 = mload v2 i256;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_4e15_0 v0 v4;
+        return v5;
+}
+
+func inline(always) private %impl_trait_SeedSlot__decode_from__gd20d(v0.@layout_2, v1.i256) -> @layout_5 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_1933 v0;
         v5.i256 = mload v2 i256;
-        v6.i256 = call %core__lib__abi__decode_field_from__g5385_54a8 v0 v4 v5;
-        v7.i256 = mload v2 i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = call %core__lib__abi__decode_msg_field_from__g5385_3605 v0 v5 v6 v4;
         v8.i256 = mload v2 i256;
-        (v10.i256, v11.i1) = uaddo v8 32.i256;
-        br v11 block2 block3;
+        v9.i256 = mload v2 i256;
+        (v11.i256, v12.i1) = uaddo v9 32.i256;
+        br v12 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -528,14 +990,14 @@ func inline(always) private %impl_trait_SeedSlot__decode_from__gd20d(v0.@layout_
         evm_revert 0.i256 36.i256;
 
     block3:
-        v19.i256 = call %core__lib__abi__decode_field_from__g5385_54a8 v0 v7 v10;
-        v20.objref<@layout_5> = obj.alloc @layout_5;
-        v22.objref<i256> = obj.proj v20 0.i256;
-        obj.store v22 v6;
-        v24.objref<i256> = obj.proj v20 1.i256;
-        obj.store v24 v19;
-        v25.@layout_5 = obj.load v20;
-        return v25;
+        v21.i256 = call %core__lib__abi__decode_msg_field_from__g5385_3605 v0 v8 v11 v4;
+        v22.objref<@layout_5> = obj.alloc @layout_5;
+        v24.objref<i256> = obj.proj v22 0.i256;
+        obj.store v24 v7;
+        v26.objref<i256> = obj.proj v22 1.i256;
+        obj.store v26 v21;
+        v27.@layout_5 = obj.load v22;
+        return v27;
 }
 
 func inline(always) private %decode_from_prechecked_head__gdaee(v0.@layout_2, v1.i256, v2.i256) -> @layout_3 {
@@ -581,6 +1043,99 @@ func inline(always) private %decode_from_prechecked_head__g1d15(v0.@layout_2, v1
         v7.i256 = mload v3 i256;
         v8.@layout_5 = call %impl_trait_SeedSlot__decode_from__gd20d v0 v7;
         return v8;
+}
+
+func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_3605(v0.@layout_2, v1.i256, v2.i256, v3.i256) -> i256 {
+    block0:
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        v6.*i256 = alloca i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        mstore v6 v3 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v9.i256 = mload v4 i256;
+        v10.i256 = mload v5 i256;
+        v11.i256 = mload v6 i256;
+        v12.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_61db v0 v9 v10 v11;
+        return v12;
+
+    block3:
+        jump block4;
+
+    block4:
+        v13.i256 = mload v6 i256;
+        v15.i256 = mload v4 i256;
+        v16.i256 = mload v5 i256;
+        v17.i256 = call %core__lib__abi__decode_field_from__g5385_23bd v0 v15 v16;
+        return v17;
+}
+
+func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_5108(v0.@layout_2, v1.i256, v2.i256, v3.i256) -> i256 {
+    block0:
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        v6.*i256 = alloca i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        mstore v6 v3 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v9.i256 = mload v4 i256;
+        v10.i256 = mload v5 i256;
+        v11.i256 = mload v6 i256;
+        v12.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_f2f8 v0 v9 v10 v11;
+        return v12;
+
+    block3:
+        jump block4;
+
+    block4:
+        v13.i256 = mload v6 i256;
+        v15.i256 = mload v4 i256;
+        v16.i256 = mload v5 i256;
+        v17.i256 = call %core__lib__abi__decode_field_from__g5385_1cc8 v0 v15 v16;
+        return v17;
+}
+
+func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_7d42(v0.@layout_2, v1.i256, v2.i256, v3.i256) -> i256 {
+    block0:
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        v6.*i256 = alloca i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        mstore v6 v3 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v9.i256 = mload v4 i256;
+        v10.i256 = mload v5 i256;
+        v11.i256 = mload v6 i256;
+        v12.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_d7e7 v0 v9 v10 v11;
+        return v12;
+
+    block3:
+        jump block4;
+
+    block4:
+        v13.i256 = mload v6 i256;
+        v15.i256 = mload v4 i256;
+        v16.i256 = mload v5 i256;
+        v17.i256 = call %core__lib__abi__decode_field_from__g5385_48de v0 v15 v16;
+        return v17;
 }
 
 func inline(always) private %decode_runtime_args__g5aad(v0.objref<@layout_7>) -> @layout_5 {
@@ -859,6 +1414,82 @@ func private %std__lib__evm__effects__impl_trait_Evm_c913__input_dcd3() -> @layo
         return v0;
 }
 
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_1933(v0.@layout_2) -> i256 {
+    block0:
+        v1.*i256 = alloca i256;
+        v2.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v3.i256 = evm_calldata_size;
+        mstore v1 v3 i256;
+        v6.i256 = extract_value v0 0.i256;
+        v7.i256 = mload v1 i256;
+        mstore v2 v7 i256;
+        v8.i256 = mload v2 i256;
+        v9.i1 = gt v6 v8;
+        br v9 block2 block3;
+
+    block2:
+        jump block4;
+
+    block3:
+        v11.i256 = extract_value v0 0.i256;
+        v12.i256 = mload v1 i256;
+        (v13.i256, v14.i1) = usubo v12 v11;
+        br v14 block5 block6;
+
+    block4:
+        v19.i256 = phi (0.i256 block2) (v13 block6);
+        return v19;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        jump block4;
+}
+
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_392e(v0.@layout_2) -> i256 {
+    block0:
+        v1.*i256 = alloca i256;
+        v2.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v3.i256 = evm_calldata_size;
+        mstore v1 v3 i256;
+        v6.i256 = extract_value v0 0.i256;
+        v7.i256 = mload v1 i256;
+        mstore v2 v7 i256;
+        v8.i256 = mload v2 i256;
+        v9.i1 = gt v6 v8;
+        br v9 block2 block3;
+
+    block2:
+        jump block4;
+
+    block3:
+        v11.i256 = extract_value v0 0.i256;
+        v12.i256 = mload v1 i256;
+        (v13.i256, v14.i1) = usubo v12 v11;
+        br v14 block5 block6;
+
+    block4:
+        v19.i256 = phi (0.i256 block2) (v13 block6);
+        return v19;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        jump block4;
+}
+
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_4133(v0.@layout_2) -> i256 {
     block0:
         v1.*i256 = alloca i256;
@@ -898,6 +1529,44 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_960d(v0.@layout_2) -> i256 {
+    block0:
+        v1.*i256 = alloca i256;
+        v2.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v3.i256 = evm_calldata_size;
+        mstore v1 v3 i256;
+        v6.i256 = extract_value v0 0.i256;
+        v7.i256 = mload v1 i256;
+        mstore v2 v7 i256;
+        v8.i256 = mload v2 i256;
+        v9.i1 = gt v6 v8;
+        br v9 block2 block3;
+
+    block2:
+        jump block4;
+
+    block3:
+        v11.i256 = extract_value v0 0.i256;
+        v12.i256 = mload v1 i256;
+        (v13.i256, v14.i1) = usubo v12 v11;
+        br v14 block5 block6;
+
+    block4:
+        v19.i256 = phi (0.i256 block2) (v13 block6);
+        return v19;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        jump block4;
+}
+
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_9e81(v0.@layout_2) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
@@ -1183,6 +1852,20 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v8;
 }
 
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_4e15_0(v0.@layout_2, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
+}
+
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_7303(v0.@layout_2, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
@@ -1225,7 +1908,35 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v8;
 }
 
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_950e_0(v0.@layout_2, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
+}
+
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_9c31(v0.@layout_2, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
+}
+
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_9c31_0(v0.@layout_2, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;

--- a/crates/codegen/tests/fixtures/sonatina_ir/effect_handle_field_deref.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/effect_handle_field_deref.snap
@@ -140,6 +140,24 @@ func private %std__lib__evm__effects__impl_trait_Evm_c913__abort_ffa6() {
         unreachable;
 }
 
+func inline(always) private %at(v0.i256) -> @layout_0 {
+    block0:
+        v1.*i256 = alloca i256;
+        mstore v1 v0 i256;
+        jump block1;
+
+    block1:
+        v2.i256 = mload v1 i256;
+        v3.i256 = mload v1 i256;
+        v4.objref<@layout_0> = obj.alloc @layout_0;
+        v6.objref<i256> = obj.proj v4 0.i256;
+        obj.store v6 v2;
+        v8.objref<i256> = obj.proj v4 1.i256;
+        obj.store v8 v3;
+        v9.@layout_0 = obj.load v4;
+        return v9;
+}
+
 func private %base(v0.objref<@layout_0>) -> i256 {
     block0:
         jump block1;
@@ -1013,13 +1031,8 @@ func private %impl_SolEncoder__new(v0.i256) -> @layout_0 {
 
     block4:
         v8.i256 = phi (0.i256 block2) (v7 block3);
-        v9.objref<@layout_0> = obj.alloc @layout_0;
-        v10.objref<i256> = obj.proj v9 0.i256;
-        obj.store v10 v8;
-        v12.objref<i256> = obj.proj v9 1.i256;
-        obj.store v12 v8;
-        v13.@layout_0 = obj.load v9;
-        return v13;
+        v9.@layout_0 = call %at v8;
+        return v9;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_ac71() -> @layout_2 {

--- a/crates/codegen/tests/fixtures/sonatina_ir/effect_handle_field_deref.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/effect_handle_field_deref.snap
@@ -483,6 +483,51 @@ func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__
         return v5;
 }
 
+func inline(always) private %decode_from_checked_head__ge273(v0.@layout_2, v1.i256, v2.i256) -> @layout_4 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v4 i256;
+        v7.i256 = mload v3 i256;
+        v8.@layout_4 = call %impl_trait_ReadViaHolder__decode_from__gd20d v0 v7;
+        return v8;
+}
+
+func inline(always) private %decode_from_checked_head__g1d15(v0.@layout_2, v1.i256, v2.i256) -> @layout_5 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v4 i256;
+        v7.i256 = mload v3 i256;
+        v8.@layout_5 = call %impl_trait_SeedSlot__decode_from__gd20d v0 v7;
+        return v8;
+}
+
+func inline(always) private %decode_from_checked_head__gdaee(v0.@layout_2, v1.i256, v2.i256) -> @layout_3 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v4 i256;
+        v7.i256 = mload v3 i256;
+        v8.@layout_3 = call %impl_trait_BumpMover__decode_from__gd20d v0 v7;
+        return v8;
+}
+
 func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f0a9(v0.@layout_2, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
@@ -543,18 +588,14 @@ func inline(always) private %decode_runtime_args__g5aad(v0.objref<@layout_7>) ->
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
         v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v5.@layout_2 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_dcd3;
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_960d v5;
-        mstore v1 v7 i256;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt 4.i256 v9;
-        br v10 block2 block3;
+        v4.@layout_2 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_dcd3;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_960d v4;
+        mstore v1 v6 i256;
+        mstore v2 4.i256 i256;
+        br 0.i1 block2 block5;
 
     block2:
         call %std__lib__evm__effects__impl_trait_Evm_c913__abort_9c1e;
@@ -564,35 +605,16 @@ func inline(always) private %decode_runtime_args__g5aad(v0.objref<@layout_7>) ->
         jump block4;
 
     block4:
-        br 1.i1 block5 block6;
+        v12.i256 = mload v1 i256;
+        v13.@layout_5 = call %decode_from_checked_head__g1d15 v4 4.i256 v12;
+        return v13;
 
     block5:
-        mstore v3 4.i256 i256;
-        br 0.i1 block8 block11;
-
-    block6:
-        jump block7;
-
-    block7:
-        v17.@layout_5 = call %impl_trait_SeedSlot__decode_from__gd20d v5 4.i256;
-        return v17;
-
-    block8:
-        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_9c1e;
-        unreachable;
-
-    block9:
-        jump block10;
-
-    block10:
-        jump block7;
-
-    block11:
-        v18.i256 = mload v1 i256;
-        mstore v4 v18 i256;
-        v20.i256 = mload v4 i256;
-        v21.i1 = gt 68.i256 v20;
-        br v21 block8 block9;
+        v14.i256 = mload v1 i256;
+        mstore v3 v14 i256;
+        v16.i256 = mload v3 i256;
+        v17.i1 = gt 68.i256 v16;
+        br v17 block2 block3;
 }
 
 func inline(always) private %decode_runtime_args__g01e9(v0.objref<@layout_7>) -> @layout_4 {
@@ -600,18 +622,14 @@ func inline(always) private %decode_runtime_args__g01e9(v0.objref<@layout_7>) ->
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
         v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v5.@layout_2 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_c5c0;
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_f59a v5;
-        mstore v1 v7 i256;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt 4.i256 v9;
-        br v10 block2 block3;
+        v4.@layout_2 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_c5c0;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_f59a v4;
+        mstore v1 v6 i256;
+        mstore v2 4.i256 i256;
+        br 0.i1 block2 block5;
 
     block2:
         call %std__lib__evm__effects__impl_trait_Evm_c913__abort_ffa6;
@@ -621,35 +639,16 @@ func inline(always) private %decode_runtime_args__g01e9(v0.objref<@layout_7>) ->
         jump block4;
 
     block4:
-        br 1.i1 block5 block6;
+        v12.i256 = mload v1 i256;
+        v13.@layout_4 = call %decode_from_checked_head__ge273 v4 4.i256 v12;
+        return v13;
 
     block5:
-        mstore v3 4.i256 i256;
-        br 0.i1 block8 block11;
-
-    block6:
-        jump block7;
-
-    block7:
-        v17.@layout_4 = call %impl_trait_ReadViaHolder__decode_from__gd20d v5 4.i256;
-        return v17;
-
-    block8:
-        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_ffa6;
-        unreachable;
-
-    block9:
-        jump block10;
-
-    block10:
-        jump block7;
-
-    block11:
-        v18.i256 = mload v1 i256;
-        mstore v4 v18 i256;
-        v20.i256 = mload v4 i256;
-        v21.i1 = gt 36.i256 v20;
-        br v21 block8 block9;
+        v14.i256 = mload v1 i256;
+        mstore v3 v14 i256;
+        v16.i256 = mload v3 i256;
+        v17.i1 = gt 36.i256 v16;
+        br v17 block2 block3;
 }
 
 func inline(always) private %decode_runtime_args__g0392(v0.objref<@layout_7>) -> @layout_3 {
@@ -657,18 +656,14 @@ func inline(always) private %decode_runtime_args__g0392(v0.objref<@layout_7>) ->
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
         v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v5.@layout_2 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_0e8a;
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_4133 v5;
-        mstore v1 v7 i256;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt 4.i256 v9;
-        br v10 block2 block3;
+        v4.@layout_2 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_0e8a;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_4133 v4;
+        mstore v1 v6 i256;
+        mstore v2 4.i256 i256;
+        br 0.i1 block2 block5;
 
     block2:
         call %std__lib__evm__effects__impl_trait_Evm_c913__abort_4c56;
@@ -678,35 +673,16 @@ func inline(always) private %decode_runtime_args__g0392(v0.objref<@layout_7>) ->
         jump block4;
 
     block4:
-        br 1.i1 block5 block6;
+        v12.i256 = mload v1 i256;
+        v13.@layout_3 = call %decode_from_checked_head__gdaee v4 4.i256 v12;
+        return v13;
 
     block5:
-        mstore v3 4.i256 i256;
-        br 0.i1 block8 block11;
-
-    block6:
-        jump block7;
-
-    block7:
-        v17.@layout_3 = call %impl_trait_BumpMover__decode_from__gd20d v5 4.i256;
-        return v17;
-
-    block8:
-        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_4c56;
-        unreachable;
-
-    block9:
-        jump block10;
-
-    block10:
-        jump block7;
-
-    block11:
-        v18.i256 = mload v1 i256;
-        mstore v4 v18 i256;
-        v20.i256 = mload v4 i256;
-        v21.i1 = gt 36.i256 v20;
-        br v21 block8 block9;
+        v14.i256 = mload v1 i256;
+        mstore v3 v14 i256;
+        v16.i256 = mload v3 i256;
+        v17.i1 = gt 36.i256 v16;
+        br v17 block2 block3;
 }
 
 func private %encode(v0.i256, v1.objref<@layout_0>) {

--- a/crates/codegen/tests/fixtures/sonatina_ir/effect_handle_field_deref.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/effect_handle_field_deref.snap
@@ -5,20 +5,18 @@ input_file: crates/codegen/tests/fixtures/effect_handle_field_deref.fe
 ---
 target = "evm-ethereum-osaka"
 
-type @layout_0 = {i256};
-type @layout_1 = {@layout_0, i256};
-type @layout_2 = {@layout_1, i256};
-type @layout_3 = {i256, i256};
+type @layout_0 = {i256, i256};
+type @layout_1 = {i256};
+type @layout_2 = {i256};
+type @layout_3 = {i256};
 type @layout_4 = {i256};
-type @layout_5 = {i256};
-type @layout_6 = {i256};
-type @layout_7 = {i256, i256};
-type @layout_8 = {};
-type @layout_9 = {@layout_8};
-type @layout_10 = {i256, i256};
-type @layout_11 = {i256, i256};
+type @layout_5 = {i256, i256};
+type @layout_6 = {};
+type @layout_7 = {@layout_6};
+type @layout_8 = {i256, i256};
+type @layout_9 = {i256, i256};
 
-global private const @layout_0 $const_region_0 = {0};
+global private const @layout_2 $const_region_0 = {0};
 
 func private %__EffectHandleFieldDeref_init(v0.i256) {
     block0:
@@ -45,12 +43,12 @@ func private %__EffectHandleFieldDeref_recv_0_1(v0.i256) -> i256 {
 
     block1:
         v2.i256 = call %stor_ptr v0;
-        v4.objref<@layout_11> = obj.alloc @layout_11;
+        v4.objref<@layout_9> = obj.alloc @layout_9;
         v6.objref<i256> = obj.proj v4 0.i256;
         obj.store v6 v2;
         v7.objref<i256> = obj.proj v4 1.i256;
         obj.store v7 1.i256;
-        v8.@layout_11 = obj.load v4;
+        v8.@layout_9 = obj.load v4;
         v9.i256 = call %extract_ptr v8;
         v10.i256 = call %read_cell v9;
         return v10;
@@ -61,11 +59,11 @@ func private %__EffectHandleFieldDeref_recv_0_2(v0.i256, v1.i256) -> i256 {
         jump block1;
 
     block1:
-        v3.objref<@layout_4> = obj.alloc @layout_4;
+        v3.objref<@layout_1> = obj.alloc @layout_1;
         v5.objref<i256> = obj.proj v3 0.i256;
         obj.store v5 v1;
-        v6.@layout_4 = obj.load v3;
-        v7.objref<@layout_4> = obj.alloc @layout_4;
+        v6.@layout_1 = obj.load v3;
+        v7.objref<@layout_1> = obj.alloc @layout_1;
         v8.objref<i256> = obj.proj v7 0.i256;
         v9.i256 = extract_value v6 0.i256;
         obj.store v8 v9;
@@ -115,37 +113,34 @@ func private %abi_single_root_size(v0.i256) -> i256 {
         return v3;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_159d(v0.objref<@layout_2>) -> i256 {
+func private %std__lib__evm__effects__impl_trait_Evm_c913__abort_4c56() {
     block0:
         jump block1;
 
     block1:
-        v3.objref<i256> = obj.proj v0 1.i256;
-        v4.i256 = obj.load v3;
-        return v4;
+        call %std__lib__evm__effects__impl_trait_Evm_0098__revert_a881 0.i256 0.i256;
+        unreachable;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_31e5(v0.objref<@layout_2>) -> i256 {
+func private %std__lib__evm__effects__impl_trait_Evm_c913__abort_9c1e() {
     block0:
         jump block1;
 
     block1:
-        v3.objref<i256> = obj.proj v0 1.i256;
-        v4.i256 = obj.load v3;
-        return v4;
+        call %std__lib__evm__effects__impl_trait_Evm_0098__revert_ba8b 0.i256 0.i256;
+        unreachable;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_7113(v0.objref<@layout_2>) -> i256 {
+func private %std__lib__evm__effects__impl_trait_Evm_c913__abort_ffa6() {
     block0:
         jump block1;
 
     block1:
-        v3.objref<i256> = obj.proj v0 1.i256;
-        v4.i256 = obj.load v3;
-        return v4;
+        call %std__lib__evm__effects__impl_trait_Evm_0098__revert_27e9 0.i256 0.i256;
+        unreachable;
 }
 
-func private %impl_trait_SolEncoder__base(v0.objref<@layout_3>) -> i256 {
+func private %base(v0.objref<@layout_0>) -> i256 {
     block0:
         jump block1;
 
@@ -155,7 +150,7 @@ func private %impl_trait_SolEncoder__base(v0.objref<@layout_3>) -> i256 {
         return v4;
 }
 
-func private %bump(v0.objref<@layout_4>, v1.i256) -> i256 {
+func private %bump(v0.objref<@layout_1>, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -226,12 +221,12 @@ func private %contract_recv_abi_EffectHandleFieldDeref_1() {
         evm_revert 0.i256 0.i256;
 
     block3:
-        v5.objref<@layout_9> = obj.alloc @layout_9;
-        v6.@layout_7 = call %decode_runtime_args__g5aad v5;
+        v5.objref<@layout_7> = obj.alloc @layout_7;
+        v6.@layout_5 = call %decode_runtime_args__g5aad v5;
         v7.i256 = extract_value v6 0.i256;
         v9.i256 = extract_value v6 1.i256;
         v10.i256 = call %__EffectHandleFieldDeref_recv_0_0 v7 v9;
-        v11.@layout_10 = call %encode_single_root_alloc v10;
+        v11.@layout_8 = call %encode_single_root_alloc v10;
         v12.i256 = extract_value v11 0.i256;
         v13.i256 = extract_value v11 1.i256;
         evm_return v12 v13;
@@ -251,11 +246,11 @@ func private %contract_recv_abi_EffectHandleFieldDeref_2() {
         evm_revert 0.i256 0.i256;
 
     block3:
-        v5.objref<@layout_9> = obj.alloc @layout_9;
-        v6.@layout_6 = call %decode_runtime_args__g01e9 v5;
+        v5.objref<@layout_7> = obj.alloc @layout_7;
+        v6.@layout_4 = call %decode_runtime_args__g01e9 v5;
         v7.i256 = extract_value v6 0.i256;
         v8.i256 = call %__EffectHandleFieldDeref_recv_0_1 v7;
-        v9.@layout_10 = call %encode_single_root_alloc v8;
+        v9.@layout_8 = call %encode_single_root_alloc v8;
         v10.i256 = extract_value v9 0.i256;
         v12.i256 = extract_value v9 1.i256;
         evm_return v10 v12;
@@ -275,11 +270,11 @@ func private %contract_recv_abi_EffectHandleFieldDeref_3() {
         evm_revert 0.i256 0.i256;
 
     block3:
-        v5.objref<@layout_9> = obj.alloc @layout_9;
-        v6.@layout_5 = call %decode_runtime_args__g0392 v5;
+        v5.objref<@layout_7> = obj.alloc @layout_7;
+        v6.@layout_3 = call %decode_runtime_args__g0392 v5;
         v7.i256 = extract_value v6 0.i256;
         v8.i256 = call %__EffectHandleFieldDeref_recv_0_2 v7 0.i256;
-        v9.@layout_10 = call %encode_single_root_alloc v8;
+        v9.@layout_8 = call %encode_single_root_alloc v8;
         v10.i256 = extract_value v9 0.i256;
         v12.i256 = extract_value v9 1.i256;
         evm_return v10 v12;
@@ -316,26 +311,31 @@ func private %contract_runtime_root_EffectHandleFieldDeref() {
         unreachable;
 }
 
-func inline(always) private %core__lib__abi__decode_field__g7400_6974(v0.objref<@layout_2>) -> i256 {
+func inline(always) private %core__lib__abi__decode_field_from__g5385_27c8(v0.@layout_2, v1.i256, v2.i256) -> i256 {
     block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v3.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_3710 v0;
-        v4.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_31e5 v0;
-        v5.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g8f43_868e v0;
-        (v6.i256, v7.i1) = uaddo v4 v3;
-        br v7 block5 block6;
+        v7.i256 = mload v4 i256;
+        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_7c41 v0 v7;
+        v9.i256 = mload v3 i256;
+        (v10.i256, v11.i1) = uaddo v9 v8;
+        br v11 block5 block6;
 
     block3:
         jump block4;
 
     block4:
-        v23.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_payload__g574e_4028 v0;
-        return v23;
+        v20.i256 = mload v4 i256;
+        v21.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_a878 v0 v20;
+        return v21;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -343,35 +343,35 @@ func inline(always) private %core__lib__abi__decode_field__g7400_6974(v0.objref<
         evm_revert 0.i256 36.i256;
 
     block6:
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_5248 v0 v6;
-        v15.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_31e5 v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_07fb v0 v15;
-        v17.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_payload__g574e_4028 v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_5248 v0 v4;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_07fb v0 v5;
-        return v17;
+        v18.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_a878 v0 v10;
+        return v18;
 }
 
-func inline(always) private %core__lib__abi__decode_field__g7400_709e(v0.objref<@layout_2>) -> i256 {
+func inline(always) private %core__lib__abi__decode_field_from__g5385_54a8(v0.@layout_2, v1.i256, v2.i256) -> i256 {
     block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v3.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_b395 v0;
-        v4.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_159d v0;
-        v5.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g8f43_0d04 v0;
-        (v6.i256, v7.i1) = uaddo v4 v3;
-        br v7 block5 block6;
+        v7.i256 = mload v4 i256;
+        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_dee9 v0 v7;
+        v9.i256 = mload v3 i256;
+        (v10.i256, v11.i1) = uaddo v9 v8;
+        br v11 block5 block6;
 
     block3:
         jump block4;
 
     block4:
-        v23.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_payload__g574e_324c v0;
-        return v23;
+        v20.i256 = mload v4 i256;
+        v21.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f0a9 v0 v20;
+        return v21;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -379,35 +379,35 @@ func inline(always) private %core__lib__abi__decode_field__g7400_709e(v0.objref<
         evm_revert 0.i256 36.i256;
 
     block6:
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_75a5 v0 v6;
-        v15.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_159d v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_495b v0 v15;
-        v17.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_payload__g574e_324c v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_75a5 v0 v4;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_495b v0 v5;
-        return v17;
+        v18.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f0a9 v0 v10;
+        return v18;
 }
 
-func inline(always) private %core__lib__abi__decode_field__g7400_78ea(v0.objref<@layout_2>) -> i256 {
+func inline(always) private %core__lib__abi__decode_field_from__g5385_7f7d(v0.@layout_2, v1.i256, v2.i256) -> i256 {
     block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v3.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_9a89 v0;
-        v4.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_7113 v0;
-        v5.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g8f43_b231 v0;
-        (v6.i256, v7.i1) = uaddo v4 v3;
-        br v7 block5 block6;
+        v7.i256 = mload v4 i256;
+        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_7303 v0 v7;
+        v9.i256 = mload v3 i256;
+        (v10.i256, v11.i1) = uaddo v9 v8;
+        br v11 block5 block6;
 
     block3:
         jump block4;
 
     block4:
-        v23.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_payload__g574e_a00c v0;
-        return v23;
+        v20.i256 = mload v4 i256;
+        v21.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f4af v0 v20;
+        return v21;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -415,193 +415,283 @@ func inline(always) private %core__lib__abi__decode_field__g7400_78ea(v0.objref<
         evm_revert 0.i256 36.i256;
 
     block6:
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_ac6c v0 v6;
-        v15.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_7113 v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_c4d0 v0 v15;
-        v17.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_payload__g574e_a00c v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_ac6c v0 v4;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_c4d0 v0 v5;
+        v18.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f4af v0 v10;
+        return v18;
+}
+
+func inline(always) private %impl_trait_BumpMover__decode_from__gd20d(v0.@layout_2, v1.i256) -> @layout_3 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v2 i256;
+        v6.i256 = call %core__lib__abi__decode_field_from__g5385_7f7d v0 v4 v5;
+        v7.objref<@layout_3> = obj.alloc @layout_3;
+        v9.objref<i256> = obj.proj v7 0.i256;
+        obj.store v9 v6;
+        v10.@layout_3 = obj.load v7;
+        return v10;
+}
+
+func inline(always) private %impl_trait_ReadViaHolder__decode_from__gd20d(v0.@layout_2, v1.i256) -> @layout_4 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v2 i256;
+        v6.i256 = call %core__lib__abi__decode_field_from__g5385_27c8 v0 v4 v5;
+        v7.objref<@layout_4> = obj.alloc @layout_4;
+        v9.objref<i256> = obj.proj v7 0.i256;
+        obj.store v9 v6;
+        v10.@layout_4 = obj.load v7;
+        return v10;
+}
+
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_a878(v0.@layout_2, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_9c31 v0 v4;
+        return v5;
+}
+
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f0a9(v0.@layout_2, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_950e v0 v4;
+        return v5;
+}
+
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f4af(v0.@layout_2, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_4e15 v0 v4;
+        return v5;
+}
+
+func inline(always) private %impl_trait_SeedSlot__decode_from__gd20d(v0.@layout_2, v1.i256) -> @layout_5 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v2 i256;
+        v6.i256 = call %core__lib__abi__decode_field_from__g5385_54a8 v0 v4 v5;
+        v7.i256 = mload v2 i256;
+        v8.i256 = mload v2 i256;
+        (v10.i256, v11.i1) = uaddo v8 32.i256;
+        br v11 block2 block3;
+
+    block2:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block3:
+        v19.i256 = call %core__lib__abi__decode_field_from__g5385_54a8 v0 v7 v10;
+        v20.objref<@layout_5> = obj.alloc @layout_5;
+        v22.objref<i256> = obj.proj v20 0.i256;
+        obj.store v22 v6;
+        v24.objref<i256> = obj.proj v20 1.i256;
+        obj.store v24 v19;
+        v25.@layout_5 = obj.load v20;
+        return v25;
+}
+
+func inline(always) private %decode_runtime_args__g5aad(v0.objref<@layout_7>) -> @layout_5 {
+    block0:
+        v1.*i256 = alloca i256;
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v5.@layout_2 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_dcd3;
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_960d v5;
+        mstore v1 v7 i256;
+        v8.i256 = mload v1 i256;
+        mstore v2 v8 i256;
+        v9.i256 = mload v2 i256;
+        v10.i1 = gt 4.i256 v9;
+        br v10 block2 block3;
+
+    block2:
+        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_9c1e;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        br 1.i1 block5 block6;
+
+    block5:
+        mstore v3 4.i256 i256;
+        br 0.i1 block8 block11;
+
+    block6:
+        jump block7;
+
+    block7:
+        v17.@layout_5 = call %impl_trait_SeedSlot__decode_from__gd20d v5 4.i256;
         return v17;
+
+    block8:
+        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_9c1e;
+        unreachable;
+
+    block9:
+        jump block10;
+
+    block10:
+        jump block7;
+
+    block11:
+        v18.i256 = mload v1 i256;
+        mstore v4 v18 i256;
+        v20.i256 = mload v4 i256;
+        v21.i1 = gt 68.i256 v20;
+        br v21 block8 block9;
 }
 
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_payload__g574e_324c(v0.objref<@layout_2>) -> i256 {
+func inline(always) private %decode_runtime_args__g01e9(v0.objref<@layout_7>) -> @layout_4 {
     block0:
-        jump block1;
-
-    block1:
-        v2.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_5f60 v0;
-        return v2;
-}
-
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_payload__g574e_4028(v0.objref<@layout_2>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_a802 v0;
-        return v2;
-}
-
-func inline(always) private %impl_trait_BumpMover__decode_payload__g3a69(v0.objref<@layout_2>) -> @layout_5 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.i256 = call %core__lib__abi__decode_field__g7400_709e v0;
-        v3.objref<@layout_5> = obj.alloc @layout_5;
-        v5.objref<i256> = obj.proj v3 0.i256;
-        obj.store v5 v2;
-        v6.@layout_5 = obj.load v3;
-        return v6;
-}
-
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_payload__g574e_a00c(v0.objref<@layout_2>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_7344 v0;
-        return v2;
-}
-
-func inline(always) private %impl_trait_ReadViaHolder__decode_payload__g3a69(v0.objref<@layout_2>) -> @layout_6 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.i256 = call %core__lib__abi__decode_field__g7400_78ea v0;
-        v3.objref<@layout_6> = obj.alloc @layout_6;
-        v5.objref<i256> = obj.proj v3 0.i256;
-        obj.store v5 v2;
-        v6.@layout_6 = obj.load v3;
-        return v6;
-}
-
-func inline(always) private %impl_trait_SeedSlot__decode_payload__g3a69(v0.objref<@layout_2>) -> @layout_7 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.i256 = call %core__lib__abi__decode_field__g7400_6974 v0;
-        v3.i256 = call %core__lib__abi__decode_field__g7400_6974 v0;
-        v4.objref<@layout_7> = obj.alloc @layout_7;
-        v6.objref<i256> = obj.proj v4 0.i256;
-        obj.store v6 v2;
-        v8.objref<i256> = obj.proj v4 1.i256;
-        obj.store v8 v3;
-        v9.@layout_7 = obj.load v4;
-        return v9;
-}
-
-func inline(always) private %decode_runtime_args__g5aad(v0.objref<@layout_9>) -> @layout_7 {
-    block0:
-        jump block1;
-
-    block1:
-        v1.@layout_2 = call %core__lib__contracts__trait_ContractHost__runtime_decoder__g736d_220a;
-        v2.objref<@layout_2> = obj.alloc @layout_2;
-        v4.objref<@layout_1> = obj.proj v2 0.i256;
-        v5.@layout_1 = extract_value v1 0.i256;
-        v6.objref<@layout_0> = obj.proj v4 0.i256;
-        v7.@layout_0 = extract_value v5 0.i256;
-        v8.objref<i256> = obj.proj v6 0.i256;
-        v9.i256 = extract_value v7 0.i256;
-        obj.store v8 v9;
-        v11.objref<i256> = obj.proj v4 1.i256;
-        v12.i256 = extract_value v5 1.i256;
-        obj.store v11 v12;
-        v13.objref<i256> = obj.proj v2 1.i256;
-        v14.i256 = extract_value v1 1.i256;
-        obj.store v13 v14;
-        v15.@layout_7 = call %impl_trait_SeedSlot__decode_payload__g3a69 v2;
-        return v15;
-}
-
-func inline(always) private %decode_runtime_args__g01e9(v0.objref<@layout_9>) -> @layout_6 {
-    block0:
-        jump block1;
-
-    block1:
-        v1.@layout_2 = call %core__lib__contracts__trait_ContractHost__runtime_decoder__g736d_b8e4;
-        v2.objref<@layout_2> = obj.alloc @layout_2;
-        v4.objref<@layout_1> = obj.proj v2 0.i256;
-        v5.@layout_1 = extract_value v1 0.i256;
-        v6.objref<@layout_0> = obj.proj v4 0.i256;
-        v7.@layout_0 = extract_value v5 0.i256;
-        v8.objref<i256> = obj.proj v6 0.i256;
-        v9.i256 = extract_value v7 0.i256;
-        obj.store v8 v9;
-        v11.objref<i256> = obj.proj v4 1.i256;
-        v12.i256 = extract_value v5 1.i256;
-        obj.store v11 v12;
-        v13.objref<i256> = obj.proj v2 1.i256;
-        v14.i256 = extract_value v1 1.i256;
-        obj.store v13 v14;
-        v15.@layout_6 = call %impl_trait_ReadViaHolder__decode_payload__g3a69 v2;
-        return v15;
-}
-
-func inline(always) private %decode_runtime_args__g0392(v0.objref<@layout_9>) -> @layout_5 {
-    block0:
-        jump block1;
-
-    block1:
-        v1.@layout_2 = call %core__lib__contracts__trait_ContractHost__runtime_decoder__g736d_d80d;
-        v2.objref<@layout_2> = obj.alloc @layout_2;
-        v4.objref<@layout_1> = obj.proj v2 0.i256;
-        v5.@layout_1 = extract_value v1 0.i256;
-        v6.objref<@layout_0> = obj.proj v4 0.i256;
-        v7.@layout_0 = extract_value v5 0.i256;
-        v8.objref<i256> = obj.proj v6 0.i256;
-        v9.i256 = extract_value v7 0.i256;
-        obj.store v8 v9;
-        v11.objref<i256> = obj.proj v4 1.i256;
-        v12.i256 = extract_value v5 1.i256;
-        obj.store v11 v12;
-        v13.objref<i256> = obj.proj v2 1.i256;
-        v14.i256 = extract_value v1 1.i256;
-        obj.store v13 v14;
-        v15.@layout_5 = call %impl_trait_BumpMover__decode_payload__g3a69 v2;
-        return v15;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decoder_with_base__gd20d_2ee7(v0.@layout_0, v1.i256) -> @layout_2 {
-    block0:
+        v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v5.@layout_2 = call %std__lib__abi__sol__impl_SolDecoder_113c__with_base__gd20d_19fc v0 v3;
-        return v5;
+        v5.@layout_2 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_c5c0;
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_f59a v5;
+        mstore v1 v7 i256;
+        v8.i256 = mload v1 i256;
+        mstore v2 v8 i256;
+        v9.i256 = mload v2 i256;
+        v10.i1 = gt 4.i256 v9;
+        br v10 block2 block3;
+
+    block2:
+        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_ffa6;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        br 1.i1 block5 block6;
+
+    block5:
+        mstore v3 4.i256 i256;
+        br 0.i1 block8 block11;
+
+    block6:
+        jump block7;
+
+    block7:
+        v17.@layout_4 = call %impl_trait_ReadViaHolder__decode_from__gd20d v5 4.i256;
+        return v17;
+
+    block8:
+        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_ffa6;
+        unreachable;
+
+    block9:
+        jump block10;
+
+    block10:
+        jump block7;
+
+    block11:
+        v18.i256 = mload v1 i256;
+        mstore v4 v18 i256;
+        v20.i256 = mload v4 i256;
+        v21.i1 = gt 36.i256 v20;
+        br v21 block8 block9;
 }
 
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decoder_with_base__gd20d_5160(v0.@layout_0, v1.i256) -> @layout_2 {
+func inline(always) private %decode_runtime_args__g0392(v0.objref<@layout_7>) -> @layout_3 {
     block0:
+        v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v5.@layout_2 = call %std__lib__abi__sol__impl_SolDecoder_113c__with_base__gd20d_8747 v0 v3;
-        return v5;
+        v5.@layout_2 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_0e8a;
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_4133 v5;
+        mstore v1 v7 i256;
+        v8.i256 = mload v1 i256;
+        mstore v2 v8 i256;
+        v9.i256 = mload v2 i256;
+        v10.i1 = gt 4.i256 v9;
+        br v10 block2 block3;
+
+    block2:
+        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_4c56;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        br 1.i1 block5 block6;
+
+    block5:
+        mstore v3 4.i256 i256;
+        br 0.i1 block8 block11;
+
+    block6:
+        jump block7;
+
+    block7:
+        v17.@layout_3 = call %impl_trait_BumpMover__decode_from__gd20d v5 4.i256;
+        return v17;
+
+    block8:
+        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_4c56;
+        unreachable;
+
+    block9:
+        jump block10;
+
+    block10:
+        jump block7;
+
+    block11:
+        v18.i256 = mload v1 i256;
+        mstore v4 v18 i256;
+        v20.i256 = mload v4 i256;
+        v21.i1 = gt 36.i256 v20;
+        br v21 block8 block9;
 }
 
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decoder_with_base__gd20d_88be(v0.@layout_0, v1.i256) -> @layout_2 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v5.@layout_2 = call %std__lib__abi__sol__impl_SolDecoder_113c__with_base__gd20d_9476 v0 v3;
-        return v5;
-}
-
-func private %encode(v0.i256, v1.objref<@layout_3>) {
+func private %encode(v0.i256, v1.objref<@layout_0>) {
     block0:
         jump block1;
 
@@ -610,7 +700,7 @@ func private %encode(v0.i256, v1.objref<@layout_3>) {
         return;
 }
 
-func private %encode_field(v0.i256, v1.objref<@layout_3>, v2.i256) {
+func private %encode_field(v0.i256, v1.objref<@layout_0>, v2.i256) {
     block0:
         jump block1;
 
@@ -618,19 +708,19 @@ func private %encode_field(v0.i256, v1.objref<@layout_3>, v2.i256) {
         br 0.i1 block2 block3;
 
     block2:
-        v5.i256 = call %impl_trait_SolEncoder__base v1;
+        v5.i256 = call %base v1;
         v8.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_a8bc v0;
         v9.i256 = mload v2 i256;
         v10.i256 = sub v9 v5;
         call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_8a50 v1 v10;
-        v12.i256 = call %impl_trait_SolEncoder__pos v1;
+        v12.i256 = call %pos v1;
         v13.i256 = mload v2 i256;
-        call %impl_trait_SolEncoder__set_base v1 v13;
+        call %set_base v1 v13;
         v15.i256 = mload v2 i256;
-        call %impl_trait_SolEncoder__set_pos v1 v15;
+        call %set_pos v1 v15;
         call %encode v0 v1;
-        call %impl_trait_SolEncoder__set_base v1 v5;
-        call %impl_trait_SolEncoder__set_pos v1 v12;
+        call %set_base v1 v5;
+        call %set_pos v1 v12;
         v20.i256 = mload v2 i256;
         v21.i256 = add v20 v8;
         mstore v2 v21 i256;
@@ -643,10 +733,10 @@ func private %encode_field(v0.i256, v1.objref<@layout_3>, v2.i256) {
         br 1.i1 block5 block6;
 
     block5:
-        v24.i256 = call %impl_trait_SolEncoder__pos v1;
+        v24.i256 = call %pos v1;
         call %encode_to_ptr v0 v24;
         v28.i256 = add v24 32.i256;
-        call %impl_trait_SolEncoder__set_pos v1 v28;
+        call %set_pos v1 v28;
         return;
 
     block6:
@@ -657,13 +747,13 @@ func private %encode_field(v0.i256, v1.objref<@layout_3>, v2.i256) {
         return;
 }
 
-func private %encode_single_root(v0.i256, v1.objref<@layout_3>) {
+func private %encode_single_root(v0.i256, v1.objref<@layout_0>) {
     block0:
         v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v4.i256 = call %impl_trait_SolEncoder__base v1;
+        v4.i256 = call %base v1;
         v6.i256 = add v4 32.i256;
         mstore v2 v6 i256;
         v7.i256 = ptr_to_int v2 i256;
@@ -671,28 +761,28 @@ func private %encode_single_root(v0.i256, v1.objref<@layout_3>) {
         return;
 }
 
-func private %encode_single_root_alloc(v0.i256) -> @layout_10 {
+func private %encode_single_root_alloc(v0.i256) -> @layout_8 {
     block0:
         jump block1;
 
     block1:
         v2.i256 = call %abi_single_root_size v0;
-        v3.@layout_3 = call %encoder_new v2;
-        v4.objref<@layout_3> = obj.alloc @layout_3;
+        v3.@layout_0 = call %encoder_new v2;
+        v4.objref<@layout_0> = obj.alloc @layout_0;
         v6.objref<i256> = obj.proj v4 0.i256;
         v7.i256 = extract_value v3 0.i256;
         obj.store v6 v7;
         v9.objref<i256> = obj.proj v4 1.i256;
         v10.i256 = extract_value v3 1.i256;
         obj.store v9 v10;
-        v11.i256 = call %impl_trait_SolEncoder__base v4;
+        v11.i256 = call %base v4;
         call %encode_single_root v0 v4;
-        v13.objref<@layout_10> = obj.alloc @layout_10;
+        v13.objref<@layout_8> = obj.alloc @layout_8;
         v14.objref<i256> = obj.proj v13 0.i256;
         obj.store v14 v11;
         v15.objref<i256> = obj.proj v13 1.i256;
         obj.store v15 v2;
-        v16.@layout_10 = obj.load v13;
+        v16.@layout_8 = obj.load v13;
         return v16;
 }
 
@@ -708,7 +798,7 @@ func private %encode_to_ptr(v0.i256, v1.i256) {
         return;
 }
 
-func private %encoder_new(v0.i256) -> @layout_3 {
+func private %encoder_new(v0.i256) -> @layout_0 {
     block0:
         v1.*i256 = alloca i256;
         mstore v1 v0 i256;
@@ -716,13 +806,13 @@ func private %encoder_new(v0.i256) -> @layout_3 {
 
     block1:
         v2.i256 = mload v1 i256;
-        v3.@layout_3 = call %impl_SolEncoder__new v2;
+        v3.@layout_0 = call %impl_SolEncoder__new v2;
         return v3;
 }
 
-func private %extract_ptr(v0.@layout_11) -> i256 {
+func private %extract_ptr(v0.@layout_9) -> i256 {
     block0:
-        v1.objref<@layout_11> = obj.alloc @layout_11;
+        v1.objref<@layout_9> = obj.alloc @layout_9;
         v3.objref<i256> = obj.proj v1 0.i256;
         v4.i256 = extract_value v0 0.i256;
         obj.store v3 v4;
@@ -737,66 +827,6 @@ func private %extract_ptr(v0.@layout_11) -> i256 {
         return v9;
 }
 
-func inline(always) private %core__lib__abi__impl_Cursor_1a04__fork__gd20d_04a5(v0.@layout_1, v1.i256) -> @layout_1 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v5.@layout_0 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.objref<@layout_1> = obj.alloc @layout_1;
-        v8.objref<@layout_0> = obj.proj v7 0.i256;
-        v9.objref<i256> = obj.proj v8 0.i256;
-        v10.i256 = extract_value v5 0.i256;
-        obj.store v9 v10;
-        v12.objref<i256> = obj.proj v7 1.i256;
-        obj.store v12 v6;
-        v13.@layout_1 = obj.load v7;
-        return v13;
-}
-
-func inline(always) private %core__lib__abi__impl_Cursor_1a04__fork__gd20d_3c6b(v0.@layout_1, v1.i256) -> @layout_1 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v5.@layout_0 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.objref<@layout_1> = obj.alloc @layout_1;
-        v8.objref<@layout_0> = obj.proj v7 0.i256;
-        v9.objref<i256> = obj.proj v8 0.i256;
-        v10.i256 = extract_value v5 0.i256;
-        obj.store v9 v10;
-        v12.objref<i256> = obj.proj v7 1.i256;
-        obj.store v12 v6;
-        v13.@layout_1 = obj.load v7;
-        return v13;
-}
-
-func inline(always) private %core__lib__abi__impl_Cursor_1a04__fork__gd20d_e634(v0.@layout_1, v1.i256) -> @layout_1 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v5.@layout_0 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.objref<@layout_1> = obj.alloc @layout_1;
-        v8.objref<@layout_0> = obj.proj v7 0.i256;
-        v9.objref<i256> = obj.proj v8 0.i256;
-        v10.i256 = extract_value v5 0.i256;
-        obj.store v9 v10;
-        v12.objref<i256> = obj.proj v7 1.i256;
-        obj.store v12 v6;
-        v13.@layout_1 = obj.load v7;
-        return v13;
-}
-
 func private %from_raw(v0.i256) -> i256 {
     block0:
         v1.*i256 = alloca i256;
@@ -808,34 +838,34 @@ func private %from_raw(v0.i256) -> i256 {
         return v2;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_47a6() -> @layout_0 {
+func private %std__lib__evm__effects__impl_trait_Evm_c913__input_0e8a() -> @layout_2 {
     block0:
         jump block1;
 
     block1:
-        v0.@layout_0 = call %std__lib__evm__calldata__impl_CallData_8f43__new_39f2;
+        v0.@layout_2 = call %std__lib__evm__calldata__impl_CallData_8f43__new_ac71;
         return v0;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_c8ef() -> @layout_0 {
+func private %std__lib__evm__effects__impl_trait_Evm_c913__input_c5c0() -> @layout_2 {
     block0:
         jump block1;
 
     block1:
-        v0.@layout_0 = call %std__lib__evm__calldata__impl_CallData_8f43__new_4b95;
+        v0.@layout_2 = call %std__lib__evm__calldata__impl_CallData_8f43__new_e145;
         return v0;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_ca13() -> @layout_0 {
+func private %std__lib__evm__effects__impl_trait_Evm_c913__input_dcd3() -> @layout_2 {
     block0:
         jump block1;
 
     block1:
-        v0.@layout_0 = call %std__lib__evm__calldata__impl_CallData_8f43__new_2037;
+        v0.@layout_2 = call %std__lib__evm__calldata__impl_CallData_8f43__new_0a05;
         return v0;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_130b(v0.objref<@layout_0>) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_4133(v0.@layout_2) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
@@ -844,27 +874,25 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
     block1:
         v3.i256 = evm_calldata_size;
         mstore v1 v3 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        v7.i256 = obj.load v6;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt v7 v9;
-        br v10 block2 block3;
+        v6.i256 = extract_value v0 0.i256;
+        v7.i256 = mload v1 i256;
+        mstore v2 v7 i256;
+        v8.i256 = mload v2 i256;
+        v9.i1 = gt v6 v8;
+        br v9 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v12.objref<i256> = obj.proj v0 0.i256;
-        v13.i256 = obj.load v12;
-        v14.i256 = mload v1 i256;
-        (v15.i256, v16.i1) = usubo v14 v13;
-        br v16 block5 block6;
+        v11.i256 = extract_value v0 0.i256;
+        v12.i256 = mload v1 i256;
+        (v13.i256, v14.i1) = usubo v12 v11;
+        br v14 block5 block6;
 
     block4:
-        v21.i256 = phi (0.i256 block2) (v15 block6);
-        return v21;
+        v19.i256 = phi (0.i256 block2) (v13 block6);
+        return v19;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -875,7 +903,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         jump block4;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_5a16(v0.objref<@layout_0>) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_960d(v0.@layout_2) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
@@ -884,27 +912,25 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
     block1:
         v3.i256 = evm_calldata_size;
         mstore v1 v3 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        v7.i256 = obj.load v6;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt v7 v9;
-        br v10 block2 block3;
+        v6.i256 = extract_value v0 0.i256;
+        v7.i256 = mload v1 i256;
+        mstore v2 v7 i256;
+        v8.i256 = mload v2 i256;
+        v9.i1 = gt v6 v8;
+        br v9 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v12.objref<i256> = obj.proj v0 0.i256;
-        v13.i256 = obj.load v12;
-        v14.i256 = mload v1 i256;
-        (v15.i256, v16.i1) = usubo v14 v13;
-        br v16 block5 block6;
+        v11.i256 = extract_value v0 0.i256;
+        v12.i256 = mload v1 i256;
+        (v13.i256, v14.i1) = usubo v12 v11;
+        br v14 block5 block6;
 
     block4:
-        v21.i256 = phi (0.i256 block2) (v15 block6);
-        return v21;
+        v19.i256 = phi (0.i256 block2) (v13 block6);
+        return v19;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -915,7 +941,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         jump block4;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_657a(v0.objref<@layout_0>) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_f59a(v0.@layout_2) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
@@ -924,27 +950,25 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
     block1:
         v3.i256 = evm_calldata_size;
         mstore v1 v3 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        v7.i256 = obj.load v6;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt v7 v9;
-        br v10 block2 block3;
+        v6.i256 = extract_value v0 0.i256;
+        v7.i256 = mload v1 i256;
+        mstore v2 v7 i256;
+        v8.i256 = mload v2 i256;
+        v9.i1 = gt v6 v8;
+        br v9 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v12.objref<i256> = obj.proj v0 0.i256;
-        v13.i256 = obj.load v12;
-        v14.i256 = mload v1 i256;
-        (v15.i256, v16.i1) = usubo v14 v13;
-        br v16 block5 block6;
+        v11.i256 = extract_value v0 0.i256;
+        v12.i256 = mload v1 i256;
+        (v13.i256, v14.i1) = usubo v12 v11;
+        br v14 block5 block6;
 
     block4:
-        v21.i256 = phi (0.i256 block2) (v15 block6);
-        return v21;
+        v19.i256 = phi (0.i256 block2) (v13 block6);
+        return v19;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -955,139 +979,19 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         jump block4;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_7768(v0.objref<@layout_0>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        v7.i256 = obj.load v6;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt v7 v9;
-        br v10 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v12.objref<i256> = obj.proj v0 0.i256;
-        v13.i256 = obj.load v12;
-        v14.i256 = mload v1 i256;
-        (v15.i256, v16.i1) = usubo v14 v13;
-        br v16 block5 block6;
-
-    block4:
-        v21.i256 = phi (0.i256 block2) (v15 block6);
-        return v21;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_a028(v0.objref<@layout_0>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        v7.i256 = obj.load v6;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt v7 v9;
-        br v10 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v12.objref<i256> = obj.proj v0 0.i256;
-        v13.i256 = obj.load v12;
-        v14.i256 = mload v1 i256;
-        (v15.i256, v16.i1) = usubo v14 v13;
-        br v16 block5 block6;
-
-    block4:
-        v21.i256 = phi (0.i256 block2) (v15 block6);
-        return v21;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_d49e(v0.objref<@layout_0>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        v7.i256 = obj.load v6;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt v7 v9;
-        br v10 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v12.objref<i256> = obj.proj v0 0.i256;
-        v13.i256 = obj.load v12;
-        v14.i256 = mload v1 i256;
-        (v15.i256, v16.i1) = usubo v14 v13;
-        br v16 block5 block6;
-
-    block4:
-        v21.i256 = phi (0.i256 block2) (v15 block6);
-        return v21;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_2037() -> @layout_0 {
+func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_0a05() -> @layout_2 {
     block0:
         jump block1;
 
     block1:
-        v1.constref<@layout_0> = const.ref $const_region_0;
-        v2.objref<@layout_0> = obj.alloc @layout_0;
+        v1.constref<@layout_2> = const.ref $const_region_0;
+        v2.objref<@layout_2> = obj.alloc @layout_2;
         obj.init.const v2 v1;
-        v3.@layout_0 = obj.load v2;
+        v3.@layout_2 = obj.load v2;
         return v3;
 }
 
-func private %impl_SolEncoder__new(v0.i256) -> @layout_3 {
+func private %impl_SolEncoder__new(v0.i256) -> @layout_0 {
     block0:
         v1.*i256 = alloca i256;
         mstore v1 v0 i256;
@@ -1109,85 +1013,37 @@ func private %impl_SolEncoder__new(v0.i256) -> @layout_3 {
 
     block4:
         v8.i256 = phi (0.i256 block2) (v7 block3);
-        v9.objref<@layout_3> = obj.alloc @layout_3;
+        v9.objref<@layout_0> = obj.alloc @layout_0;
         v10.objref<i256> = obj.proj v9 0.i256;
         obj.store v10 v8;
         v12.objref<i256> = obj.proj v9 1.i256;
         obj.store v12 v8;
-        v13.@layout_3 = obj.load v9;
+        v13.@layout_0 = obj.load v9;
         return v13;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_39f2() -> @layout_0 {
+func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_ac71() -> @layout_2 {
     block0:
         jump block1;
 
     block1:
-        v1.constref<@layout_0> = const.ref $const_region_0;
-        v2.objref<@layout_0> = obj.alloc @layout_0;
+        v1.constref<@layout_2> = const.ref $const_region_0;
+        v2.objref<@layout_2> = obj.alloc @layout_2;
         obj.init.const v2 v1;
-        v3.@layout_0 = obj.load v2;
+        v3.@layout_2 = obj.load v2;
         return v3;
 }
 
-func inline(always) private %core__lib__abi__impl_Cursor_1a04__new__gd20d_4886(v0.@layout_0) -> @layout_1 {
+func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_e145() -> @layout_2 {
     block0:
         jump block1;
 
     block1:
-        v2.objref<@layout_1> = obj.alloc @layout_1;
-        v4.objref<@layout_0> = obj.proj v2 0.i256;
-        v5.objref<i256> = obj.proj v4 0.i256;
-        v6.i256 = extract_value v0 0.i256;
-        obj.store v5 v6;
-        v8.objref<i256> = obj.proj v2 1.i256;
-        obj.store v8 0.i256;
-        v9.@layout_1 = obj.load v2;
-        return v9;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_4b95() -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v1.constref<@layout_0> = const.ref $const_region_0;
-        v2.objref<@layout_0> = obj.alloc @layout_0;
+        v1.constref<@layout_2> = const.ref $const_region_0;
+        v2.objref<@layout_2> = obj.alloc @layout_2;
         obj.init.const v2 v1;
-        v3.@layout_0 = obj.load v2;
+        v3.@layout_2 = obj.load v2;
         return v3;
-}
-
-func inline(always) private %core__lib__abi__impl_Cursor_1a04__new__gd20d_70f0(v0.@layout_0) -> @layout_1 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.objref<@layout_1> = obj.alloc @layout_1;
-        v4.objref<@layout_0> = obj.proj v2 0.i256;
-        v5.objref<i256> = obj.proj v4 0.i256;
-        v6.i256 = extract_value v0 0.i256;
-        obj.store v5 v6;
-        v8.objref<i256> = obj.proj v2 1.i256;
-        obj.store v8 0.i256;
-        v9.@layout_1 = obj.load v2;
-        return v9;
-}
-
-func inline(always) private %core__lib__abi__impl_Cursor_1a04__new__gd20d_d24a(v0.@layout_0) -> @layout_1 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.objref<@layout_1> = obj.alloc @layout_1;
-        v4.objref<@layout_0> = obj.proj v2 0.i256;
-        v5.objref<i256> = obj.proj v4 0.i256;
-        v6.i256 = extract_value v0 0.i256;
-        obj.store v5 v6;
-        v8.objref<i256> = obj.proj v2 1.i256;
-        obj.store v8 0.i256;
-        v9.@layout_1 = obj.load v2;
-        return v9;
 }
 
 func private %core__lib__abi__trait_AbiSize__payload_size__ge513_a8bc(v0.i256) -> i256 {
@@ -1210,18 +1066,7 @@ func private %core__lib__abi__trait_AbiSize__payload_size__ge513_a8bc_0(v0.i256)
         return 32.i256;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g8f43_0d04(v0.objref<@layout_2>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<@layout_1> = obj.proj v0 0.i256;
-        v5.objref<i256> = obj.proj v3 1.i256;
-        v6.i256 = obj.load v5;
-        return v6;
-}
-
-func private %impl_trait_SolEncoder__pos(v0.objref<@layout_3>) -> i256 {
+func private %pos(v0.objref<@layout_0>) -> i256 {
     block0:
         jump block1;
 
@@ -1229,28 +1074,6 @@ func private %impl_trait_SolEncoder__pos(v0.objref<@layout_3>) -> i256 {
         v3.objref<i256> = obj.proj v0 1.i256;
         v4.i256 = obj.load v3;
         return v4;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g8f43_868e(v0.objref<@layout_2>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<@layout_1> = obj.proj v0 0.i256;
-        v5.objref<i256> = obj.proj v3 1.i256;
-        v6.i256 = obj.load v5;
-        return v6;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g8f43_b231(v0.objref<@layout_2>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<@layout_1> = obj.proj v0 0.i256;
-        v5.objref<i256> = obj.proj v3 1.i256;
-        v6.i256 = obj.load v5;
-        return v6;
 }
 
 func private %read_cell(v0.i256) -> i256 {
@@ -1262,429 +1085,49 @@ func private %read_cell(v0.i256) -> i256 {
         return v2;
 }
 
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_3710(v0.objref<@layout_2>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v5.objref<@layout_1> = obj.proj v0 0.i256;
-        v6.objref<@layout_0> = obj.proj v5 0.i256;
-        v7.@layout_0 = obj.load v6;
-        v8.objref<@layout_1> = obj.proj v0 0.i256;
-        v9.objref<@layout_0> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_5a16 v9;
-        mstore v1 v10 i256;
-        v11.objref<@layout_1> = obj.proj v0 0.i256;
-        v13.objref<i256> = obj.proj v11 1.i256;
-        v14.i256 = obj.load v13;
-        (v16.i256, v17.i1) = uaddo v14 32.i256;
-        br v17 block6 block7;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v28.objref<@layout_1> = obj.proj v0 0.i256;
-        v29.objref<@layout_0> = obj.proj v28 0.i256;
-        v30.@layout_0 = obj.load v29;
-        v31.objref<@layout_1> = obj.proj v0 0.i256;
-        v32.objref<i256> = obj.proj v31 1.i256;
-        v33.i256 = obj.load v32;
-        v34.objref<@layout_1> = obj.proj v0 0.i256;
-        v35.objref<@layout_0> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_da20 v35 v33;
-        v38.objref<@layout_1> = obj.proj v0 0.i256;
-        v39.objref<i256> = obj.proj v38 1.i256;
-        obj.store v39 v16;
-        return v36;
-
-    block5:
-        v40.i256 = mload v1 i256;
-        mstore v2 v40 i256;
-        v42.i256 = mload v2 i256;
-        v43.i1 = gt v16 v42;
-        br v43 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v23.objref<@layout_1> = obj.proj v0 0.i256;
-        v24.objref<i256> = obj.proj v23 1.i256;
-        v25.i256 = obj.load v24;
-        v26.i1 = lt v16 v25;
-        br v26 block2 block5;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_5f60(v0.objref<@layout_2>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v5.objref<@layout_1> = obj.proj v0 0.i256;
-        v6.objref<@layout_0> = obj.proj v5 0.i256;
-        v7.@layout_0 = obj.load v6;
-        v8.objref<@layout_1> = obj.proj v0 0.i256;
-        v9.objref<@layout_0> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_a028 v9;
-        mstore v1 v10 i256;
-        v11.objref<@layout_1> = obj.proj v0 0.i256;
-        v13.objref<i256> = obj.proj v11 1.i256;
-        v14.i256 = obj.load v13;
-        (v16.i256, v17.i1) = uaddo v14 32.i256;
-        br v17 block6 block7;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v28.objref<@layout_1> = obj.proj v0 0.i256;
-        v29.objref<@layout_0> = obj.proj v28 0.i256;
-        v30.@layout_0 = obj.load v29;
-        v31.objref<@layout_1> = obj.proj v0 0.i256;
-        v32.objref<i256> = obj.proj v31 1.i256;
-        v33.i256 = obj.load v32;
-        v34.objref<@layout_1> = obj.proj v0 0.i256;
-        v35.objref<@layout_0> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b133 v35 v33;
-        v38.objref<@layout_1> = obj.proj v0 0.i256;
-        v39.objref<i256> = obj.proj v38 1.i256;
-        obj.store v39 v16;
-        return v36;
-
-    block5:
-        v40.i256 = mload v1 i256;
-        mstore v2 v40 i256;
-        v42.i256 = mload v2 i256;
-        v43.i1 = gt v16 v42;
-        br v43 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v23.objref<@layout_1> = obj.proj v0 0.i256;
-        v24.objref<i256> = obj.proj v23 1.i256;
-        v25.i256 = obj.load v24;
-        v26.i1 = lt v16 v25;
-        br v26 block2 block5;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_7344(v0.objref<@layout_2>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v5.objref<@layout_1> = obj.proj v0 0.i256;
-        v6.objref<@layout_0> = obj.proj v5 0.i256;
-        v7.@layout_0 = obj.load v6;
-        v8.objref<@layout_1> = obj.proj v0 0.i256;
-        v9.objref<@layout_0> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_657a v9;
-        mstore v1 v10 i256;
-        v11.objref<@layout_1> = obj.proj v0 0.i256;
-        v13.objref<i256> = obj.proj v11 1.i256;
-        v14.i256 = obj.load v13;
-        (v16.i256, v17.i1) = uaddo v14 32.i256;
-        br v17 block6 block7;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v28.objref<@layout_1> = obj.proj v0 0.i256;
-        v29.objref<@layout_0> = obj.proj v28 0.i256;
-        v30.@layout_0 = obj.load v29;
-        v31.objref<@layout_1> = obj.proj v0 0.i256;
-        v32.objref<i256> = obj.proj v31 1.i256;
-        v33.i256 = obj.load v32;
-        v34.objref<@layout_1> = obj.proj v0 0.i256;
-        v35.objref<@layout_0> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_2e7e v35 v33;
-        v38.objref<@layout_1> = obj.proj v0 0.i256;
-        v39.objref<i256> = obj.proj v38 1.i256;
-        obj.store v39 v16;
-        return v36;
-
-    block5:
-        v40.i256 = mload v1 i256;
-        mstore v2 v40 i256;
-        v42.i256 = mload v2 i256;
-        v43.i1 = gt v16 v42;
-        br v43 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v23.objref<@layout_1> = obj.proj v0 0.i256;
-        v24.objref<i256> = obj.proj v23 1.i256;
-        v25.i256 = obj.load v24;
-        v26.i1 = lt v16 v25;
-        br v26 block2 block5;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_9a89(v0.objref<@layout_2>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v5.objref<@layout_1> = obj.proj v0 0.i256;
-        v6.objref<@layout_0> = obj.proj v5 0.i256;
-        v7.@layout_0 = obj.load v6;
-        v8.objref<@layout_1> = obj.proj v0 0.i256;
-        v9.objref<@layout_0> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_7768 v9;
-        mstore v1 v10 i256;
-        v11.objref<@layout_1> = obj.proj v0 0.i256;
-        v13.objref<i256> = obj.proj v11 1.i256;
-        v14.i256 = obj.load v13;
-        (v16.i256, v17.i1) = uaddo v14 32.i256;
-        br v17 block6 block7;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v28.objref<@layout_1> = obj.proj v0 0.i256;
-        v29.objref<@layout_0> = obj.proj v28 0.i256;
-        v30.@layout_0 = obj.load v29;
-        v31.objref<@layout_1> = obj.proj v0 0.i256;
-        v32.objref<i256> = obj.proj v31 1.i256;
-        v33.i256 = obj.load v32;
-        v34.objref<@layout_1> = obj.proj v0 0.i256;
-        v35.objref<@layout_0> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_d1f9 v35 v33;
-        v38.objref<@layout_1> = obj.proj v0 0.i256;
-        v39.objref<i256> = obj.proj v38 1.i256;
-        obj.store v39 v16;
-        return v36;
-
-    block5:
-        v40.i256 = mload v1 i256;
-        mstore v2 v40 i256;
-        v42.i256 = mload v2 i256;
-        v43.i1 = gt v16 v42;
-        br v43 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v23.objref<@layout_1> = obj.proj v0 0.i256;
-        v24.objref<i256> = obj.proj v23 1.i256;
-        v25.i256 = obj.load v24;
-        v26.i1 = lt v16 v25;
-        br v26 block2 block5;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_a802(v0.objref<@layout_2>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v5.objref<@layout_1> = obj.proj v0 0.i256;
-        v6.objref<@layout_0> = obj.proj v5 0.i256;
-        v7.@layout_0 = obj.load v6;
-        v8.objref<@layout_1> = obj.proj v0 0.i256;
-        v9.objref<@layout_0> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_d49e v9;
-        mstore v1 v10 i256;
-        v11.objref<@layout_1> = obj.proj v0 0.i256;
-        v13.objref<i256> = obj.proj v11 1.i256;
-        v14.i256 = obj.load v13;
-        (v16.i256, v17.i1) = uaddo v14 32.i256;
-        br v17 block6 block7;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v28.objref<@layout_1> = obj.proj v0 0.i256;
-        v29.objref<@layout_0> = obj.proj v28 0.i256;
-        v30.@layout_0 = obj.load v29;
-        v31.objref<@layout_1> = obj.proj v0 0.i256;
-        v32.objref<i256> = obj.proj v31 1.i256;
-        v33.i256 = obj.load v32;
-        v34.objref<@layout_1> = obj.proj v0 0.i256;
-        v35.objref<@layout_0> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_290f v35 v33;
-        v38.objref<@layout_1> = obj.proj v0 0.i256;
-        v39.objref<i256> = obj.proj v38 1.i256;
-        obj.store v39 v16;
-        return v36;
-
-    block5:
-        v40.i256 = mload v1 i256;
-        mstore v2 v40 i256;
-        v42.i256 = mload v2 i256;
-        v43.i1 = gt v16 v42;
-        br v43 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v23.objref<@layout_1> = obj.proj v0 0.i256;
-        v24.objref<i256> = obj.proj v23 1.i256;
-        v25.i256 = obj.load v24;
-        v26.i1 = lt v16 v25;
-        br v26 block2 block5;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_b395(v0.objref<@layout_2>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v5.objref<@layout_1> = obj.proj v0 0.i256;
-        v6.objref<@layout_0> = obj.proj v5 0.i256;
-        v7.@layout_0 = obj.load v6;
-        v8.objref<@layout_1> = obj.proj v0 0.i256;
-        v9.objref<@layout_0> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_130b v9;
-        mstore v1 v10 i256;
-        v11.objref<@layout_1> = obj.proj v0 0.i256;
-        v13.objref<i256> = obj.proj v11 1.i256;
-        v14.i256 = obj.load v13;
-        (v16.i256, v17.i1) = uaddo v14 32.i256;
-        br v17 block6 block7;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v28.objref<@layout_1> = obj.proj v0 0.i256;
-        v29.objref<@layout_0> = obj.proj v28 0.i256;
-        v30.@layout_0 = obj.load v29;
-        v31.objref<@layout_1> = obj.proj v0 0.i256;
-        v32.objref<i256> = obj.proj v31 1.i256;
-        v33.i256 = obj.load v32;
-        v34.objref<@layout_1> = obj.proj v0 0.i256;
-        v35.objref<@layout_0> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_1aee v35 v33;
-        v38.objref<@layout_1> = obj.proj v0 0.i256;
-        v39.objref<i256> = obj.proj v38 1.i256;
-        obj.store v39 v16;
-        return v36;
-
-    block5:
-        v40.i256 = mload v1 i256;
-        mstore v2 v40 i256;
-        v42.i256 = mload v2 i256;
-        v43.i1 = gt v16 v42;
-        br v43 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v23.objref<@layout_1> = obj.proj v0 0.i256;
-        v24.objref<i256> = obj.proj v23 1.i256;
-        v25.i256 = obj.load v24;
-        v26.i1 = lt v16 v25;
-        br v26 block2 block5;
-}
-
-func inline(always) private %core__lib__contracts__trait_ContractHost__runtime_decoder__g736d_220a() -> @layout_2 {
-    block0:
-        jump block1;
-
-    block1:
-        v0.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_47a6;
-        v2.@layout_2 = call %std__lib__abi__sol__impl_trait_Sol_1f5f__decoder_with_base__gd20d_5160 v0 4.i256;
-        return v2;
-}
-
-func inline(always) private %core__lib__contracts__trait_ContractHost__runtime_decoder__g736d_b8e4() -> @layout_2 {
-    block0:
-        jump block1;
-
-    block1:
-        v0.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_c8ef;
-        v2.@layout_2 = call %std__lib__abi__sol__impl_trait_Sol_1f5f__decoder_with_base__gd20d_2ee7 v0 4.i256;
-        return v2;
-}
-
-func inline(always) private %core__lib__contracts__trait_ContractHost__runtime_decoder__g736d_d80d() -> @layout_2 {
-    block0:
-        jump block1;
-
-    block1:
-        v0.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_ca13;
-        v2.@layout_2 = call %std__lib__abi__sol__impl_trait_Sol_1f5f__decoder_with_base__gd20d_88be v0 4.i256;
-        return v2;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_5248(v0.objref<@layout_2>, v1.i256) {
+func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_27e9(v0.i256, v1.i256) {
     block0:
         v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
+        v3.*i256 = alloca i256;
+        mstore v2 v0 i256;
+        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 1.i256;
-        obj.store v6 v3;
-        return;
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v3 i256;
+        evm_revert v4 v5;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_75a5(v0.objref<@layout_2>, v1.i256) {
+func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_a881(v0.i256, v1.i256) {
     block0:
         v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
+        v3.*i256 = alloca i256;
+        mstore v2 v0 i256;
+        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 1.i256;
-        obj.store v6 v3;
-        return;
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v3 i256;
+        evm_revert v4 v5;
 }
 
-func private %impl_trait_SolEncoder__set_base(v0.objref<@layout_3>, v1.i256) {
+func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_ba8b(v0.i256, v1.i256) {
+    block0:
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        mstore v2 v0 i256;
+        mstore v3 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v3 i256;
+        evm_revert v4 v5;
+}
+
+func private %set_base(v0.objref<@layout_0>, v1.i256) {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -1697,7 +1140,7 @@ func private %impl_trait_SolEncoder__set_base(v0.objref<@layout_3>, v1.i256) {
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_ac6c(v0.objref<@layout_2>, v1.i256) {
+func private %set_pos(v0.objref<@layout_0>, v1.i256) {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -1707,61 +1150,6 @@ func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_ac
         v3.i256 = mload v2 i256;
         v6.objref<i256> = obj.proj v0 1.i256;
         obj.store v6 v3;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_07fb(v0.objref<@layout_2>, v1.i256) {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<@layout_1> = obj.proj v0 0.i256;
-        v8.objref<i256> = obj.proj v6 1.i256;
-        obj.store v8 v3;
-        return;
-}
-
-func private %impl_trait_SolEncoder__set_pos(v0.objref<@layout_3>, v1.i256) {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 1.i256;
-        obj.store v6 v3;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_495b(v0.objref<@layout_2>, v1.i256) {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<@layout_1> = obj.proj v0 0.i256;
-        v8.objref<i256> = obj.proj v6 1.i256;
-        obj.store v8 v3;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_c4d0(v0.objref<@layout_2>, v1.i256) {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<@layout_1> = obj.proj v0 0.i256;
-        v8.objref<i256> = obj.proj v6 1.i256;
-        obj.store v8 v3;
         return;
 }
 
@@ -1792,175 +1180,88 @@ func private %store_word(v0.i256, v1.i256) {
         return;
 }
 
-func inline(always) private %std__lib__abi__sol__impl_SolDecoder_113c__with_base__gd20d_19fc(v0.@layout_0, v1.i256) -> @layout_2 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_4e15(v0.@layout_2, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.@layout_1 = call %core__lib__abi__impl_Cursor_1a04__new__gd20d_d24a v0;
-        v5.i256 = mload v2 i256;
-        v6.@layout_1 = call %core__lib__abi__impl_Cursor_1a04__fork__gd20d_04a5 v4 v5;
-        v7.i256 = mload v2 i256;
-        v8.objref<@layout_2> = obj.alloc @layout_2;
-        v10.objref<@layout_1> = obj.proj v8 0.i256;
-        v11.objref<@layout_0> = obj.proj v10 0.i256;
-        v12.@layout_0 = extract_value v6 0.i256;
-        v13.objref<i256> = obj.proj v11 0.i256;
-        v14.i256 = extract_value v12 0.i256;
-        obj.store v13 v14;
-        v16.objref<i256> = obj.proj v10 1.i256;
-        v17.i256 = extract_value v6 1.i256;
-        obj.store v16 v17;
-        v18.objref<i256> = obj.proj v8 1.i256;
-        obj.store v18 v7;
-        v19.@layout_2 = obj.load v8;
-        return v19;
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
 }
 
-func inline(always) private %std__lib__abi__sol__impl_SolDecoder_113c__with_base__gd20d_8747(v0.@layout_0, v1.i256) -> @layout_2 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_7303(v0.@layout_2, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.@layout_1 = call %core__lib__abi__impl_Cursor_1a04__new__gd20d_4886 v0;
-        v5.i256 = mload v2 i256;
-        v6.@layout_1 = call %core__lib__abi__impl_Cursor_1a04__fork__gd20d_3c6b v4 v5;
-        v7.i256 = mload v2 i256;
-        v8.objref<@layout_2> = obj.alloc @layout_2;
-        v10.objref<@layout_1> = obj.proj v8 0.i256;
-        v11.objref<@layout_0> = obj.proj v10 0.i256;
-        v12.@layout_0 = extract_value v6 0.i256;
-        v13.objref<i256> = obj.proj v11 0.i256;
-        v14.i256 = extract_value v12 0.i256;
-        obj.store v13 v14;
-        v16.objref<i256> = obj.proj v10 1.i256;
-        v17.i256 = extract_value v6 1.i256;
-        obj.store v16 v17;
-        v18.objref<i256> = obj.proj v8 1.i256;
-        obj.store v18 v7;
-        v19.@layout_2 = obj.load v8;
-        return v19;
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
 }
 
-func inline(always) private %std__lib__abi__sol__impl_SolDecoder_113c__with_base__gd20d_9476(v0.@layout_0, v1.i256) -> @layout_2 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_7c41(v0.@layout_2, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.@layout_1 = call %core__lib__abi__impl_Cursor_1a04__new__gd20d_70f0 v0;
-        v5.i256 = mload v2 i256;
-        v6.@layout_1 = call %core__lib__abi__impl_Cursor_1a04__fork__gd20d_e634 v4 v5;
-        v7.i256 = mload v2 i256;
-        v8.objref<@layout_2> = obj.alloc @layout_2;
-        v10.objref<@layout_1> = obj.proj v8 0.i256;
-        v11.objref<@layout_0> = obj.proj v10 0.i256;
-        v12.@layout_0 = extract_value v6 0.i256;
-        v13.objref<i256> = obj.proj v11 0.i256;
-        v14.i256 = extract_value v12 0.i256;
-        obj.store v13 v14;
-        v16.objref<i256> = obj.proj v10 1.i256;
-        v17.i256 = extract_value v6 1.i256;
-        obj.store v16 v17;
-        v18.objref<i256> = obj.proj v8 1.i256;
-        obj.store v18 v7;
-        v19.@layout_2 = obj.load v8;
-        return v19;
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_1aee(v0.objref<@layout_0>, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_950e(v0.@layout_2, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = evm_calldata_load v8;
-        return v9;
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_290f(v0.objref<@layout_0>, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_9c31(v0.@layout_2, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = evm_calldata_load v8;
-        return v9;
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_2e7e(v0.objref<@layout_0>, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_dee9(v0.@layout_2, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = evm_calldata_load v8;
-        return v9;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b133(v0.objref<@layout_0>, v1.i256) -> i256 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = evm_calldata_load v8;
-        return v9;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_d1f9(v0.objref<@layout_0>, v1.i256) -> i256 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = evm_calldata_load v8;
-        return v9;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_da20(v0.objref<@layout_0>, v1.i256) -> i256 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = evm_calldata_load v8;
-        return v9;
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
 }
 
 func private %write_cell(v0.i256, v1.i256) -> i256 {
@@ -1976,7 +1277,7 @@ func private %write_cell(v0.i256, v1.i256) -> i256 {
         return v5;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_2aa5(v0.objref<@layout_3>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_2aa5(v0.objref<@layout_0>, v1.i256) {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -1993,7 +1294,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_2aa5(v0
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_8a50(v0.objref<@layout_3>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_8a50(v0.objref<@layout_0>, v1.i256) {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;

--- a/crates/codegen/tests/fixtures/sonatina_ir/erc20.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/erc20.snap
@@ -7,31 +7,29 @@ target = "evm-ethereum-osaka"
 
 type @layout_0 = {i256};
 type @layout_1 = {i256, i256};
-type @layout_2 = {i256};
+type @layout_2 = {i256, i256};
 type @layout_3 = {@layout_2, i256};
 type @layout_4 = {@layout_3, i256};
-type @layout_5 = {i256, i256};
-type @layout_6 = {@layout_5, i256};
-type @layout_7 = {@layout_6, i256};
+type @layout_5 = {i256};
+type @layout_6 = {@layout_0, @layout_0};
+type @layout_7 = {@layout_0, i256};
 type @layout_8 = {@layout_0, i256};
-type @layout_9 = {@layout_0};
-type @layout_10 = {i256};
-type @layout_11 = {@layout_0, i256};
-type @layout_12 = {@layout_0, @layout_0, i256};
-type @layout_13 = {@layout_0, i256};
+type @layout_9 = {i256};
+type @layout_10 = {@layout_0, i256};
+type @layout_11 = {@layout_0};
+type @layout_12 = {@layout_0, i256};
+type @layout_13 = {@layout_0, @layout_0, i256};
 type @layout_14 = {@layout_0, i256};
-type @layout_15 = {i256, @layout_0};
-type @layout_16 = {@layout_0, i256};
-type @layout_17 = {@layout_0, @layout_0};
-type @layout_18 = {@layout_0, i256};
-type @layout_19 = {};
-type @layout_20 = {@layout_19};
-type @layout_21 = {@layout_0, @layout_0, i256};
-type @layout_22 = {@layout_0, @layout_0, i256};
-type @layout_23 = {i256, i256};
-type @layout_24 = {@layout_0, @layout_0};
+type @layout_15 = {@layout_0, i256};
+type @layout_16 = {i256, @layout_0};
+type @layout_17 = {};
+type @layout_18 = {@layout_17};
+type @layout_19 = {@layout_0, @layout_0, i256};
+type @layout_20 = {@layout_0, @layout_0, i256};
+type @layout_21 = {i256, i256};
+type @layout_22 = {@layout_0, @layout_0};
 
-global private const @layout_2 $const_region_0 = {0};
+global private const @layout_5 $const_region_0 = {0};
 global private const @layout_0 $const_region_1 = {0};
 
 func private %__CoolCoin_init(v0.i256, v1.@layout_0, v2.i256, v3.i256) {
@@ -104,7 +102,7 @@ func private %__CoolCoin_recv_0_4(v0.@layout_0, v1.@layout_0, v2.i256) -> i256 {
         jump block1;
 
     block1:
-        v3.objref<@layout_24> = obj.alloc @layout_24;
+        v3.objref<@layout_22> = obj.alloc @layout_22;
         v6.objref<@layout_0> = obj.proj v3 0.i256;
         v7.objref<i256> = obj.proj v6 0.i256;
         v8.i256 = extract_value v0 0.i256;
@@ -113,7 +111,7 @@ func private %__CoolCoin_recv_0_4(v0.@layout_0, v1.@layout_0, v2.i256) -> i256 {
         v12.objref<i256> = obj.proj v11 0.i256;
         v13.i256 = extract_value v1 0.i256;
         obj.store v12 v13;
-        v14.@layout_24 = obj.load v3;
+        v14.@layout_22 = obj.load v3;
         v15.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get__ga15b_cf04 v14;
         return v15;
 }
@@ -189,7 +187,7 @@ func private %__CoolCoin_recv_1_3(v0.@layout_0, v1.i256, v2.i256) -> i1 {
 
     block1:
         v3.@layout_0 = call %caller;
-        v4.objref<@layout_24> = obj.alloc @layout_24;
+        v4.objref<@layout_22> = obj.alloc @layout_22;
         v6.objref<@layout_0> = obj.proj v4 0.i256;
         v7.objref<i256> = obj.proj v6 0.i256;
         v8.i256 = extract_value v3 0.i256;
@@ -198,7 +196,7 @@ func private %__CoolCoin_recv_1_3(v0.@layout_0, v1.i256, v2.i256) -> i1 {
         v12.objref<i256> = obj.proj v11 0.i256;
         v13.i256 = extract_value v0 0.i256;
         obj.store v12 v13;
-        v14.@layout_24 = obj.load v4;
+        v14.@layout_22 = obj.load v4;
         v15.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get__ga15b_b5d5_0 v14;
         (v17.i256, v18.i1) = uaddo v15 v1;
         br v18 block2 block3;
@@ -222,7 +220,7 @@ func private %__CoolCoin_recv_1_4(v0.@layout_0, v1.i256, v2.i256) -> i1 {
 
     block1:
         v5.@layout_0 = call %caller;
-        v6.objref<@layout_24> = obj.alloc @layout_24;
+        v6.objref<@layout_22> = obj.alloc @layout_22;
         v8.objref<@layout_0> = obj.proj v6 0.i256;
         v9.objref<i256> = obj.proj v8 0.i256;
         v10.i256 = extract_value v5 0.i256;
@@ -231,7 +229,7 @@ func private %__CoolCoin_recv_1_4(v0.@layout_0, v1.i256, v2.i256) -> i1 {
         v14.objref<i256> = obj.proj v13 0.i256;
         v15.i256 = extract_value v0 0.i256;
         obj.store v14 v15;
-        v16.@layout_24 = obj.load v6;
+        v16.@layout_22 = obj.load v6;
         v17.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get__ga15b_b5d5_0 v16;
         v18.i256 = mload v3 i256;
         mstore v4 v18 i256;
@@ -503,6 +501,132 @@ func private %abi_single_root_size__g5535(v0.i256) -> i256 {
         return v3;
 }
 
+func private %std__lib__evm__effects__impl_trait_Evm_c913__abort_0a69() {
+    block0:
+        jump block1;
+
+    block1:
+        call %std__lib__evm__effects__impl_trait_Evm_0098__revert_2b5d 0.i256 0.i256;
+        unreachable;
+}
+
+func private %std__lib__evm__effects__impl_trait_Evm_c913__abort_12ed() {
+    block0:
+        jump block1;
+
+    block1:
+        call %std__lib__evm__effects__impl_trait_Evm_0098__revert_34f1 0.i256 0.i256;
+        unreachable;
+}
+
+func private %std__lib__evm__effects__impl_trait_Evm_c913__abort_20f2() {
+    block0:
+        jump block1;
+
+    block1:
+        call %std__lib__evm__effects__impl_trait_Evm_0098__revert_0ea2 0.i256 0.i256;
+        unreachable;
+}
+
+func private %std__lib__evm__effects__impl_trait_Evm_c913__abort_2f36() {
+    block0:
+        jump block1;
+
+    block1:
+        call %std__lib__evm__effects__impl_trait_Evm_0098__revert_6471 0.i256 0.i256;
+        unreachable;
+}
+
+func private %std__lib__evm__effects__impl_trait_Evm_c913__abort_57a6() {
+    block0:
+        jump block1;
+
+    block1:
+        call %std__lib__evm__effects__impl_trait_Evm_0098__revert_9e6f 0.i256 0.i256;
+        unreachable;
+}
+
+func private %std__lib__evm__effects__impl_trait_Evm_c913__abort_66b1() {
+    block0:
+        jump block1;
+
+    block1:
+        call %std__lib__evm__effects__impl_trait_Evm_0098__revert_a28f 0.i256 0.i256;
+        unreachable;
+}
+
+func private %std__lib__evm__effects__impl_trait_Evm_c913__abort_6993() {
+    block0:
+        jump block1;
+
+    block1:
+        call %std__lib__evm__effects__impl_trait_Evm_0098__revert_41e6 0.i256 0.i256;
+        unreachable;
+}
+
+func private %std__lib__evm__effects__impl_trait_Evm_c913__abort_98a8() {
+    block0:
+        jump block1;
+
+    block1:
+        call %std__lib__evm__effects__impl_trait_Evm_0098__revert_2efa 0.i256 0.i256;
+        unreachable;
+}
+
+func private %std__lib__evm__effects__impl_trait_Evm_c913__abort_9941() {
+    block0:
+        jump block1;
+
+    block1:
+        call %std__lib__evm__effects__impl_trait_Evm_0098__revert_35af 0.i256 0.i256;
+        unreachable;
+}
+
+func private %std__lib__evm__effects__impl_trait_Evm_c913__abort_a20a() {
+    block0:
+        jump block1;
+
+    block1:
+        call %std__lib__evm__effects__impl_trait_Evm_0098__revert_3bd1 0.i256 0.i256;
+        unreachable;
+}
+
+func private %std__lib__evm__effects__impl_trait_Evm_c913__abort_b229() {
+    block0:
+        jump block1;
+
+    block1:
+        call %std__lib__evm__effects__impl_trait_Evm_0098__revert_9fb4 0.i256 0.i256;
+        unreachable;
+}
+
+func private %std__lib__evm__effects__impl_trait_Evm_c913__abort_cb5c() {
+    block0:
+        jump block1;
+
+    block1:
+        call %std__lib__evm__effects__impl_trait_Evm_0098__revert_cab9 0.i256 0.i256;
+        unreachable;
+}
+
+func private %std__lib__evm__effects__impl_trait_Evm_c913__abort_ce6e() {
+    block0:
+        jump block1;
+
+    block1:
+        call %std__lib__evm__effects__impl_trait_Evm_0098__revert_cb12 0.i256 0.i256;
+        unreachable;
+}
+
+func private %std__lib__evm__effects__impl_trait_Evm_c913__abort_cf57() {
+    block0:
+        jump block1;
+
+    block1:
+        call %std__lib__evm__effects__impl_trait_Evm_0098__revert_62f4 0.i256 0.i256;
+        unreachable;
+}
+
 func private %standalone_erc20__erc20__approve__g5c3f_1f37(v0.@layout_0, v1.@layout_0, v2.i256, v3.i256) {
     block0:
         v4.*i256 = alloca i256;
@@ -550,7 +674,7 @@ func private %standalone_erc20__erc20__approve__g5c3f_1f37(v0.@layout_0, v1.@lay
         br v39 block8 block10;
 
     block7:
-        v45.objref<@layout_24> = obj.alloc @layout_24;
+        v45.objref<@layout_22> = obj.alloc @layout_22;
         v46.objref<@layout_0> = obj.proj v45 0.i256;
         v47.objref<i256> = obj.proj v46 0.i256;
         v48.i256 = extract_value v0 0.i256;
@@ -559,11 +683,11 @@ func private %standalone_erc20__erc20__approve__g5c3f_1f37(v0.@layout_0, v1.@lay
         v51.objref<i256> = obj.proj v50 0.i256;
         v52.i256 = extract_value v1 0.i256;
         obj.store v51 v52;
-        v53.@layout_24 = obj.load v45;
+        v53.@layout_22 = obj.load v45;
         v54.i256 = mload v4 i256;
         call %std__lib__evm__storage_map__impl_StorageMap_9f54__set__ga15b_f7f7_0 v53 v54;
         v56.i256 = mload v4 i256;
-        v57.objref<@layout_22> = obj.alloc @layout_22;
+        v57.objref<@layout_20> = obj.alloc @layout_20;
         v58.objref<@layout_0> = obj.proj v57 0.i256;
         v59.objref<i256> = obj.proj v58 0.i256;
         v60.i256 = extract_value v0 0.i256;
@@ -574,7 +698,7 @@ func private %standalone_erc20__erc20__approve__g5c3f_1f37(v0.@layout_0, v1.@lay
         obj.store v62 v63;
         v65.objref<i256> = obj.proj v57 2.i256;
         obj.store v65 v56;
-        v66.@layout_22 = obj.load v57;
+        v66.@layout_20 = obj.load v57;
         call %emit__g9cd0 v66;
         return;
 
@@ -639,7 +763,7 @@ func private %standalone_erc20__erc20__approve__g5c3f_43cb(v0.@layout_0, v1.@lay
         br v39 block8 block10;
 
     block7:
-        v45.objref<@layout_24> = obj.alloc @layout_24;
+        v45.objref<@layout_22> = obj.alloc @layout_22;
         v46.objref<@layout_0> = obj.proj v45 0.i256;
         v47.objref<i256> = obj.proj v46 0.i256;
         v48.i256 = extract_value v0 0.i256;
@@ -648,11 +772,11 @@ func private %standalone_erc20__erc20__approve__g5c3f_43cb(v0.@layout_0, v1.@lay
         v51.objref<i256> = obj.proj v50 0.i256;
         v52.i256 = extract_value v1 0.i256;
         obj.store v51 v52;
-        v53.@layout_24 = obj.load v45;
+        v53.@layout_22 = obj.load v45;
         v54.i256 = mload v4 i256;
         call %std__lib__evm__storage_map__impl_StorageMap_9f54__set__ga15b_f7f7_0 v53 v54;
         v56.i256 = mload v4 i256;
-        v57.objref<@layout_22> = obj.alloc @layout_22;
+        v57.objref<@layout_20> = obj.alloc @layout_20;
         v58.objref<@layout_0> = obj.proj v57 0.i256;
         v59.objref<i256> = obj.proj v58 0.i256;
         v60.i256 = extract_value v0 0.i256;
@@ -663,7 +787,7 @@ func private %standalone_erc20__erc20__approve__g5c3f_43cb(v0.@layout_0, v1.@lay
         obj.store v62 v63;
         v65.objref<i256> = obj.proj v57 2.i256;
         obj.store v65 v56;
-        v66.@layout_22 = obj.load v57;
+        v66.@layout_20 = obj.load v57;
         call %emit__g9cd0 v66;
         return;
 
@@ -728,7 +852,7 @@ func private %standalone_erc20__erc20__approve__g5c3f_7d3b(v0.@layout_0, v1.@lay
         br v39 block8 block10;
 
     block7:
-        v45.objref<@layout_24> = obj.alloc @layout_24;
+        v45.objref<@layout_22> = obj.alloc @layout_22;
         v46.objref<@layout_0> = obj.proj v45 0.i256;
         v47.objref<i256> = obj.proj v46 0.i256;
         v48.i256 = extract_value v0 0.i256;
@@ -737,11 +861,11 @@ func private %standalone_erc20__erc20__approve__g5c3f_7d3b(v0.@layout_0, v1.@lay
         v51.objref<i256> = obj.proj v50 0.i256;
         v52.i256 = extract_value v1 0.i256;
         obj.store v51 v52;
-        v53.@layout_24 = obj.load v45;
+        v53.@layout_22 = obj.load v45;
         v54.i256 = mload v4 i256;
         call %std__lib__evm__storage_map__impl_StorageMap_9f54__set__ga15b_f7f7_0 v53 v54;
         v56.i256 = mload v4 i256;
-        v57.objref<@layout_22> = obj.alloc @layout_22;
+        v57.objref<@layout_20> = obj.alloc @layout_20;
         v58.objref<@layout_0> = obj.proj v57 0.i256;
         v59.objref<i256> = obj.proj v58 0.i256;
         v60.i256 = extract_value v0 0.i256;
@@ -752,7 +876,7 @@ func private %standalone_erc20__erc20__approve__g5c3f_7d3b(v0.@layout_0, v1.@lay
         obj.store v62 v63;
         v65.objref<i256> = obj.proj v57 2.i256;
         obj.store v65 v56;
-        v66.@layout_22 = obj.load v57;
+        v66.@layout_20 = obj.load v57;
         call %emit__g9cd0 v66;
         return;
 
@@ -800,36 +924,6 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_009f(v0.objre
         return v4;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_1e5d(v0.objref<@layout_4>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 1.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_2366(v0.objref<@layout_4>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 1.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_23b9(v0.objref<@layout_4>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 1.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_25d4(v0.objref<@layout_1>) -> i256 {
     block0:
         jump block1;
@@ -840,7 +934,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_25d4(v0.objre
         return v4;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_2c1b(v0.objref<@layout_7>) -> i256 {
+func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_2c1b(v0.objref<@layout_4>) -> i256 {
     block0:
         jump block1;
 
@@ -850,17 +944,7 @@ func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_2c1b(v
         return v4;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_2c1b_0(v0.objref<@layout_7>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 1.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_39d6(v0.objref<@layout_4>) -> i256 {
+func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_2c1b_0(v0.objref<@layout_4>) -> i256 {
     block0:
         jump block1;
 
@@ -880,82 +964,12 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_6030(v0.objre
         return v4;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_6a8f(v0.objref<@layout_4>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 1.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_6b4a(v0.objref<@layout_4>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 1.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_6caa(v0.objref<@layout_4>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 1.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_7453(v0.objref<@layout_4>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 1.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_8751(v0.objref<@layout_1>) -> i256 {
     block0:
         jump block1;
 
     block1:
         v3.objref<i256> = obj.proj v0 0.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_8d3e(v0.objref<@layout_4>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 1.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_9981(v0.objref<@layout_4>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 1.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_9b2c(v0.objref<@layout_4>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 1.i256;
         v4.i256 = obj.load v3;
         return v4;
 }
@@ -990,72 +1004,12 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_c13e(v0.objre
         return v4;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_c2a7(v0.objref<@layout_4>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 1.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_d16a(v0.objref<@layout_4>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 1.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_dd69(v0.objref<@layout_1>) -> i256 {
     block0:
         jump block1;
 
     block1:
         v3.objref<i256> = obj.proj v0 0.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_efc3(v0.objref<@layout_4>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 1.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_f01e(v0.objref<@layout_4>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 1.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_f638(v0.objref<@layout_4>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 1.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_f81d(v0.objref<@layout_4>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 1.i256;
         v4.i256 = obj.load v3;
         return v4;
 }
@@ -1142,7 +1096,7 @@ func private %standalone_erc20__erc20__burn__g5c3f_7f45(v0.@layout_0, v1.i256, v
         evm_sstore v2 v50;
         v54.@layout_0 = call %zero;
         v55.i256 = mload v3 i256;
-        v56.objref<@layout_21> = obj.alloc @layout_21;
+        v56.objref<@layout_19> = obj.alloc @layout_19;
         v57.objref<@layout_0> = obj.proj v56 0.i256;
         v58.objref<i256> = obj.proj v57 0.i256;
         v59.i256 = extract_value v0 0.i256;
@@ -1153,7 +1107,7 @@ func private %standalone_erc20__erc20__burn__g5c3f_7f45(v0.@layout_0, v1.i256, v
         obj.store v62 v63;
         v65.objref<i256> = obj.proj v56 2.i256;
         obj.store v65 v55;
-        v66.@layout_21 = obj.load v56;
+        v66.@layout_19 = obj.load v56;
         call %emit__g4c3d v66;
         return;
 }
@@ -1230,7 +1184,7 @@ func private %standalone_erc20__erc20__burn__g5c3f_97eb(v0.@layout_0, v1.i256, v
         evm_sstore v2 v50;
         v54.@layout_0 = call %zero;
         v55.i256 = mload v3 i256;
-        v56.objref<@layout_21> = obj.alloc @layout_21;
+        v56.objref<@layout_19> = obj.alloc @layout_19;
         v57.objref<@layout_0> = obj.proj v56 0.i256;
         v58.objref<i256> = obj.proj v57 0.i256;
         v59.i256 = extract_value v0 0.i256;
@@ -1241,7 +1195,7 @@ func private %standalone_erc20__erc20__burn__g5c3f_97eb(v0.@layout_0, v1.i256, v
         obj.store v62 v63;
         v65.objref<i256> = obj.proj v56 2.i256;
         obj.store v65 v55;
-        v66.@layout_21 = obj.load v56;
+        v66.@layout_19 = obj.load v56;
         call %emit__g4c3d v66;
         return;
 }
@@ -1261,8 +1215,8 @@ func private %caller() -> @layout_0 {
 
 func private %contract_init_abi_CoolCoin() {
     block0:
-        v0.objref<@layout_5> = obj.alloc @layout_5;
-        v1.objref<@layout_7> = obj.alloc @layout_7;
+        v0.objref<@layout_2> = obj.alloc @layout_2;
+        v1.objref<@layout_4> = obj.alloc @layout_4;
         jump block1;
 
     block1:
@@ -1300,12 +1254,12 @@ func private %contract_init_abi_CoolCoin() {
         obj.store v23 v20;
         v25.objref<i256> = obj.proj v0 1.i256;
         obj.store v25 v13;
-        v26.@layout_5 = obj.load v0;
-        v27.@layout_7 = call %decoder_new v26;
-        v28.objref<@layout_6> = obj.proj v1 0.i256;
-        v29.@layout_6 = extract_value v27 0.i256;
-        v30.objref<@layout_5> = obj.proj v28 0.i256;
-        v31.@layout_5 = extract_value v29 0.i256;
+        v26.@layout_2 = obj.load v0;
+        v27.@layout_4 = call %decoder_new v26;
+        v28.objref<@layout_3> = obj.proj v1 0.i256;
+        v29.@layout_3 = extract_value v27 0.i256;
+        v30.objref<@layout_2> = obj.proj v28 0.i256;
+        v31.@layout_2 = extract_value v29 0.i256;
         v32.objref<i256> = obj.proj v30 0.i256;
         v33.i256 = extract_value v31 0.i256;
         obj.store v32 v33;
@@ -1318,7 +1272,7 @@ func private %contract_init_abi_CoolCoin() {
         v38.objref<i256> = obj.proj v1 1.i256;
         v39.i256 = extract_value v27 1.i256;
         obj.store v38 v39;
-        v40.@layout_15 = call %decode_payload__gf566 v1;
+        v40.@layout_16 = call %decode_payload__gf566 v1;
         v41.i256 = extract_value v40 0.i256;
         v42.@layout_0 = extract_value v40 1.i256;
         call %__CoolCoin_init v41 v42 0.i256 3.i256;
@@ -1351,12 +1305,12 @@ func private %contract_recv_abi_CoolCoin_1086394137() {
         evm_revert 0.i256 0.i256;
 
     block3:
-        v5.objref<@layout_20> = obj.alloc @layout_20;
-        v6.@layout_18 = call %decode_runtime_args__g2273 v5;
+        v5.objref<@layout_18> = obj.alloc @layout_18;
+        v6.@layout_8 = call %decode_runtime_args__g2273 v5;
         v7.@layout_0 = extract_value v6 0.i256;
         v9.i256 = extract_value v6 1.i256;
         v11.i1 = call %__CoolCoin_recv_1_0 v7 v9 0.i256 3.i256;
-        v12.@layout_23 = call %encode_single_root_alloc__g09ca v11;
+        v12.@layout_21 = call %encode_single_root_alloc__g09ca v11;
         v13.i256 = extract_value v12 0.i256;
         v14.i256 = extract_value v12 1.i256;
         evm_return v13 v14;
@@ -1376,11 +1330,11 @@ func private %contract_recv_abi_CoolCoin_1117154408() {
         evm_revert 0.i256 0.i256;
 
     block3:
-        v5.objref<@layout_20> = obj.alloc @layout_20;
-        v6.@layout_10 = call %decode_runtime_args__gf629 v5;
+        v5.objref<@layout_18> = obj.alloc @layout_18;
+        v6.@layout_9 = call %decode_runtime_args__gf629 v5;
         v7.i256 = extract_value v6 0.i256;
         v8.i1 = call %__CoolCoin_recv_1_1 v7 0.i256;
-        v9.@layout_23 = call %encode_single_root_alloc__g09ca v8;
+        v9.@layout_21 = call %encode_single_root_alloc__g09ca v8;
         v10.i256 = extract_value v9 0.i256;
         v12.i256 = extract_value v9 1.i256;
         evm_return v10 v12;
@@ -1400,10 +1354,10 @@ func private %contract_recv_abi_CoolCoin_117300739() {
         evm_revert 0.i256 0.i256;
 
     block3:
-        v5.objref<@layout_20> = obj.alloc @layout_20;
+        v5.objref<@layout_18> = obj.alloc @layout_18;
         call %decode_runtime_args__gce2e v5;
         v7.i256 = call %__CoolCoin_recv_0_6;
-        v8.@layout_23 = call %encode_single_root_alloc__g472d v7;
+        v8.@layout_21 = call %encode_single_root_alloc__g472d v7;
         v9.i256 = extract_value v8 0.i256;
         v11.i256 = extract_value v8 1.i256;
         evm_return v9 v11;
@@ -1423,12 +1377,12 @@ func private %contract_recv_abi_CoolCoin_157198259() {
         evm_revert 0.i256 0.i256;
 
     block3:
-        v5.objref<@layout_20> = obj.alloc @layout_20;
-        v6.@layout_11 = call %decode_runtime_args__g7a2c v5;
+        v5.objref<@layout_18> = obj.alloc @layout_18;
+        v6.@layout_7 = call %decode_runtime_args__g7a2c v5;
         v7.@layout_0 = extract_value v6 0.i256;
         v9.i256 = extract_value v6 1.i256;
         v10.i1 = call %__CoolCoin_recv_0_1 v7 v9 0.i256;
-        v11.@layout_23 = call %encode_single_root_alloc__g09ca v10;
+        v11.@layout_21 = call %encode_single_root_alloc__g09ca v10;
         v12.i256 = extract_value v11 0.i256;
         v13.i256 = extract_value v11 1.i256;
         evm_return v12 v13;
@@ -1448,11 +1402,11 @@ func private %contract_recv_abi_CoolCoin_1889567281() {
         evm_revert 0.i256 0.i256;
 
     block3:
-        v5.objref<@layout_20> = obj.alloc @layout_20;
-        v6.@layout_9 = call %decode_runtime_args__g953d v5;
+        v5.objref<@layout_18> = obj.alloc @layout_18;
+        v6.@layout_11 = call %decode_runtime_args__g953d v5;
         v7.@layout_0 = extract_value v6 0.i256;
         v8.i256 = call %__CoolCoin_recv_0_3 v7 0.i256;
-        v9.@layout_23 = call %encode_single_root_alloc__gac80 v8;
+        v9.@layout_21 = call %encode_single_root_alloc__gac80 v8;
         v10.i256 = extract_value v9 0.i256;
         v12.i256 = extract_value v9 1.i256;
         evm_return v10 v12;
@@ -1472,12 +1426,12 @@ func private %contract_recv_abi_CoolCoin_2043438992() {
         evm_revert 0.i256 0.i256;
 
     block3:
-        v5.objref<@layout_20> = obj.alloc @layout_20;
-        v6.@layout_14 = call %decode_runtime_args__g216b v5;
+        v5.objref<@layout_18> = obj.alloc @layout_18;
+        v6.@layout_10 = call %decode_runtime_args__g216b v5;
         v7.@layout_0 = extract_value v6 0.i256;
         v9.i256 = extract_value v6 1.i256;
         v10.i1 = call %__CoolCoin_recv_1_2 v7 v9 0.i256;
-        v11.@layout_23 = call %encode_single_root_alloc__g09ca v10;
+        v11.@layout_21 = call %encode_single_root_alloc__g09ca v10;
         v12.i256 = extract_value v11 0.i256;
         v13.i256 = extract_value v11 1.i256;
         evm_return v12 v13;
@@ -1497,10 +1451,10 @@ func private %contract_recv_abi_CoolCoin_2514000705() {
         evm_revert 0.i256 0.i256;
 
     block3:
-        v5.objref<@layout_20> = obj.alloc @layout_20;
+        v5.objref<@layout_18> = obj.alloc @layout_18;
         call %decode_runtime_args__g295c v5;
         v7.i256 = call %__CoolCoin_recv_0_7;
-        v8.@layout_23 = call %encode_single_root_alloc__g0c18 v7;
+        v8.@layout_21 = call %encode_single_root_alloc__g0c18 v7;
         v9.i256 = extract_value v8 0.i256;
         v11.i256 = extract_value v8 1.i256;
         evm_return v9 v11;
@@ -1520,12 +1474,12 @@ func private %contract_recv_abi_CoolCoin_2757214935() {
         evm_revert 0.i256 0.i256;
 
     block3:
-        v5.objref<@layout_20> = obj.alloc @layout_20;
-        v6.@layout_8 = call %decode_runtime_args__g6a7c v5;
+        v5.objref<@layout_18> = obj.alloc @layout_18;
+        v6.@layout_15 = call %decode_runtime_args__g6a7c v5;
         v7.@layout_0 = extract_value v6 0.i256;
         v9.i256 = extract_value v6 1.i256;
         v10.i1 = call %__CoolCoin_recv_1_4 v7 v9 0.i256;
-        v11.@layout_23 = call %encode_single_root_alloc__g09ca v10;
+        v11.@layout_21 = call %encode_single_root_alloc__g09ca v10;
         v12.i256 = extract_value v11 0.i256;
         v13.i256 = extract_value v11 1.i256;
         evm_return v12 v13;
@@ -1545,12 +1499,12 @@ func private %contract_recv_abi_CoolCoin_2835717307() {
         evm_revert 0.i256 0.i256;
 
     block3:
-        v5.objref<@layout_20> = obj.alloc @layout_20;
-        v6.@layout_13 = call %decode_runtime_args__ge035 v5;
+        v5.objref<@layout_18> = obj.alloc @layout_18;
+        v6.@layout_14 = call %decode_runtime_args__ge035 v5;
         v7.@layout_0 = extract_value v6 0.i256;
         v9.i256 = extract_value v6 1.i256;
         v10.i1 = call %__CoolCoin_recv_0_0 v7 v9 0.i256;
-        v11.@layout_23 = call %encode_single_root_alloc__g09ca v10;
+        v11.@layout_21 = call %encode_single_root_alloc__g09ca v10;
         v12.i256 = extract_value v11 0.i256;
         v13.i256 = extract_value v11 1.i256;
         evm_return v12 v13;
@@ -1570,12 +1524,12 @@ func private %contract_recv_abi_CoolCoin_3714247998() {
         evm_revert 0.i256 0.i256;
 
     block3:
-        v5.objref<@layout_20> = obj.alloc @layout_20;
-        v6.@layout_17 = call %decode_runtime_args__gc772 v5;
+        v5.objref<@layout_18> = obj.alloc @layout_18;
+        v6.@layout_6 = call %decode_runtime_args__gc772 v5;
         v7.@layout_0 = extract_value v6 0.i256;
         v9.@layout_0 = extract_value v6 1.i256;
         v10.i256 = call %__CoolCoin_recv_0_4 v7 v9 0.i256;
-        v11.@layout_23 = call %encode_single_root_alloc__gac80 v10;
+        v11.@layout_21 = call %encode_single_root_alloc__gac80 v10;
         v12.i256 = extract_value v11 0.i256;
         v13.i256 = extract_value v11 1.i256;
         evm_return v12 v13;
@@ -1595,10 +1549,10 @@ func private %contract_recv_abi_CoolCoin_404098525() {
         evm_revert 0.i256 0.i256;
 
     block3:
-        v5.objref<@layout_20> = obj.alloc @layout_20;
+        v5.objref<@layout_18> = obj.alloc @layout_18;
         call %decode_runtime_args__gce7d v5;
         v7.i256 = call %__CoolCoin_recv_0_5 0.i256;
-        v8.@layout_23 = call %encode_single_root_alloc__gac80 v7;
+        v8.@layout_21 = call %encode_single_root_alloc__gac80 v7;
         v9.i256 = extract_value v8 0.i256;
         v11.i256 = extract_value v8 1.i256;
         evm_return v9 v11;
@@ -1618,13 +1572,13 @@ func private %contract_recv_abi_CoolCoin_599290589() {
         evm_revert 0.i256 0.i256;
 
     block3:
-        v5.objref<@layout_20> = obj.alloc @layout_20;
-        v6.@layout_12 = call %decode_runtime_args__g4e54 v5;
+        v5.objref<@layout_18> = obj.alloc @layout_18;
+        v6.@layout_13 = call %decode_runtime_args__g4e54 v5;
         v7.@layout_0 = extract_value v6 0.i256;
         v9.@layout_0 = extract_value v6 1.i256;
         v11.i256 = extract_value v6 2.i256;
         v12.i1 = call %__CoolCoin_recv_0_2 v7 v9 v11 0.i256;
-        v13.@layout_23 = call %encode_single_root_alloc__g09ca v12;
+        v13.@layout_21 = call %encode_single_root_alloc__g09ca v12;
         v14.i256 = extract_value v13 0.i256;
         v15.i256 = extract_value v13 1.i256;
         evm_return v14 v15;
@@ -1644,10 +1598,10 @@ func private %contract_recv_abi_CoolCoin_826074471() {
         evm_revert 0.i256 0.i256;
 
     block3:
-        v5.objref<@layout_20> = obj.alloc @layout_20;
+        v5.objref<@layout_18> = obj.alloc @layout_18;
         call %decode_runtime_args__g5a0b v5;
         v7.i8 = call %__CoolCoin_recv_0_8;
-        v8.@layout_23 = call %encode_single_root_alloc__gcb0a v7;
+        v8.@layout_21 = call %encode_single_root_alloc__gcb0a v7;
         v9.i256 = extract_value v8 0.i256;
         v11.i256 = extract_value v8 1.i256;
         evm_return v9 v11;
@@ -1667,12 +1621,12 @@ func private %contract_recv_abi_CoolCoin_961581905() {
         evm_revert 0.i256 0.i256;
 
     block3:
-        v5.objref<@layout_20> = obj.alloc @layout_20;
-        v6.@layout_16 = call %decode_runtime_args__g698d v5;
+        v5.objref<@layout_18> = obj.alloc @layout_18;
+        v6.@layout_12 = call %decode_runtime_args__g698d v5;
         v7.@layout_0 = extract_value v6 0.i256;
         v9.i256 = extract_value v6 1.i256;
         v10.i1 = call %__CoolCoin_recv_1_3 v7 v9 0.i256;
-        v11.@layout_23 = call %encode_single_root_alloc__g09ca v10;
+        v11.@layout_21 = call %encode_single_root_alloc__g09ca v10;
         v12.i256 = extract_value v11 0.i256;
         v13.i256 = extract_value v11 1.i256;
         evm_return v12 v13;
@@ -1753,403 +1707,7 @@ func private %contract_runtime_root_CoolCoin() {
         unreachable;
 }
 
-func inline(always) private %core__lib__abi__decode_field__gaa38_0306(v0.objref<@layout_4>) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        br 0.i1 block2 block3;
-
-    block2:
-        v3.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_3df5 v0;
-        v4.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_39d6 v0;
-        v5.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g8f43_1b8b v0;
-        (v6.i256, v7.i1) = uaddo v4 v3;
-        br v7 block5 block6;
-
-    block3:
-        jump block4;
-
-    block4:
-        v23.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_payload__g574e_e3de v0;
-        return v23;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_f70c v0 v6;
-        v15.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_39d6 v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_a5d2 v0 v15;
-        v17.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_payload__g574e_e3de v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_f70c v0 v4;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_a5d2 v0 v5;
-        return v17;
-}
-
-func inline(always) private %core__lib__abi__decode_field__gaa38_0bfd(v0.objref<@layout_4>) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        br 0.i1 block2 block3;
-
-    block2:
-        v3.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_90ee v0;
-        v4.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_6caa v0;
-        v5.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g8f43_732d v0;
-        (v6.i256, v7.i1) = uaddo v4 v3;
-        br v7 block5 block6;
-
-    block3:
-        jump block4;
-
-    block4:
-        v23.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_payload__g574e_1ff5 v0;
-        return v23;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_cbf7 v0 v6;
-        v15.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_6caa v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_499d v0 v15;
-        v17.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_payload__g574e_1ff5 v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_cbf7 v0 v4;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_499d v0 v5;
-        return v17;
-}
-
-func inline(always) private %core__lib__abi__decode_field__g7400_11ec(v0.objref<@layout_4>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        br 0.i1 block2 block3;
-
-    block2:
-        v3.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_68c5 v0;
-        v4.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_d16a v0;
-        v5.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g8f43_03cc v0;
-        (v6.i256, v7.i1) = uaddo v4 v3;
-        br v7 block5 block6;
-
-    block3:
-        jump block4;
-
-    block4:
-        v23.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_payload__g574e_423a v0;
-        return v23;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_2047 v0 v6;
-        v15.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_d16a v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_3c9e v0 v15;
-        v17.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_payload__g574e_423a v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_2047 v0 v4;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_3c9e v0 v5;
-        return v17;
-}
-
-func inline(always) private %core__lib__abi__decode_field__gaa38_13f3(v0.objref<@layout_4>) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        br 0.i1 block2 block3;
-
-    block2:
-        v3.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_3e00 v0;
-        v4.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_2366 v0;
-        v5.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g8f43_e9e7 v0;
-        (v6.i256, v7.i1) = uaddo v4 v3;
-        br v7 block5 block6;
-
-    block3:
-        jump block4;
-
-    block4:
-        v23.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_payload__g574e_fe07 v0;
-        return v23;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_2c03 v0 v6;
-        v15.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_2366 v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_3496 v0 v15;
-        v17.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_payload__g574e_fe07 v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_2c03 v0 v4;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_3496 v0 v5;
-        return v17;
-}
-
-func inline(always) private %core__lib__abi__decode_field__gaa38_1a99(v0.objref<@layout_4>) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        br 0.i1 block2 block3;
-
-    block2:
-        v3.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_0aaa v0;
-        v4.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_9981 v0;
-        v5.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g8f43_2469 v0;
-        (v6.i256, v7.i1) = uaddo v4 v3;
-        br v7 block5 block6;
-
-    block3:
-        jump block4;
-
-    block4:
-        v23.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_payload__g574e_0684 v0;
-        return v23;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_6069 v0 v6;
-        v15.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_9981 v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_a284 v0 v15;
-        v17.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_payload__g574e_0684 v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_6069 v0 v4;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_a284 v0 v5;
-        return v17;
-}
-
-func inline(always) private %core__lib__abi__decode_field__gaa38_2931(v0.objref<@layout_4>) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        br 0.i1 block2 block3;
-
-    block2:
-        v3.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_2f5f v0;
-        v4.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_9b2c v0;
-        v5.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g8f43_2476 v0;
-        (v6.i256, v7.i1) = uaddo v4 v3;
-        br v7 block5 block6;
-
-    block3:
-        jump block4;
-
-    block4:
-        v23.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_payload__g574e_66a8 v0;
-        return v23;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_37ba v0 v6;
-        v15.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_9b2c v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_ec24 v0 v15;
-        v17.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_payload__g574e_66a8 v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_37ba v0 v4;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_ec24 v0 v5;
-        return v17;
-}
-
-func inline(always) private %core__lib__abi__decode_field__gaa38_3063(v0.objref<@layout_4>) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        br 0.i1 block2 block3;
-
-    block2:
-        v3.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_648f v0;
-        v4.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_f81d v0;
-        v5.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g8f43_1f03 v0;
-        (v6.i256, v7.i1) = uaddo v4 v3;
-        br v7 block5 block6;
-
-    block3:
-        jump block4;
-
-    block4:
-        v23.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_payload__g574e_69f0 v0;
-        return v23;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_8f23 v0 v6;
-        v15.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_f81d v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_0f8a v0 v15;
-        v17.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_payload__g574e_69f0 v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_8f23 v0 v4;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_0f8a v0 v5;
-        return v17;
-}
-
-func inline(always) private %core__lib__abi__decode_field__g7400_4cf3(v0.objref<@layout_4>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        br 0.i1 block2 block3;
-
-    block2:
-        v3.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_daa6 v0;
-        v4.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_f638 v0;
-        v5.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g8f43_7902 v0;
-        (v6.i256, v7.i1) = uaddo v4 v3;
-        br v7 block5 block6;
-
-    block3:
-        jump block4;
-
-    block4:
-        v23.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_payload__g574e_89fa v0;
-        return v23;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_71fe v0 v6;
-        v15.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_f638 v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_1627 v0 v15;
-        v17.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_payload__g574e_89fa v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_71fe v0 v4;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_1627 v0 v5;
-        return v17;
-}
-
-func inline(always) private %core__lib__abi__decode_field__gaa38_59b3(v0.objref<@layout_4>) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        br 0.i1 block2 block3;
-
-    block2:
-        v3.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_99b4 v0;
-        v4.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_23b9 v0;
-        v5.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g8f43_f79e v0;
-        (v6.i256, v7.i1) = uaddo v4 v3;
-        br v7 block5 block6;
-
-    block3:
-        jump block4;
-
-    block4:
-        v23.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_payload__g574e_15e7 v0;
-        return v23;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_88e6 v0 v6;
-        v15.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_23b9 v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_3709 v0 v15;
-        v17.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_payload__g574e_15e7 v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_88e6 v0 v4;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_3709 v0 v5;
-        return v17;
-}
-
-func inline(always) private %core__lib__abi__decode_field__g7400_67a5(v0.objref<@layout_4>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        br 0.i1 block2 block3;
-
-    block2:
-        v3.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_0c51 v0;
-        v4.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_f01e v0;
-        v5.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g8f43_359e v0;
-        (v6.i256, v7.i1) = uaddo v4 v3;
-        br v7 block5 block6;
-
-    block3:
-        jump block4;
-
-    block4:
-        v23.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_payload__g574e_d74a v0;
-        return v23;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_08ad v0 v6;
-        v15.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_f01e v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_c11e v0 v15;
-        v17.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_payload__g574e_d74a v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_08ad v0 v4;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_c11e v0 v5;
-        return v17;
-}
-
-func inline(always) private %core__lib__abi__decode_field__g7400_6a67(v0.objref<@layout_4>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        br 0.i1 block2 block3;
-
-    block2:
-        v3.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_e181 v0;
-        v4.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_8d3e v0;
-        v5.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g8f43_d52d v0;
-        (v6.i256, v7.i1) = uaddo v4 v3;
-        br v7 block5 block6;
-
-    block3:
-        jump block4;
-
-    block4:
-        v23.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_payload__g574e_8b49 v0;
-        return v23;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_3353 v0 v6;
-        v15.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_8d3e v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_cfe1 v0 v15;
-        v17.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_payload__g574e_8b49 v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_3353 v0 v4;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_cfe1 v0 v5;
-        return v17;
-}
-
-func inline(always) private %decode_field__g8463(v0.objref<@layout_7>) -> @layout_0 {
+func inline(always) private %decode_field__g8463(v0.objref<@layout_4>) -> @layout_0 {
     block0:
         jump block1;
 
@@ -2185,115 +1743,7 @@ func inline(always) private %decode_field__g8463(v0.objref<@layout_7>) -> @layou
         return v17;
 }
 
-func inline(always) private %core__lib__abi__decode_field__g7400_8cdf(v0.objref<@layout_4>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        br 0.i1 block2 block3;
-
-    block2:
-        v3.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_9abb v0;
-        v4.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_efc3 v0;
-        v5.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g8f43_389a v0;
-        (v6.i256, v7.i1) = uaddo v4 v3;
-        br v7 block5 block6;
-
-    block3:
-        jump block4;
-
-    block4:
-        v23.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_payload__g574e_e794 v0;
-        return v23;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_abec v0 v6;
-        v15.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_efc3 v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_79da v0 v15;
-        v17.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_payload__g574e_e794 v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_abec v0 v4;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_79da v0 v5;
-        return v17;
-}
-
-func inline(always) private %core__lib__abi__decode_field__gaa38_98d1(v0.objref<@layout_4>) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        br 0.i1 block2 block3;
-
-    block2:
-        v3.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_7998 v0;
-        v4.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_6b4a v0;
-        v5.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g8f43_c0cb v0;
-        (v6.i256, v7.i1) = uaddo v4 v3;
-        br v7 block5 block6;
-
-    block3:
-        jump block4;
-
-    block4:
-        v23.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_payload__g574e_e2c8 v0;
-        return v23;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_8271 v0 v6;
-        v15.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_6b4a v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_04a3 v0 v15;
-        v17.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_payload__g574e_e2c8 v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_8271 v0 v4;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_04a3 v0 v5;
-        return v17;
-}
-
-func inline(always) private %core__lib__abi__decode_field__g7400_ac4e(v0.objref<@layout_4>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        br 0.i1 block2 block3;
-
-    block2:
-        v3.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_ec92 v0;
-        v4.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_1e5d v0;
-        v5.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g8f43_5f56 v0;
-        (v6.i256, v7.i1) = uaddo v4 v3;
-        br v7 block5 block6;
-
-    block3:
-        jump block4;
-
-    block4:
-        v23.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_payload__g574e_8546 v0;
-        return v23;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_625a v0 v6;
-        v15.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_1e5d v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_763e v0 v15;
-        v17.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_payload__g574e_8546 v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_625a v0 v4;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_763e v0 v5;
-        return v17;
-}
-
-func inline(always) private %decode_field__g3854(v0.objref<@layout_7>) -> i256 {
+func inline(always) private %decode_field__g3854(v0.objref<@layout_4>) -> i256 {
     block0:
         jump block1;
 
@@ -2329,26 +1779,31 @@ func inline(always) private %decode_field__g3854(v0.objref<@layout_7>) -> i256 {
         return v17;
 }
 
-func inline(always) private %core__lib__abi__decode_field__g7400_be39(v0.objref<@layout_4>) -> i256 {
+func inline(always) private %core__lib__abi__decode_field_from__gcfb5_05e1(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
     block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v3.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_8f7a v0;
-        v4.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_6a8f v0;
-        v5.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g8f43_79bd v0;
-        (v6.i256, v7.i1) = uaddo v4 v3;
-        br v7 block5 block6;
+        v7.i256 = mload v4 i256;
+        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c2d4 v0 v7;
+        v9.i256 = mload v3 i256;
+        (v10.i256, v11.i1) = uaddo v9 v8;
+        br v11 block5 block6;
 
     block3:
         jump block4;
 
     block4:
-        v23.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_payload__g574e_c028 v0;
-        return v23;
+        v20.i256 = mload v4 i256;
+        v21.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_4e5e v0 v20;
+        return v21;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -2356,35 +1811,35 @@ func inline(always) private %core__lib__abi__decode_field__g7400_be39(v0.objref<
         evm_revert 0.i256 36.i256;
 
     block6:
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_b0be v0 v6;
-        v15.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_6a8f v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_34da v0 v15;
-        v17.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_payload__g574e_c028 v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_b0be v0 v4;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_34da v0 v5;
-        return v17;
+        v18.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_4e5e v0 v10;
+        return v18;
 }
 
-func inline(always) private %core__lib__abi__decode_field__gaa38_e11f(v0.objref<@layout_4>) -> @layout_0 {
+func inline(always) private %core__lib__abi__decode_field_from__gcfb5_1aba(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
     block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v3.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_8451 v0;
-        v4.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_c2a7 v0;
-        v5.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g8f43_e2e4 v0;
-        (v6.i256, v7.i1) = uaddo v4 v3;
-        br v7 block5 block6;
+        v7.i256 = mload v4 i256;
+        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_88a1 v0 v7;
+        v9.i256 = mload v3 i256;
+        (v10.i256, v11.i1) = uaddo v9 v8;
+        br v11 block5 block6;
 
     block3:
         jump block4;
 
     block4:
-        v23.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_payload__g574e_f87e v0;
-        return v23;
+        v20.i256 = mload v4 i256;
+        v21.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_9286 v0 v20;
+        return v21;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -2392,35 +1847,35 @@ func inline(always) private %core__lib__abi__decode_field__gaa38_e11f(v0.objref<
         evm_revert 0.i256 36.i256;
 
     block6:
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_b760 v0 v6;
-        v15.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_c2a7 v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_de99 v0 v15;
-        v17.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_payload__g574e_f87e v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_b760 v0 v4;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_de99 v0 v5;
-        return v17;
+        v18.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_9286 v0 v10;
+        return v18;
 }
 
-func inline(always) private %core__lib__abi__decode_field__g7400_eed2(v0.objref<@layout_4>) -> i256 {
+func inline(always) private %core__lib__abi__decode_field_from__gcfb5_2b31(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
     block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v3.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_d406 v0;
-        v4.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_7453 v0;
-        v5.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g8f43_c11d v0;
-        (v6.i256, v7.i1) = uaddo v4 v3;
-        br v7 block5 block6;
+        v7.i256 = mload v4 i256;
+        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_fdcb v0 v7;
+        v9.i256 = mload v3 i256;
+        (v10.i256, v11.i1) = uaddo v9 v8;
+        br v11 block5 block6;
 
     block3:
         jump block4;
 
     block4:
-        v23.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_payload__g574e_646d v0;
-        return v23;
+        v20.i256 = mload v4 i256;
+        v21.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_db93 v0 v20;
+        return v21;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -2428,43 +1883,551 @@ func inline(always) private %core__lib__abi__decode_field__g7400_eed2(v0.objref<
         evm_revert 0.i256 36.i256;
 
     block6:
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_5e07 v0 v6;
-        v15.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g8f43_7453 v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_592f v0 v15;
-        v17.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_payload__g574e_646d v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_5e07 v0 v4;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_592f v0 v5;
-        return v17;
+        v18.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_db93 v0 v10;
+        return v18;
 }
 
-func inline(always) private %impl_trait_DecreaseAllowance__decode_payload__g3a69(v0.objref<@layout_4>) -> @layout_8 {
+func inline(always) private %core__lib__abi__decode_field_from__g5385_30a1(v0.@layout_5, v1.i256, v2.i256) -> i256 {
     block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v2.@layout_0 = call %core__lib__abi__decode_field__gaa38_59b3 v0;
-        v3.i256 = call %core__lib__abi__decode_field__g7400_67a5 v0;
-        v4.objref<@layout_8> = obj.alloc @layout_8;
-        v6.objref<@layout_0> = obj.proj v4 0.i256;
-        v7.objref<i256> = obj.proj v6 0.i256;
-        v8.i256 = extract_value v2 0.i256;
-        obj.store v7 v8;
-        v10.objref<i256> = obj.proj v4 1.i256;
-        obj.store v10 v3;
-        v11.@layout_8 = obj.load v4;
-        return v11;
+        br 0.i1 block2 block3;
+
+    block2:
+        v7.i256 = mload v4 i256;
+        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_9725 v0 v7;
+        v9.i256 = mload v3 i256;
+        (v10.i256, v11.i1) = uaddo v9 v8;
+        br v11 block5 block6;
+
+    block3:
+        jump block4;
+
+    block4:
+        v20.i256 = mload v4 i256;
+        v21.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_3a7c v0 v20;
+        return v21;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        v18.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_3a7c v0 v10;
+        return v18;
 }
 
-func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_payload__g574e_0684(v0.objref<@layout_4>) -> @layout_0 {
+func inline(always) private %core__lib__abi__decode_field_from__g5385_4478(v0.@layout_5, v1.i256, v2.i256) -> i256 {
     block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v2.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_df17 v0;
-        v4.i256 = shr 160.i256 v2;
-        v6.i1 = eq v4 0.i256;
-        v7.i1 = is_zero v6;
-        br v7 block2 block3;
+        br 0.i1 block2 block3;
+
+    block2:
+        v7.i256 = mload v4 i256;
+        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_5ce9 v0 v7;
+        v9.i256 = mload v3 i256;
+        (v10.i256, v11.i1) = uaddo v9 v8;
+        br v11 block5 block6;
+
+    block3:
+        jump block4;
+
+    block4:
+        v20.i256 = mload v4 i256;
+        v21.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_b39f v0 v20;
+        return v21;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        v18.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_b39f v0 v10;
+        return v18;
+}
+
+func inline(always) private %core__lib__abi__decode_field_from__gcfb5_6a4b(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v7.i256 = mload v4 i256;
+        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_ce64 v0 v7;
+        v9.i256 = mload v3 i256;
+        (v10.i256, v11.i1) = uaddo v9 v8;
+        br v11 block5 block6;
+
+    block3:
+        jump block4;
+
+    block4:
+        v20.i256 = mload v4 i256;
+        v21.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_2519 v0 v20;
+        return v21;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        v18.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_2519 v0 v10;
+        return v18;
+}
+
+func inline(always) private %core__lib__abi__decode_field_from__g5385_7d9f(v0.@layout_5, v1.i256, v2.i256) -> i256 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v7.i256 = mload v4 i256;
+        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_27ad v0 v7;
+        v9.i256 = mload v3 i256;
+        (v10.i256, v11.i1) = uaddo v9 v8;
+        br v11 block5 block6;
+
+    block3:
+        jump block4;
+
+    block4:
+        v20.i256 = mload v4 i256;
+        v21.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8d9f v0 v20;
+        return v21;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        v18.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8d9f v0 v10;
+        return v18;
+}
+
+func inline(always) private %core__lib__abi__decode_field_from__g5385_8921(v0.@layout_5, v1.i256, v2.i256) -> i256 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v7.i256 = mload v4 i256;
+        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c32c v0 v7;
+        v9.i256 = mload v3 i256;
+        (v10.i256, v11.i1) = uaddo v9 v8;
+        br v11 block5 block6;
+
+    block3:
+        jump block4;
+
+    block4:
+        v20.i256 = mload v4 i256;
+        v21.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_5c31 v0 v20;
+        return v21;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        v18.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_5c31 v0 v10;
+        return v18;
+}
+
+func inline(always) private %core__lib__abi__decode_field_from__gcfb5_8ab8(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v7.i256 = mload v4 i256;
+        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_faf2 v0 v7;
+        v9.i256 = mload v3 i256;
+        (v10.i256, v11.i1) = uaddo v9 v8;
+        br v11 block5 block6;
+
+    block3:
+        jump block4;
+
+    block4:
+        v20.i256 = mload v4 i256;
+        v21.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_5535 v0 v20;
+        return v21;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        v18.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_5535 v0 v10;
+        return v18;
+}
+
+func inline(always) private %core__lib__abi__decode_field_from__g5385_9c75(v0.@layout_5, v1.i256, v2.i256) -> i256 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v7.i256 = mload v4 i256;
+        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_780b v0 v7;
+        v9.i256 = mload v3 i256;
+        (v10.i256, v11.i1) = uaddo v9 v8;
+        br v11 block5 block6;
+
+    block3:
+        jump block4;
+
+    block4:
+        v20.i256 = mload v4 i256;
+        v21.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_0a95 v0 v20;
+        return v21;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        v18.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_0a95 v0 v10;
+        return v18;
+}
+
+func inline(always) private %core__lib__abi__decode_field_from__gcfb5_b81d(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v7.i256 = mload v4 i256;
+        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_0f5c v0 v7;
+        v9.i256 = mload v3 i256;
+        (v10.i256, v11.i1) = uaddo v9 v8;
+        br v11 block5 block6;
+
+    block3:
+        jump block4;
+
+    block4:
+        v20.i256 = mload v4 i256;
+        v21.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_f4e0 v0 v20;
+        return v21;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        v18.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_f4e0 v0 v10;
+        return v18;
+}
+
+func inline(always) private %core__lib__abi__decode_field_from__g5385_c0de(v0.@layout_5, v1.i256, v2.i256) -> i256 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v7.i256 = mload v4 i256;
+        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c259 v0 v7;
+        v9.i256 = mload v3 i256;
+        (v10.i256, v11.i1) = uaddo v9 v8;
+        br v11 block5 block6;
+
+    block3:
+        jump block4;
+
+    block4:
+        v20.i256 = mload v4 i256;
+        v21.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_4e52 v0 v20;
+        return v21;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        v18.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_4e52 v0 v10;
+        return v18;
+}
+
+func inline(always) private %core__lib__abi__decode_field_from__gcfb5_c63b(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v7.i256 = mload v4 i256;
+        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_69bf v0 v7;
+        v9.i256 = mload v3 i256;
+        (v10.i256, v11.i1) = uaddo v9 v8;
+        br v11 block5 block6;
+
+    block3:
+        jump block4;
+
+    block4:
+        v20.i256 = mload v4 i256;
+        v21.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_3716 v0 v20;
+        return v21;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        v18.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_3716 v0 v10;
+        return v18;
+}
+
+func inline(always) private %core__lib__abi__decode_field_from__g5385_c71a(v0.@layout_5, v1.i256, v2.i256) -> i256 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v7.i256 = mload v4 i256;
+        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_49c5 v0 v7;
+        v9.i256 = mload v3 i256;
+        (v10.i256, v11.i1) = uaddo v9 v8;
+        br v11 block5 block6;
+
+    block3:
+        jump block4;
+
+    block4:
+        v20.i256 = mload v4 i256;
+        v21.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_18e6 v0 v20;
+        return v21;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        v18.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_18e6 v0 v10;
+        return v18;
+}
+
+func inline(always) private %core__lib__abi__decode_field_from__gcfb5_cd1a(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v7.i256 = mload v4 i256;
+        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_7946 v0 v7;
+        v9.i256 = mload v3 i256;
+        (v10.i256, v11.i1) = uaddo v9 v8;
+        br v11 block5 block6;
+
+    block3:
+        jump block4;
+
+    block4:
+        v20.i256 = mload v4 i256;
+        v21.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_b822 v0 v20;
+        return v21;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        v18.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_b822 v0 v10;
+        return v18;
+}
+
+func inline(always) private %core__lib__abi__decode_field_from__g5385_d823(v0.@layout_5, v1.i256, v2.i256) -> i256 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v7.i256 = mload v4 i256;
+        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b870 v0 v7;
+        v9.i256 = mload v3 i256;
+        (v10.i256, v11.i1) = uaddo v9 v8;
+        br v11 block5 block6;
+
+    block3:
+        jump block4;
+
+    block4:
+        v20.i256 = mload v4 i256;
+        v21.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_251a v0 v20;
+        return v21;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        v18.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_251a v0 v10;
+        return v18;
+}
+
+func inline(always) private %core__lib__abi__decode_field_from__gcfb5_fd62(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v7.i256 = mload v4 i256;
+        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_6dae v0 v7;
+        v9.i256 = mload v3 i256;
+        (v10.i256, v11.i1) = uaddo v9 v8;
+        br v11 block5 block6;
+
+    block3:
+        jump block4;
+
+    block4:
+        v20.i256 = mload v4 i256;
+        v21.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_3641 v0 v20;
+        return v21;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        v18.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_3641 v0 v10;
+        return v18;
+}
+
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_0a95(v0.@layout_5, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c700 v0 v4;
+        return v5;
+}
+
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_18e6(v0.@layout_5, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b705 v0 v4;
+        return v5;
+}
+
+func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_2519(v0.@layout_5, v1.i256) -> @layout_0 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_8736 v0 v4;
+        v7.i256 = shr 160.i256 v5;
+        v9.i1 = eq v7 0.i256;
+        v10.i1 = is_zero v9;
+        br v10 block2 block3;
 
     block2:
         evm_revert 0.i256 0.i256;
@@ -2473,102 +2436,48 @@ func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__de
         jump block4;
 
     block4:
-        v8.objref<@layout_0> = obj.alloc @layout_0;
-        v10.objref<i256> = obj.proj v8 0.i256;
-        obj.store v10 v2;
-        v11.@layout_0 = obj.load v8;
-        return v11;
+        v11.objref<@layout_0> = obj.alloc @layout_0;
+        v13.objref<i256> = obj.proj v11 0.i256;
+        obj.store v13 v5;
+        v14.@layout_0 = obj.load v11;
+        return v14;
 }
 
-func inline(always) private %impl_trait_BalanceOf__decode_payload__g3a69(v0.objref<@layout_4>) -> @layout_9 {
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_251a(v0.@layout_5, v1.i256) -> i256 {
     block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v2.@layout_0 = call %core__lib__abi__decode_field__gaa38_e11f v0;
-        v3.objref<@layout_9> = obj.alloc @layout_9;
-        v5.objref<@layout_0> = obj.proj v3 0.i256;
-        v6.objref<i256> = obj.proj v5 0.i256;
-        v7.i256 = extract_value v2 0.i256;
-        obj.store v6 v7;
-        v8.@layout_9 = obj.load v3;
-        return v8;
+        v4.i256 = mload v2 i256;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3bad v0 v4;
+        return v5;
 }
 
-func inline(always) private %impl_trait_Burn__decode_payload__g3a69(v0.objref<@layout_4>) -> @layout_10 {
+func inline(always) private %impl_trait_Symbol__decode_from__gd20d(v0.@layout_5, v1.i256) {
     block0:
-        jump block1;
-
-    block1:
-        v2.i256 = call %core__lib__abi__decode_field__g7400_8cdf v0;
-        v3.objref<@layout_10> = obj.alloc @layout_10;
-        v5.objref<i256> = obj.proj v3 0.i256;
-        obj.store v5 v2;
-        v6.@layout_10 = obj.load v3;
-        return v6;
-}
-
-func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_payload__g574e_15e7(v0.objref<@layout_4>) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_9505 v0;
-        v4.i256 = shr 160.i256 v2;
-        v6.i1 = eq v4 0.i256;
-        v7.i1 = is_zero v6;
-        br v7 block2 block3;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v8.objref<@layout_0> = obj.alloc @layout_0;
-        v10.objref<i256> = obj.proj v8 0.i256;
-        obj.store v10 v2;
-        v11.@layout_0 = obj.load v8;
-        return v11;
-}
-
-func inline(always) private %impl_trait_Approve__decode_payload__g3a69(v0.objref<@layout_4>) -> @layout_11 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.@layout_0 = call %core__lib__abi__decode_field__gaa38_2931 v0;
-        v3.i256 = call %core__lib__abi__decode_field__g7400_11ec v0;
-        v4.objref<@layout_11> = obj.alloc @layout_11;
-        v6.objref<@layout_0> = obj.proj v4 0.i256;
-        v7.objref<i256> = obj.proj v6 0.i256;
-        v8.i256 = extract_value v2 0.i256;
-        obj.store v7 v8;
-        v10.objref<i256> = obj.proj v4 1.i256;
-        obj.store v10 v3;
-        v11.@layout_11 = obj.load v4;
-        return v11;
-}
-
-func inline(always) private %impl_trait_Name__decode_payload__g3a69(v0.objref<@layout_4>) {
-    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
         jump block1;
 
     block1:
         return;
 }
 
-func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_payload__g574e_1ff5(v0.objref<@layout_4>) -> @layout_0 {
+func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_3641(v0.@layout_5, v1.i256) -> @layout_0 {
     block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v2.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_e5a8 v0;
-        v4.i256 = shr 160.i256 v2;
-        v6.i1 = eq v4 0.i256;
-        v7.i1 = is_zero v6;
-        br v7 block2 block3;
+        v4.i256 = mload v2 i256;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b9ca v0 v4;
+        v7.i256 = shr 160.i256 v5;
+        v9.i1 = eq v7 0.i256;
+        v10.i1 = is_zero v9;
+        br v10 block2 block3;
 
     block2:
         evm_revert 0.i256 0.i256;
@@ -2577,98 +2486,26 @@ func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__de
         jump block4;
 
     block4:
-        v8.objref<@layout_0> = obj.alloc @layout_0;
-        v10.objref<i256> = obj.proj v8 0.i256;
-        obj.store v10 v2;
-        v11.@layout_0 = obj.load v8;
-        return v11;
+        v11.objref<@layout_0> = obj.alloc @layout_0;
+        v13.objref<i256> = obj.proj v11 0.i256;
+        obj.store v13 v5;
+        v14.@layout_0 = obj.load v11;
+        return v14;
 }
 
-func inline(always) private %impl_trait_Decimals__decode_payload__g3a69(v0.objref<@layout_4>) {
+func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_3716(v0.@layout_5, v1.i256) -> @layout_0 {
     block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        return;
-}
-
-func inline(always) private %impl_trait_TotalSupply__decode_payload__g3a69(v0.objref<@layout_4>) {
-    block0:
-        jump block1;
-
-    block1:
-        return;
-}
-
-func inline(always) private %impl_trait_TransferFrom__decode_payload__g3a69(v0.objref<@layout_4>) -> @layout_12 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.@layout_0 = call %core__lib__abi__decode_field__gaa38_3063 v0;
-        v3.@layout_0 = call %core__lib__abi__decode_field__gaa38_3063 v0;
-        v4.i256 = call %core__lib__abi__decode_field__g7400_6a67 v0;
-        v5.objref<@layout_12> = obj.alloc @layout_12;
-        v7.objref<@layout_0> = obj.proj v5 0.i256;
-        v8.objref<i256> = obj.proj v7 0.i256;
-        v9.i256 = extract_value v2 0.i256;
-        obj.store v8 v9;
-        v11.objref<@layout_0> = obj.proj v5 1.i256;
-        v12.objref<i256> = obj.proj v11 0.i256;
-        v13.i256 = extract_value v3 0.i256;
-        obj.store v12 v13;
-        v15.objref<i256> = obj.proj v5 2.i256;
-        obj.store v15 v4;
-        v16.@layout_12 = obj.load v5;
-        return v16;
-}
-
-func inline(always) private %impl_trait_Transfer__decode_payload__g3a69(v0.objref<@layout_4>) -> @layout_13 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.@layout_0 = call %core__lib__abi__decode_field__gaa38_98d1 v0;
-        v3.i256 = call %core__lib__abi__decode_field__g7400_be39 v0;
-        v4.objref<@layout_13> = obj.alloc @layout_13;
-        v6.objref<@layout_0> = obj.proj v4 0.i256;
-        v7.objref<i256> = obj.proj v6 0.i256;
-        v8.i256 = extract_value v2 0.i256;
-        obj.store v7 v8;
-        v10.objref<i256> = obj.proj v4 1.i256;
-        obj.store v10 v3;
-        v11.@layout_13 = obj.load v4;
-        return v11;
-}
-
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_payload__g574e_423a(v0.objref<@layout_4>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_5416 v0;
-        return v2;
-}
-
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_payload__g574e_646d(v0.objref<@layout_4>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_d285 v0;
-        return v2;
-}
-
-func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_payload__g574e_66a8(v0.objref<@layout_4>) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_3b91 v0;
-        v4.i256 = shr 160.i256 v2;
-        v6.i1 = eq v4 0.i256;
-        v7.i1 = is_zero v6;
-        br v7 block2 block3;
+        v4.i256 = mload v2 i256;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_d831 v0 v4;
+        v7.i256 = shr 160.i256 v5;
+        v9.i1 = eq v7 0.i256;
+        v10.i1 = is_zero v9;
+        br v10 block2 block3;
 
     block2:
         evm_revert 0.i256 0.i256;
@@ -2677,23 +2514,50 @@ func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__de
         jump block4;
 
     block4:
-        v8.objref<@layout_0> = obj.alloc @layout_0;
-        v10.objref<i256> = obj.proj v8 0.i256;
-        obj.store v10 v2;
-        v11.@layout_0 = obj.load v8;
-        return v11;
+        v11.objref<@layout_0> = obj.alloc @layout_0;
+        v13.objref<i256> = obj.proj v11 0.i256;
+        obj.store v13 v5;
+        v14.@layout_0 = obj.load v11;
+        return v14;
 }
 
-func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_payload__g574e_69f0(v0.objref<@layout_4>) -> @layout_0 {
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_3a7c(v0.@layout_5, v1.i256) -> i256 {
     block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v2.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_01ce v0;
-        v4.i256 = shr 160.i256 v2;
-        v6.i1 = eq v4 0.i256;
-        v7.i1 = is_zero v6;
-        br v7 block2 block3;
+        v4.i256 = mload v2 i256;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_9757 v0 v4;
+        return v5;
+}
+
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_4e52(v0.@layout_5, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_790f v0 v4;
+        return v5;
+}
+
+func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_4e5e(v0.@layout_5, v1.i256) -> @layout_0 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_fec2 v0 v4;
+        v7.i256 = shr 160.i256 v5;
+        v9.i1 = eq v7 0.i256;
+        v10.i1 = is_zero v9;
+        br v10 block2 block3;
 
     block2:
         evm_revert 0.i256 0.i256;
@@ -2702,22 +2566,537 @@ func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__de
         jump block4;
 
     block4:
-        v8.objref<@layout_0> = obj.alloc @layout_0;
-        v10.objref<i256> = obj.proj v8 0.i256;
-        obj.store v10 v2;
-        v11.@layout_0 = obj.load v8;
-        return v11;
+        v11.objref<@layout_0> = obj.alloc @layout_0;
+        v13.objref<i256> = obj.proj v11 0.i256;
+        obj.store v13 v5;
+        v14.@layout_0 = obj.load v11;
+        return v14;
 }
 
-func inline(always) private %impl_trait_Symbol__decode_payload__g3a69(v0.objref<@layout_4>) {
+func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_5535(v0.@layout_5, v1.i256) -> @layout_0 {
     block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_a6b2 v0 v4;
+        v7.i256 = shr 160.i256 v5;
+        v9.i1 = eq v7 0.i256;
+        v10.i1 = is_zero v9;
+        br v10 block2 block3;
+
+    block2:
+        evm_revert 0.i256 0.i256;
+
+    block3:
+        jump block4;
+
+    block4:
+        v11.objref<@layout_0> = obj.alloc @layout_0;
+        v13.objref<i256> = obj.proj v11 0.i256;
+        obj.store v13 v5;
+        v14.@layout_0 = obj.load v11;
+        return v14;
+}
+
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_5c31(v0.@layout_5, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3a1f v0 v4;
+        return v5;
+}
+
+func inline(always) private %impl_trait_Allowance__decode_from__gd20d(v0.@layout_5, v1.i256) -> @layout_6 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v2 i256;
+        v6.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_1aba v0 v4 v5;
+        v7.i256 = mload v2 i256;
+        v8.i256 = mload v2 i256;
+        (v10.i256, v11.i1) = uaddo v8 32.i256;
+        br v11 block2 block3;
+
+    block2:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block3:
+        v19.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_1aba v0 v7 v10;
+        v20.objref<@layout_6> = obj.alloc @layout_6;
+        v22.objref<@layout_0> = obj.proj v20 0.i256;
+        v23.objref<i256> = obj.proj v22 0.i256;
+        v24.i256 = extract_value v6 0.i256;
+        obj.store v23 v24;
+        v26.objref<@layout_0> = obj.proj v20 1.i256;
+        v27.objref<i256> = obj.proj v26 0.i256;
+        v28.i256 = extract_value v19 0.i256;
+        obj.store v27 v28;
+        v29.@layout_6 = obj.load v20;
+        return v29;
+}
+
+func inline(always) private %impl_trait_Approve__decode_from__gd20d(v0.@layout_5, v1.i256) -> @layout_7 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v2 i256;
+        v6.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_2b31 v0 v4 v5;
+        v7.i256 = mload v2 i256;
+        v8.i256 = mload v2 i256;
+        (v10.i256, v11.i1) = uaddo v8 32.i256;
+        br v11 block2 block3;
+
+    block2:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block3:
+        v19.i256 = call %core__lib__abi__decode_field_from__g5385_7d9f v0 v7 v10;
+        v20.objref<@layout_7> = obj.alloc @layout_7;
+        v22.objref<@layout_0> = obj.proj v20 0.i256;
+        v23.objref<i256> = obj.proj v22 0.i256;
+        v24.i256 = extract_value v6 0.i256;
+        obj.store v23 v24;
+        v26.objref<i256> = obj.proj v20 1.i256;
+        obj.store v26 v19;
+        v27.@layout_7 = obj.load v20;
+        return v27;
+}
+
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8d9f(v0.@layout_5, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b461 v0 v4;
+        return v5;
+}
+
+func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_9286(v0.@layout_5, v1.i256) -> @layout_0 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_a8d6 v0 v4;
+        v7.i256 = shr 160.i256 v5;
+        v9.i1 = eq v7 0.i256;
+        v10.i1 = is_zero v9;
+        br v10 block2 block3;
+
+    block2:
+        evm_revert 0.i256 0.i256;
+
+    block3:
+        jump block4;
+
+    block4:
+        v11.objref<@layout_0> = obj.alloc @layout_0;
+        v13.objref<i256> = obj.proj v11 0.i256;
+        obj.store v13 v5;
+        v14.@layout_0 = obj.load v11;
+        return v14;
+}
+
+func inline(always) private %impl_trait_Mint__decode_from__gd20d(v0.@layout_5, v1.i256) -> @layout_8 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v2 i256;
+        v6.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_c63b v0 v4 v5;
+        v7.i256 = mload v2 i256;
+        v8.i256 = mload v2 i256;
+        (v10.i256, v11.i1) = uaddo v8 32.i256;
+        br v11 block2 block3;
+
+    block2:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block3:
+        v19.i256 = call %core__lib__abi__decode_field_from__g5385_8921 v0 v7 v10;
+        v20.objref<@layout_8> = obj.alloc @layout_8;
+        v22.objref<@layout_0> = obj.proj v20 0.i256;
+        v23.objref<i256> = obj.proj v22 0.i256;
+        v24.i256 = extract_value v6 0.i256;
+        obj.store v23 v24;
+        v26.objref<i256> = obj.proj v20 1.i256;
+        obj.store v26 v19;
+        v27.@layout_8 = obj.load v20;
+        return v27;
+}
+
+func inline(always) private %impl_trait_Burn__decode_from__gd20d(v0.@layout_5, v1.i256) -> @layout_9 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v2 i256;
+        v6.i256 = call %core__lib__abi__decode_field_from__g5385_c0de v0 v4 v5;
+        v7.objref<@layout_9> = obj.alloc @layout_9;
+        v9.objref<i256> = obj.proj v7 0.i256;
+        obj.store v9 v6;
+        v10.@layout_9 = obj.load v7;
+        return v10;
+}
+
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_b39f(v0.@layout_5, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_e134 v0 v4;
+        return v5;
+}
+
+func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_b822(v0.@layout_5, v1.i256) -> @layout_0 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_40a0 v0 v4;
+        v7.i256 = shr 160.i256 v5;
+        v9.i1 = eq v7 0.i256;
+        v10.i1 = is_zero v9;
+        br v10 block2 block3;
+
+    block2:
+        evm_revert 0.i256 0.i256;
+
+    block3:
+        jump block4;
+
+    block4:
+        v11.objref<@layout_0> = obj.alloc @layout_0;
+        v13.objref<i256> = obj.proj v11 0.i256;
+        obj.store v13 v5;
+        v14.@layout_0 = obj.load v11;
+        return v14;
+}
+
+func inline(always) private %impl_trait_BurnFrom__decode_from__gd20d(v0.@layout_5, v1.i256) -> @layout_10 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v2 i256;
+        v6.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_05e1 v0 v4 v5;
+        v7.i256 = mload v2 i256;
+        v8.i256 = mload v2 i256;
+        (v10.i256, v11.i1) = uaddo v8 32.i256;
+        br v11 block2 block3;
+
+    block2:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block3:
+        v19.i256 = call %core__lib__abi__decode_field_from__g5385_c71a v0 v7 v10;
+        v20.objref<@layout_10> = obj.alloc @layout_10;
+        v22.objref<@layout_0> = obj.proj v20 0.i256;
+        v23.objref<i256> = obj.proj v22 0.i256;
+        v24.i256 = extract_value v6 0.i256;
+        obj.store v23 v24;
+        v26.objref<i256> = obj.proj v20 1.i256;
+        obj.store v26 v19;
+        v27.@layout_10 = obj.load v20;
+        return v27;
+}
+
+func inline(always) private %impl_trait_Decimals__decode_from__gd20d(v0.@layout_5, v1.i256) {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
         jump block1;
 
     block1:
         return;
 }
 
-func inline(always) private %impl_trait_Address__decode_payload__g407e(v0.objref<@layout_7>) -> @layout_0 {
+func inline(always) private %impl_trait_BalanceOf__decode_from__gd20d(v0.@layout_5, v1.i256) -> @layout_11 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v2 i256;
+        v6.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_fd62 v0 v4 v5;
+        v7.objref<@layout_11> = obj.alloc @layout_11;
+        v9.objref<@layout_0> = obj.proj v7 0.i256;
+        v10.objref<i256> = obj.proj v9 0.i256;
+        v11.i256 = extract_value v6 0.i256;
+        obj.store v10 v11;
+        v12.@layout_11 = obj.load v7;
+        return v12;
+}
+
+func inline(always) private %impl_trait_Name__decode_from__gd20d(v0.@layout_5, v1.i256) {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        return;
+}
+
+func inline(always) private %impl_trait_IncreaseAllowance__decode_from__gd20d(v0.@layout_5, v1.i256) -> @layout_12 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v2 i256;
+        v6.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_6a4b v0 v4 v5;
+        v7.i256 = mload v2 i256;
+        v8.i256 = mload v2 i256;
+        (v10.i256, v11.i1) = uaddo v8 32.i256;
+        br v11 block2 block3;
+
+    block2:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block3:
+        v19.i256 = call %core__lib__abi__decode_field_from__g5385_9c75 v0 v7 v10;
+        v20.objref<@layout_12> = obj.alloc @layout_12;
+        v22.objref<@layout_0> = obj.proj v20 0.i256;
+        v23.objref<i256> = obj.proj v22 0.i256;
+        v24.i256 = extract_value v6 0.i256;
+        obj.store v23 v24;
+        v26.objref<i256> = obj.proj v20 1.i256;
+        obj.store v26 v19;
+        v27.@layout_12 = obj.load v20;
+        return v27;
+}
+
+func inline(always) private %impl_trait_TransferFrom__decode_from__gd20d(v0.@layout_5, v1.i256) -> @layout_13 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v2 i256;
+        v6.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_8ab8 v0 v4 v5;
+        v7.i256 = mload v2 i256;
+        v8.i256 = mload v2 i256;
+        (v10.i256, v11.i1) = uaddo v8 32.i256;
+        br v11 block2 block3;
+
+    block2:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block3:
+        v19.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_8ab8 v0 v7 v10;
+        v21.i256 = mload v2 i256;
+        v22.i256 = mload v2 i256;
+        (v23.i256, v24.i1) = uaddo v22 32.i256;
+        br v24 block2 block4;
+
+    block4:
+        (v25.i256, v26.i1) = uaddo v23 32.i256;
+        br v26 block2 block5;
+
+    block5:
+        v29.i256 = call %core__lib__abi__decode_field_from__g5385_30a1 v0 v21 v25;
+        v30.objref<@layout_13> = obj.alloc @layout_13;
+        v32.objref<@layout_0> = obj.proj v30 0.i256;
+        v33.objref<i256> = obj.proj v32 0.i256;
+        v34.i256 = extract_value v6 0.i256;
+        obj.store v33 v34;
+        v37.objref<@layout_0> = obj.proj v30 1.i256;
+        v38.objref<i256> = obj.proj v37 0.i256;
+        v39.i256 = extract_value v19 0.i256;
+        obj.store v38 v39;
+        v41.objref<i256> = obj.proj v30 2.i256;
+        obj.store v41 v29;
+        v42.@layout_13 = obj.load v30;
+        return v42;
+}
+
+func inline(always) private %impl_trait_Transfer__decode_from__gd20d(v0.@layout_5, v1.i256) -> @layout_14 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v2 i256;
+        v6.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_cd1a v0 v4 v5;
+        v7.i256 = mload v2 i256;
+        v8.i256 = mload v2 i256;
+        (v10.i256, v11.i1) = uaddo v8 32.i256;
+        br v11 block2 block3;
+
+    block2:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block3:
+        v19.i256 = call %core__lib__abi__decode_field_from__g5385_d823 v0 v7 v10;
+        v20.objref<@layout_14> = obj.alloc @layout_14;
+        v22.objref<@layout_0> = obj.proj v20 0.i256;
+        v23.objref<i256> = obj.proj v22 0.i256;
+        v24.i256 = extract_value v6 0.i256;
+        obj.store v23 v24;
+        v26.objref<i256> = obj.proj v20 1.i256;
+        obj.store v26 v19;
+        v27.@layout_14 = obj.load v20;
+        return v27;
+}
+
+func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_db93(v0.@layout_5, v1.i256) -> @layout_0 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3ba3 v0 v4;
+        v7.i256 = shr 160.i256 v5;
+        v9.i1 = eq v7 0.i256;
+        v10.i1 = is_zero v9;
+        br v10 block2 block3;
+
+    block2:
+        evm_revert 0.i256 0.i256;
+
+    block3:
+        jump block4;
+
+    block4:
+        v11.objref<@layout_0> = obj.alloc @layout_0;
+        v13.objref<i256> = obj.proj v11 0.i256;
+        obj.store v13 v5;
+        v14.@layout_0 = obj.load v11;
+        return v14;
+}
+
+func inline(always) private %impl_trait_DecreaseAllowance__decode_from__gd20d(v0.@layout_5, v1.i256) -> @layout_15 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v2 i256;
+        v6.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_b81d v0 v4 v5;
+        v7.i256 = mload v2 i256;
+        v8.i256 = mload v2 i256;
+        (v10.i256, v11.i1) = uaddo v8 32.i256;
+        br v11 block2 block3;
+
+    block2:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block3:
+        v19.i256 = call %core__lib__abi__decode_field_from__g5385_4478 v0 v7 v10;
+        v20.objref<@layout_15> = obj.alloc @layout_15;
+        v22.objref<@layout_0> = obj.proj v20 0.i256;
+        v23.objref<i256> = obj.proj v22 0.i256;
+        v24.i256 = extract_value v6 0.i256;
+        obj.store v23 v24;
+        v26.objref<i256> = obj.proj v20 1.i256;
+        obj.store v26 v19;
+        v27.@layout_15 = obj.load v20;
+        return v27;
+}
+
+func inline(always) private %impl_trait_TotalSupply__decode_from__gd20d(v0.@layout_5, v1.i256) {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        return;
+}
+
+func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_f4e0(v0.@layout_5, v1.i256) -> @layout_0 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_bae8 v0 v4;
+        v7.i256 = shr 160.i256 v5;
+        v9.i1 = eq v7 0.i256;
+        v10.i1 = is_zero v9;
+        br v10 block2 block3;
+
+    block2:
+        evm_revert 0.i256 0.i256;
+
+    block3:
+        jump block4;
+
+    block4:
+        v11.objref<@layout_0> = obj.alloc @layout_0;
+        v13.objref<i256> = obj.proj v11 0.i256;
+        obj.store v13 v5;
+        v14.@layout_0 = obj.load v11;
+        return v14;
+}
+
+func inline(always) private %impl_trait_Address__decode_payload__g407e(v0.objref<@layout_4>) -> @layout_0 {
     block0:
         jump block1;
 
@@ -2742,88 +3121,25 @@ func inline(always) private %impl_trait_Address__decode_payload__g407e(v0.objref
         return v11;
 }
 
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_payload__g574e_8546(v0.objref<@layout_4>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_9776 v0;
-        return v2;
-}
-
-func inline(always) private %impl_trait_BurnFrom__decode_payload__g3a69(v0.objref<@layout_4>) -> @layout_14 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.@layout_0 = call %core__lib__abi__decode_field__gaa38_0bfd v0;
-        v3.i256 = call %core__lib__abi__decode_field__g7400_ac4e v0;
-        v4.objref<@layout_14> = obj.alloc @layout_14;
-        v6.objref<@layout_0> = obj.proj v4 0.i256;
-        v7.objref<i256> = obj.proj v6 0.i256;
-        v8.i256 = extract_value v2 0.i256;
-        obj.store v7 v8;
-        v10.objref<i256> = obj.proj v4 1.i256;
-        obj.store v10 v3;
-        v11.@layout_14 = obj.load v4;
-        return v11;
-}
-
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_payload__g574e_89fa(v0.objref<@layout_4>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_b0d4 v0;
-        return v2;
-}
-
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_payload__g574e_8b49(v0.objref<@layout_4>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_0022 v0;
-        return v2;
-}
-
-func private %decode_payload__gf566(v0.objref<@layout_7>) -> @layout_15 {
+func private %decode_payload__gf566(v0.objref<@layout_4>) -> @layout_16 {
     block0:
         jump block1;
 
     block1:
         v2.i256 = call %decode_field__g3854 v0;
         v3.@layout_0 = call %decode_field__g8463 v0;
-        v4.objref<@layout_15> = obj.alloc @layout_15;
+        v4.objref<@layout_16> = obj.alloc @layout_16;
         v6.objref<i256> = obj.proj v4 0.i256;
         obj.store v6 v2;
         v8.objref<@layout_0> = obj.proj v4 1.i256;
         v9.objref<i256> = obj.proj v8 0.i256;
         v10.i256 = extract_value v3 0.i256;
         obj.store v9 v10;
-        v11.@layout_15 = obj.load v4;
-        return v11;
-}
-
-func inline(always) private %impl_trait_IncreaseAllowance__decode_payload__g3a69(v0.objref<@layout_4>) -> @layout_16 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.@layout_0 = call %core__lib__abi__decode_field__gaa38_1a99 v0;
-        v3.i256 = call %core__lib__abi__decode_field__g7400_4cf3 v0;
-        v4.objref<@layout_16> = obj.alloc @layout_16;
-        v6.objref<@layout_0> = obj.proj v4 0.i256;
-        v7.objref<i256> = obj.proj v6 0.i256;
-        v8.i256 = extract_value v2 0.i256;
-        obj.store v7 v8;
-        v10.objref<i256> = obj.proj v4 1.i256;
-        obj.store v10 v3;
         v11.@layout_16 = obj.load v4;
         return v11;
 }
 
-func inline(always) private %impl_trait_u256__decode_payload__g407e(v0.objref<@layout_7>) -> i256 {
+func inline(always) private %impl_trait_u256__decode_payload__g407e(v0.objref<@layout_4>) -> i256 {
     block0:
         jump block1;
 
@@ -2832,685 +3148,814 @@ func inline(always) private %impl_trait_u256__decode_payload__g407e(v0.objref<@l
         return v2;
 }
 
-func inline(always) private %impl_trait_Allowance__decode_payload__g3a69(v0.objref<@layout_4>) -> @layout_17 {
+func inline(always) private %decode_runtime_args__g5a0b(v0.objref<@layout_18>) {
     block0:
+        v1.*i256 = alloca i256;
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v2.@layout_0 = call %core__lib__abi__decode_field__gaa38_0306 v0;
-        v3.@layout_0 = call %core__lib__abi__decode_field__gaa38_0306 v0;
-        v4.objref<@layout_17> = obj.alloc @layout_17;
-        v6.objref<@layout_0> = obj.proj v4 0.i256;
-        v7.objref<i256> = obj.proj v6 0.i256;
-        v8.i256 = extract_value v2 0.i256;
-        obj.store v7 v8;
-        v10.objref<@layout_0> = obj.proj v4 1.i256;
-        v11.objref<i256> = obj.proj v10 0.i256;
-        v12.i256 = extract_value v3 0.i256;
-        obj.store v11 v12;
-        v13.@layout_17 = obj.load v4;
-        return v13;
-}
-
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_payload__g574e_c028(v0.objref<@layout_4>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_80b7 v0;
-        return v2;
-}
-
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_payload__g574e_d74a(v0.objref<@layout_4>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_b3be v0;
-        return v2;
-}
-
-func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_payload__g574e_e2c8(v0.objref<@layout_4>) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_6bd8 v0;
-        v4.i256 = shr 160.i256 v2;
-        v6.i1 = eq v4 0.i256;
-        v7.i1 = is_zero v6;
-        br v7 block2 block3;
+        v5.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_cd56;
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_fc14 v5;
+        mstore v1 v7 i256;
+        v8.i256 = mload v1 i256;
+        mstore v2 v8 i256;
+        v9.i256 = mload v2 i256;
+        v10.i1 = gt 4.i256 v9;
+        br v10 block2 block3;
 
     block2:
-        evm_revert 0.i256 0.i256;
+        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_57a6;
+        unreachable;
 
     block3:
         jump block4;
 
     block4:
-        v8.objref<@layout_0> = obj.alloc @layout_0;
-        v10.objref<i256> = obj.proj v8 0.i256;
-        obj.store v10 v2;
-        v11.@layout_0 = obj.load v8;
-        return v11;
+        br 1.i1 block5 block6;
+
+    block5:
+        mstore v3 4.i256 i256;
+        br 0.i1 block8 block11;
+
+    block6:
+        jump block7;
+
+    block7:
+        call %impl_trait_Decimals__decode_from__gd20d v5 4.i256;
+        return;
+
+    block8:
+        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_57a6;
+        unreachable;
+
+    block9:
+        jump block10;
+
+    block10:
+        jump block7;
+
+    block11:
+        v17.i256 = mload v1 i256;
+        mstore v4 v17 i256;
+        v19.i256 = mload v4 i256;
+        v20.i1 = gt 4.i256 v19;
+        br v20 block8 block9;
 }
 
-func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_payload__g574e_e3de(v0.objref<@layout_4>) -> @layout_0 {
+func inline(always) private %decode_runtime_args__g6a7c(v0.objref<@layout_18>) -> @layout_15 {
     block0:
+        v1.*i256 = alloca i256;
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v2.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_fd2f v0;
-        v4.i256 = shr 160.i256 v2;
-        v6.i1 = eq v4 0.i256;
-        v7.i1 = is_zero v6;
-        br v7 block2 block3;
+        v5.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_663b;
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_5dcb v5;
+        mstore v1 v7 i256;
+        v8.i256 = mload v1 i256;
+        mstore v2 v8 i256;
+        v9.i256 = mload v2 i256;
+        v10.i1 = gt 4.i256 v9;
+        br v10 block2 block3;
 
     block2:
-        evm_revert 0.i256 0.i256;
+        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_20f2;
+        unreachable;
 
     block3:
         jump block4;
 
     block4:
-        v8.objref<@layout_0> = obj.alloc @layout_0;
-        v10.objref<i256> = obj.proj v8 0.i256;
-        obj.store v10 v2;
-        v11.@layout_0 = obj.load v8;
-        return v11;
+        br 1.i1 block5 block6;
+
+    block5:
+        mstore v3 4.i256 i256;
+        br 0.i1 block8 block11;
+
+    block6:
+        jump block7;
+
+    block7:
+        v17.@layout_15 = call %impl_trait_DecreaseAllowance__decode_from__gd20d v5 4.i256;
+        return v17;
+
+    block8:
+        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_20f2;
+        unreachable;
+
+    block9:
+        jump block10;
+
+    block10:
+        jump block7;
+
+    block11:
+        v18.i256 = mload v1 i256;
+        mstore v4 v18 i256;
+        v20.i256 = mload v4 i256;
+        v21.i1 = gt 68.i256 v20;
+        br v21 block8 block9;
 }
 
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_payload__g574e_e794(v0.objref<@layout_4>) -> i256 {
+func inline(always) private %decode_runtime_args__g7a2c(v0.objref<@layout_18>) -> @layout_7 {
+    block0:
+        v1.*i256 = alloca i256;
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v5.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_a580;
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_22ff v5;
+        mstore v1 v7 i256;
+        v8.i256 = mload v1 i256;
+        mstore v2 v8 i256;
+        v9.i256 = mload v2 i256;
+        v10.i1 = gt 4.i256 v9;
+        br v10 block2 block3;
+
+    block2:
+        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_ce6e;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        br 1.i1 block5 block6;
+
+    block5:
+        mstore v3 4.i256 i256;
+        br 0.i1 block8 block11;
+
+    block6:
+        jump block7;
+
+    block7:
+        v17.@layout_7 = call %impl_trait_Approve__decode_from__gd20d v5 4.i256;
+        return v17;
+
+    block8:
+        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_ce6e;
+        unreachable;
+
+    block9:
+        jump block10;
+
+    block10:
+        jump block7;
+
+    block11:
+        v18.i256 = mload v1 i256;
+        mstore v4 v18 i256;
+        v20.i256 = mload v4 i256;
+        v21.i1 = gt 68.i256 v20;
+        br v21 block8 block9;
+}
+
+func inline(always) private %decode_runtime_args__g295c(v0.objref<@layout_18>) {
+    block0:
+        v1.*i256 = alloca i256;
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v5.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_5bd8;
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_ae2f v5;
+        mstore v1 v7 i256;
+        v8.i256 = mload v1 i256;
+        mstore v2 v8 i256;
+        v9.i256 = mload v2 i256;
+        v10.i1 = gt 4.i256 v9;
+        br v10 block2 block3;
+
+    block2:
+        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_9941;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        br 1.i1 block5 block6;
+
+    block5:
+        mstore v3 4.i256 i256;
+        br 0.i1 block8 block11;
+
+    block6:
+        jump block7;
+
+    block7:
+        call %impl_trait_Symbol__decode_from__gd20d v5 4.i256;
+        return;
+
+    block8:
+        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_9941;
+        unreachable;
+
+    block9:
+        jump block10;
+
+    block10:
+        jump block7;
+
+    block11:
+        v17.i256 = mload v1 i256;
+        mstore v4 v17 i256;
+        v19.i256 = mload v4 i256;
+        v20.i1 = gt 4.i256 v19;
+        br v20 block8 block9;
+}
+
+func inline(always) private %decode_runtime_args__gce7d(v0.objref<@layout_18>) {
+    block0:
+        v1.*i256 = alloca i256;
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v5.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_88e5;
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_9efd v5;
+        mstore v1 v7 i256;
+        v8.i256 = mload v1 i256;
+        mstore v2 v8 i256;
+        v9.i256 = mload v2 i256;
+        v10.i1 = gt 4.i256 v9;
+        br v10 block2 block3;
+
+    block2:
+        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_b229;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        br 1.i1 block5 block6;
+
+    block5:
+        mstore v3 4.i256 i256;
+        br 0.i1 block8 block11;
+
+    block6:
+        jump block7;
+
+    block7:
+        call %impl_trait_TotalSupply__decode_from__gd20d v5 4.i256;
+        return;
+
+    block8:
+        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_b229;
+        unreachable;
+
+    block9:
+        jump block10;
+
+    block10:
+        jump block7;
+
+    block11:
+        v17.i256 = mload v1 i256;
+        mstore v4 v17 i256;
+        v19.i256 = mload v4 i256;
+        v20.i1 = gt 4.i256 v19;
+        br v20 block8 block9;
+}
+
+func inline(always) private %decode_runtime_args__g2273(v0.objref<@layout_18>) -> @layout_8 {
+    block0:
+        v1.*i256 = alloca i256;
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v5.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_f89e;
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_5742 v5;
+        mstore v1 v7 i256;
+        v8.i256 = mload v1 i256;
+        mstore v2 v8 i256;
+        v9.i256 = mload v2 i256;
+        v10.i1 = gt 4.i256 v9;
+        br v10 block2 block3;
+
+    block2:
+        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_0a69;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        br 1.i1 block5 block6;
+
+    block5:
+        mstore v3 4.i256 i256;
+        br 0.i1 block8 block11;
+
+    block6:
+        jump block7;
+
+    block7:
+        v17.@layout_8 = call %impl_trait_Mint__decode_from__gd20d v5 4.i256;
+        return v17;
+
+    block8:
+        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_0a69;
+        unreachable;
+
+    block9:
+        jump block10;
+
+    block10:
+        jump block7;
+
+    block11:
+        v18.i256 = mload v1 i256;
+        mstore v4 v18 i256;
+        v20.i256 = mload v4 i256;
+        v21.i1 = gt 68.i256 v20;
+        br v21 block8 block9;
+}
+
+func inline(always) private %decode_runtime_args__g4e54(v0.objref<@layout_18>) -> @layout_13 {
+    block0:
+        v1.*i256 = alloca i256;
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v5.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_3dc9;
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_ce93 v5;
+        mstore v1 v7 i256;
+        v8.i256 = mload v1 i256;
+        mstore v2 v8 i256;
+        v9.i256 = mload v2 i256;
+        v10.i1 = gt 4.i256 v9;
+        br v10 block2 block3;
+
+    block2:
+        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_2f36;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        br 1.i1 block5 block6;
+
+    block5:
+        mstore v3 4.i256 i256;
+        br 0.i1 block8 block11;
+
+    block6:
+        jump block7;
+
+    block7:
+        v17.@layout_13 = call %impl_trait_TransferFrom__decode_from__gd20d v5 4.i256;
+        return v17;
+
+    block8:
+        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_2f36;
+        unreachable;
+
+    block9:
+        jump block10;
+
+    block10:
+        jump block7;
+
+    block11:
+        v18.i256 = mload v1 i256;
+        mstore v4 v18 i256;
+        v20.i256 = mload v4 i256;
+        v21.i1 = gt 100.i256 v20;
+        br v21 block8 block9;
+}
+
+func inline(always) private %decode_runtime_args__g698d(v0.objref<@layout_18>) -> @layout_12 {
+    block0:
+        v1.*i256 = alloca i256;
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v5.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_d673;
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_f03b v5;
+        mstore v1 v7 i256;
+        v8.i256 = mload v1 i256;
+        mstore v2 v8 i256;
+        v9.i256 = mload v2 i256;
+        v10.i1 = gt 4.i256 v9;
+        br v10 block2 block3;
+
+    block2:
+        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_cb5c;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        br 1.i1 block5 block6;
+
+    block5:
+        mstore v3 4.i256 i256;
+        br 0.i1 block8 block11;
+
+    block6:
+        jump block7;
+
+    block7:
+        v17.@layout_12 = call %impl_trait_IncreaseAllowance__decode_from__gd20d v5 4.i256;
+        return v17;
+
+    block8:
+        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_cb5c;
+        unreachable;
+
+    block9:
+        jump block10;
+
+    block10:
+        jump block7;
+
+    block11:
+        v18.i256 = mload v1 i256;
+        mstore v4 v18 i256;
+        v20.i256 = mload v4 i256;
+        v21.i1 = gt 68.i256 v20;
+        br v21 block8 block9;
+}
+
+func inline(always) private %decode_runtime_args__gc772(v0.objref<@layout_18>) -> @layout_6 {
+    block0:
+        v1.*i256 = alloca i256;
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v5.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_3347;
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_4a91 v5;
+        mstore v1 v7 i256;
+        v8.i256 = mload v1 i256;
+        mstore v2 v8 i256;
+        v9.i256 = mload v2 i256;
+        v10.i1 = gt 4.i256 v9;
+        br v10 block2 block3;
+
+    block2:
+        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_12ed;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        br 1.i1 block5 block6;
+
+    block5:
+        mstore v3 4.i256 i256;
+        br 0.i1 block8 block11;
+
+    block6:
+        jump block7;
+
+    block7:
+        v17.@layout_6 = call %impl_trait_Allowance__decode_from__gd20d v5 4.i256;
+        return v17;
+
+    block8:
+        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_12ed;
+        unreachable;
+
+    block9:
+        jump block10;
+
+    block10:
+        jump block7;
+
+    block11:
+        v18.i256 = mload v1 i256;
+        mstore v4 v18 i256;
+        v20.i256 = mload v4 i256;
+        v21.i1 = gt 68.i256 v20;
+        br v21 block8 block9;
+}
+
+func inline(always) private %decode_runtime_args__g953d(v0.objref<@layout_18>) -> @layout_11 {
+    block0:
+        v1.*i256 = alloca i256;
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v5.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_b73f;
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_6107 v5;
+        mstore v1 v7 i256;
+        v8.i256 = mload v1 i256;
+        mstore v2 v8 i256;
+        v9.i256 = mload v2 i256;
+        v10.i1 = gt 4.i256 v9;
+        br v10 block2 block3;
+
+    block2:
+        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_6993;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        br 1.i1 block5 block6;
+
+    block5:
+        mstore v3 4.i256 i256;
+        br 0.i1 block8 block11;
+
+    block6:
+        jump block7;
+
+    block7:
+        v17.@layout_11 = call %impl_trait_BalanceOf__decode_from__gd20d v5 4.i256;
+        return v17;
+
+    block8:
+        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_6993;
+        unreachable;
+
+    block9:
+        jump block10;
+
+    block10:
+        jump block7;
+
+    block11:
+        v18.i256 = mload v1 i256;
+        mstore v4 v18 i256;
+        v20.i256 = mload v4 i256;
+        v21.i1 = gt 36.i256 v20;
+        br v21 block8 block9;
+}
+
+func inline(always) private %decode_runtime_args__g216b(v0.objref<@layout_18>) -> @layout_10 {
+    block0:
+        v1.*i256 = alloca i256;
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v5.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_6a54;
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_7388 v5;
+        mstore v1 v7 i256;
+        v8.i256 = mload v1 i256;
+        mstore v2 v8 i256;
+        v9.i256 = mload v2 i256;
+        v10.i1 = gt 4.i256 v9;
+        br v10 block2 block3;
+
+    block2:
+        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_cf57;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        br 1.i1 block5 block6;
+
+    block5:
+        mstore v3 4.i256 i256;
+        br 0.i1 block8 block11;
+
+    block6:
+        jump block7;
+
+    block7:
+        v17.@layout_10 = call %impl_trait_BurnFrom__decode_from__gd20d v5 4.i256;
+        return v17;
+
+    block8:
+        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_cf57;
+        unreachable;
+
+    block9:
+        jump block10;
+
+    block10:
+        jump block7;
+
+    block11:
+        v18.i256 = mload v1 i256;
+        mstore v4 v18 i256;
+        v20.i256 = mload v4 i256;
+        v21.i1 = gt 68.i256 v20;
+        br v21 block8 block9;
+}
+
+func inline(always) private %decode_runtime_args__gf629(v0.objref<@layout_18>) -> @layout_9 {
+    block0:
+        v1.*i256 = alloca i256;
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v5.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_e029;
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_c018 v5;
+        mstore v1 v7 i256;
+        v8.i256 = mload v1 i256;
+        mstore v2 v8 i256;
+        v9.i256 = mload v2 i256;
+        v10.i1 = gt 4.i256 v9;
+        br v10 block2 block3;
+
+    block2:
+        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_98a8;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        br 1.i1 block5 block6;
+
+    block5:
+        mstore v3 4.i256 i256;
+        br 0.i1 block8 block11;
+
+    block6:
+        jump block7;
+
+    block7:
+        v17.@layout_9 = call %impl_trait_Burn__decode_from__gd20d v5 4.i256;
+        return v17;
+
+    block8:
+        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_98a8;
+        unreachable;
+
+    block9:
+        jump block10;
+
+    block10:
+        jump block7;
+
+    block11:
+        v18.i256 = mload v1 i256;
+        mstore v4 v18 i256;
+        v20.i256 = mload v4 i256;
+        v21.i1 = gt 36.i256 v20;
+        br v21 block8 block9;
+}
+
+func inline(always) private %decode_runtime_args__gce2e(v0.objref<@layout_18>) {
+    block0:
+        v1.*i256 = alloca i256;
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v5.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_844a;
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_b318 v5;
+        mstore v1 v7 i256;
+        v8.i256 = mload v1 i256;
+        mstore v2 v8 i256;
+        v9.i256 = mload v2 i256;
+        v10.i1 = gt 4.i256 v9;
+        br v10 block2 block3;
+
+    block2:
+        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_66b1;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        br 1.i1 block5 block6;
+
+    block5:
+        mstore v3 4.i256 i256;
+        br 0.i1 block8 block11;
+
+    block6:
+        jump block7;
+
+    block7:
+        call %impl_trait_Name__decode_from__gd20d v5 4.i256;
+        return;
+
+    block8:
+        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_66b1;
+        unreachable;
+
+    block9:
+        jump block10;
+
+    block10:
+        jump block7;
+
+    block11:
+        v17.i256 = mload v1 i256;
+        mstore v4 v17 i256;
+        v19.i256 = mload v4 i256;
+        v20.i1 = gt 4.i256 v19;
+        br v20 block8 block9;
+}
+
+func inline(always) private %decode_runtime_args__ge035(v0.objref<@layout_18>) -> @layout_14 {
+    block0:
+        v1.*i256 = alloca i256;
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v5.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_dac7;
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_1a14 v5;
+        mstore v1 v7 i256;
+        v8.i256 = mload v1 i256;
+        mstore v2 v8 i256;
+        v9.i256 = mload v2 i256;
+        v10.i1 = gt 4.i256 v9;
+        br v10 block2 block3;
+
+    block2:
+        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_a20a;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        br 1.i1 block5 block6;
+
+    block5:
+        mstore v3 4.i256 i256;
+        br 0.i1 block8 block11;
+
+    block6:
+        jump block7;
+
+    block7:
+        v17.@layout_14 = call %impl_trait_Transfer__decode_from__gd20d v5 4.i256;
+        return v17;
+
+    block8:
+        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_a20a;
+        unreachable;
+
+    block9:
+        jump block10;
+
+    block10:
+        jump block7;
+
+    block11:
+        v18.i256 = mload v1 i256;
+        mstore v4 v18 i256;
+        v20.i256 = mload v4 i256;
+        v21.i1 = gt 68.i256 v20;
+        br v21 block8 block9;
+}
+
+func private %decoder_new(v0.@layout_2) -> @layout_4 {
     block0:
         jump block1;
 
     block1:
-        v2.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_a7b0 v0;
+        v2.@layout_4 = call %impl_SolDecoder__new__g463e v0;
         return v2;
 }
 
-func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_payload__g574e_f87e(v0.objref<@layout_4>) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_2ad2 v0;
-        v4.i256 = shr 160.i256 v2;
-        v6.i1 = eq v4 0.i256;
-        v7.i1 = is_zero v6;
-        br v7 block2 block3;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v8.objref<@layout_0> = obj.alloc @layout_0;
-        v10.objref<i256> = obj.proj v8 0.i256;
-        obj.store v10 v2;
-        v11.@layout_0 = obj.load v8;
-        return v11;
-}
-
-func inline(always) private %impl_trait_Mint__decode_payload__g3a69(v0.objref<@layout_4>) -> @layout_18 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.@layout_0 = call %core__lib__abi__decode_field__gaa38_13f3 v0;
-        v3.i256 = call %core__lib__abi__decode_field__g7400_eed2 v0;
-        v4.objref<@layout_18> = obj.alloc @layout_18;
-        v6.objref<@layout_0> = obj.proj v4 0.i256;
-        v7.objref<i256> = obj.proj v6 0.i256;
-        v8.i256 = extract_value v2 0.i256;
-        obj.store v7 v8;
-        v10.objref<i256> = obj.proj v4 1.i256;
-        obj.store v10 v3;
-        v11.@layout_18 = obj.load v4;
-        return v11;
-}
-
-func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_payload__g574e_fe07(v0.objref<@layout_4>) -> @layout_0 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_d635 v0;
-        v4.i256 = shr 160.i256 v2;
-        v6.i1 = eq v4 0.i256;
-        v7.i1 = is_zero v6;
-        br v7 block2 block3;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v8.objref<@layout_0> = obj.alloc @layout_0;
-        v10.objref<i256> = obj.proj v8 0.i256;
-        obj.store v10 v2;
-        v11.@layout_0 = obj.load v8;
-        return v11;
-}
-
-func inline(always) private %decode_runtime_args__g5a0b(v0.objref<@layout_20>) {
-    block0:
-        jump block1;
-
-    block1:
-        v1.@layout_4 = call %core__lib__contracts__trait_ContractHost__runtime_decoder__g736d_a9a1;
-        v2.objref<@layout_4> = obj.alloc @layout_4;
-        v4.objref<@layout_3> = obj.proj v2 0.i256;
-        v5.@layout_3 = extract_value v1 0.i256;
-        v6.objref<@layout_2> = obj.proj v4 0.i256;
-        v7.@layout_2 = extract_value v5 0.i256;
-        v8.objref<i256> = obj.proj v6 0.i256;
-        v9.i256 = extract_value v7 0.i256;
-        obj.store v8 v9;
-        v11.objref<i256> = obj.proj v4 1.i256;
-        v12.i256 = extract_value v5 1.i256;
-        obj.store v11 v12;
-        v13.objref<i256> = obj.proj v2 1.i256;
-        v14.i256 = extract_value v1 1.i256;
-        obj.store v13 v14;
-        call %impl_trait_Decimals__decode_payload__g3a69 v2;
-        return;
-}
-
-func inline(always) private %decode_runtime_args__g6a7c(v0.objref<@layout_20>) -> @layout_8 {
-    block0:
-        jump block1;
-
-    block1:
-        v1.@layout_4 = call %core__lib__contracts__trait_ContractHost__runtime_decoder__g736d_f123;
-        v2.objref<@layout_4> = obj.alloc @layout_4;
-        v4.objref<@layout_3> = obj.proj v2 0.i256;
-        v5.@layout_3 = extract_value v1 0.i256;
-        v6.objref<@layout_2> = obj.proj v4 0.i256;
-        v7.@layout_2 = extract_value v5 0.i256;
-        v8.objref<i256> = obj.proj v6 0.i256;
-        v9.i256 = extract_value v7 0.i256;
-        obj.store v8 v9;
-        v11.objref<i256> = obj.proj v4 1.i256;
-        v12.i256 = extract_value v5 1.i256;
-        obj.store v11 v12;
-        v13.objref<i256> = obj.proj v2 1.i256;
-        v14.i256 = extract_value v1 1.i256;
-        obj.store v13 v14;
-        v15.@layout_8 = call %impl_trait_DecreaseAllowance__decode_payload__g3a69 v2;
-        return v15;
-}
-
-func inline(always) private %decode_runtime_args__g7a2c(v0.objref<@layout_20>) -> @layout_11 {
-    block0:
-        jump block1;
-
-    block1:
-        v1.@layout_4 = call %core__lib__contracts__trait_ContractHost__runtime_decoder__g736d_3d42;
-        v2.objref<@layout_4> = obj.alloc @layout_4;
-        v4.objref<@layout_3> = obj.proj v2 0.i256;
-        v5.@layout_3 = extract_value v1 0.i256;
-        v6.objref<@layout_2> = obj.proj v4 0.i256;
-        v7.@layout_2 = extract_value v5 0.i256;
-        v8.objref<i256> = obj.proj v6 0.i256;
-        v9.i256 = extract_value v7 0.i256;
-        obj.store v8 v9;
-        v11.objref<i256> = obj.proj v4 1.i256;
-        v12.i256 = extract_value v5 1.i256;
-        obj.store v11 v12;
-        v13.objref<i256> = obj.proj v2 1.i256;
-        v14.i256 = extract_value v1 1.i256;
-        obj.store v13 v14;
-        v15.@layout_11 = call %impl_trait_Approve__decode_payload__g3a69 v2;
-        return v15;
-}
-
-func inline(always) private %decode_runtime_args__g295c(v0.objref<@layout_20>) {
-    block0:
-        jump block1;
-
-    block1:
-        v1.@layout_4 = call %core__lib__contracts__trait_ContractHost__runtime_decoder__g736d_e77a;
-        v2.objref<@layout_4> = obj.alloc @layout_4;
-        v4.objref<@layout_3> = obj.proj v2 0.i256;
-        v5.@layout_3 = extract_value v1 0.i256;
-        v6.objref<@layout_2> = obj.proj v4 0.i256;
-        v7.@layout_2 = extract_value v5 0.i256;
-        v8.objref<i256> = obj.proj v6 0.i256;
-        v9.i256 = extract_value v7 0.i256;
-        obj.store v8 v9;
-        v11.objref<i256> = obj.proj v4 1.i256;
-        v12.i256 = extract_value v5 1.i256;
-        obj.store v11 v12;
-        v13.objref<i256> = obj.proj v2 1.i256;
-        v14.i256 = extract_value v1 1.i256;
-        obj.store v13 v14;
-        call %impl_trait_Symbol__decode_payload__g3a69 v2;
-        return;
-}
-
-func inline(always) private %decode_runtime_args__gce7d(v0.objref<@layout_20>) {
-    block0:
-        jump block1;
-
-    block1:
-        v1.@layout_4 = call %core__lib__contracts__trait_ContractHost__runtime_decoder__g736d_a8b6;
-        v2.objref<@layout_4> = obj.alloc @layout_4;
-        v4.objref<@layout_3> = obj.proj v2 0.i256;
-        v5.@layout_3 = extract_value v1 0.i256;
-        v6.objref<@layout_2> = obj.proj v4 0.i256;
-        v7.@layout_2 = extract_value v5 0.i256;
-        v8.objref<i256> = obj.proj v6 0.i256;
-        v9.i256 = extract_value v7 0.i256;
-        obj.store v8 v9;
-        v11.objref<i256> = obj.proj v4 1.i256;
-        v12.i256 = extract_value v5 1.i256;
-        obj.store v11 v12;
-        v13.objref<i256> = obj.proj v2 1.i256;
-        v14.i256 = extract_value v1 1.i256;
-        obj.store v13 v14;
-        call %impl_trait_TotalSupply__decode_payload__g3a69 v2;
-        return;
-}
-
-func inline(always) private %decode_runtime_args__g2273(v0.objref<@layout_20>) -> @layout_18 {
-    block0:
-        jump block1;
-
-    block1:
-        v1.@layout_4 = call %core__lib__contracts__trait_ContractHost__runtime_decoder__g736d_dcc2;
-        v2.objref<@layout_4> = obj.alloc @layout_4;
-        v4.objref<@layout_3> = obj.proj v2 0.i256;
-        v5.@layout_3 = extract_value v1 0.i256;
-        v6.objref<@layout_2> = obj.proj v4 0.i256;
-        v7.@layout_2 = extract_value v5 0.i256;
-        v8.objref<i256> = obj.proj v6 0.i256;
-        v9.i256 = extract_value v7 0.i256;
-        obj.store v8 v9;
-        v11.objref<i256> = obj.proj v4 1.i256;
-        v12.i256 = extract_value v5 1.i256;
-        obj.store v11 v12;
-        v13.objref<i256> = obj.proj v2 1.i256;
-        v14.i256 = extract_value v1 1.i256;
-        obj.store v13 v14;
-        v15.@layout_18 = call %impl_trait_Mint__decode_payload__g3a69 v2;
-        return v15;
-}
-
-func inline(always) private %decode_runtime_args__g4e54(v0.objref<@layout_20>) -> @layout_12 {
-    block0:
-        jump block1;
-
-    block1:
-        v1.@layout_4 = call %core__lib__contracts__trait_ContractHost__runtime_decoder__g736d_ccfe;
-        v2.objref<@layout_4> = obj.alloc @layout_4;
-        v4.objref<@layout_3> = obj.proj v2 0.i256;
-        v5.@layout_3 = extract_value v1 0.i256;
-        v6.objref<@layout_2> = obj.proj v4 0.i256;
-        v7.@layout_2 = extract_value v5 0.i256;
-        v8.objref<i256> = obj.proj v6 0.i256;
-        v9.i256 = extract_value v7 0.i256;
-        obj.store v8 v9;
-        v11.objref<i256> = obj.proj v4 1.i256;
-        v12.i256 = extract_value v5 1.i256;
-        obj.store v11 v12;
-        v13.objref<i256> = obj.proj v2 1.i256;
-        v14.i256 = extract_value v1 1.i256;
-        obj.store v13 v14;
-        v15.@layout_12 = call %impl_trait_TransferFrom__decode_payload__g3a69 v2;
-        return v15;
-}
-
-func inline(always) private %decode_runtime_args__g698d(v0.objref<@layout_20>) -> @layout_16 {
-    block0:
-        jump block1;
-
-    block1:
-        v1.@layout_4 = call %core__lib__contracts__trait_ContractHost__runtime_decoder__g736d_0a0b;
-        v2.objref<@layout_4> = obj.alloc @layout_4;
-        v4.objref<@layout_3> = obj.proj v2 0.i256;
-        v5.@layout_3 = extract_value v1 0.i256;
-        v6.objref<@layout_2> = obj.proj v4 0.i256;
-        v7.@layout_2 = extract_value v5 0.i256;
-        v8.objref<i256> = obj.proj v6 0.i256;
-        v9.i256 = extract_value v7 0.i256;
-        obj.store v8 v9;
-        v11.objref<i256> = obj.proj v4 1.i256;
-        v12.i256 = extract_value v5 1.i256;
-        obj.store v11 v12;
-        v13.objref<i256> = obj.proj v2 1.i256;
-        v14.i256 = extract_value v1 1.i256;
-        obj.store v13 v14;
-        v15.@layout_16 = call %impl_trait_IncreaseAllowance__decode_payload__g3a69 v2;
-        return v15;
-}
-
-func inline(always) private %decode_runtime_args__gc772(v0.objref<@layout_20>) -> @layout_17 {
-    block0:
-        jump block1;
-
-    block1:
-        v1.@layout_4 = call %core__lib__contracts__trait_ContractHost__runtime_decoder__g736d_69cd;
-        v2.objref<@layout_4> = obj.alloc @layout_4;
-        v4.objref<@layout_3> = obj.proj v2 0.i256;
-        v5.@layout_3 = extract_value v1 0.i256;
-        v6.objref<@layout_2> = obj.proj v4 0.i256;
-        v7.@layout_2 = extract_value v5 0.i256;
-        v8.objref<i256> = obj.proj v6 0.i256;
-        v9.i256 = extract_value v7 0.i256;
-        obj.store v8 v9;
-        v11.objref<i256> = obj.proj v4 1.i256;
-        v12.i256 = extract_value v5 1.i256;
-        obj.store v11 v12;
-        v13.objref<i256> = obj.proj v2 1.i256;
-        v14.i256 = extract_value v1 1.i256;
-        obj.store v13 v14;
-        v15.@layout_17 = call %impl_trait_Allowance__decode_payload__g3a69 v2;
-        return v15;
-}
-
-func inline(always) private %decode_runtime_args__g953d(v0.objref<@layout_20>) -> @layout_9 {
-    block0:
-        jump block1;
-
-    block1:
-        v1.@layout_4 = call %core__lib__contracts__trait_ContractHost__runtime_decoder__g736d_56dd;
-        v2.objref<@layout_4> = obj.alloc @layout_4;
-        v4.objref<@layout_3> = obj.proj v2 0.i256;
-        v5.@layout_3 = extract_value v1 0.i256;
-        v6.objref<@layout_2> = obj.proj v4 0.i256;
-        v7.@layout_2 = extract_value v5 0.i256;
-        v8.objref<i256> = obj.proj v6 0.i256;
-        v9.i256 = extract_value v7 0.i256;
-        obj.store v8 v9;
-        v11.objref<i256> = obj.proj v4 1.i256;
-        v12.i256 = extract_value v5 1.i256;
-        obj.store v11 v12;
-        v13.objref<i256> = obj.proj v2 1.i256;
-        v14.i256 = extract_value v1 1.i256;
-        obj.store v13 v14;
-        v15.@layout_9 = call %impl_trait_BalanceOf__decode_payload__g3a69 v2;
-        return v15;
-}
-
-func inline(always) private %decode_runtime_args__g216b(v0.objref<@layout_20>) -> @layout_14 {
-    block0:
-        jump block1;
-
-    block1:
-        v1.@layout_4 = call %core__lib__contracts__trait_ContractHost__runtime_decoder__g736d_90a6;
-        v2.objref<@layout_4> = obj.alloc @layout_4;
-        v4.objref<@layout_3> = obj.proj v2 0.i256;
-        v5.@layout_3 = extract_value v1 0.i256;
-        v6.objref<@layout_2> = obj.proj v4 0.i256;
-        v7.@layout_2 = extract_value v5 0.i256;
-        v8.objref<i256> = obj.proj v6 0.i256;
-        v9.i256 = extract_value v7 0.i256;
-        obj.store v8 v9;
-        v11.objref<i256> = obj.proj v4 1.i256;
-        v12.i256 = extract_value v5 1.i256;
-        obj.store v11 v12;
-        v13.objref<i256> = obj.proj v2 1.i256;
-        v14.i256 = extract_value v1 1.i256;
-        obj.store v13 v14;
-        v15.@layout_14 = call %impl_trait_BurnFrom__decode_payload__g3a69 v2;
-        return v15;
-}
-
-func inline(always) private %decode_runtime_args__gf629(v0.objref<@layout_20>) -> @layout_10 {
-    block0:
-        jump block1;
-
-    block1:
-        v1.@layout_4 = call %core__lib__contracts__trait_ContractHost__runtime_decoder__g736d_d57b;
-        v2.objref<@layout_4> = obj.alloc @layout_4;
-        v4.objref<@layout_3> = obj.proj v2 0.i256;
-        v5.@layout_3 = extract_value v1 0.i256;
-        v6.objref<@layout_2> = obj.proj v4 0.i256;
-        v7.@layout_2 = extract_value v5 0.i256;
-        v8.objref<i256> = obj.proj v6 0.i256;
-        v9.i256 = extract_value v7 0.i256;
-        obj.store v8 v9;
-        v11.objref<i256> = obj.proj v4 1.i256;
-        v12.i256 = extract_value v5 1.i256;
-        obj.store v11 v12;
-        v13.objref<i256> = obj.proj v2 1.i256;
-        v14.i256 = extract_value v1 1.i256;
-        obj.store v13 v14;
-        v15.@layout_10 = call %impl_trait_Burn__decode_payload__g3a69 v2;
-        return v15;
-}
-
-func inline(always) private %decode_runtime_args__gce2e(v0.objref<@layout_20>) {
-    block0:
-        jump block1;
-
-    block1:
-        v1.@layout_4 = call %core__lib__contracts__trait_ContractHost__runtime_decoder__g736d_5b9b;
-        v2.objref<@layout_4> = obj.alloc @layout_4;
-        v4.objref<@layout_3> = obj.proj v2 0.i256;
-        v5.@layout_3 = extract_value v1 0.i256;
-        v6.objref<@layout_2> = obj.proj v4 0.i256;
-        v7.@layout_2 = extract_value v5 0.i256;
-        v8.objref<i256> = obj.proj v6 0.i256;
-        v9.i256 = extract_value v7 0.i256;
-        obj.store v8 v9;
-        v11.objref<i256> = obj.proj v4 1.i256;
-        v12.i256 = extract_value v5 1.i256;
-        obj.store v11 v12;
-        v13.objref<i256> = obj.proj v2 1.i256;
-        v14.i256 = extract_value v1 1.i256;
-        obj.store v13 v14;
-        call %impl_trait_Name__decode_payload__g3a69 v2;
-        return;
-}
-
-func inline(always) private %decode_runtime_args__ge035(v0.objref<@layout_20>) -> @layout_13 {
-    block0:
-        jump block1;
-
-    block1:
-        v1.@layout_4 = call %core__lib__contracts__trait_ContractHost__runtime_decoder__g736d_f38f;
-        v2.objref<@layout_4> = obj.alloc @layout_4;
-        v4.objref<@layout_3> = obj.proj v2 0.i256;
-        v5.@layout_3 = extract_value v1 0.i256;
-        v6.objref<@layout_2> = obj.proj v4 0.i256;
-        v7.@layout_2 = extract_value v5 0.i256;
-        v8.objref<i256> = obj.proj v6 0.i256;
-        v9.i256 = extract_value v7 0.i256;
-        obj.store v8 v9;
-        v11.objref<i256> = obj.proj v4 1.i256;
-        v12.i256 = extract_value v5 1.i256;
-        obj.store v11 v12;
-        v13.objref<i256> = obj.proj v2 1.i256;
-        v14.i256 = extract_value v1 1.i256;
-        obj.store v13 v14;
-        v15.@layout_13 = call %impl_trait_Transfer__decode_payload__g3a69 v2;
-        return v15;
-}
-
-func private %decoder_new(v0.@layout_5) -> @layout_7 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.@layout_7 = call %impl_SolDecoder__new__g463e v0;
-        return v2;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decoder_with_base__gd20d_1790(v0.@layout_2, v1.i256) -> @layout_4 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v5.@layout_4 = call %std__lib__abi__sol__impl_SolDecoder_113c__with_base__gd20d_dd64 v0 v3;
-        return v5;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decoder_with_base__gd20d_2089(v0.@layout_2, v1.i256) -> @layout_4 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v5.@layout_4 = call %std__lib__abi__sol__impl_SolDecoder_113c__with_base__gd20d_57e7 v0 v3;
-        return v5;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decoder_with_base__gd20d_372b(v0.@layout_2, v1.i256) -> @layout_4 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v5.@layout_4 = call %std__lib__abi__sol__impl_SolDecoder_113c__with_base__gd20d_56ca v0 v3;
-        return v5;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decoder_with_base__gd20d_41f6(v0.@layout_2, v1.i256) -> @layout_4 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v5.@layout_4 = call %std__lib__abi__sol__impl_SolDecoder_113c__with_base__gd20d_f665 v0 v3;
-        return v5;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decoder_with_base__gd20d_46bc(v0.@layout_2, v1.i256) -> @layout_4 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v5.@layout_4 = call %std__lib__abi__sol__impl_SolDecoder_113c__with_base__gd20d_a45d v0 v3;
-        return v5;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decoder_with_base__gd20d_691a(v0.@layout_2, v1.i256) -> @layout_4 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v5.@layout_4 = call %std__lib__abi__sol__impl_SolDecoder_113c__with_base__gd20d_dba1 v0 v3;
-        return v5;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decoder_with_base__gd20d_7ee4(v0.@layout_2, v1.i256) -> @layout_4 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v5.@layout_4 = call %std__lib__abi__sol__impl_SolDecoder_113c__with_base__gd20d_4009 v0 v3;
-        return v5;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decoder_with_base__gd20d_911d(v0.@layout_2, v1.i256) -> @layout_4 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v5.@layout_4 = call %std__lib__abi__sol__impl_SolDecoder_113c__with_base__gd20d_6cde v0 v3;
-        return v5;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decoder_with_base__gd20d_9aa7(v0.@layout_2, v1.i256) -> @layout_4 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v5.@layout_4 = call %std__lib__abi__sol__impl_SolDecoder_113c__with_base__gd20d_1583 v0 v3;
-        return v5;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decoder_with_base__gd20d_9b9c(v0.@layout_2, v1.i256) -> @layout_4 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v5.@layout_4 = call %std__lib__abi__sol__impl_SolDecoder_113c__with_base__gd20d_7c6f v0 v3;
-        return v5;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decoder_with_base__gd20d_b2fb(v0.@layout_2, v1.i256) -> @layout_4 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v5.@layout_4 = call %std__lib__abi__sol__impl_SolDecoder_113c__with_base__gd20d_df78 v0 v3;
-        return v5;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decoder_with_base__gd20d_c673(v0.@layout_2, v1.i256) -> @layout_4 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v5.@layout_4 = call %std__lib__abi__sol__impl_SolDecoder_113c__with_base__gd20d_3cb6 v0 v3;
-        return v5;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decoder_with_base__gd20d_db7f(v0.@layout_2, v1.i256) -> @layout_4 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v5.@layout_4 = call %std__lib__abi__sol__impl_SolDecoder_113c__with_base__gd20d_43fc v0 v3;
-        return v5;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decoder_with_base__gd20d_dc77(v0.@layout_2, v1.i256) -> @layout_4 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v5.@layout_4 = call %std__lib__abi__sol__impl_SolDecoder_113c__with_base__gd20d_b4c9 v0 v3;
-        return v5;
-}
-
-func private %emit__g4c3d(v0.@layout_21) {
+func private %emit__g4c3d(v0.@layout_19) {
     block0:
         jump block1;
 
@@ -3519,7 +3964,7 @@ func private %emit__g4c3d(v0.@layout_21) {
         return;
 }
 
-func private %emit__g9cd0(v0.@layout_22) {
+func private %emit__g9cd0(v0.@layout_20) {
     block0:
         jump block1;
 
@@ -3528,9 +3973,9 @@ func private %emit__g9cd0(v0.@layout_22) {
         return;
 }
 
-func private %impl_trait_ApprovalEvent__emit__gcd5c(v0.@layout_22) {
+func private %impl_trait_ApprovalEvent__emit__gcd5c(v0.@layout_20) {
     block0:
-        v1.objref<@layout_22> = obj.alloc @layout_22;
+        v1.objref<@layout_20> = obj.alloc @layout_20;
         v3.objref<@layout_0> = obj.proj v1 0.i256;
         v4.@layout_0 = extract_value v0 0.i256;
         v5.objref<i256> = obj.proj v3 0.i256;
@@ -3549,8 +3994,8 @@ func private %impl_trait_ApprovalEvent__emit__gcd5c(v0.@layout_22) {
     block1:
         v15.objref<i256> = obj.proj v1 2.i256;
         v16.i256 = obj.load v15;
-        v17.@layout_23 = call %std__lib__evm__effects__encode_abi_payload__ge513_bb73 v16;
-        v18.objref<@layout_23> = obj.alloc @layout_23;
+        v17.@layout_21 = call %std__lib__evm__effects__encode_abi_payload__ge513_bb73 v16;
+        v18.objref<@layout_21> = obj.alloc @layout_21;
         v19.objref<i256> = obj.proj v18 0.i256;
         v20.i256 = extract_value v17 0.i256;
         obj.store v19 v20;
@@ -3573,9 +4018,9 @@ func private %impl_trait_ApprovalEvent__emit__gcd5c(v0.@layout_22) {
         return;
 }
 
-func private %impl_trait_TransferEvent__emit__gcd5c(v0.@layout_21) {
+func private %impl_trait_TransferEvent__emit__gcd5c(v0.@layout_19) {
     block0:
-        v1.objref<@layout_21> = obj.alloc @layout_21;
+        v1.objref<@layout_19> = obj.alloc @layout_19;
         v3.objref<@layout_0> = obj.proj v1 0.i256;
         v4.@layout_0 = extract_value v0 0.i256;
         v5.objref<i256> = obj.proj v3 0.i256;
@@ -3594,8 +4039,8 @@ func private %impl_trait_TransferEvent__emit__gcd5c(v0.@layout_21) {
     block1:
         v15.objref<i256> = obj.proj v1 2.i256;
         v16.i256 = obj.load v15;
-        v17.@layout_23 = call %std__lib__evm__effects__encode_abi_payload__ge513_5dc2 v16;
-        v18.objref<@layout_23> = obj.alloc @layout_23;
+        v17.@layout_21 = call %std__lib__evm__effects__encode_abi_payload__ge513_5dc2 v16;
+        v18.objref<@layout_21> = obj.alloc @layout_21;
         v19.objref<i256> = obj.proj v18 0.i256;
         v20.i256 = extract_value v17 0.i256;
         obj.store v19 v20;
@@ -3692,21 +4137,21 @@ func private %encode__gbe21(v0.i256, v1.objref<@layout_1>) {
         return;
 }
 
-func private %std__lib__evm__effects__encode_abi_payload__ge513_5dc2(v0.i256) -> @layout_23 {
+func private %std__lib__evm__effects__encode_abi_payload__ge513_5dc2(v0.i256) -> @layout_21 {
     block0:
         jump block1;
 
     block1:
-        v2.@layout_23 = call %core__lib__abi__encode_alloc__gac80_c438 v0;
+        v2.@layout_21 = call %core__lib__abi__encode_alloc__gac80_c438 v0;
         return v2;
 }
 
-func private %std__lib__evm__effects__encode_abi_payload__ge513_bb73(v0.i256) -> @layout_23 {
+func private %std__lib__evm__effects__encode_abi_payload__ge513_bb73(v0.i256) -> @layout_21 {
     block0:
         jump block1;
 
     block1:
-        v2.@layout_23 = call %core__lib__abi__encode_alloc__gac80_492c v0;
+        v2.@layout_21 = call %core__lib__abi__encode_alloc__gac80_492c v0;
         return v2;
 }
 
@@ -3720,7 +4165,7 @@ func private %impl_trait_u8__encode__g426c(v0.i8, v1.objref<@layout_1>) {
         return;
 }
 
-func private %core__lib__abi__encode_alloc__gac80_492c(v0.i256) -> @layout_23 {
+func private %core__lib__abi__encode_alloc__gac80_492c(v0.i256) -> @layout_21 {
     block0:
         jump block1;
 
@@ -3736,16 +4181,16 @@ func private %core__lib__abi__encode_alloc__gac80_492c(v0.i256) -> @layout_23 {
         obj.store v9 v10;
         v11.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_dd69 v4;
         call %core__lib__abi__impl_trait_u256_d99e__encode__g426c_2015 v0 v4;
-        v13.objref<@layout_23> = obj.alloc @layout_23;
+        v13.objref<@layout_21> = obj.alloc @layout_21;
         v14.objref<i256> = obj.proj v13 0.i256;
         obj.store v14 v11;
         v15.objref<i256> = obj.proj v13 1.i256;
         obj.store v15 v2;
-        v16.@layout_23 = obj.load v13;
+        v16.@layout_21 = obj.load v13;
         return v16;
 }
 
-func private %core__lib__abi__encode_alloc__gac80_c438(v0.i256) -> @layout_23 {
+func private %core__lib__abi__encode_alloc__gac80_c438(v0.i256) -> @layout_21 {
     block0:
         jump block1;
 
@@ -3761,12 +4206,12 @@ func private %core__lib__abi__encode_alloc__gac80_c438(v0.i256) -> @layout_23 {
         obj.store v9 v10;
         v11.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_009f v4;
         call %core__lib__abi__impl_trait_u256_d99e__encode__g426c_c169 v0 v4;
-        v13.objref<@layout_23> = obj.alloc @layout_23;
+        v13.objref<@layout_21> = obj.alloc @layout_21;
         v14.objref<i256> = obj.proj v13 0.i256;
         obj.store v14 v11;
         v15.objref<i256> = obj.proj v13 1.i256;
         obj.store v15 v2;
-        v16.@layout_23 = obj.load v13;
+        v16.@layout_21 = obj.load v13;
         return v16;
 }
 
@@ -4099,7 +4544,7 @@ func private %encode_single_root__g2e64(v0.i256, v1.objref<@layout_1>) {
         return;
 }
 
-func private %encode_single_root_alloc__gcb0a(v0.i8) -> @layout_23 {
+func private %encode_single_root_alloc__gcb0a(v0.i8) -> @layout_21 {
     block0:
         jump block1;
 
@@ -4115,16 +4560,16 @@ func private %encode_single_root_alloc__gcb0a(v0.i8) -> @layout_23 {
         obj.store v9 v10;
         v11.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_a9a0 v4;
         call %encode_single_root__g0a88 v0 v4;
-        v13.objref<@layout_23> = obj.alloc @layout_23;
+        v13.objref<@layout_21> = obj.alloc @layout_21;
         v14.objref<i256> = obj.proj v13 0.i256;
         obj.store v14 v11;
         v15.objref<i256> = obj.proj v13 1.i256;
         obj.store v15 v2;
-        v16.@layout_23 = obj.load v13;
+        v16.@layout_21 = obj.load v13;
         return v16;
 }
 
-func private %encode_single_root_alloc__gac80(v0.i256) -> @layout_23 {
+func private %encode_single_root_alloc__gac80(v0.i256) -> @layout_21 {
     block0:
         jump block1;
 
@@ -4140,16 +4585,16 @@ func private %encode_single_root_alloc__gac80(v0.i256) -> @layout_23 {
         obj.store v9 v10;
         v11.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_fd6f v4;
         call %encode_single_root__g2e64 v0 v4;
-        v13.objref<@layout_23> = obj.alloc @layout_23;
+        v13.objref<@layout_21> = obj.alloc @layout_21;
         v14.objref<i256> = obj.proj v13 0.i256;
         obj.store v14 v11;
         v15.objref<i256> = obj.proj v13 1.i256;
         obj.store v15 v2;
-        v16.@layout_23 = obj.load v13;
+        v16.@layout_21 = obj.load v13;
         return v16;
 }
 
-func private %encode_single_root_alloc__g0c18(v0.i256) -> @layout_23 {
+func private %encode_single_root_alloc__g0c18(v0.i256) -> @layout_21 {
     block0:
         jump block1;
 
@@ -4165,16 +4610,16 @@ func private %encode_single_root_alloc__g0c18(v0.i256) -> @layout_23 {
         obj.store v9 v10;
         v11.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_6030 v4;
         call %encode_single_root__g6d7e v0 v4;
-        v13.objref<@layout_23> = obj.alloc @layout_23;
+        v13.objref<@layout_21> = obj.alloc @layout_21;
         v14.objref<i256> = obj.proj v13 0.i256;
         obj.store v14 v11;
         v15.objref<i256> = obj.proj v13 1.i256;
         obj.store v15 v2;
-        v16.@layout_23 = obj.load v13;
+        v16.@layout_21 = obj.load v13;
         return v16;
 }
 
-func private %encode_single_root_alloc__g09ca(v0.i1) -> @layout_23 {
+func private %encode_single_root_alloc__g09ca(v0.i1) -> @layout_21 {
     block0:
         jump block1;
 
@@ -4190,16 +4635,16 @@ func private %encode_single_root_alloc__g09ca(v0.i1) -> @layout_23 {
         obj.store v9 v10;
         v11.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_c13e v4;
         call %encode_single_root__ge927 v0 v4;
-        v13.objref<@layout_23> = obj.alloc @layout_23;
+        v13.objref<@layout_21> = obj.alloc @layout_21;
         v14.objref<i256> = obj.proj v13 0.i256;
         obj.store v14 v11;
         v15.objref<i256> = obj.proj v13 1.i256;
         obj.store v15 v2;
-        v16.@layout_23 = obj.load v13;
+        v16.@layout_21 = obj.load v13;
         return v16;
 }
 
-func private %encode_single_root_alloc__g472d(v0.i256) -> @layout_23 {
+func private %encode_single_root_alloc__g472d(v0.i256) -> @layout_21 {
     block0:
         jump block1;
 
@@ -4215,12 +4660,12 @@ func private %encode_single_root_alloc__g472d(v0.i256) -> @layout_23 {
         obj.store v9 v10;
         v11.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_25d4 v4;
         call %encode_single_root__g859f v0 v4;
-        v13.objref<@layout_23> = obj.alloc @layout_23;
+        v13.objref<@layout_21> = obj.alloc @layout_21;
         v14.objref<i256> = obj.proj v13 0.i256;
         obj.store v14 v11;
         v15.objref<i256> = obj.proj v13 1.i256;
         obj.store v15 v2;
-        v16.@layout_23 = obj.load v13;
+        v16.@layout_21 = obj.load v13;
         return v16;
 }
 
@@ -4387,286 +4832,6 @@ func private %eq(v0.@layout_0, v1.@layout_0) -> i1 {
         return v7;
 }
 
-func inline(always) private %core__lib__abi__impl_Cursor_1a04__fork__gd20d_08b4(v0.@layout_3, v1.i256) -> @layout_3 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v5.@layout_2 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.objref<@layout_3> = obj.alloc @layout_3;
-        v8.objref<@layout_2> = obj.proj v7 0.i256;
-        v9.objref<i256> = obj.proj v8 0.i256;
-        v10.i256 = extract_value v5 0.i256;
-        obj.store v9 v10;
-        v12.objref<i256> = obj.proj v7 1.i256;
-        obj.store v12 v6;
-        v13.@layout_3 = obj.load v7;
-        return v13;
-}
-
-func inline(always) private %core__lib__abi__impl_Cursor_1a04__fork__gd20d_320d(v0.@layout_3, v1.i256) -> @layout_3 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v5.@layout_2 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.objref<@layout_3> = obj.alloc @layout_3;
-        v8.objref<@layout_2> = obj.proj v7 0.i256;
-        v9.objref<i256> = obj.proj v8 0.i256;
-        v10.i256 = extract_value v5 0.i256;
-        obj.store v9 v10;
-        v12.objref<i256> = obj.proj v7 1.i256;
-        obj.store v12 v6;
-        v13.@layout_3 = obj.load v7;
-        return v13;
-}
-
-func inline(always) private %core__lib__abi__impl_Cursor_1a04__fork__gd20d_3257(v0.@layout_3, v1.i256) -> @layout_3 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v5.@layout_2 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.objref<@layout_3> = obj.alloc @layout_3;
-        v8.objref<@layout_2> = obj.proj v7 0.i256;
-        v9.objref<i256> = obj.proj v8 0.i256;
-        v10.i256 = extract_value v5 0.i256;
-        obj.store v9 v10;
-        v12.objref<i256> = obj.proj v7 1.i256;
-        obj.store v12 v6;
-        v13.@layout_3 = obj.load v7;
-        return v13;
-}
-
-func inline(always) private %core__lib__abi__impl_Cursor_1a04__fork__gd20d_542f(v0.@layout_3, v1.i256) -> @layout_3 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v5.@layout_2 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.objref<@layout_3> = obj.alloc @layout_3;
-        v8.objref<@layout_2> = obj.proj v7 0.i256;
-        v9.objref<i256> = obj.proj v8 0.i256;
-        v10.i256 = extract_value v5 0.i256;
-        obj.store v9 v10;
-        v12.objref<i256> = obj.proj v7 1.i256;
-        obj.store v12 v6;
-        v13.@layout_3 = obj.load v7;
-        return v13;
-}
-
-func inline(always) private %core__lib__abi__impl_Cursor_1a04__fork__gd20d_5db0(v0.@layout_3, v1.i256) -> @layout_3 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v5.@layout_2 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.objref<@layout_3> = obj.alloc @layout_3;
-        v8.objref<@layout_2> = obj.proj v7 0.i256;
-        v9.objref<i256> = obj.proj v8 0.i256;
-        v10.i256 = extract_value v5 0.i256;
-        obj.store v9 v10;
-        v12.objref<i256> = obj.proj v7 1.i256;
-        obj.store v12 v6;
-        v13.@layout_3 = obj.load v7;
-        return v13;
-}
-
-func inline(always) private %core__lib__abi__impl_Cursor_1a04__fork__gd20d_64b6(v0.@layout_3, v1.i256) -> @layout_3 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v5.@layout_2 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.objref<@layout_3> = obj.alloc @layout_3;
-        v8.objref<@layout_2> = obj.proj v7 0.i256;
-        v9.objref<i256> = obj.proj v8 0.i256;
-        v10.i256 = extract_value v5 0.i256;
-        obj.store v9 v10;
-        v12.objref<i256> = obj.proj v7 1.i256;
-        obj.store v12 v6;
-        v13.@layout_3 = obj.load v7;
-        return v13;
-}
-
-func inline(always) private %core__lib__abi__impl_Cursor_1a04__fork__gd20d_7e69(v0.@layout_3, v1.i256) -> @layout_3 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v5.@layout_2 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.objref<@layout_3> = obj.alloc @layout_3;
-        v8.objref<@layout_2> = obj.proj v7 0.i256;
-        v9.objref<i256> = obj.proj v8 0.i256;
-        v10.i256 = extract_value v5 0.i256;
-        obj.store v9 v10;
-        v12.objref<i256> = obj.proj v7 1.i256;
-        obj.store v12 v6;
-        v13.@layout_3 = obj.load v7;
-        return v13;
-}
-
-func inline(always) private %core__lib__abi__impl_Cursor_1a04__fork__gd20d_84e3(v0.@layout_3, v1.i256) -> @layout_3 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v5.@layout_2 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.objref<@layout_3> = obj.alloc @layout_3;
-        v8.objref<@layout_2> = obj.proj v7 0.i256;
-        v9.objref<i256> = obj.proj v8 0.i256;
-        v10.i256 = extract_value v5 0.i256;
-        obj.store v9 v10;
-        v12.objref<i256> = obj.proj v7 1.i256;
-        obj.store v12 v6;
-        v13.@layout_3 = obj.load v7;
-        return v13;
-}
-
-func inline(always) private %core__lib__abi__impl_Cursor_1a04__fork__gd20d_ace8(v0.@layout_3, v1.i256) -> @layout_3 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v5.@layout_2 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.objref<@layout_3> = obj.alloc @layout_3;
-        v8.objref<@layout_2> = obj.proj v7 0.i256;
-        v9.objref<i256> = obj.proj v8 0.i256;
-        v10.i256 = extract_value v5 0.i256;
-        obj.store v9 v10;
-        v12.objref<i256> = obj.proj v7 1.i256;
-        obj.store v12 v6;
-        v13.@layout_3 = obj.load v7;
-        return v13;
-}
-
-func inline(always) private %core__lib__abi__impl_Cursor_1a04__fork__gd20d_baad(v0.@layout_3, v1.i256) -> @layout_3 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v5.@layout_2 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.objref<@layout_3> = obj.alloc @layout_3;
-        v8.objref<@layout_2> = obj.proj v7 0.i256;
-        v9.objref<i256> = obj.proj v8 0.i256;
-        v10.i256 = extract_value v5 0.i256;
-        obj.store v9 v10;
-        v12.objref<i256> = obj.proj v7 1.i256;
-        obj.store v12 v6;
-        v13.@layout_3 = obj.load v7;
-        return v13;
-}
-
-func inline(always) private %core__lib__abi__impl_Cursor_1a04__fork__gd20d_cd99(v0.@layout_3, v1.i256) -> @layout_3 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v5.@layout_2 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.objref<@layout_3> = obj.alloc @layout_3;
-        v8.objref<@layout_2> = obj.proj v7 0.i256;
-        v9.objref<i256> = obj.proj v8 0.i256;
-        v10.i256 = extract_value v5 0.i256;
-        obj.store v9 v10;
-        v12.objref<i256> = obj.proj v7 1.i256;
-        obj.store v12 v6;
-        v13.@layout_3 = obj.load v7;
-        return v13;
-}
-
-func inline(always) private %core__lib__abi__impl_Cursor_1a04__fork__gd20d_d4d6(v0.@layout_3, v1.i256) -> @layout_3 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v5.@layout_2 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.objref<@layout_3> = obj.alloc @layout_3;
-        v8.objref<@layout_2> = obj.proj v7 0.i256;
-        v9.objref<i256> = obj.proj v8 0.i256;
-        v10.i256 = extract_value v5 0.i256;
-        obj.store v9 v10;
-        v12.objref<i256> = obj.proj v7 1.i256;
-        obj.store v12 v6;
-        v13.@layout_3 = obj.load v7;
-        return v13;
-}
-
-func inline(always) private %core__lib__abi__impl_Cursor_1a04__fork__gd20d_d620(v0.@layout_3, v1.i256) -> @layout_3 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v5.@layout_2 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.objref<@layout_3> = obj.alloc @layout_3;
-        v8.objref<@layout_2> = obj.proj v7 0.i256;
-        v9.objref<i256> = obj.proj v8 0.i256;
-        v10.i256 = extract_value v5 0.i256;
-        obj.store v9 v10;
-        v12.objref<i256> = obj.proj v7 1.i256;
-        obj.store v12 v6;
-        v13.@layout_3 = obj.load v7;
-        return v13;
-}
-
-func inline(always) private %core__lib__abi__impl_Cursor_1a04__fork__gd20d_f9b8(v0.@layout_3, v1.i256) -> @layout_3 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v5.@layout_2 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.objref<@layout_3> = obj.alloc @layout_3;
-        v8.objref<@layout_2> = obj.proj v7 0.i256;
-        v9.objref<i256> = obj.proj v8 0.i256;
-        v10.i256 = extract_value v5 0.i256;
-        obj.store v9 v10;
-        v12.objref<i256> = obj.proj v7 1.i256;
-        obj.store v12 v6;
-        v13.@layout_3 = obj.load v7;
-        return v13;
-}
-
 func private %std__lib__evm__word__impl_trait_u256_1f9e__from_word_2f17(v0.i256) -> i256 {
     block0:
         v1.*i256 = alloca i256;
@@ -4755,7 +4920,7 @@ func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__g
         return v4;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__get__ga15b_b5d5(v0.@layout_24) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__get__ga15b_b5d5(v0.@layout_22) -> i256 {
     block0:
         jump block1;
 
@@ -4765,7 +4930,7 @@ func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__g
         return v4;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__get__ga15b_b5d5_0(v0.@layout_24) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__get__ga15b_b5d5_0(v0.@layout_22) -> i256 {
     block0:
         jump block1;
 
@@ -4775,7 +4940,7 @@ func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__g
         return v4;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__get__ga15b_cf04(v0.@layout_24) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__get__ga15b_cf04(v0.@layout_22) -> i256 {
     block0:
         jump block1;
 
@@ -4785,7 +4950,7 @@ func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__g
         return v4;
 }
 
-func inline(always) private %get__gc9ba(v0.@layout_15) -> i1 {
+func inline(always) private %get__gc9ba(v0.@layout_16) -> i1 {
     block0:
         jump block1;
 
@@ -4803,145 +4968,145 @@ func private %grant(v0.i256, v1.i256, v2.@layout_0) {
 
     block1:
         v4.i256 = mload v3 i256;
-        v6.objref<@layout_15> = obj.alloc @layout_15;
+        v6.objref<@layout_16> = obj.alloc @layout_16;
         v8.objref<i256> = obj.proj v6 0.i256;
         obj.store v8 v4;
         v10.objref<@layout_0> = obj.proj v6 1.i256;
         v11.objref<i256> = obj.proj v10 0.i256;
         v12.i256 = extract_value v2 0.i256;
         obj.store v11 v12;
-        v13.@layout_15 = obj.load v6;
+        v13.@layout_16 = obj.load v6;
         call %set__gc9ba v13 1.i1;
         return;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_015b() -> @layout_2 {
+func private %std__lib__evm__effects__impl_trait_Evm_c913__input_3347() -> @layout_5 {
     block0:
         jump block1;
 
     block1:
-        v0.@layout_2 = call %std__lib__evm__calldata__impl_CallData_8f43__new_e8bc;
+        v0.@layout_5 = call %std__lib__evm__calldata__impl_CallData_8f43__new_f11a;
         return v0;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_0e0b() -> @layout_2 {
+func private %std__lib__evm__effects__impl_trait_Evm_c913__input_3dc9() -> @layout_5 {
     block0:
         jump block1;
 
     block1:
-        v0.@layout_2 = call %std__lib__evm__calldata__impl_CallData_8f43__new_03f9;
+        v0.@layout_5 = call %std__lib__evm__calldata__impl_CallData_8f43__new_0d2c;
         return v0;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_1aa7() -> @layout_2 {
+func private %std__lib__evm__effects__impl_trait_Evm_c913__input_5bd8() -> @layout_5 {
     block0:
         jump block1;
 
     block1:
-        v0.@layout_2 = call %std__lib__evm__calldata__impl_CallData_8f43__new_87cb;
+        v0.@layout_5 = call %std__lib__evm__calldata__impl_CallData_8f43__new_b0b8;
         return v0;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_1ba1() -> @layout_2 {
+func private %std__lib__evm__effects__impl_trait_Evm_c913__input_663b() -> @layout_5 {
     block0:
         jump block1;
 
     block1:
-        v0.@layout_2 = call %std__lib__evm__calldata__impl_CallData_8f43__new_4f1d;
+        v0.@layout_5 = call %std__lib__evm__calldata__impl_CallData_8f43__new_0fa9;
         return v0;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_2d6f() -> @layout_2 {
+func private %std__lib__evm__effects__impl_trait_Evm_c913__input_6a54() -> @layout_5 {
     block0:
         jump block1;
 
     block1:
-        v0.@layout_2 = call %std__lib__evm__calldata__impl_CallData_8f43__new_a382;
+        v0.@layout_5 = call %std__lib__evm__calldata__impl_CallData_8f43__new_147c;
         return v0;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_3f88() -> @layout_2 {
+func private %std__lib__evm__effects__impl_trait_Evm_c913__input_844a() -> @layout_5 {
     block0:
         jump block1;
 
     block1:
-        v0.@layout_2 = call %std__lib__evm__calldata__impl_CallData_8f43__new_b58c;
+        v0.@layout_5 = call %std__lib__evm__calldata__impl_CallData_8f43__new_923b;
         return v0;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_5a78() -> @layout_2 {
+func private %std__lib__evm__effects__impl_trait_Evm_c913__input_88e5() -> @layout_5 {
     block0:
         jump block1;
 
     block1:
-        v0.@layout_2 = call %std__lib__evm__calldata__impl_CallData_8f43__new_6b3a;
+        v0.@layout_5 = call %std__lib__evm__calldata__impl_CallData_8f43__new_53e2;
         return v0;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_7b84() -> @layout_2 {
+func private %std__lib__evm__effects__impl_trait_Evm_c913__input_a580() -> @layout_5 {
     block0:
         jump block1;
 
     block1:
-        v0.@layout_2 = call %std__lib__evm__calldata__impl_CallData_8f43__new_92f9;
+        v0.@layout_5 = call %std__lib__evm__calldata__impl_CallData_8f43__new_8102;
         return v0;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_938b() -> @layout_2 {
+func private %std__lib__evm__effects__impl_trait_Evm_c913__input_b73f() -> @layout_5 {
     block0:
         jump block1;
 
     block1:
-        v0.@layout_2 = call %std__lib__evm__calldata__impl_CallData_8f43__new_5ebc;
+        v0.@layout_5 = call %std__lib__evm__calldata__impl_CallData_8f43__new_bc34;
         return v0;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_b348() -> @layout_2 {
+func private %std__lib__evm__effects__impl_trait_Evm_c913__input_cd56() -> @layout_5 {
     block0:
         jump block1;
 
     block1:
-        v0.@layout_2 = call %std__lib__evm__calldata__impl_CallData_8f43__new_5a69;
+        v0.@layout_5 = call %std__lib__evm__calldata__impl_CallData_8f43__new_5438;
         return v0;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_b9f8() -> @layout_2 {
+func private %std__lib__evm__effects__impl_trait_Evm_c913__input_d673() -> @layout_5 {
     block0:
         jump block1;
 
     block1:
-        v0.@layout_2 = call %std__lib__evm__calldata__impl_CallData_8f43__new_7fee;
+        v0.@layout_5 = call %std__lib__evm__calldata__impl_CallData_8f43__new_d306;
         return v0;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_bf4c() -> @layout_2 {
+func private %std__lib__evm__effects__impl_trait_Evm_c913__input_dac7() -> @layout_5 {
     block0:
         jump block1;
 
     block1:
-        v0.@layout_2 = call %std__lib__evm__calldata__impl_CallData_8f43__new_9e29;
+        v0.@layout_5 = call %std__lib__evm__calldata__impl_CallData_8f43__new_0199;
         return v0;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_d0c9() -> @layout_2 {
+func private %std__lib__evm__effects__impl_trait_Evm_c913__input_e029() -> @layout_5 {
     block0:
         jump block1;
 
     block1:
-        v0.@layout_2 = call %std__lib__evm__calldata__impl_CallData_8f43__new_fce4;
+        v0.@layout_5 = call %std__lib__evm__calldata__impl_CallData_8f43__new_f379;
         return v0;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_fd52() -> @layout_2 {
+func private %std__lib__evm__effects__impl_trait_Evm_c913__input_f89e() -> @layout_5 {
     block0:
         jump block1;
 
     block1:
-        v0.@layout_2 = call %std__lib__evm__calldata__impl_CallData_8f43__new_42ba;
+        v0.@layout_5 = call %std__lib__evm__calldata__impl_CallData_8f43__new_b671;
         return v0;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_01a6(v0.objref<@layout_5>) -> i256 {
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_01a6(v0.objref<@layout_2>) -> i256 {
     block0:
         jump block1;
 
@@ -4951,7 +5116,7 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_01a6
         return v4;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_02a3(v0.objref<@layout_2>) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_1a14(v0.@layout_5) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
@@ -4960,27 +5125,25 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
     block1:
         v3.i256 = evm_calldata_size;
         mstore v1 v3 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        v7.i256 = obj.load v6;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt v7 v9;
-        br v10 block2 block3;
+        v6.i256 = extract_value v0 0.i256;
+        v7.i256 = mload v1 i256;
+        mstore v2 v7 i256;
+        v8.i256 = mload v2 i256;
+        v9.i1 = gt v6 v8;
+        br v9 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v12.objref<i256> = obj.proj v0 0.i256;
-        v13.i256 = obj.load v12;
-        v14.i256 = mload v1 i256;
-        (v15.i256, v16.i1) = usubo v14 v13;
-        br v16 block5 block6;
+        v11.i256 = extract_value v0 0.i256;
+        v12.i256 = mload v1 i256;
+        (v13.i256, v14.i1) = usubo v12 v11;
+        br v14 block5 block6;
 
     block4:
-        v21.i256 = phi (0.i256 block2) (v15 block6);
-        return v21;
+        v19.i256 = phi (0.i256 block2) (v13 block6);
+        return v19;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -4991,7 +5154,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         jump block4;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_0859(v0.objref<@layout_2>) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_22ff(v0.@layout_5) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
@@ -5000,27 +5163,25 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
     block1:
         v3.i256 = evm_calldata_size;
         mstore v1 v3 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        v7.i256 = obj.load v6;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt v7 v9;
-        br v10 block2 block3;
+        v6.i256 = extract_value v0 0.i256;
+        v7.i256 = mload v1 i256;
+        mstore v2 v7 i256;
+        v8.i256 = mload v2 i256;
+        v9.i1 = gt v6 v8;
+        br v9 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v12.objref<i256> = obj.proj v0 0.i256;
-        v13.i256 = obj.load v12;
-        v14.i256 = mload v1 i256;
-        (v15.i256, v16.i1) = usubo v14 v13;
-        br v16 block5 block6;
+        v11.i256 = extract_value v0 0.i256;
+        v12.i256 = mload v1 i256;
+        (v13.i256, v14.i1) = usubo v12 v11;
+        br v14 block5 block6;
 
     block4:
-        v21.i256 = phi (0.i256 block2) (v15 block6);
-        return v21;
+        v19.i256 = phi (0.i256 block2) (v13 block6);
+        return v19;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -5031,7 +5192,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         jump block4;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_0a1b(v0.objref<@layout_2>) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_4a91(v0.@layout_5) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
@@ -5040,27 +5201,25 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
     block1:
         v3.i256 = evm_calldata_size;
         mstore v1 v3 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        v7.i256 = obj.load v6;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt v7 v9;
-        br v10 block2 block3;
+        v6.i256 = extract_value v0 0.i256;
+        v7.i256 = mload v1 i256;
+        mstore v2 v7 i256;
+        v8.i256 = mload v2 i256;
+        v9.i1 = gt v6 v8;
+        br v9 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v12.objref<i256> = obj.proj v0 0.i256;
-        v13.i256 = obj.load v12;
-        v14.i256 = mload v1 i256;
-        (v15.i256, v16.i1) = usubo v14 v13;
-        br v16 block5 block6;
+        v11.i256 = extract_value v0 0.i256;
+        v12.i256 = mload v1 i256;
+        (v13.i256, v14.i1) = usubo v12 v11;
+        br v14 block5 block6;
 
     block4:
-        v21.i256 = phi (0.i256 block2) (v15 block6);
-        return v21;
+        v19.i256 = phi (0.i256 block2) (v13 block6);
+        return v19;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -5071,7 +5230,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         jump block4;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_0e32(v0.objref<@layout_2>) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_5742(v0.@layout_5) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
@@ -5080,27 +5239,25 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
     block1:
         v3.i256 = evm_calldata_size;
         mstore v1 v3 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        v7.i256 = obj.load v6;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt v7 v9;
-        br v10 block2 block3;
+        v6.i256 = extract_value v0 0.i256;
+        v7.i256 = mload v1 i256;
+        mstore v2 v7 i256;
+        v8.i256 = mload v2 i256;
+        v9.i1 = gt v6 v8;
+        br v9 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v12.objref<i256> = obj.proj v0 0.i256;
-        v13.i256 = obj.load v12;
-        v14.i256 = mload v1 i256;
-        (v15.i256, v16.i1) = usubo v14 v13;
-        br v16 block5 block6;
+        v11.i256 = extract_value v0 0.i256;
+        v12.i256 = mload v1 i256;
+        (v13.i256, v14.i1) = usubo v12 v11;
+        br v14 block5 block6;
 
     block4:
-        v21.i256 = phi (0.i256 block2) (v15 block6);
-        return v21;
+        v19.i256 = phi (0.i256 block2) (v13 block6);
+        return v19;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -5111,7 +5268,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         jump block4;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_0e90(v0.objref<@layout_2>) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_5dcb(v0.@layout_5) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
@@ -5120,27 +5277,25 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
     block1:
         v3.i256 = evm_calldata_size;
         mstore v1 v3 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        v7.i256 = obj.load v6;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt v7 v9;
-        br v10 block2 block3;
+        v6.i256 = extract_value v0 0.i256;
+        v7.i256 = mload v1 i256;
+        mstore v2 v7 i256;
+        v8.i256 = mload v2 i256;
+        v9.i1 = gt v6 v8;
+        br v9 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v12.objref<i256> = obj.proj v0 0.i256;
-        v13.i256 = obj.load v12;
-        v14.i256 = mload v1 i256;
-        (v15.i256, v16.i1) = usubo v14 v13;
-        br v16 block5 block6;
+        v11.i256 = extract_value v0 0.i256;
+        v12.i256 = mload v1 i256;
+        (v13.i256, v14.i1) = usubo v12 v11;
+        br v14 block5 block6;
 
     block4:
-        v21.i256 = phi (0.i256 block2) (v15 block6);
-        return v21;
+        v19.i256 = phi (0.i256 block2) (v13 block6);
+        return v19;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -5151,7 +5306,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         jump block4;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_16d7(v0.objref<@layout_2>) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_6107(v0.@layout_5) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
@@ -5160,27 +5315,25 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
     block1:
         v3.i256 = evm_calldata_size;
         mstore v1 v3 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        v7.i256 = obj.load v6;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt v7 v9;
-        br v10 block2 block3;
+        v6.i256 = extract_value v0 0.i256;
+        v7.i256 = mload v1 i256;
+        mstore v2 v7 i256;
+        v8.i256 = mload v2 i256;
+        v9.i1 = gt v6 v8;
+        br v9 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v12.objref<i256> = obj.proj v0 0.i256;
-        v13.i256 = obj.load v12;
-        v14.i256 = mload v1 i256;
-        (v15.i256, v16.i1) = usubo v14 v13;
-        br v16 block5 block6;
+        v11.i256 = extract_value v0 0.i256;
+        v12.i256 = mload v1 i256;
+        (v13.i256, v14.i1) = usubo v12 v11;
+        br v14 block5 block6;
 
     block4:
-        v21.i256 = phi (0.i256 block2) (v15 block6);
-        return v21;
+        v19.i256 = phi (0.i256 block2) (v13 block6);
+        return v19;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -5191,7 +5344,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         jump block4;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_1f84(v0.objref<@layout_2>) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_7388(v0.@layout_5) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
@@ -5200,27 +5353,25 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
     block1:
         v3.i256 = evm_calldata_size;
         mstore v1 v3 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        v7.i256 = obj.load v6;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt v7 v9;
-        br v10 block2 block3;
+        v6.i256 = extract_value v0 0.i256;
+        v7.i256 = mload v1 i256;
+        mstore v2 v7 i256;
+        v8.i256 = mload v2 i256;
+        v9.i1 = gt v6 v8;
+        br v9 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v12.objref<i256> = obj.proj v0 0.i256;
-        v13.i256 = obj.load v12;
-        v14.i256 = mload v1 i256;
-        (v15.i256, v16.i1) = usubo v14 v13;
-        br v16 block5 block6;
+        v11.i256 = extract_value v0 0.i256;
+        v12.i256 = mload v1 i256;
+        (v13.i256, v14.i1) = usubo v12 v11;
+        br v14 block5 block6;
 
     block4:
-        v21.i256 = phi (0.i256 block2) (v15 block6);
-        return v21;
+        v19.i256 = phi (0.i256 block2) (v13 block6);
+        return v19;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -5231,7 +5382,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         jump block4;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_26f0(v0.objref<@layout_2>) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_9efd(v0.@layout_5) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
@@ -5240,27 +5391,25 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
     block1:
         v3.i256 = evm_calldata_size;
         mstore v1 v3 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        v7.i256 = obj.load v6;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt v7 v9;
-        br v10 block2 block3;
+        v6.i256 = extract_value v0 0.i256;
+        v7.i256 = mload v1 i256;
+        mstore v2 v7 i256;
+        v8.i256 = mload v2 i256;
+        v9.i1 = gt v6 v8;
+        br v9 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v12.objref<i256> = obj.proj v0 0.i256;
-        v13.i256 = obj.load v12;
-        v14.i256 = mload v1 i256;
-        (v15.i256, v16.i1) = usubo v14 v13;
-        br v16 block5 block6;
+        v11.i256 = extract_value v0 0.i256;
+        v12.i256 = mload v1 i256;
+        (v13.i256, v14.i1) = usubo v12 v11;
+        br v14 block5 block6;
 
     block4:
-        v21.i256 = phi (0.i256 block2) (v15 block6);
-        return v21;
+        v19.i256 = phi (0.i256 block2) (v13 block6);
+        return v19;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -5271,7 +5420,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         jump block4;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_3f86(v0.objref<@layout_2>) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_ae2f(v0.@layout_5) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
@@ -5280,27 +5429,25 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
     block1:
         v3.i256 = evm_calldata_size;
         mstore v1 v3 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        v7.i256 = obj.load v6;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt v7 v9;
-        br v10 block2 block3;
+        v6.i256 = extract_value v0 0.i256;
+        v7.i256 = mload v1 i256;
+        mstore v2 v7 i256;
+        v8.i256 = mload v2 i256;
+        v9.i1 = gt v6 v8;
+        br v9 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v12.objref<i256> = obj.proj v0 0.i256;
-        v13.i256 = obj.load v12;
-        v14.i256 = mload v1 i256;
-        (v15.i256, v16.i1) = usubo v14 v13;
-        br v16 block5 block6;
+        v11.i256 = extract_value v0 0.i256;
+        v12.i256 = mload v1 i256;
+        (v13.i256, v14.i1) = usubo v12 v11;
+        br v14 block5 block6;
 
     block4:
-        v21.i256 = phi (0.i256 block2) (v15 block6);
-        return v21;
+        v19.i256 = phi (0.i256 block2) (v13 block6);
+        return v19;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -5311,7 +5458,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         jump block4;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_4f08(v0.objref<@layout_2>) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_b318(v0.@layout_5) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
@@ -5320,27 +5467,25 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
     block1:
         v3.i256 = evm_calldata_size;
         mstore v1 v3 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        v7.i256 = obj.load v6;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt v7 v9;
-        br v10 block2 block3;
+        v6.i256 = extract_value v0 0.i256;
+        v7.i256 = mload v1 i256;
+        mstore v2 v7 i256;
+        v8.i256 = mload v2 i256;
+        v9.i1 = gt v6 v8;
+        br v9 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v12.objref<i256> = obj.proj v0 0.i256;
-        v13.i256 = obj.load v12;
-        v14.i256 = mload v1 i256;
-        (v15.i256, v16.i1) = usubo v14 v13;
-        br v16 block5 block6;
+        v11.i256 = extract_value v0 0.i256;
+        v12.i256 = mload v1 i256;
+        (v13.i256, v14.i1) = usubo v12 v11;
+        br v14 block5 block6;
 
     block4:
-        v21.i256 = phi (0.i256 block2) (v15 block6);
-        return v21;
+        v19.i256 = phi (0.i256 block2) (v13 block6);
+        return v19;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -5351,567 +5496,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         jump block4;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_5904(v0.objref<@layout_2>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        v7.i256 = obj.load v6;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt v7 v9;
-        br v10 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v12.objref<i256> = obj.proj v0 0.i256;
-        v13.i256 = obj.load v12;
-        v14.i256 = mload v1 i256;
-        (v15.i256, v16.i1) = usubo v14 v13;
-        br v16 block5 block6;
-
-    block4:
-        v21.i256 = phi (0.i256 block2) (v15 block6);
-        return v21;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_60f7(v0.objref<@layout_2>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        v7.i256 = obj.load v6;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt v7 v9;
-        br v10 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v12.objref<i256> = obj.proj v0 0.i256;
-        v13.i256 = obj.load v12;
-        v14.i256 = mload v1 i256;
-        (v15.i256, v16.i1) = usubo v14 v13;
-        br v16 block5 block6;
-
-    block4:
-        v21.i256 = phi (0.i256 block2) (v15 block6);
-        return v21;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_66d5(v0.objref<@layout_2>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        v7.i256 = obj.load v6;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt v7 v9;
-        br v10 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v12.objref<i256> = obj.proj v0 0.i256;
-        v13.i256 = obj.load v12;
-        v14.i256 = mload v1 i256;
-        (v15.i256, v16.i1) = usubo v14 v13;
-        br v16 block5 block6;
-
-    block4:
-        v21.i256 = phi (0.i256 block2) (v15 block6);
-        return v21;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_66ec(v0.objref<@layout_2>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        v7.i256 = obj.load v6;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt v7 v9;
-        br v10 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v12.objref<i256> = obj.proj v0 0.i256;
-        v13.i256 = obj.load v12;
-        v14.i256 = mload v1 i256;
-        (v15.i256, v16.i1) = usubo v14 v13;
-        br v16 block5 block6;
-
-    block4:
-        v21.i256 = phi (0.i256 block2) (v15 block6);
-        return v21;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_670f(v0.objref<@layout_2>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        v7.i256 = obj.load v6;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt v7 v9;
-        br v10 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v12.objref<i256> = obj.proj v0 0.i256;
-        v13.i256 = obj.load v12;
-        v14.i256 = mload v1 i256;
-        (v15.i256, v16.i1) = usubo v14 v13;
-        br v16 block5 block6;
-
-    block4:
-        v21.i256 = phi (0.i256 block2) (v15 block6);
-        return v21;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_6b68(v0.objref<@layout_2>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        v7.i256 = obj.load v6;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt v7 v9;
-        br v10 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v12.objref<i256> = obj.proj v0 0.i256;
-        v13.i256 = obj.load v12;
-        v14.i256 = mload v1 i256;
-        (v15.i256, v16.i1) = usubo v14 v13;
-        br v16 block5 block6;
-
-    block4:
-        v21.i256 = phi (0.i256 block2) (v15 block6);
-        return v21;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_6d9d(v0.objref<@layout_2>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        v7.i256 = obj.load v6;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt v7 v9;
-        br v10 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v12.objref<i256> = obj.proj v0 0.i256;
-        v13.i256 = obj.load v12;
-        v14.i256 = mload v1 i256;
-        (v15.i256, v16.i1) = usubo v14 v13;
-        br v16 block5 block6;
-
-    block4:
-        v21.i256 = phi (0.i256 block2) (v15 block6);
-        return v21;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_75fd(v0.objref<@layout_2>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        v7.i256 = obj.load v6;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt v7 v9;
-        br v10 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v12.objref<i256> = obj.proj v0 0.i256;
-        v13.i256 = obj.load v12;
-        v14.i256 = mload v1 i256;
-        (v15.i256, v16.i1) = usubo v14 v13;
-        br v16 block5 block6;
-
-    block4:
-        v21.i256 = phi (0.i256 block2) (v15 block6);
-        return v21;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_874b(v0.objref<@layout_2>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        v7.i256 = obj.load v6;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt v7 v9;
-        br v10 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v12.objref<i256> = obj.proj v0 0.i256;
-        v13.i256 = obj.load v12;
-        v14.i256 = mload v1 i256;
-        (v15.i256, v16.i1) = usubo v14 v13;
-        br v16 block5 block6;
-
-    block4:
-        v21.i256 = phi (0.i256 block2) (v15 block6);
-        return v21;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_8a80(v0.objref<@layout_2>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        v7.i256 = obj.load v6;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt v7 v9;
-        br v10 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v12.objref<i256> = obj.proj v0 0.i256;
-        v13.i256 = obj.load v12;
-        v14.i256 = mload v1 i256;
-        (v15.i256, v16.i1) = usubo v14 v13;
-        br v16 block5 block6;
-
-    block4:
-        v21.i256 = phi (0.i256 block2) (v15 block6);
-        return v21;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_9245(v0.objref<@layout_2>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        v7.i256 = obj.load v6;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt v7 v9;
-        br v10 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v12.objref<i256> = obj.proj v0 0.i256;
-        v13.i256 = obj.load v12;
-        v14.i256 = mload v1 i256;
-        (v15.i256, v16.i1) = usubo v14 v13;
-        br v16 block5 block6;
-
-    block4:
-        v21.i256 = phi (0.i256 block2) (v15 block6);
-        return v21;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_94a3(v0.objref<@layout_2>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        v7.i256 = obj.load v6;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt v7 v9;
-        br v10 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v12.objref<i256> = obj.proj v0 0.i256;
-        v13.i256 = obj.load v12;
-        v14.i256 = mload v1 i256;
-        (v15.i256, v16.i1) = usubo v14 v13;
-        br v16 block5 block6;
-
-    block4:
-        v21.i256 = phi (0.i256 block2) (v15 block6);
-        return v21;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_9ee6(v0.objref<@layout_2>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        v7.i256 = obj.load v6;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt v7 v9;
-        br v10 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v12.objref<i256> = obj.proj v0 0.i256;
-        v13.i256 = obj.load v12;
-        v14.i256 = mload v1 i256;
-        (v15.i256, v16.i1) = usubo v14 v13;
-        br v16 block5 block6;
-
-    block4:
-        v21.i256 = phi (0.i256 block2) (v15 block6);
-        return v21;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_a887(v0.objref<@layout_2>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        v7.i256 = obj.load v6;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt v7 v9;
-        br v10 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v12.objref<i256> = obj.proj v0 0.i256;
-        v13.i256 = obj.load v12;
-        v14.i256 = mload v1 i256;
-        (v15.i256, v16.i1) = usubo v14 v13;
-        br v16 block5 block6;
-
-    block4:
-        v21.i256 = phi (0.i256 block2) (v15 block6);
-        return v21;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_be96(v0.objref<@layout_5>) -> i256 {
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_be96(v0.objref<@layout_2>) -> i256 {
     block0:
         jump block1;
 
@@ -5921,7 +5506,7 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_be96
         return v4;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_be96_0(v0.objref<@layout_5>) -> i256 {
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_be96_0(v0.objref<@layout_2>) -> i256 {
     block0:
         jump block1;
 
@@ -5931,7 +5516,7 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_be96
         return v4;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_c0ed(v0.objref<@layout_2>) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_c018(v0.@layout_5) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
@@ -5940,27 +5525,25 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
     block1:
         v3.i256 = evm_calldata_size;
         mstore v1 v3 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        v7.i256 = obj.load v6;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt v7 v9;
-        br v10 block2 block3;
+        v6.i256 = extract_value v0 0.i256;
+        v7.i256 = mload v1 i256;
+        mstore v2 v7 i256;
+        v8.i256 = mload v2 i256;
+        v9.i1 = gt v6 v8;
+        br v9 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v12.objref<i256> = obj.proj v0 0.i256;
-        v13.i256 = obj.load v12;
-        v14.i256 = mload v1 i256;
-        (v15.i256, v16.i1) = usubo v14 v13;
-        br v16 block5 block6;
+        v11.i256 = extract_value v0 0.i256;
+        v12.i256 = mload v1 i256;
+        (v13.i256, v14.i1) = usubo v12 v11;
+        br v14 block5 block6;
 
     block4:
-        v21.i256 = phi (0.i256 block2) (v15 block6);
-        return v21;
+        v19.i256 = phi (0.i256 block2) (v13 block6);
+        return v19;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -5971,7 +5554,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         jump block4;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_c1ca(v0.objref<@layout_2>) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_ce93(v0.@layout_5) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
@@ -5980,27 +5563,25 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
     block1:
         v3.i256 = evm_calldata_size;
         mstore v1 v3 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        v7.i256 = obj.load v6;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt v7 v9;
-        br v10 block2 block3;
+        v6.i256 = extract_value v0 0.i256;
+        v7.i256 = mload v1 i256;
+        mstore v2 v7 i256;
+        v8.i256 = mload v2 i256;
+        v9.i1 = gt v6 v8;
+        br v9 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v12.objref<i256> = obj.proj v0 0.i256;
-        v13.i256 = obj.load v12;
-        v14.i256 = mload v1 i256;
-        (v15.i256, v16.i1) = usubo v14 v13;
-        br v16 block5 block6;
+        v11.i256 = extract_value v0 0.i256;
+        v12.i256 = mload v1 i256;
+        (v13.i256, v14.i1) = usubo v12 v11;
+        br v14 block5 block6;
 
     block4:
-        v21.i256 = phi (0.i256 block2) (v15 block6);
-        return v21;
+        v19.i256 = phi (0.i256 block2) (v13 block6);
+        return v19;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -6011,287 +5592,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         jump block4;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_c1cd(v0.objref<@layout_2>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        v7.i256 = obj.load v6;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt v7 v9;
-        br v10 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v12.objref<i256> = obj.proj v0 0.i256;
-        v13.i256 = obj.load v12;
-        v14.i256 = mload v1 i256;
-        (v15.i256, v16.i1) = usubo v14 v13;
-        br v16 block5 block6;
-
-    block4:
-        v21.i256 = phi (0.i256 block2) (v15 block6);
-        return v21;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_c364(v0.objref<@layout_2>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        v7.i256 = obj.load v6;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt v7 v9;
-        br v10 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v12.objref<i256> = obj.proj v0 0.i256;
-        v13.i256 = obj.load v12;
-        v14.i256 = mload v1 i256;
-        (v15.i256, v16.i1) = usubo v14 v13;
-        br v16 block5 block6;
-
-    block4:
-        v21.i256 = phi (0.i256 block2) (v15 block6);
-        return v21;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_c44b(v0.objref<@layout_2>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        v7.i256 = obj.load v6;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt v7 v9;
-        br v10 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v12.objref<i256> = obj.proj v0 0.i256;
-        v13.i256 = obj.load v12;
-        v14.i256 = mload v1 i256;
-        (v15.i256, v16.i1) = usubo v14 v13;
-        br v16 block5 block6;
-
-    block4:
-        v21.i256 = phi (0.i256 block2) (v15 block6);
-        return v21;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_c624(v0.objref<@layout_2>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        v7.i256 = obj.load v6;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt v7 v9;
-        br v10 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v12.objref<i256> = obj.proj v0 0.i256;
-        v13.i256 = obj.load v12;
-        v14.i256 = mload v1 i256;
-        (v15.i256, v16.i1) = usubo v14 v13;
-        br v16 block5 block6;
-
-    block4:
-        v21.i256 = phi (0.i256 block2) (v15 block6);
-        return v21;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_c8b6(v0.objref<@layout_2>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        v7.i256 = obj.load v6;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt v7 v9;
-        br v10 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v12.objref<i256> = obj.proj v0 0.i256;
-        v13.i256 = obj.load v12;
-        v14.i256 = mload v1 i256;
-        (v15.i256, v16.i1) = usubo v14 v13;
-        br v16 block5 block6;
-
-    block4:
-        v21.i256 = phi (0.i256 block2) (v15 block6);
-        return v21;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_d849(v0.objref<@layout_2>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        v7.i256 = obj.load v6;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt v7 v9;
-        br v10 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v12.objref<i256> = obj.proj v0 0.i256;
-        v13.i256 = obj.load v12;
-        v14.i256 = mload v1 i256;
-        (v15.i256, v16.i1) = usubo v14 v13;
-        br v16 block5 block6;
-
-    block4:
-        v21.i256 = phi (0.i256 block2) (v15 block6);
-        return v21;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_dd5c(v0.objref<@layout_2>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        v7.i256 = obj.load v6;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt v7 v9;
-        br v10 block2 block3;
-
-    block2:
-        jump block4;
-
-    block3:
-        v12.objref<i256> = obj.proj v0 0.i256;
-        v13.i256 = obj.load v12;
-        v14.i256 = mload v1 i256;
-        (v15.i256, v16.i1) = usubo v14 v13;
-        br v16 block5 block6;
-
-    block4:
-        v21.i256 = phi (0.i256 block2) (v15 block6);
-        return v21;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        jump block4;
-}
-
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_e00f(v0.objref<@layout_5>) -> i256 {
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_e00f(v0.objref<@layout_2>) -> i256 {
     block0:
         jump block1;
 
@@ -6301,7 +5602,7 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_e00f
         return v4;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_e8a2(v0.objref<@layout_2>) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_f03b(v0.@layout_5) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
@@ -6310,27 +5611,63 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
     block1:
         v3.i256 = evm_calldata_size;
         mstore v1 v3 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        v7.i256 = obj.load v6;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt v7 v9;
-        br v10 block2 block3;
+        v6.i256 = extract_value v0 0.i256;
+        v7.i256 = mload v1 i256;
+        mstore v2 v7 i256;
+        v8.i256 = mload v2 i256;
+        v9.i1 = gt v6 v8;
+        br v9 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v12.objref<i256> = obj.proj v0 0.i256;
-        v13.i256 = obj.load v12;
-        v14.i256 = mload v1 i256;
-        (v15.i256, v16.i1) = usubo v14 v13;
-        br v16 block5 block6;
+        v11.i256 = extract_value v0 0.i256;
+        v12.i256 = mload v1 i256;
+        (v13.i256, v14.i1) = usubo v12 v11;
+        br v14 block5 block6;
 
     block4:
-        v21.i256 = phi (0.i256 block2) (v15 block6);
-        return v21;
+        v19.i256 = phi (0.i256 block2) (v13 block6);
+        return v19;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        jump block4;
+}
+
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_fc14(v0.@layout_5) -> i256 {
+    block0:
+        v1.*i256 = alloca i256;
+        v2.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v3.i256 = evm_calldata_size;
+        mstore v1 v3 i256;
+        v6.i256 = extract_value v0 0.i256;
+        v7.i256 = mload v1 i256;
+        mstore v2 v7 i256;
+        v8.i256 = mload v2 i256;
+        v9.i1 = gt v6 v8;
+        br v9 block2 block3;
+
+    block2:
+        jump block4;
+
+    block3:
+        v11.i256 = extract_value v0 0.i256;
+        v12.i256 = mload v1 i256;
+        (v13.i256, v14.i1) = usubo v12 v11;
+        br v14 block5 block6;
+
+    block4:
+        v19.i256 = phi (0.i256 block2) (v13 block6);
+        return v19;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -6441,7 +5778,7 @@ func private %standalone_erc20__erc20__mint__g5c3f_3140(v0.@layout_0, v1.i256, v
         call %set__g2163 v0 v36;
         v40.@layout_0 = call %zero;
         v42.i256 = mload v3 i256;
-        v43.objref<@layout_21> = obj.alloc @layout_21;
+        v43.objref<@layout_19> = obj.alloc @layout_19;
         v44.objref<@layout_0> = obj.proj v43 0.i256;
         v45.objref<i256> = obj.proj v44 0.i256;
         v46.i256 = extract_value v40 0.i256;
@@ -6452,7 +5789,7 @@ func private %standalone_erc20__erc20__mint__g5c3f_3140(v0.@layout_0, v1.i256, v
         obj.store v49 v50;
         v52.objref<i256> = obj.proj v43 2.i256;
         obj.store v52 v42;
-        v53.@layout_21 = obj.load v43;
+        v53.@layout_19 = obj.load v43;
         call %emit__g4c3d v53;
         return;
 }
@@ -6509,7 +5846,7 @@ func private %standalone_erc20__erc20__mint__g5c3f_dd30(v0.@layout_0, v1.i256, v
         call %set__g2163 v0 v36;
         v40.@layout_0 = call %zero;
         v42.i256 = mload v3 i256;
-        v43.objref<@layout_21> = obj.alloc @layout_21;
+        v43.objref<@layout_19> = obj.alloc @layout_19;
         v44.objref<@layout_0> = obj.proj v43 0.i256;
         v45.objref<i256> = obj.proj v44 0.i256;
         v46.i256 = extract_value v40 0.i256;
@@ -6520,7 +5857,7 @@ func private %standalone_erc20__erc20__mint__g5c3f_dd30(v0.@layout_0, v1.i256, v
         obj.store v49 v50;
         v52.objref<i256> = obj.proj v43 2.i256;
         obj.store v52 v42;
-        v53.@layout_21 = obj.load v43;
+        v53.@layout_19 = obj.load v43;
         call %emit__g4c3d v53;
         return;
 }
@@ -6535,32 +5872,40 @@ func private %ne(v0.@layout_0, v1.@layout_0) -> i1 {
         return v5;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_03f9() -> @layout_2 {
+func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_0199() -> @layout_5 {
     block0:
         jump block1;
 
     block1:
-        v1.constref<@layout_2> = const.ref $const_region_0;
-        v2.objref<@layout_2> = obj.alloc @layout_2;
+        v1.constref<@layout_5> = const.ref $const_region_0;
+        v2.objref<@layout_5> = obj.alloc @layout_5;
         obj.init.const v2 v1;
-        v3.@layout_2 = obj.load v2;
+        v3.@layout_5 = obj.load v2;
         return v3;
 }
 
-func inline(always) private %core__lib__abi__impl_Cursor_1a04__new__gd20d_0a92(v0.@layout_2) -> @layout_3 {
+func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_0d2c() -> @layout_5 {
     block0:
         jump block1;
 
     block1:
-        v2.objref<@layout_3> = obj.alloc @layout_3;
-        v4.objref<@layout_2> = obj.proj v2 0.i256;
-        v5.objref<i256> = obj.proj v4 0.i256;
-        v6.i256 = extract_value v0 0.i256;
-        obj.store v5 v6;
-        v8.objref<i256> = obj.proj v2 1.i256;
-        obj.store v8 0.i256;
-        v9.@layout_3 = obj.load v2;
-        return v9;
+        v1.constref<@layout_5> = const.ref $const_region_0;
+        v2.objref<@layout_5> = obj.alloc @layout_5;
+        obj.init.const v2 v1;
+        v3.@layout_5 = obj.load v2;
+        return v3;
+}
+
+func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_0fa9() -> @layout_5 {
+    block0:
+        jump block1;
+
+    block1:
+        v1.constref<@layout_5> = const.ref $const_region_0;
+        v2.objref<@layout_5> = obj.alloc @layout_5;
+        obj.init.const v2 v1;
+        v3.@layout_5 = obj.load v2;
+        return v3;
 }
 
 func private %std__lib__abi__sol__impl_SolEncoder_ce34__new_1301(v0.i256) -> @layout_1 {
@@ -6594,36 +5939,16 @@ func private %std__lib__abi__sol__impl_SolEncoder_ce34__new_1301(v0.i256) -> @la
         return v13;
 }
 
-func inline(always) private %core__lib__abi__impl_Cursor_1a04__new__gd20d_200e(v0.@layout_2) -> @layout_3 {
+func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_147c() -> @layout_5 {
     block0:
         jump block1;
 
     block1:
-        v2.objref<@layout_3> = obj.alloc @layout_3;
-        v4.objref<@layout_2> = obj.proj v2 0.i256;
-        v5.objref<i256> = obj.proj v4 0.i256;
-        v6.i256 = extract_value v0 0.i256;
-        obj.store v5 v6;
-        v8.objref<i256> = obj.proj v2 1.i256;
-        obj.store v8 0.i256;
-        v9.@layout_3 = obj.load v2;
-        return v9;
-}
-
-func inline(always) private %core__lib__abi__impl_Cursor_1a04__new__gd20d_232c(v0.@layout_2) -> @layout_3 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.objref<@layout_3> = obj.alloc @layout_3;
-        v4.objref<@layout_2> = obj.proj v2 0.i256;
-        v5.objref<i256> = obj.proj v4 0.i256;
-        v6.i256 = extract_value v0 0.i256;
-        obj.store v5 v6;
-        v8.objref<i256> = obj.proj v2 1.i256;
-        obj.store v8 0.i256;
-        v9.@layout_3 = obj.load v2;
-        return v9;
+        v1.constref<@layout_5> = const.ref $const_region_0;
+        v2.objref<@layout_5> = obj.alloc @layout_5;
+        obj.init.const v2 v1;
+        v3.@layout_5 = obj.load v2;
+        return v3;
 }
 
 func private %std__lib__abi__sol__impl_SolEncoder_ce34__new_24a6(v0.i256) -> @layout_1 {
@@ -6657,16 +5982,16 @@ func private %std__lib__abi__sol__impl_SolEncoder_ce34__new_24a6(v0.i256) -> @la
         return v13;
 }
 
-func inline(always) private %impl_SolDecoder__new__g463e(v0.@layout_5) -> @layout_7 {
+func inline(always) private %impl_SolDecoder__new__g463e(v0.@layout_2) -> @layout_4 {
     block0:
         jump block1;
 
     block1:
-        v2.@layout_6 = call %impl_Cursor__new__g463e v0;
-        v4.objref<@layout_7> = obj.alloc @layout_7;
-        v5.objref<@layout_6> = obj.proj v4 0.i256;
-        v6.objref<@layout_5> = obj.proj v5 0.i256;
-        v7.@layout_5 = extract_value v2 0.i256;
+        v2.@layout_3 = call %impl_Cursor__new__g463e v0;
+        v4.objref<@layout_4> = obj.alloc @layout_4;
+        v5.objref<@layout_3> = obj.proj v4 0.i256;
+        v6.objref<@layout_2> = obj.proj v5 0.i256;
+        v7.@layout_2 = extract_value v2 0.i256;
         v8.objref<i256> = obj.proj v6 0.i256;
         v9.i256 = extract_value v7 0.i256;
         obj.store v8 v9;
@@ -6678,159 +6003,43 @@ func inline(always) private %impl_SolDecoder__new__g463e(v0.@layout_5) -> @layou
         obj.store v13 v14;
         v15.objref<i256> = obj.proj v4 1.i256;
         obj.store v15 0.i256;
-        v16.@layout_7 = obj.load v4;
+        v16.@layout_4 = obj.load v4;
         return v16;
 }
 
-func inline(always) private %core__lib__abi__impl_Cursor_1a04__new__gd20d_2e66(v0.@layout_2) -> @layout_3 {
+func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_53e2() -> @layout_5 {
     block0:
         jump block1;
 
     block1:
-        v2.objref<@layout_3> = obj.alloc @layout_3;
-        v4.objref<@layout_2> = obj.proj v2 0.i256;
-        v5.objref<i256> = obj.proj v4 0.i256;
-        v6.i256 = extract_value v0 0.i256;
-        obj.store v5 v6;
-        v8.objref<i256> = obj.proj v2 1.i256;
-        obj.store v8 0.i256;
-        v9.@layout_3 = obj.load v2;
-        return v9;
-}
-
-func inline(always) private %core__lib__abi__impl_Cursor_1a04__new__gd20d_3ec1(v0.@layout_2) -> @layout_3 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.objref<@layout_3> = obj.alloc @layout_3;
-        v4.objref<@layout_2> = obj.proj v2 0.i256;
-        v5.objref<i256> = obj.proj v4 0.i256;
-        v6.i256 = extract_value v0 0.i256;
-        obj.store v5 v6;
-        v8.objref<i256> = obj.proj v2 1.i256;
-        obj.store v8 0.i256;
-        v9.@layout_3 = obj.load v2;
-        return v9;
-}
-
-func inline(always) private %core__lib__abi__impl_Cursor_1a04__new__gd20d_4240(v0.@layout_2) -> @layout_3 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.objref<@layout_3> = obj.alloc @layout_3;
-        v4.objref<@layout_2> = obj.proj v2 0.i256;
-        v5.objref<i256> = obj.proj v4 0.i256;
-        v6.i256 = extract_value v0 0.i256;
-        obj.store v5 v6;
-        v8.objref<i256> = obj.proj v2 1.i256;
-        obj.store v8 0.i256;
-        v9.@layout_3 = obj.load v2;
-        return v9;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_42ba() -> @layout_2 {
-    block0:
-        jump block1;
-
-    block1:
-        v1.constref<@layout_2> = const.ref $const_region_0;
-        v2.objref<@layout_2> = obj.alloc @layout_2;
+        v1.constref<@layout_5> = const.ref $const_region_0;
+        v2.objref<@layout_5> = obj.alloc @layout_5;
         obj.init.const v2 v1;
-        v3.@layout_2 = obj.load v2;
+        v3.@layout_5 = obj.load v2;
         return v3;
 }
 
-func inline(always) private %core__lib__abi__impl_Cursor_1a04__new__gd20d_4eb9(v0.@layout_2) -> @layout_3 {
+func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_5438() -> @layout_5 {
     block0:
         jump block1;
 
     block1:
-        v2.objref<@layout_3> = obj.alloc @layout_3;
-        v4.objref<@layout_2> = obj.proj v2 0.i256;
-        v5.objref<i256> = obj.proj v4 0.i256;
-        v6.i256 = extract_value v0 0.i256;
-        obj.store v5 v6;
-        v8.objref<i256> = obj.proj v2 1.i256;
-        obj.store v8 0.i256;
-        v9.@layout_3 = obj.load v2;
-        return v9;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_4f1d() -> @layout_2 {
-    block0:
-        jump block1;
-
-    block1:
-        v1.constref<@layout_2> = const.ref $const_region_0;
-        v2.objref<@layout_2> = obj.alloc @layout_2;
+        v1.constref<@layout_5> = const.ref $const_region_0;
+        v2.objref<@layout_5> = obj.alloc @layout_5;
         obj.init.const v2 v1;
-        v3.@layout_2 = obj.load v2;
+        v3.@layout_5 = obj.load v2;
         return v3;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_5a69() -> @layout_2 {
+func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_8102() -> @layout_5 {
     block0:
         jump block1;
 
     block1:
-        v1.constref<@layout_2> = const.ref $const_region_0;
-        v2.objref<@layout_2> = obj.alloc @layout_2;
+        v1.constref<@layout_5> = const.ref $const_region_0;
+        v2.objref<@layout_5> = obj.alloc @layout_5;
         obj.init.const v2 v1;
-        v3.@layout_2 = obj.load v2;
-        return v3;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_5ebc() -> @layout_2 {
-    block0:
-        jump block1;
-
-    block1:
-        v1.constref<@layout_2> = const.ref $const_region_0;
-        v2.objref<@layout_2> = obj.alloc @layout_2;
-        obj.init.const v2 v1;
-        v3.@layout_2 = obj.load v2;
-        return v3;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_6b3a() -> @layout_2 {
-    block0:
-        jump block1;
-
-    block1:
-        v1.constref<@layout_2> = const.ref $const_region_0;
-        v2.objref<@layout_2> = obj.alloc @layout_2;
-        obj.init.const v2 v1;
-        v3.@layout_2 = obj.load v2;
-        return v3;
-}
-
-func inline(always) private %core__lib__abi__impl_Cursor_1a04__new__gd20d_6e18(v0.@layout_2) -> @layout_3 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.objref<@layout_3> = obj.alloc @layout_3;
-        v4.objref<@layout_2> = obj.proj v2 0.i256;
-        v5.objref<i256> = obj.proj v4 0.i256;
-        v6.i256 = extract_value v0 0.i256;
-        obj.store v5 v6;
-        v8.objref<i256> = obj.proj v2 1.i256;
-        obj.store v8 0.i256;
-        v9.@layout_3 = obj.load v2;
-        return v9;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_7fee() -> @layout_2 {
-    block0:
-        jump block1;
-
-    block1:
-        v1.constref<@layout_2> = const.ref $const_region_0;
-        v2.objref<@layout_2> = obj.alloc @layout_2;
-        obj.init.const v2 v1;
-        v3.@layout_2 = obj.load v2;
+        v3.@layout_5 = obj.load v2;
         return v3;
 }
 
@@ -6865,43 +6074,15 @@ func private %std__lib__abi__sol__impl_SolEncoder_ce34__new_8670(v0.i256) -> @la
         return v13;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_87cb() -> @layout_2 {
+func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_923b() -> @layout_5 {
     block0:
         jump block1;
 
     block1:
-        v1.constref<@layout_2> = const.ref $const_region_0;
-        v2.objref<@layout_2> = obj.alloc @layout_2;
+        v1.constref<@layout_5> = const.ref $const_region_0;
+        v2.objref<@layout_5> = obj.alloc @layout_5;
         obj.init.const v2 v1;
-        v3.@layout_2 = obj.load v2;
-        return v3;
-}
-
-func inline(always) private %core__lib__abi__impl_Cursor_1a04__new__gd20d_8b54(v0.@layout_2) -> @layout_3 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.objref<@layout_3> = obj.alloc @layout_3;
-        v4.objref<@layout_2> = obj.proj v2 0.i256;
-        v5.objref<i256> = obj.proj v4 0.i256;
-        v6.i256 = extract_value v0 0.i256;
-        obj.store v5 v6;
-        v8.objref<i256> = obj.proj v2 1.i256;
-        obj.store v8 0.i256;
-        v9.@layout_3 = obj.load v2;
-        return v9;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_92f9() -> @layout_2 {
-    block0:
-        jump block1;
-
-    block1:
-        v1.constref<@layout_2> = const.ref $const_region_0;
-        v2.objref<@layout_2> = obj.alloc @layout_2;
-        obj.init.const v2 v1;
-        v3.@layout_2 = obj.load v2;
+        v3.@layout_5 = obj.load v2;
         return v3;
 }
 
@@ -6936,37 +6117,13 @@ func private %std__lib__abi__sol__impl_SolEncoder_ce34__new_978f(v0.i256) -> @la
         return v13;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_9e29() -> @layout_2 {
+func inline(always) private %impl_Cursor__new__g463e(v0.@layout_2) -> @layout_3 {
     block0:
         jump block1;
 
     block1:
-        v1.constref<@layout_2> = const.ref $const_region_0;
-        v2.objref<@layout_2> = obj.alloc @layout_2;
-        obj.init.const v2 v1;
-        v3.@layout_2 = obj.load v2;
-        return v3;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_a382() -> @layout_2 {
-    block0:
-        jump block1;
-
-    block1:
-        v1.constref<@layout_2> = const.ref $const_region_0;
-        v2.objref<@layout_2> = obj.alloc @layout_2;
-        obj.init.const v2 v1;
-        v3.@layout_2 = obj.load v2;
-        return v3;
-}
-
-func inline(always) private %impl_Cursor__new__g463e(v0.@layout_5) -> @layout_6 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.objref<@layout_6> = obj.alloc @layout_6;
-        v4.objref<@layout_5> = obj.proj v2 0.i256;
+        v2.objref<@layout_3> = obj.alloc @layout_3;
+        v4.objref<@layout_2> = obj.proj v2 0.i256;
         v5.objref<i256> = obj.proj v4 0.i256;
         v6.i256 = extract_value v0 0.i256;
         obj.store v5 v6;
@@ -6975,19 +6132,43 @@ func inline(always) private %impl_Cursor__new__g463e(v0.@layout_5) -> @layout_6 
         obj.store v8 v9;
         v10.objref<i256> = obj.proj v2 1.i256;
         obj.store v10 0.i256;
-        v11.@layout_6 = obj.load v2;
+        v11.@layout_3 = obj.load v2;
         return v11;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_b58c() -> @layout_2 {
+func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_b0b8() -> @layout_5 {
     block0:
         jump block1;
 
     block1:
-        v1.constref<@layout_2> = const.ref $const_region_0;
-        v2.objref<@layout_2> = obj.alloc @layout_2;
+        v1.constref<@layout_5> = const.ref $const_region_0;
+        v2.objref<@layout_5> = obj.alloc @layout_5;
         obj.init.const v2 v1;
-        v3.@layout_2 = obj.load v2;
+        v3.@layout_5 = obj.load v2;
+        return v3;
+}
+
+func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_b671() -> @layout_5 {
+    block0:
+        jump block1;
+
+    block1:
+        v1.constref<@layout_5> = const.ref $const_region_0;
+        v2.objref<@layout_5> = obj.alloc @layout_5;
+        obj.init.const v2 v1;
+        v3.@layout_5 = obj.load v2;
+        return v3;
+}
+
+func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_bc34() -> @layout_5 {
+    block0:
+        jump block1;
+
+    block1:
+        v1.constref<@layout_5> = const.ref $const_region_0;
+        v2.objref<@layout_5> = obj.alloc @layout_5;
+        obj.init.const v2 v1;
+        v3.@layout_5 = obj.load v2;
         return v3;
 }
 
@@ -7022,22 +6203,6 @@ func private %std__lib__abi__sol__impl_SolEncoder_ce34__new_c2ff(v0.i256) -> @la
         return v13;
 }
 
-func inline(always) private %core__lib__abi__impl_Cursor_1a04__new__gd20d_c3a0(v0.@layout_2) -> @layout_3 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.objref<@layout_3> = obj.alloc @layout_3;
-        v4.objref<@layout_2> = obj.proj v2 0.i256;
-        v5.objref<i256> = obj.proj v4 0.i256;
-        v6.i256 = extract_value v0 0.i256;
-        obj.store v5 v6;
-        v8.objref<i256> = obj.proj v2 1.i256;
-        obj.store v8 0.i256;
-        v9.@layout_3 = obj.load v2;
-        return v9;
-}
-
 func private %std__lib__abi__sol__impl_SolEncoder_ce34__new_c575(v0.i256) -> @layout_1 {
     block0:
         v1.*i256 = alloca i256;
@@ -7069,80 +6234,16 @@ func private %std__lib__abi__sol__impl_SolEncoder_ce34__new_c575(v0.i256) -> @la
         return v13;
 }
 
-func inline(always) private %core__lib__abi__impl_Cursor_1a04__new__gd20d_cb66(v0.@layout_2) -> @layout_3 {
+func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_d306() -> @layout_5 {
     block0:
         jump block1;
 
     block1:
-        v2.objref<@layout_3> = obj.alloc @layout_3;
-        v4.objref<@layout_2> = obj.proj v2 0.i256;
-        v5.objref<i256> = obj.proj v4 0.i256;
-        v6.i256 = extract_value v0 0.i256;
-        obj.store v5 v6;
-        v8.objref<i256> = obj.proj v2 1.i256;
-        obj.store v8 0.i256;
-        v9.@layout_3 = obj.load v2;
-        return v9;
-}
-
-func inline(always) private %core__lib__abi__impl_Cursor_1a04__new__gd20d_cc0f(v0.@layout_2) -> @layout_3 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.objref<@layout_3> = obj.alloc @layout_3;
-        v4.objref<@layout_2> = obj.proj v2 0.i256;
-        v5.objref<i256> = obj.proj v4 0.i256;
-        v6.i256 = extract_value v0 0.i256;
-        obj.store v5 v6;
-        v8.objref<i256> = obj.proj v2 1.i256;
-        obj.store v8 0.i256;
-        v9.@layout_3 = obj.load v2;
-        return v9;
-}
-
-func inline(always) private %core__lib__abi__impl_Cursor_1a04__new__gd20d_d550(v0.@layout_2) -> @layout_3 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.objref<@layout_3> = obj.alloc @layout_3;
-        v4.objref<@layout_2> = obj.proj v2 0.i256;
-        v5.objref<i256> = obj.proj v4 0.i256;
-        v6.i256 = extract_value v0 0.i256;
-        obj.store v5 v6;
-        v8.objref<i256> = obj.proj v2 1.i256;
-        obj.store v8 0.i256;
-        v9.@layout_3 = obj.load v2;
-        return v9;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_e8bc() -> @layout_2 {
-    block0:
-        jump block1;
-
-    block1:
-        v1.constref<@layout_2> = const.ref $const_region_0;
-        v2.objref<@layout_2> = obj.alloc @layout_2;
+        v1.constref<@layout_5> = const.ref $const_region_0;
+        v2.objref<@layout_5> = obj.alloc @layout_5;
         obj.init.const v2 v1;
-        v3.@layout_2 = obj.load v2;
+        v3.@layout_5 = obj.load v2;
         return v3;
-}
-
-func inline(always) private %core__lib__abi__impl_Cursor_1a04__new__gd20d_edc0(v0.@layout_2) -> @layout_3 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.objref<@layout_3> = obj.alloc @layout_3;
-        v4.objref<@layout_2> = obj.proj v2 0.i256;
-        v5.objref<i256> = obj.proj v4 0.i256;
-        v6.i256 = extract_value v0 0.i256;
-        obj.store v5 v6;
-        v8.objref<i256> = obj.proj v2 1.i256;
-        obj.store v8 0.i256;
-        v9.@layout_3 = obj.load v2;
-        return v9;
 }
 
 func private %std__lib__abi__sol__impl_SolEncoder_ce34__new_f042(v0.i256) -> @layout_1 {
@@ -7176,15 +6277,27 @@ func private %std__lib__abi__sol__impl_SolEncoder_ce34__new_f042(v0.i256) -> @la
         return v13;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_fce4() -> @layout_2 {
+func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_f11a() -> @layout_5 {
     block0:
         jump block1;
 
     block1:
-        v1.constref<@layout_2> = const.ref $const_region_0;
-        v2.objref<@layout_2> = obj.alloc @layout_2;
+        v1.constref<@layout_5> = const.ref $const_region_0;
+        v2.objref<@layout_5> = obj.alloc @layout_5;
         obj.init.const v2 v1;
-        v3.@layout_2 = obj.load v2;
+        v3.@layout_5 = obj.load v2;
+        return v3;
+}
+
+func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_f379() -> @layout_5 {
+    block0:
+        jump block1;
+
+    block1:
+        v1.constref<@layout_5> = const.ref $const_region_0;
+        v2.objref<@layout_5> = obj.alloc @layout_5;
+        obj.init.const v2 v1;
+        v3.@layout_5 = obj.load v2;
         return v3;
 }
 
@@ -7612,17 +6725,6 @@ func private %core__lib__abi__impl_trait_String_c06e__payload_size__g3eb7_f656_0
         return v7;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g8f43_03cc(v0.objref<@layout_4>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<@layout_3> = obj.proj v0 0.i256;
-        v5.objref<i256> = obj.proj v3 1.i256;
-        v6.i256 = obj.load v5;
-        return v6;
-}
-
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_0de4(v0.objref<@layout_1>) -> i256 {
     block0:
         jump block1;
@@ -7633,7 +6735,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_0de4(v0.objref
         return v4;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g8f43_1b8b(v0.objref<@layout_4>) -> i256 {
+func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g463e_1f4c(v0.objref<@layout_4>) -> i256 {
     block0:
         jump block1;
 
@@ -7644,51 +6746,7 @@ func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g8f43_1b8b(v0
         return v6;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g8f43_1f03(v0.objref<@layout_4>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<@layout_3> = obj.proj v0 0.i256;
-        v5.objref<i256> = obj.proj v3 1.i256;
-        v6.i256 = obj.load v5;
-        return v6;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g463e_1f4c(v0.objref<@layout_7>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<@layout_6> = obj.proj v0 0.i256;
-        v5.objref<i256> = obj.proj v3 1.i256;
-        v6.i256 = obj.load v5;
-        return v6;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g463e_1f4c_0(v0.objref<@layout_7>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<@layout_6> = obj.proj v0 0.i256;
-        v5.objref<i256> = obj.proj v3 1.i256;
-        v6.i256 = obj.load v5;
-        return v6;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g8f43_2469(v0.objref<@layout_4>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<@layout_3> = obj.proj v0 0.i256;
-        v5.objref<i256> = obj.proj v3 1.i256;
-        v6.i256 = obj.load v5;
-        return v6;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g8f43_2476(v0.objref<@layout_4>) -> i256 {
+func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g463e_1f4c_0(v0.objref<@layout_4>) -> i256 {
     block0:
         jump block1;
 
@@ -7709,39 +6767,6 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_324d(v0.objref
         return v4;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g8f43_359e(v0.objref<@layout_4>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<@layout_3> = obj.proj v0 0.i256;
-        v5.objref<i256> = obj.proj v3 1.i256;
-        v6.i256 = obj.load v5;
-        return v6;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g8f43_389a(v0.objref<@layout_4>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<@layout_3> = obj.proj v0 0.i256;
-        v5.objref<i256> = obj.proj v3 1.i256;
-        v6.i256 = obj.load v5;
-        return v6;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g8f43_5f56(v0.objref<@layout_4>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<@layout_3> = obj.proj v0 0.i256;
-        v5.objref<i256> = obj.proj v3 1.i256;
-        v6.i256 = obj.load v5;
-        return v6;
-}
-
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_6cac(v0.objref<@layout_1>) -> i256 {
     block0:
         jump block1;
@@ -7750,39 +6775,6 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_6cac(v0.objref
         v3.objref<i256> = obj.proj v0 1.i256;
         v4.i256 = obj.load v3;
         return v4;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g8f43_732d(v0.objref<@layout_4>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<@layout_3> = obj.proj v0 0.i256;
-        v5.objref<i256> = obj.proj v3 1.i256;
-        v6.i256 = obj.load v5;
-        return v6;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g8f43_7902(v0.objref<@layout_4>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<@layout_3> = obj.proj v0 0.i256;
-        v5.objref<i256> = obj.proj v3 1.i256;
-        v6.i256 = obj.load v5;
-        return v6;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g8f43_79bd(v0.objref<@layout_4>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<@layout_3> = obj.proj v0 0.i256;
-        v5.objref<i256> = obj.proj v3 1.i256;
-        v6.i256 = obj.load v5;
-        return v6;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_7b90(v0.objref<@layout_1>) -> i256 {
@@ -7795,39 +6787,6 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_7b90(v0.objref
         return v4;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g8f43_c0cb(v0.objref<@layout_4>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<@layout_3> = obj.proj v0 0.i256;
-        v5.objref<i256> = obj.proj v3 1.i256;
-        v6.i256 = obj.load v5;
-        return v6;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g8f43_c11d(v0.objref<@layout_4>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<@layout_3> = obj.proj v0 0.i256;
-        v5.objref<i256> = obj.proj v3 1.i256;
-        v6.i256 = obj.load v5;
-        return v6;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g8f43_d52d(v0.objref<@layout_4>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<@layout_3> = obj.proj v0 0.i256;
-        v5.objref<i256> = obj.proj v3 1.i256;
-        v6.i256 = obj.load v5;
-        return v6;
-}
-
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_d8ed(v0.objref<@layout_1>) -> i256 {
     block0:
         jump block1;
@@ -7838,40 +6797,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_d8ed(v0.objref
         return v4;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g8f43_e2e4(v0.objref<@layout_4>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<@layout_3> = obj.proj v0 0.i256;
-        v5.objref<i256> = obj.proj v3 1.i256;
-        v6.i256 = obj.load v5;
-        return v6;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g8f43_e9e7(v0.objref<@layout_4>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<@layout_3> = obj.proj v0 0.i256;
-        v5.objref<i256> = obj.proj v3 1.i256;
-        v6.i256 = obj.load v5;
-        return v6;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g8f43_f79e(v0.objref<@layout_4>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<@layout_3> = obj.proj v0 0.i256;
-        v5.objref<i256> = obj.proj v3 1.i256;
-        v6.i256 = obj.load v5;
-        return v6;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_0022(v0.objref<@layout_4>) -> i256 {
+func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_44f9(v0.objref<@layout_4>) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
@@ -7883,558 +6809,9 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         v7.@layout_2 = obj.load v6;
         v8.objref<@layout_3> = obj.proj v0 0.i256;
         v9.objref<@layout_2> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_dd5c v9;
-        mstore v1 v10 i256;
-        v11.objref<@layout_3> = obj.proj v0 0.i256;
-        v13.objref<i256> = obj.proj v11 1.i256;
-        v14.i256 = obj.load v13;
-        (v16.i256, v17.i1) = uaddo v14 32.i256;
-        br v17 block6 block7;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v28.objref<@layout_3> = obj.proj v0 0.i256;
-        v29.objref<@layout_2> = obj.proj v28 0.i256;
-        v30.@layout_2 = obj.load v29;
-        v31.objref<@layout_3> = obj.proj v0 0.i256;
-        v32.objref<i256> = obj.proj v31 1.i256;
-        v33.i256 = obj.load v32;
-        v34.objref<@layout_3> = obj.proj v0 0.i256;
-        v35.objref<@layout_2> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_59f2 v35 v33;
-        v38.objref<@layout_3> = obj.proj v0 0.i256;
-        v39.objref<i256> = obj.proj v38 1.i256;
-        obj.store v39 v16;
-        return v36;
-
-    block5:
-        v40.i256 = mload v1 i256;
-        mstore v2 v40 i256;
-        v42.i256 = mload v2 i256;
-        v43.i1 = gt v16 v42;
-        br v43 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v23.objref<@layout_3> = obj.proj v0 0.i256;
-        v24.objref<i256> = obj.proj v23 1.i256;
-        v25.i256 = obj.load v24;
-        v26.i1 = lt v16 v25;
-        br v26 block2 block5;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_01ce(v0.objref<@layout_4>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v5.objref<@layout_3> = obj.proj v0 0.i256;
-        v6.objref<@layout_2> = obj.proj v5 0.i256;
-        v7.@layout_2 = obj.load v6;
-        v8.objref<@layout_3> = obj.proj v0 0.i256;
-        v9.objref<@layout_2> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_5904 v9;
-        mstore v1 v10 i256;
-        v11.objref<@layout_3> = obj.proj v0 0.i256;
-        v13.objref<i256> = obj.proj v11 1.i256;
-        v14.i256 = obj.load v13;
-        (v16.i256, v17.i1) = uaddo v14 32.i256;
-        br v17 block6 block7;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v28.objref<@layout_3> = obj.proj v0 0.i256;
-        v29.objref<@layout_2> = obj.proj v28 0.i256;
-        v30.@layout_2 = obj.load v29;
-        v31.objref<@layout_3> = obj.proj v0 0.i256;
-        v32.objref<i256> = obj.proj v31 1.i256;
-        v33.i256 = obj.load v32;
-        v34.objref<@layout_3> = obj.proj v0 0.i256;
-        v35.objref<@layout_2> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3f26 v35 v33;
-        v38.objref<@layout_3> = obj.proj v0 0.i256;
-        v39.objref<i256> = obj.proj v38 1.i256;
-        obj.store v39 v16;
-        return v36;
-
-    block5:
-        v40.i256 = mload v1 i256;
-        mstore v2 v40 i256;
-        v42.i256 = mload v2 i256;
-        v43.i1 = gt v16 v42;
-        br v43 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v23.objref<@layout_3> = obj.proj v0 0.i256;
-        v24.objref<i256> = obj.proj v23 1.i256;
-        v25.i256 = obj.load v24;
-        v26.i1 = lt v16 v25;
-        br v26 block2 block5;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_0aaa(v0.objref<@layout_4>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v5.objref<@layout_3> = obj.proj v0 0.i256;
-        v6.objref<@layout_2> = obj.proj v5 0.i256;
-        v7.@layout_2 = obj.load v6;
-        v8.objref<@layout_3> = obj.proj v0 0.i256;
-        v9.objref<@layout_2> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_0859 v9;
-        mstore v1 v10 i256;
-        v11.objref<@layout_3> = obj.proj v0 0.i256;
-        v13.objref<i256> = obj.proj v11 1.i256;
-        v14.i256 = obj.load v13;
-        (v16.i256, v17.i1) = uaddo v14 32.i256;
-        br v17 block6 block7;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v28.objref<@layout_3> = obj.proj v0 0.i256;
-        v29.objref<@layout_2> = obj.proj v28 0.i256;
-        v30.@layout_2 = obj.load v29;
-        v31.objref<@layout_3> = obj.proj v0 0.i256;
-        v32.objref<i256> = obj.proj v31 1.i256;
-        v33.i256 = obj.load v32;
-        v34.objref<@layout_3> = obj.proj v0 0.i256;
-        v35.objref<@layout_2> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_dbd0 v35 v33;
-        v38.objref<@layout_3> = obj.proj v0 0.i256;
-        v39.objref<i256> = obj.proj v38 1.i256;
-        obj.store v39 v16;
-        return v36;
-
-    block5:
-        v40.i256 = mload v1 i256;
-        mstore v2 v40 i256;
-        v42.i256 = mload v2 i256;
-        v43.i1 = gt v16 v42;
-        br v43 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v23.objref<@layout_3> = obj.proj v0 0.i256;
-        v24.objref<i256> = obj.proj v23 1.i256;
-        v25.i256 = obj.load v24;
-        v26.i1 = lt v16 v25;
-        br v26 block2 block5;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_0c51(v0.objref<@layout_4>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v5.objref<@layout_3> = obj.proj v0 0.i256;
-        v6.objref<@layout_2> = obj.proj v5 0.i256;
-        v7.@layout_2 = obj.load v6;
-        v8.objref<@layout_3> = obj.proj v0 0.i256;
-        v9.objref<@layout_2> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_6b68 v9;
-        mstore v1 v10 i256;
-        v11.objref<@layout_3> = obj.proj v0 0.i256;
-        v13.objref<i256> = obj.proj v11 1.i256;
-        v14.i256 = obj.load v13;
-        (v16.i256, v17.i1) = uaddo v14 32.i256;
-        br v17 block6 block7;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v28.objref<@layout_3> = obj.proj v0 0.i256;
-        v29.objref<@layout_2> = obj.proj v28 0.i256;
-        v30.@layout_2 = obj.load v29;
-        v31.objref<@layout_3> = obj.proj v0 0.i256;
-        v32.objref<i256> = obj.proj v31 1.i256;
-        v33.i256 = obj.load v32;
-        v34.objref<@layout_3> = obj.proj v0 0.i256;
-        v35.objref<@layout_2> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_7244 v35 v33;
-        v38.objref<@layout_3> = obj.proj v0 0.i256;
-        v39.objref<i256> = obj.proj v38 1.i256;
-        obj.store v39 v16;
-        return v36;
-
-    block5:
-        v40.i256 = mload v1 i256;
-        mstore v2 v40 i256;
-        v42.i256 = mload v2 i256;
-        v43.i1 = gt v16 v42;
-        br v43 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v23.objref<@layout_3> = obj.proj v0 0.i256;
-        v24.objref<i256> = obj.proj v23 1.i256;
-        v25.i256 = obj.load v24;
-        v26.i1 = lt v16 v25;
-        br v26 block2 block5;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_2ad2(v0.objref<@layout_4>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v5.objref<@layout_3> = obj.proj v0 0.i256;
-        v6.objref<@layout_2> = obj.proj v5 0.i256;
-        v7.@layout_2 = obj.load v6;
-        v8.objref<@layout_3> = obj.proj v0 0.i256;
-        v9.objref<@layout_2> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_16d7 v9;
-        mstore v1 v10 i256;
-        v11.objref<@layout_3> = obj.proj v0 0.i256;
-        v13.objref<i256> = obj.proj v11 1.i256;
-        v14.i256 = obj.load v13;
-        (v16.i256, v17.i1) = uaddo v14 32.i256;
-        br v17 block6 block7;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v28.objref<@layout_3> = obj.proj v0 0.i256;
-        v29.objref<@layout_2> = obj.proj v28 0.i256;
-        v30.@layout_2 = obj.load v29;
-        v31.objref<@layout_3> = obj.proj v0 0.i256;
-        v32.objref<i256> = obj.proj v31 1.i256;
-        v33.i256 = obj.load v32;
-        v34.objref<@layout_3> = obj.proj v0 0.i256;
-        v35.objref<@layout_2> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_7f0e v35 v33;
-        v38.objref<@layout_3> = obj.proj v0 0.i256;
-        v39.objref<i256> = obj.proj v38 1.i256;
-        obj.store v39 v16;
-        return v36;
-
-    block5:
-        v40.i256 = mload v1 i256;
-        mstore v2 v40 i256;
-        v42.i256 = mload v2 i256;
-        v43.i1 = gt v16 v42;
-        br v43 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v23.objref<@layout_3> = obj.proj v0 0.i256;
-        v24.objref<i256> = obj.proj v23 1.i256;
-        v25.i256 = obj.load v24;
-        v26.i1 = lt v16 v25;
-        br v26 block2 block5;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_2f5f(v0.objref<@layout_4>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v5.objref<@layout_3> = obj.proj v0 0.i256;
-        v6.objref<@layout_2> = obj.proj v5 0.i256;
-        v7.@layout_2 = obj.load v6;
-        v8.objref<@layout_3> = obj.proj v0 0.i256;
-        v9.objref<@layout_2> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_9245 v9;
-        mstore v1 v10 i256;
-        v11.objref<@layout_3> = obj.proj v0 0.i256;
-        v13.objref<i256> = obj.proj v11 1.i256;
-        v14.i256 = obj.load v13;
-        (v16.i256, v17.i1) = uaddo v14 32.i256;
-        br v17 block6 block7;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v28.objref<@layout_3> = obj.proj v0 0.i256;
-        v29.objref<@layout_2> = obj.proj v28 0.i256;
-        v30.@layout_2 = obj.load v29;
-        v31.objref<@layout_3> = obj.proj v0 0.i256;
-        v32.objref<i256> = obj.proj v31 1.i256;
-        v33.i256 = obj.load v32;
-        v34.objref<@layout_3> = obj.proj v0 0.i256;
-        v35.objref<@layout_2> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_0de0 v35 v33;
-        v38.objref<@layout_3> = obj.proj v0 0.i256;
-        v39.objref<i256> = obj.proj v38 1.i256;
-        obj.store v39 v16;
-        return v36;
-
-    block5:
-        v40.i256 = mload v1 i256;
-        mstore v2 v40 i256;
-        v42.i256 = mload v2 i256;
-        v43.i1 = gt v16 v42;
-        br v43 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v23.objref<@layout_3> = obj.proj v0 0.i256;
-        v24.objref<i256> = obj.proj v23 1.i256;
-        v25.i256 = obj.load v24;
-        v26.i1 = lt v16 v25;
-        br v26 block2 block5;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_3b91(v0.objref<@layout_4>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v5.objref<@layout_3> = obj.proj v0 0.i256;
-        v6.objref<@layout_2> = obj.proj v5 0.i256;
-        v7.@layout_2 = obj.load v6;
-        v8.objref<@layout_3> = obj.proj v0 0.i256;
-        v9.objref<@layout_2> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_0e90 v9;
-        mstore v1 v10 i256;
-        v11.objref<@layout_3> = obj.proj v0 0.i256;
-        v13.objref<i256> = obj.proj v11 1.i256;
-        v14.i256 = obj.load v13;
-        (v16.i256, v17.i1) = uaddo v14 32.i256;
-        br v17 block6 block7;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v28.objref<@layout_3> = obj.proj v0 0.i256;
-        v29.objref<@layout_2> = obj.proj v28 0.i256;
-        v30.@layout_2 = obj.load v29;
-        v31.objref<@layout_3> = obj.proj v0 0.i256;
-        v32.objref<i256> = obj.proj v31 1.i256;
-        v33.i256 = obj.load v32;
-        v34.objref<@layout_3> = obj.proj v0 0.i256;
-        v35.objref<@layout_2> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_d5b3 v35 v33;
-        v38.objref<@layout_3> = obj.proj v0 0.i256;
-        v39.objref<i256> = obj.proj v38 1.i256;
-        obj.store v39 v16;
-        return v36;
-
-    block5:
-        v40.i256 = mload v1 i256;
-        mstore v2 v40 i256;
-        v42.i256 = mload v2 i256;
-        v43.i1 = gt v16 v42;
-        br v43 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v23.objref<@layout_3> = obj.proj v0 0.i256;
-        v24.objref<i256> = obj.proj v23 1.i256;
-        v25.i256 = obj.load v24;
-        v26.i1 = lt v16 v25;
-        br v26 block2 block5;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_3df5(v0.objref<@layout_4>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v5.objref<@layout_3> = obj.proj v0 0.i256;
-        v6.objref<@layout_2> = obj.proj v5 0.i256;
-        v7.@layout_2 = obj.load v6;
-        v8.objref<@layout_3> = obj.proj v0 0.i256;
-        v9.objref<@layout_2> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_0a1b v9;
-        mstore v1 v10 i256;
-        v11.objref<@layout_3> = obj.proj v0 0.i256;
-        v13.objref<i256> = obj.proj v11 1.i256;
-        v14.i256 = obj.load v13;
-        (v16.i256, v17.i1) = uaddo v14 32.i256;
-        br v17 block6 block7;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v28.objref<@layout_3> = obj.proj v0 0.i256;
-        v29.objref<@layout_2> = obj.proj v28 0.i256;
-        v30.@layout_2 = obj.load v29;
-        v31.objref<@layout_3> = obj.proj v0 0.i256;
-        v32.objref<i256> = obj.proj v31 1.i256;
-        v33.i256 = obj.load v32;
-        v34.objref<@layout_3> = obj.proj v0 0.i256;
-        v35.objref<@layout_2> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_e224 v35 v33;
-        v38.objref<@layout_3> = obj.proj v0 0.i256;
-        v39.objref<i256> = obj.proj v38 1.i256;
-        obj.store v39 v16;
-        return v36;
-
-    block5:
-        v40.i256 = mload v1 i256;
-        mstore v2 v40 i256;
-        v42.i256 = mload v2 i256;
-        v43.i1 = gt v16 v42;
-        br v43 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v23.objref<@layout_3> = obj.proj v0 0.i256;
-        v24.objref<i256> = obj.proj v23 1.i256;
-        v25.i256 = obj.load v24;
-        v26.i1 = lt v16 v25;
-        br v26 block2 block5;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_3e00(v0.objref<@layout_4>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v5.objref<@layout_3> = obj.proj v0 0.i256;
-        v6.objref<@layout_2> = obj.proj v5 0.i256;
-        v7.@layout_2 = obj.load v6;
-        v8.objref<@layout_3> = obj.proj v0 0.i256;
-        v9.objref<@layout_2> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_a887 v9;
-        mstore v1 v10 i256;
-        v11.objref<@layout_3> = obj.proj v0 0.i256;
-        v13.objref<i256> = obj.proj v11 1.i256;
-        v14.i256 = obj.load v13;
-        (v16.i256, v17.i1) = uaddo v14 32.i256;
-        br v17 block6 block7;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v28.objref<@layout_3> = obj.proj v0 0.i256;
-        v29.objref<@layout_2> = obj.proj v28 0.i256;
-        v30.@layout_2 = obj.load v29;
-        v31.objref<@layout_3> = obj.proj v0 0.i256;
-        v32.objref<i256> = obj.proj v31 1.i256;
-        v33.i256 = obj.load v32;
-        v34.objref<@layout_3> = obj.proj v0 0.i256;
-        v35.objref<@layout_2> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_60f2 v35 v33;
-        v38.objref<@layout_3> = obj.proj v0 0.i256;
-        v39.objref<i256> = obj.proj v38 1.i256;
-        obj.store v39 v16;
-        return v36;
-
-    block5:
-        v40.i256 = mload v1 i256;
-        mstore v2 v40 i256;
-        v42.i256 = mload v2 i256;
-        v43.i1 = gt v16 v42;
-        br v43 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v23.objref<@layout_3> = obj.proj v0 0.i256;
-        v24.objref<i256> = obj.proj v23 1.i256;
-        v25.i256 = obj.load v24;
-        v26.i1 = lt v16 v25;
-        br v26 block2 block5;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_44f9(v0.objref<@layout_7>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v5.objref<@layout_6> = obj.proj v0 0.i256;
-        v6.objref<@layout_5> = obj.proj v5 0.i256;
-        v7.@layout_5 = obj.load v6;
-        v8.objref<@layout_6> = obj.proj v0 0.i256;
-        v9.objref<@layout_5> = obj.proj v8 0.i256;
         v10.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_e00f v9;
         mstore v1 v10 i256;
-        v11.objref<@layout_6> = obj.proj v0 0.i256;
+        v11.objref<@layout_3> = obj.proj v0 0.i256;
         v13.objref<i256> = obj.proj v11 1.i256;
         v14.i256 = obj.load v13;
         (v16.i256, v17.i1) = uaddo v14 32.i256;
@@ -8447,76 +6824,15 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         jump block4;
 
     block4:
-        v28.objref<@layout_6> = obj.proj v0 0.i256;
-        v29.objref<@layout_5> = obj.proj v28 0.i256;
-        v30.@layout_5 = obj.load v29;
-        v31.objref<@layout_6> = obj.proj v0 0.i256;
+        v28.objref<@layout_3> = obj.proj v0 0.i256;
+        v29.objref<@layout_2> = obj.proj v28 0.i256;
+        v30.@layout_2 = obj.load v29;
+        v31.objref<@layout_3> = obj.proj v0 0.i256;
         v32.objref<i256> = obj.proj v31 1.i256;
         v33.i256 = obj.load v32;
-        v34.objref<@layout_6> = obj.proj v0 0.i256;
-        v35.objref<@layout_5> = obj.proj v34 0.i256;
+        v34.objref<@layout_3> = obj.proj v0 0.i256;
+        v35.objref<@layout_2> = obj.proj v34 0.i256;
         v36.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_c66d v35 v33;
-        v38.objref<@layout_6> = obj.proj v0 0.i256;
-        v39.objref<i256> = obj.proj v38 1.i256;
-        obj.store v39 v16;
-        return v36;
-
-    block5:
-        v40.i256 = mload v1 i256;
-        mstore v2 v40 i256;
-        v42.i256 = mload v2 i256;
-        v43.i1 = gt v16 v42;
-        br v43 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v23.objref<@layout_6> = obj.proj v0 0.i256;
-        v24.objref<i256> = obj.proj v23 1.i256;
-        v25.i256 = obj.load v24;
-        v26.i1 = lt v16 v25;
-        br v26 block2 block5;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_5416(v0.objref<@layout_4>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v5.objref<@layout_3> = obj.proj v0 0.i256;
-        v6.objref<@layout_2> = obj.proj v5 0.i256;
-        v7.@layout_2 = obj.load v6;
-        v8.objref<@layout_3> = obj.proj v0 0.i256;
-        v9.objref<@layout_2> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_3f86 v9;
-        mstore v1 v10 i256;
-        v11.objref<@layout_3> = obj.proj v0 0.i256;
-        v13.objref<i256> = obj.proj v11 1.i256;
-        v14.i256 = obj.load v13;
-        (v16.i256, v17.i1) = uaddo v14 32.i256;
-        br v17 block6 block7;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v28.objref<@layout_3> = obj.proj v0 0.i256;
-        v29.objref<@layout_2> = obj.proj v28 0.i256;
-        v30.@layout_2 = obj.load v29;
-        v31.objref<@layout_3> = obj.proj v0 0.i256;
-        v32.objref<i256> = obj.proj v31 1.i256;
-        v33.i256 = obj.load v32;
-        v34.objref<@layout_3> = obj.proj v0 0.i256;
-        v35.objref<@layout_2> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_dc0f v35 v33;
         v38.objref<@layout_3> = obj.proj v0 0.i256;
         v39.objref<i256> = obj.proj v38 1.i256;
         obj.store v39 v16;
@@ -8542,7 +6858,7 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         br v26 block2 block5;
 }
 
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_648f(v0.objref<@layout_4>) -> i256 {
+func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_83b2(v0.objref<@layout_4>) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
@@ -8554,374 +6870,8 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         v7.@layout_2 = obj.load v6;
         v8.objref<@layout_3> = obj.proj v0 0.i256;
         v9.objref<@layout_2> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_02a3 v9;
-        mstore v1 v10 i256;
-        v11.objref<@layout_3> = obj.proj v0 0.i256;
-        v13.objref<i256> = obj.proj v11 1.i256;
-        v14.i256 = obj.load v13;
-        (v16.i256, v17.i1) = uaddo v14 32.i256;
-        br v17 block6 block7;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v28.objref<@layout_3> = obj.proj v0 0.i256;
-        v29.objref<@layout_2> = obj.proj v28 0.i256;
-        v30.@layout_2 = obj.load v29;
-        v31.objref<@layout_3> = obj.proj v0 0.i256;
-        v32.objref<i256> = obj.proj v31 1.i256;
-        v33.i256 = obj.load v32;
-        v34.objref<@layout_3> = obj.proj v0 0.i256;
-        v35.objref<@layout_2> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_7f8f v35 v33;
-        v38.objref<@layout_3> = obj.proj v0 0.i256;
-        v39.objref<i256> = obj.proj v38 1.i256;
-        obj.store v39 v16;
-        return v36;
-
-    block5:
-        v40.i256 = mload v1 i256;
-        mstore v2 v40 i256;
-        v42.i256 = mload v2 i256;
-        v43.i1 = gt v16 v42;
-        br v43 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v23.objref<@layout_3> = obj.proj v0 0.i256;
-        v24.objref<i256> = obj.proj v23 1.i256;
-        v25.i256 = obj.load v24;
-        v26.i1 = lt v16 v25;
-        br v26 block2 block5;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_68c5(v0.objref<@layout_4>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v5.objref<@layout_3> = obj.proj v0 0.i256;
-        v6.objref<@layout_2> = obj.proj v5 0.i256;
-        v7.@layout_2 = obj.load v6;
-        v8.objref<@layout_3> = obj.proj v0 0.i256;
-        v9.objref<@layout_2> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_d849 v9;
-        mstore v1 v10 i256;
-        v11.objref<@layout_3> = obj.proj v0 0.i256;
-        v13.objref<i256> = obj.proj v11 1.i256;
-        v14.i256 = obj.load v13;
-        (v16.i256, v17.i1) = uaddo v14 32.i256;
-        br v17 block6 block7;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v28.objref<@layout_3> = obj.proj v0 0.i256;
-        v29.objref<@layout_2> = obj.proj v28 0.i256;
-        v30.@layout_2 = obj.load v29;
-        v31.objref<@layout_3> = obj.proj v0 0.i256;
-        v32.objref<i256> = obj.proj v31 1.i256;
-        v33.i256 = obj.load v32;
-        v34.objref<@layout_3> = obj.proj v0 0.i256;
-        v35.objref<@layout_2> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c2fe v35 v33;
-        v38.objref<@layout_3> = obj.proj v0 0.i256;
-        v39.objref<i256> = obj.proj v38 1.i256;
-        obj.store v39 v16;
-        return v36;
-
-    block5:
-        v40.i256 = mload v1 i256;
-        mstore v2 v40 i256;
-        v42.i256 = mload v2 i256;
-        v43.i1 = gt v16 v42;
-        br v43 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v23.objref<@layout_3> = obj.proj v0 0.i256;
-        v24.objref<i256> = obj.proj v23 1.i256;
-        v25.i256 = obj.load v24;
-        v26.i1 = lt v16 v25;
-        br v26 block2 block5;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_6bd8(v0.objref<@layout_4>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v5.objref<@layout_3> = obj.proj v0 0.i256;
-        v6.objref<@layout_2> = obj.proj v5 0.i256;
-        v7.@layout_2 = obj.load v6;
-        v8.objref<@layout_3> = obj.proj v0 0.i256;
-        v9.objref<@layout_2> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_c1ca v9;
-        mstore v1 v10 i256;
-        v11.objref<@layout_3> = obj.proj v0 0.i256;
-        v13.objref<i256> = obj.proj v11 1.i256;
-        v14.i256 = obj.load v13;
-        (v16.i256, v17.i1) = uaddo v14 32.i256;
-        br v17 block6 block7;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v28.objref<@layout_3> = obj.proj v0 0.i256;
-        v29.objref<@layout_2> = obj.proj v28 0.i256;
-        v30.@layout_2 = obj.load v29;
-        v31.objref<@layout_3> = obj.proj v0 0.i256;
-        v32.objref<i256> = obj.proj v31 1.i256;
-        v33.i256 = obj.load v32;
-        v34.objref<@layout_3> = obj.proj v0 0.i256;
-        v35.objref<@layout_2> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_013b v35 v33;
-        v38.objref<@layout_3> = obj.proj v0 0.i256;
-        v39.objref<i256> = obj.proj v38 1.i256;
-        obj.store v39 v16;
-        return v36;
-
-    block5:
-        v40.i256 = mload v1 i256;
-        mstore v2 v40 i256;
-        v42.i256 = mload v2 i256;
-        v43.i1 = gt v16 v42;
-        br v43 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v23.objref<@layout_3> = obj.proj v0 0.i256;
-        v24.objref<i256> = obj.proj v23 1.i256;
-        v25.i256 = obj.load v24;
-        v26.i1 = lt v16 v25;
-        br v26 block2 block5;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_7998(v0.objref<@layout_4>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v5.objref<@layout_3> = obj.proj v0 0.i256;
-        v6.objref<@layout_2> = obj.proj v5 0.i256;
-        v7.@layout_2 = obj.load v6;
-        v8.objref<@layout_3> = obj.proj v0 0.i256;
-        v9.objref<@layout_2> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_94a3 v9;
-        mstore v1 v10 i256;
-        v11.objref<@layout_3> = obj.proj v0 0.i256;
-        v13.objref<i256> = obj.proj v11 1.i256;
-        v14.i256 = obj.load v13;
-        (v16.i256, v17.i1) = uaddo v14 32.i256;
-        br v17 block6 block7;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v28.objref<@layout_3> = obj.proj v0 0.i256;
-        v29.objref<@layout_2> = obj.proj v28 0.i256;
-        v30.@layout_2 = obj.load v29;
-        v31.objref<@layout_3> = obj.proj v0 0.i256;
-        v32.objref<i256> = obj.proj v31 1.i256;
-        v33.i256 = obj.load v32;
-        v34.objref<@layout_3> = obj.proj v0 0.i256;
-        v35.objref<@layout_2> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_4e61 v35 v33;
-        v38.objref<@layout_3> = obj.proj v0 0.i256;
-        v39.objref<i256> = obj.proj v38 1.i256;
-        obj.store v39 v16;
-        return v36;
-
-    block5:
-        v40.i256 = mload v1 i256;
-        mstore v2 v40 i256;
-        v42.i256 = mload v2 i256;
-        v43.i1 = gt v16 v42;
-        br v43 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v23.objref<@layout_3> = obj.proj v0 0.i256;
-        v24.objref<i256> = obj.proj v23 1.i256;
-        v25.i256 = obj.load v24;
-        v26.i1 = lt v16 v25;
-        br v26 block2 block5;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_80b7(v0.objref<@layout_4>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v5.objref<@layout_3> = obj.proj v0 0.i256;
-        v6.objref<@layout_2> = obj.proj v5 0.i256;
-        v7.@layout_2 = obj.load v6;
-        v8.objref<@layout_3> = obj.proj v0 0.i256;
-        v9.objref<@layout_2> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_8a80 v9;
-        mstore v1 v10 i256;
-        v11.objref<@layout_3> = obj.proj v0 0.i256;
-        v13.objref<i256> = obj.proj v11 1.i256;
-        v14.i256 = obj.load v13;
-        (v16.i256, v17.i1) = uaddo v14 32.i256;
-        br v17 block6 block7;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v28.objref<@layout_3> = obj.proj v0 0.i256;
-        v29.objref<@layout_2> = obj.proj v28 0.i256;
-        v30.@layout_2 = obj.load v29;
-        v31.objref<@layout_3> = obj.proj v0 0.i256;
-        v32.objref<i256> = obj.proj v31 1.i256;
-        v33.i256 = obj.load v32;
-        v34.objref<@layout_3> = obj.proj v0 0.i256;
-        v35.objref<@layout_2> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_0fd5 v35 v33;
-        v38.objref<@layout_3> = obj.proj v0 0.i256;
-        v39.objref<i256> = obj.proj v38 1.i256;
-        obj.store v39 v16;
-        return v36;
-
-    block5:
-        v40.i256 = mload v1 i256;
-        mstore v2 v40 i256;
-        v42.i256 = mload v2 i256;
-        v43.i1 = gt v16 v42;
-        br v43 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v23.objref<@layout_3> = obj.proj v0 0.i256;
-        v24.objref<i256> = obj.proj v23 1.i256;
-        v25.i256 = obj.load v24;
-        v26.i1 = lt v16 v25;
-        br v26 block2 block5;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_83b2(v0.objref<@layout_7>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v5.objref<@layout_6> = obj.proj v0 0.i256;
-        v6.objref<@layout_5> = obj.proj v5 0.i256;
-        v7.@layout_5 = obj.load v6;
-        v8.objref<@layout_6> = obj.proj v0 0.i256;
-        v9.objref<@layout_5> = obj.proj v8 0.i256;
         v10.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_01a6 v9;
         mstore v1 v10 i256;
-        v11.objref<@layout_6> = obj.proj v0 0.i256;
-        v13.objref<i256> = obj.proj v11 1.i256;
-        v14.i256 = obj.load v13;
-        (v16.i256, v17.i1) = uaddo v14 32.i256;
-        br v17 block6 block7;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v28.objref<@layout_6> = obj.proj v0 0.i256;
-        v29.objref<@layout_5> = obj.proj v28 0.i256;
-        v30.@layout_5 = obj.load v29;
-        v31.objref<@layout_6> = obj.proj v0 0.i256;
-        v32.objref<i256> = obj.proj v31 1.i256;
-        v33.i256 = obj.load v32;
-        v34.objref<@layout_6> = obj.proj v0 0.i256;
-        v35.objref<@layout_5> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_3a7f v35 v33;
-        v38.objref<@layout_6> = obj.proj v0 0.i256;
-        v39.objref<i256> = obj.proj v38 1.i256;
-        obj.store v39 v16;
-        return v36;
-
-    block5:
-        v40.i256 = mload v1 i256;
-        mstore v2 v40 i256;
-        v42.i256 = mload v2 i256;
-        v43.i1 = gt v16 v42;
-        br v43 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v23.objref<@layout_6> = obj.proj v0 0.i256;
-        v24.objref<i256> = obj.proj v23 1.i256;
-        v25.i256 = obj.load v24;
-        v26.i1 = lt v16 v25;
-        br v26 block2 block5;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_8451(v0.objref<@layout_4>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v5.objref<@layout_3> = obj.proj v0 0.i256;
-        v6.objref<@layout_2> = obj.proj v5 0.i256;
-        v7.@layout_2 = obj.load v6;
-        v8.objref<@layout_3> = obj.proj v0 0.i256;
-        v9.objref<@layout_2> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_670f v9;
-        mstore v1 v10 i256;
         v11.objref<@layout_3> = obj.proj v0 0.i256;
         v13.objref<i256> = obj.proj v11 1.i256;
         v14.i256 = obj.load v13;
@@ -8943,7 +6893,7 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         v33.i256 = obj.load v32;
         v34.objref<@layout_3> = obj.proj v0 0.i256;
         v35.objref<@layout_2> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_9376 v35 v33;
+        v36.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_3a7f v35 v33;
         v38.objref<@layout_3> = obj.proj v0 0.i256;
         v39.objref<i256> = obj.proj v38 1.i256;
         obj.store v39 v16;
@@ -8969,21 +6919,21 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         br v26 block2 block5;
 }
 
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_8be4(v0.objref<@layout_7>) -> i256 {
+func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_8be4(v0.objref<@layout_4>) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v5.objref<@layout_6> = obj.proj v0 0.i256;
-        v6.objref<@layout_5> = obj.proj v5 0.i256;
-        v7.@layout_5 = obj.load v6;
-        v8.objref<@layout_6> = obj.proj v0 0.i256;
-        v9.objref<@layout_5> = obj.proj v8 0.i256;
+        v5.objref<@layout_3> = obj.proj v0 0.i256;
+        v6.objref<@layout_2> = obj.proj v5 0.i256;
+        v7.@layout_2 = obj.load v6;
+        v8.objref<@layout_3> = obj.proj v0 0.i256;
+        v9.objref<@layout_2> = obj.proj v8 0.i256;
         v10.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_be96 v9;
         mstore v1 v10 i256;
-        v11.objref<@layout_6> = obj.proj v0 0.i256;
+        v11.objref<@layout_3> = obj.proj v0 0.i256;
         v13.objref<i256> = obj.proj v11 1.i256;
         v14.i256 = obj.load v13;
         (v16.i256, v17.i1) = uaddo v14 32.i256;
@@ -8996,16 +6946,16 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         jump block4;
 
     block4:
-        v28.objref<@layout_6> = obj.proj v0 0.i256;
-        v29.objref<@layout_5> = obj.proj v28 0.i256;
-        v30.@layout_5 = obj.load v29;
-        v31.objref<@layout_6> = obj.proj v0 0.i256;
+        v28.objref<@layout_3> = obj.proj v0 0.i256;
+        v29.objref<@layout_2> = obj.proj v28 0.i256;
+        v30.@layout_2 = obj.load v29;
+        v31.objref<@layout_3> = obj.proj v0 0.i256;
         v32.objref<i256> = obj.proj v31 1.i256;
         v33.i256 = obj.load v32;
-        v34.objref<@layout_6> = obj.proj v0 0.i256;
-        v35.objref<@layout_5> = obj.proj v34 0.i256;
+        v34.objref<@layout_3> = obj.proj v0 0.i256;
+        v35.objref<@layout_2> = obj.proj v34 0.i256;
         v36.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_20e1 v35 v33;
-        v38.objref<@layout_6> = obj.proj v0 0.i256;
+        v38.objref<@layout_3> = obj.proj v0 0.i256;
         v39.objref<i256> = obj.proj v38 1.i256;
         obj.store v39 v16;
         return v36;
@@ -9023,28 +6973,28 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         evm_revert 0.i256 36.i256;
 
     block7:
-        v23.objref<@layout_6> = obj.proj v0 0.i256;
+        v23.objref<@layout_3> = obj.proj v0 0.i256;
         v24.objref<i256> = obj.proj v23 1.i256;
         v25.i256 = obj.load v24;
         v26.i1 = lt v16 v25;
         br v26 block2 block5;
 }
 
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_8be4_0(v0.objref<@layout_7>) -> i256 {
+func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_8be4_0(v0.objref<@layout_4>) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v5.objref<@layout_6> = obj.proj v0 0.i256;
-        v6.objref<@layout_5> = obj.proj v5 0.i256;
-        v7.@layout_5 = obj.load v6;
-        v8.objref<@layout_6> = obj.proj v0 0.i256;
-        v9.objref<@layout_5> = obj.proj v8 0.i256;
+        v5.objref<@layout_3> = obj.proj v0 0.i256;
+        v6.objref<@layout_2> = obj.proj v5 0.i256;
+        v7.@layout_2 = obj.load v6;
+        v8.objref<@layout_3> = obj.proj v0 0.i256;
+        v9.objref<@layout_2> = obj.proj v8 0.i256;
         v10.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_be96_0 v9;
         mstore v1 v10 i256;
-        v11.objref<@layout_6> = obj.proj v0 0.i256;
+        v11.objref<@layout_3> = obj.proj v0 0.i256;
         v13.objref<i256> = obj.proj v11 1.i256;
         v14.i256 = obj.load v13;
         (v16.i256, v17.i1) = uaddo v14 32.i256;
@@ -9057,1113 +7007,15 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         jump block4;
 
     block4:
-        v28.objref<@layout_6> = obj.proj v0 0.i256;
-        v29.objref<@layout_5> = obj.proj v28 0.i256;
-        v30.@layout_5 = obj.load v29;
-        v31.objref<@layout_6> = obj.proj v0 0.i256;
+        v28.objref<@layout_3> = obj.proj v0 0.i256;
+        v29.objref<@layout_2> = obj.proj v28 0.i256;
+        v30.@layout_2 = obj.load v29;
+        v31.objref<@layout_3> = obj.proj v0 0.i256;
         v32.objref<i256> = obj.proj v31 1.i256;
         v33.i256 = obj.load v32;
-        v34.objref<@layout_6> = obj.proj v0 0.i256;
-        v35.objref<@layout_5> = obj.proj v34 0.i256;
+        v34.objref<@layout_3> = obj.proj v0 0.i256;
+        v35.objref<@layout_2> = obj.proj v34 0.i256;
         v36.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_20e1_0 v35 v33;
-        v38.objref<@layout_6> = obj.proj v0 0.i256;
-        v39.objref<i256> = obj.proj v38 1.i256;
-        obj.store v39 v16;
-        return v36;
-
-    block5:
-        v40.i256 = mload v1 i256;
-        mstore v2 v40 i256;
-        v42.i256 = mload v2 i256;
-        v43.i1 = gt v16 v42;
-        br v43 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v23.objref<@layout_6> = obj.proj v0 0.i256;
-        v24.objref<i256> = obj.proj v23 1.i256;
-        v25.i256 = obj.load v24;
-        v26.i1 = lt v16 v25;
-        br v26 block2 block5;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_8f7a(v0.objref<@layout_4>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v5.objref<@layout_3> = obj.proj v0 0.i256;
-        v6.objref<@layout_2> = obj.proj v5 0.i256;
-        v7.@layout_2 = obj.load v6;
-        v8.objref<@layout_3> = obj.proj v0 0.i256;
-        v9.objref<@layout_2> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_c364 v9;
-        mstore v1 v10 i256;
-        v11.objref<@layout_3> = obj.proj v0 0.i256;
-        v13.objref<i256> = obj.proj v11 1.i256;
-        v14.i256 = obj.load v13;
-        (v16.i256, v17.i1) = uaddo v14 32.i256;
-        br v17 block6 block7;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v28.objref<@layout_3> = obj.proj v0 0.i256;
-        v29.objref<@layout_2> = obj.proj v28 0.i256;
-        v30.@layout_2 = obj.load v29;
-        v31.objref<@layout_3> = obj.proj v0 0.i256;
-        v32.objref<i256> = obj.proj v31 1.i256;
-        v33.i256 = obj.load v32;
-        v34.objref<@layout_3> = obj.proj v0 0.i256;
-        v35.objref<@layout_2> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_321e v35 v33;
-        v38.objref<@layout_3> = obj.proj v0 0.i256;
-        v39.objref<i256> = obj.proj v38 1.i256;
-        obj.store v39 v16;
-        return v36;
-
-    block5:
-        v40.i256 = mload v1 i256;
-        mstore v2 v40 i256;
-        v42.i256 = mload v2 i256;
-        v43.i1 = gt v16 v42;
-        br v43 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v23.objref<@layout_3> = obj.proj v0 0.i256;
-        v24.objref<i256> = obj.proj v23 1.i256;
-        v25.i256 = obj.load v24;
-        v26.i1 = lt v16 v25;
-        br v26 block2 block5;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_90ee(v0.objref<@layout_4>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v5.objref<@layout_3> = obj.proj v0 0.i256;
-        v6.objref<@layout_2> = obj.proj v5 0.i256;
-        v7.@layout_2 = obj.load v6;
-        v8.objref<@layout_3> = obj.proj v0 0.i256;
-        v9.objref<@layout_2> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_c8b6 v9;
-        mstore v1 v10 i256;
-        v11.objref<@layout_3> = obj.proj v0 0.i256;
-        v13.objref<i256> = obj.proj v11 1.i256;
-        v14.i256 = obj.load v13;
-        (v16.i256, v17.i1) = uaddo v14 32.i256;
-        br v17 block6 block7;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v28.objref<@layout_3> = obj.proj v0 0.i256;
-        v29.objref<@layout_2> = obj.proj v28 0.i256;
-        v30.@layout_2 = obj.load v29;
-        v31.objref<@layout_3> = obj.proj v0 0.i256;
-        v32.objref<i256> = obj.proj v31 1.i256;
-        v33.i256 = obj.load v32;
-        v34.objref<@layout_3> = obj.proj v0 0.i256;
-        v35.objref<@layout_2> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_509a v35 v33;
-        v38.objref<@layout_3> = obj.proj v0 0.i256;
-        v39.objref<i256> = obj.proj v38 1.i256;
-        obj.store v39 v16;
-        return v36;
-
-    block5:
-        v40.i256 = mload v1 i256;
-        mstore v2 v40 i256;
-        v42.i256 = mload v2 i256;
-        v43.i1 = gt v16 v42;
-        br v43 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v23.objref<@layout_3> = obj.proj v0 0.i256;
-        v24.objref<i256> = obj.proj v23 1.i256;
-        v25.i256 = obj.load v24;
-        v26.i1 = lt v16 v25;
-        br v26 block2 block5;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_9505(v0.objref<@layout_4>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v5.objref<@layout_3> = obj.proj v0 0.i256;
-        v6.objref<@layout_2> = obj.proj v5 0.i256;
-        v7.@layout_2 = obj.load v6;
-        v8.objref<@layout_3> = obj.proj v0 0.i256;
-        v9.objref<@layout_2> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_6d9d v9;
-        mstore v1 v10 i256;
-        v11.objref<@layout_3> = obj.proj v0 0.i256;
-        v13.objref<i256> = obj.proj v11 1.i256;
-        v14.i256 = obj.load v13;
-        (v16.i256, v17.i1) = uaddo v14 32.i256;
-        br v17 block6 block7;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v28.objref<@layout_3> = obj.proj v0 0.i256;
-        v29.objref<@layout_2> = obj.proj v28 0.i256;
-        v30.@layout_2 = obj.load v29;
-        v31.objref<@layout_3> = obj.proj v0 0.i256;
-        v32.objref<i256> = obj.proj v31 1.i256;
-        v33.i256 = obj.load v32;
-        v34.objref<@layout_3> = obj.proj v0 0.i256;
-        v35.objref<@layout_2> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b2c9 v35 v33;
-        v38.objref<@layout_3> = obj.proj v0 0.i256;
-        v39.objref<i256> = obj.proj v38 1.i256;
-        obj.store v39 v16;
-        return v36;
-
-    block5:
-        v40.i256 = mload v1 i256;
-        mstore v2 v40 i256;
-        v42.i256 = mload v2 i256;
-        v43.i1 = gt v16 v42;
-        br v43 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v23.objref<@layout_3> = obj.proj v0 0.i256;
-        v24.objref<i256> = obj.proj v23 1.i256;
-        v25.i256 = obj.load v24;
-        v26.i1 = lt v16 v25;
-        br v26 block2 block5;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_9776(v0.objref<@layout_4>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v5.objref<@layout_3> = obj.proj v0 0.i256;
-        v6.objref<@layout_2> = obj.proj v5 0.i256;
-        v7.@layout_2 = obj.load v6;
-        v8.objref<@layout_3> = obj.proj v0 0.i256;
-        v9.objref<@layout_2> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_1f84 v9;
-        mstore v1 v10 i256;
-        v11.objref<@layout_3> = obj.proj v0 0.i256;
-        v13.objref<i256> = obj.proj v11 1.i256;
-        v14.i256 = obj.load v13;
-        (v16.i256, v17.i1) = uaddo v14 32.i256;
-        br v17 block6 block7;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v28.objref<@layout_3> = obj.proj v0 0.i256;
-        v29.objref<@layout_2> = obj.proj v28 0.i256;
-        v30.@layout_2 = obj.load v29;
-        v31.objref<@layout_3> = obj.proj v0 0.i256;
-        v32.objref<i256> = obj.proj v31 1.i256;
-        v33.i256 = obj.load v32;
-        v34.objref<@layout_3> = obj.proj v0 0.i256;
-        v35.objref<@layout_2> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_712d v35 v33;
-        v38.objref<@layout_3> = obj.proj v0 0.i256;
-        v39.objref<i256> = obj.proj v38 1.i256;
-        obj.store v39 v16;
-        return v36;
-
-    block5:
-        v40.i256 = mload v1 i256;
-        mstore v2 v40 i256;
-        v42.i256 = mload v2 i256;
-        v43.i1 = gt v16 v42;
-        br v43 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v23.objref<@layout_3> = obj.proj v0 0.i256;
-        v24.objref<i256> = obj.proj v23 1.i256;
-        v25.i256 = obj.load v24;
-        v26.i1 = lt v16 v25;
-        br v26 block2 block5;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_99b4(v0.objref<@layout_4>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v5.objref<@layout_3> = obj.proj v0 0.i256;
-        v6.objref<@layout_2> = obj.proj v5 0.i256;
-        v7.@layout_2 = obj.load v6;
-        v8.objref<@layout_3> = obj.proj v0 0.i256;
-        v9.objref<@layout_2> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_874b v9;
-        mstore v1 v10 i256;
-        v11.objref<@layout_3> = obj.proj v0 0.i256;
-        v13.objref<i256> = obj.proj v11 1.i256;
-        v14.i256 = obj.load v13;
-        (v16.i256, v17.i1) = uaddo v14 32.i256;
-        br v17 block6 block7;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v28.objref<@layout_3> = obj.proj v0 0.i256;
-        v29.objref<@layout_2> = obj.proj v28 0.i256;
-        v30.@layout_2 = obj.load v29;
-        v31.objref<@layout_3> = obj.proj v0 0.i256;
-        v32.objref<i256> = obj.proj v31 1.i256;
-        v33.i256 = obj.load v32;
-        v34.objref<@layout_3> = obj.proj v0 0.i256;
-        v35.objref<@layout_2> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_aed6 v35 v33;
-        v38.objref<@layout_3> = obj.proj v0 0.i256;
-        v39.objref<i256> = obj.proj v38 1.i256;
-        obj.store v39 v16;
-        return v36;
-
-    block5:
-        v40.i256 = mload v1 i256;
-        mstore v2 v40 i256;
-        v42.i256 = mload v2 i256;
-        v43.i1 = gt v16 v42;
-        br v43 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v23.objref<@layout_3> = obj.proj v0 0.i256;
-        v24.objref<i256> = obj.proj v23 1.i256;
-        v25.i256 = obj.load v24;
-        v26.i1 = lt v16 v25;
-        br v26 block2 block5;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_9abb(v0.objref<@layout_4>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v5.objref<@layout_3> = obj.proj v0 0.i256;
-        v6.objref<@layout_2> = obj.proj v5 0.i256;
-        v7.@layout_2 = obj.load v6;
-        v8.objref<@layout_3> = obj.proj v0 0.i256;
-        v9.objref<@layout_2> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_c624 v9;
-        mstore v1 v10 i256;
-        v11.objref<@layout_3> = obj.proj v0 0.i256;
-        v13.objref<i256> = obj.proj v11 1.i256;
-        v14.i256 = obj.load v13;
-        (v16.i256, v17.i1) = uaddo v14 32.i256;
-        br v17 block6 block7;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v28.objref<@layout_3> = obj.proj v0 0.i256;
-        v29.objref<@layout_2> = obj.proj v28 0.i256;
-        v30.@layout_2 = obj.load v29;
-        v31.objref<@layout_3> = obj.proj v0 0.i256;
-        v32.objref<i256> = obj.proj v31 1.i256;
-        v33.i256 = obj.load v32;
-        v34.objref<@layout_3> = obj.proj v0 0.i256;
-        v35.objref<@layout_2> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c912 v35 v33;
-        v38.objref<@layout_3> = obj.proj v0 0.i256;
-        v39.objref<i256> = obj.proj v38 1.i256;
-        obj.store v39 v16;
-        return v36;
-
-    block5:
-        v40.i256 = mload v1 i256;
-        mstore v2 v40 i256;
-        v42.i256 = mload v2 i256;
-        v43.i1 = gt v16 v42;
-        br v43 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v23.objref<@layout_3> = obj.proj v0 0.i256;
-        v24.objref<i256> = obj.proj v23 1.i256;
-        v25.i256 = obj.load v24;
-        v26.i1 = lt v16 v25;
-        br v26 block2 block5;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_a7b0(v0.objref<@layout_4>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v5.objref<@layout_3> = obj.proj v0 0.i256;
-        v6.objref<@layout_2> = obj.proj v5 0.i256;
-        v7.@layout_2 = obj.load v6;
-        v8.objref<@layout_3> = obj.proj v0 0.i256;
-        v9.objref<@layout_2> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_75fd v9;
-        mstore v1 v10 i256;
-        v11.objref<@layout_3> = obj.proj v0 0.i256;
-        v13.objref<i256> = obj.proj v11 1.i256;
-        v14.i256 = obj.load v13;
-        (v16.i256, v17.i1) = uaddo v14 32.i256;
-        br v17 block6 block7;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v28.objref<@layout_3> = obj.proj v0 0.i256;
-        v29.objref<@layout_2> = obj.proj v28 0.i256;
-        v30.@layout_2 = obj.load v29;
-        v31.objref<@layout_3> = obj.proj v0 0.i256;
-        v32.objref<i256> = obj.proj v31 1.i256;
-        v33.i256 = obj.load v32;
-        v34.objref<@layout_3> = obj.proj v0 0.i256;
-        v35.objref<@layout_2> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_0b94 v35 v33;
-        v38.objref<@layout_3> = obj.proj v0 0.i256;
-        v39.objref<i256> = obj.proj v38 1.i256;
-        obj.store v39 v16;
-        return v36;
-
-    block5:
-        v40.i256 = mload v1 i256;
-        mstore v2 v40 i256;
-        v42.i256 = mload v2 i256;
-        v43.i1 = gt v16 v42;
-        br v43 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v23.objref<@layout_3> = obj.proj v0 0.i256;
-        v24.objref<i256> = obj.proj v23 1.i256;
-        v25.i256 = obj.load v24;
-        v26.i1 = lt v16 v25;
-        br v26 block2 block5;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_b0d4(v0.objref<@layout_4>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v5.objref<@layout_3> = obj.proj v0 0.i256;
-        v6.objref<@layout_2> = obj.proj v5 0.i256;
-        v7.@layout_2 = obj.load v6;
-        v8.objref<@layout_3> = obj.proj v0 0.i256;
-        v9.objref<@layout_2> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_66ec v9;
-        mstore v1 v10 i256;
-        v11.objref<@layout_3> = obj.proj v0 0.i256;
-        v13.objref<i256> = obj.proj v11 1.i256;
-        v14.i256 = obj.load v13;
-        (v16.i256, v17.i1) = uaddo v14 32.i256;
-        br v17 block6 block7;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v28.objref<@layout_3> = obj.proj v0 0.i256;
-        v29.objref<@layout_2> = obj.proj v28 0.i256;
-        v30.@layout_2 = obj.load v29;
-        v31.objref<@layout_3> = obj.proj v0 0.i256;
-        v32.objref<i256> = obj.proj v31 1.i256;
-        v33.i256 = obj.load v32;
-        v34.objref<@layout_3> = obj.proj v0 0.i256;
-        v35.objref<@layout_2> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b9f2 v35 v33;
-        v38.objref<@layout_3> = obj.proj v0 0.i256;
-        v39.objref<i256> = obj.proj v38 1.i256;
-        obj.store v39 v16;
-        return v36;
-
-    block5:
-        v40.i256 = mload v1 i256;
-        mstore v2 v40 i256;
-        v42.i256 = mload v2 i256;
-        v43.i1 = gt v16 v42;
-        br v43 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v23.objref<@layout_3> = obj.proj v0 0.i256;
-        v24.objref<i256> = obj.proj v23 1.i256;
-        v25.i256 = obj.load v24;
-        v26.i1 = lt v16 v25;
-        br v26 block2 block5;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_b3be(v0.objref<@layout_4>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v5.objref<@layout_3> = obj.proj v0 0.i256;
-        v6.objref<@layout_2> = obj.proj v5 0.i256;
-        v7.@layout_2 = obj.load v6;
-        v8.objref<@layout_3> = obj.proj v0 0.i256;
-        v9.objref<@layout_2> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_0e32 v9;
-        mstore v1 v10 i256;
-        v11.objref<@layout_3> = obj.proj v0 0.i256;
-        v13.objref<i256> = obj.proj v11 1.i256;
-        v14.i256 = obj.load v13;
-        (v16.i256, v17.i1) = uaddo v14 32.i256;
-        br v17 block6 block7;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v28.objref<@layout_3> = obj.proj v0 0.i256;
-        v29.objref<@layout_2> = obj.proj v28 0.i256;
-        v30.@layout_2 = obj.load v29;
-        v31.objref<@layout_3> = obj.proj v0 0.i256;
-        v32.objref<i256> = obj.proj v31 1.i256;
-        v33.i256 = obj.load v32;
-        v34.objref<@layout_3> = obj.proj v0 0.i256;
-        v35.objref<@layout_2> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_d42e v35 v33;
-        v38.objref<@layout_3> = obj.proj v0 0.i256;
-        v39.objref<i256> = obj.proj v38 1.i256;
-        obj.store v39 v16;
-        return v36;
-
-    block5:
-        v40.i256 = mload v1 i256;
-        mstore v2 v40 i256;
-        v42.i256 = mload v2 i256;
-        v43.i1 = gt v16 v42;
-        br v43 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v23.objref<@layout_3> = obj.proj v0 0.i256;
-        v24.objref<i256> = obj.proj v23 1.i256;
-        v25.i256 = obj.load v24;
-        v26.i1 = lt v16 v25;
-        br v26 block2 block5;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_d285(v0.objref<@layout_4>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v5.objref<@layout_3> = obj.proj v0 0.i256;
-        v6.objref<@layout_2> = obj.proj v5 0.i256;
-        v7.@layout_2 = obj.load v6;
-        v8.objref<@layout_3> = obj.proj v0 0.i256;
-        v9.objref<@layout_2> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_e8a2 v9;
-        mstore v1 v10 i256;
-        v11.objref<@layout_3> = obj.proj v0 0.i256;
-        v13.objref<i256> = obj.proj v11 1.i256;
-        v14.i256 = obj.load v13;
-        (v16.i256, v17.i1) = uaddo v14 32.i256;
-        br v17 block6 block7;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v28.objref<@layout_3> = obj.proj v0 0.i256;
-        v29.objref<@layout_2> = obj.proj v28 0.i256;
-        v30.@layout_2 = obj.load v29;
-        v31.objref<@layout_3> = obj.proj v0 0.i256;
-        v32.objref<i256> = obj.proj v31 1.i256;
-        v33.i256 = obj.load v32;
-        v34.objref<@layout_3> = obj.proj v0 0.i256;
-        v35.objref<@layout_2> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_2cde v35 v33;
-        v38.objref<@layout_3> = obj.proj v0 0.i256;
-        v39.objref<i256> = obj.proj v38 1.i256;
-        obj.store v39 v16;
-        return v36;
-
-    block5:
-        v40.i256 = mload v1 i256;
-        mstore v2 v40 i256;
-        v42.i256 = mload v2 i256;
-        v43.i1 = gt v16 v42;
-        br v43 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v23.objref<@layout_3> = obj.proj v0 0.i256;
-        v24.objref<i256> = obj.proj v23 1.i256;
-        v25.i256 = obj.load v24;
-        v26.i1 = lt v16 v25;
-        br v26 block2 block5;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_d406(v0.objref<@layout_4>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v5.objref<@layout_3> = obj.proj v0 0.i256;
-        v6.objref<@layout_2> = obj.proj v5 0.i256;
-        v7.@layout_2 = obj.load v6;
-        v8.objref<@layout_3> = obj.proj v0 0.i256;
-        v9.objref<@layout_2> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_9ee6 v9;
-        mstore v1 v10 i256;
-        v11.objref<@layout_3> = obj.proj v0 0.i256;
-        v13.objref<i256> = obj.proj v11 1.i256;
-        v14.i256 = obj.load v13;
-        (v16.i256, v17.i1) = uaddo v14 32.i256;
-        br v17 block6 block7;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v28.objref<@layout_3> = obj.proj v0 0.i256;
-        v29.objref<@layout_2> = obj.proj v28 0.i256;
-        v30.@layout_2 = obj.load v29;
-        v31.objref<@layout_3> = obj.proj v0 0.i256;
-        v32.objref<i256> = obj.proj v31 1.i256;
-        v33.i256 = obj.load v32;
-        v34.objref<@layout_3> = obj.proj v0 0.i256;
-        v35.objref<@layout_2> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_81ff v35 v33;
-        v38.objref<@layout_3> = obj.proj v0 0.i256;
-        v39.objref<i256> = obj.proj v38 1.i256;
-        obj.store v39 v16;
-        return v36;
-
-    block5:
-        v40.i256 = mload v1 i256;
-        mstore v2 v40 i256;
-        v42.i256 = mload v2 i256;
-        v43.i1 = gt v16 v42;
-        br v43 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v23.objref<@layout_3> = obj.proj v0 0.i256;
-        v24.objref<i256> = obj.proj v23 1.i256;
-        v25.i256 = obj.load v24;
-        v26.i1 = lt v16 v25;
-        br v26 block2 block5;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_d635(v0.objref<@layout_4>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v5.objref<@layout_3> = obj.proj v0 0.i256;
-        v6.objref<@layout_2> = obj.proj v5 0.i256;
-        v7.@layout_2 = obj.load v6;
-        v8.objref<@layout_3> = obj.proj v0 0.i256;
-        v9.objref<@layout_2> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_66d5 v9;
-        mstore v1 v10 i256;
-        v11.objref<@layout_3> = obj.proj v0 0.i256;
-        v13.objref<i256> = obj.proj v11 1.i256;
-        v14.i256 = obj.load v13;
-        (v16.i256, v17.i1) = uaddo v14 32.i256;
-        br v17 block6 block7;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v28.objref<@layout_3> = obj.proj v0 0.i256;
-        v29.objref<@layout_2> = obj.proj v28 0.i256;
-        v30.@layout_2 = obj.load v29;
-        v31.objref<@layout_3> = obj.proj v0 0.i256;
-        v32.objref<i256> = obj.proj v31 1.i256;
-        v33.i256 = obj.load v32;
-        v34.objref<@layout_3> = obj.proj v0 0.i256;
-        v35.objref<@layout_2> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_4724 v35 v33;
-        v38.objref<@layout_3> = obj.proj v0 0.i256;
-        v39.objref<i256> = obj.proj v38 1.i256;
-        obj.store v39 v16;
-        return v36;
-
-    block5:
-        v40.i256 = mload v1 i256;
-        mstore v2 v40 i256;
-        v42.i256 = mload v2 i256;
-        v43.i1 = gt v16 v42;
-        br v43 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v23.objref<@layout_3> = obj.proj v0 0.i256;
-        v24.objref<i256> = obj.proj v23 1.i256;
-        v25.i256 = obj.load v24;
-        v26.i1 = lt v16 v25;
-        br v26 block2 block5;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_daa6(v0.objref<@layout_4>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v5.objref<@layout_3> = obj.proj v0 0.i256;
-        v6.objref<@layout_2> = obj.proj v5 0.i256;
-        v7.@layout_2 = obj.load v6;
-        v8.objref<@layout_3> = obj.proj v0 0.i256;
-        v9.objref<@layout_2> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_4f08 v9;
-        mstore v1 v10 i256;
-        v11.objref<@layout_3> = obj.proj v0 0.i256;
-        v13.objref<i256> = obj.proj v11 1.i256;
-        v14.i256 = obj.load v13;
-        (v16.i256, v17.i1) = uaddo v14 32.i256;
-        br v17 block6 block7;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v28.objref<@layout_3> = obj.proj v0 0.i256;
-        v29.objref<@layout_2> = obj.proj v28 0.i256;
-        v30.@layout_2 = obj.load v29;
-        v31.objref<@layout_3> = obj.proj v0 0.i256;
-        v32.objref<i256> = obj.proj v31 1.i256;
-        v33.i256 = obj.load v32;
-        v34.objref<@layout_3> = obj.proj v0 0.i256;
-        v35.objref<@layout_2> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_e6fd v35 v33;
-        v38.objref<@layout_3> = obj.proj v0 0.i256;
-        v39.objref<i256> = obj.proj v38 1.i256;
-        obj.store v39 v16;
-        return v36;
-
-    block5:
-        v40.i256 = mload v1 i256;
-        mstore v2 v40 i256;
-        v42.i256 = mload v2 i256;
-        v43.i1 = gt v16 v42;
-        br v43 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v23.objref<@layout_3> = obj.proj v0 0.i256;
-        v24.objref<i256> = obj.proj v23 1.i256;
-        v25.i256 = obj.load v24;
-        v26.i1 = lt v16 v25;
-        br v26 block2 block5;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_df17(v0.objref<@layout_4>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v5.objref<@layout_3> = obj.proj v0 0.i256;
-        v6.objref<@layout_2> = obj.proj v5 0.i256;
-        v7.@layout_2 = obj.load v6;
-        v8.objref<@layout_3> = obj.proj v0 0.i256;
-        v9.objref<@layout_2> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_c44b v9;
-        mstore v1 v10 i256;
-        v11.objref<@layout_3> = obj.proj v0 0.i256;
-        v13.objref<i256> = obj.proj v11 1.i256;
-        v14.i256 = obj.load v13;
-        (v16.i256, v17.i1) = uaddo v14 32.i256;
-        br v17 block6 block7;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v28.objref<@layout_3> = obj.proj v0 0.i256;
-        v29.objref<@layout_2> = obj.proj v28 0.i256;
-        v30.@layout_2 = obj.load v29;
-        v31.objref<@layout_3> = obj.proj v0 0.i256;
-        v32.objref<i256> = obj.proj v31 1.i256;
-        v33.i256 = obj.load v32;
-        v34.objref<@layout_3> = obj.proj v0 0.i256;
-        v35.objref<@layout_2> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_698d v35 v33;
-        v38.objref<@layout_3> = obj.proj v0 0.i256;
-        v39.objref<i256> = obj.proj v38 1.i256;
-        obj.store v39 v16;
-        return v36;
-
-    block5:
-        v40.i256 = mload v1 i256;
-        mstore v2 v40 i256;
-        v42.i256 = mload v2 i256;
-        v43.i1 = gt v16 v42;
-        br v43 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v23.objref<@layout_3> = obj.proj v0 0.i256;
-        v24.objref<i256> = obj.proj v23 1.i256;
-        v25.i256 = obj.load v24;
-        v26.i1 = lt v16 v25;
-        br v26 block2 block5;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_e181(v0.objref<@layout_4>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v5.objref<@layout_3> = obj.proj v0 0.i256;
-        v6.objref<@layout_2> = obj.proj v5 0.i256;
-        v7.@layout_2 = obj.load v6;
-        v8.objref<@layout_3> = obj.proj v0 0.i256;
-        v9.objref<@layout_2> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_c0ed v9;
-        mstore v1 v10 i256;
-        v11.objref<@layout_3> = obj.proj v0 0.i256;
-        v13.objref<i256> = obj.proj v11 1.i256;
-        v14.i256 = obj.load v13;
-        (v16.i256, v17.i1) = uaddo v14 32.i256;
-        br v17 block6 block7;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v28.objref<@layout_3> = obj.proj v0 0.i256;
-        v29.objref<@layout_2> = obj.proj v28 0.i256;
-        v30.@layout_2 = obj.load v29;
-        v31.objref<@layout_3> = obj.proj v0 0.i256;
-        v32.objref<i256> = obj.proj v31 1.i256;
-        v33.i256 = obj.load v32;
-        v34.objref<@layout_3> = obj.proj v0 0.i256;
-        v35.objref<@layout_2> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_ee40 v35 v33;
-        v38.objref<@layout_3> = obj.proj v0 0.i256;
-        v39.objref<i256> = obj.proj v38 1.i256;
-        obj.store v39 v16;
-        return v36;
-
-    block5:
-        v40.i256 = mload v1 i256;
-        mstore v2 v40 i256;
-        v42.i256 = mload v2 i256;
-        v43.i1 = gt v16 v42;
-        br v43 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v23.objref<@layout_3> = obj.proj v0 0.i256;
-        v24.objref<i256> = obj.proj v23 1.i256;
-        v25.i256 = obj.load v24;
-        v26.i1 = lt v16 v25;
-        br v26 block2 block5;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_e5a8(v0.objref<@layout_4>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v5.objref<@layout_3> = obj.proj v0 0.i256;
-        v6.objref<@layout_2> = obj.proj v5 0.i256;
-        v7.@layout_2 = obj.load v6;
-        v8.objref<@layout_3> = obj.proj v0 0.i256;
-        v9.objref<@layout_2> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_26f0 v9;
-        mstore v1 v10 i256;
-        v11.objref<@layout_3> = obj.proj v0 0.i256;
-        v13.objref<i256> = obj.proj v11 1.i256;
-        v14.i256 = obj.load v13;
-        (v16.i256, v17.i1) = uaddo v14 32.i256;
-        br v17 block6 block7;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v28.objref<@layout_3> = obj.proj v0 0.i256;
-        v29.objref<@layout_2> = obj.proj v28 0.i256;
-        v30.@layout_2 = obj.load v29;
-        v31.objref<@layout_3> = obj.proj v0 0.i256;
-        v32.objref<i256> = obj.proj v31 1.i256;
-        v33.i256 = obj.load v32;
-        v34.objref<@layout_3> = obj.proj v0 0.i256;
-        v35.objref<@layout_2> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_add5 v35 v33;
-        v38.objref<@layout_3> = obj.proj v0 0.i256;
-        v39.objref<i256> = obj.proj v38 1.i256;
-        obj.store v39 v16;
-        return v36;
-
-    block5:
-        v40.i256 = mload v1 i256;
-        mstore v2 v40 i256;
-        v42.i256 = mload v2 i256;
-        v43.i1 = gt v16 v42;
-        br v43 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v23.objref<@layout_3> = obj.proj v0 0.i256;
-        v24.objref<i256> = obj.proj v23 1.i256;
-        v25.i256 = obj.load v24;
-        v26.i1 = lt v16 v25;
-        br v26 block2 block5;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_ec92(v0.objref<@layout_4>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v5.objref<@layout_3> = obj.proj v0 0.i256;
-        v6.objref<@layout_2> = obj.proj v5 0.i256;
-        v7.@layout_2 = obj.load v6;
-        v8.objref<@layout_3> = obj.proj v0 0.i256;
-        v9.objref<@layout_2> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_c1cd v9;
-        mstore v1 v10 i256;
-        v11.objref<@layout_3> = obj.proj v0 0.i256;
-        v13.objref<i256> = obj.proj v11 1.i256;
-        v14.i256 = obj.load v13;
-        (v16.i256, v17.i1) = uaddo v14 32.i256;
-        br v17 block6 block7;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v28.objref<@layout_3> = obj.proj v0 0.i256;
-        v29.objref<@layout_2> = obj.proj v28 0.i256;
-        v30.@layout_2 = obj.load v29;
-        v31.objref<@layout_3> = obj.proj v0 0.i256;
-        v32.objref<i256> = obj.proj v31 1.i256;
-        v33.i256 = obj.load v32;
-        v34.objref<@layout_3> = obj.proj v0 0.i256;
-        v35.objref<@layout_2> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_553d v35 v33;
-        v38.objref<@layout_3> = obj.proj v0 0.i256;
-        v39.objref<i256> = obj.proj v38 1.i256;
-        obj.store v39 v16;
-        return v36;
-
-    block5:
-        v40.i256 = mload v1 i256;
-        mstore v2 v40 i256;
-        v42.i256 = mload v2 i256;
-        v43.i1 = gt v16 v42;
-        br v43 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v23.objref<@layout_3> = obj.proj v0 0.i256;
-        v24.objref<i256> = obj.proj v23 1.i256;
-        v25.i256 = obj.load v24;
-        v26.i1 = lt v16 v25;
-        br v26 block2 block5;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_fd2f(v0.objref<@layout_4>) -> i256 {
-    block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        jump block1;
-
-    block1:
-        v5.objref<@layout_3> = obj.proj v0 0.i256;
-        v6.objref<@layout_2> = obj.proj v5 0.i256;
-        v7.@layout_2 = obj.load v6;
-        v8.objref<@layout_3> = obj.proj v0 0.i256;
-        v9.objref<@layout_2> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_60f7 v9;
-        mstore v1 v10 i256;
-        v11.objref<@layout_3> = obj.proj v0 0.i256;
-        v13.objref<i256> = obj.proj v11 1.i256;
-        v14.i256 = obj.load v13;
-        (v16.i256, v17.i1) = uaddo v14 32.i256;
-        br v17 block6 block7;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v28.objref<@layout_3> = obj.proj v0 0.i256;
-        v29.objref<@layout_2> = obj.proj v28 0.i256;
-        v30.@layout_2 = obj.load v29;
-        v31.objref<@layout_3> = obj.proj v0 0.i256;
-        v32.objref<i256> = obj.proj v31 1.i256;
-        v33.i256 = obj.load v32;
-        v34.objref<@layout_3> = obj.proj v0 0.i256;
-        v35.objref<@layout_2> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3a89 v35 v33;
         v38.objref<@layout_3> = obj.proj v0 0.i256;
         v39.objref<i256> = obj.proj v38 1.i256;
         obj.store v39 v16;
@@ -10198,14 +7050,14 @@ func private %require(v0.i256) {
     block1:
         v2.i256 = mload v1 i256;
         v3.@layout_0 = call %caller;
-        v4.objref<@layout_15> = obj.alloc @layout_15;
+        v4.objref<@layout_16> = obj.alloc @layout_16;
         v6.objref<i256> = obj.proj v4 0.i256;
         obj.store v6 v2;
         v8.objref<@layout_0> = obj.proj v4 1.i256;
         v9.objref<i256> = obj.proj v8 0.i256;
         v10.i256 = extract_value v3 0.i256;
         obj.store v9 v10;
-        v11.@layout_15 = obj.load v4;
+        v11.@layout_16 = obj.load v4;
         v12.i1 = call %get__gc9ba v11;
         v14.i1 = eq v12 1.i1;
         br v14 block2 block3;
@@ -10231,6 +7083,202 @@ func private %require(v0.i256) {
     block6:
         mstore v22 26959946667150639794667015087019630673637144422540572481103610249216.i256 i256;
         evm_revert v18 36.i256;
+}
+
+func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_0ea2(v0.i256, v1.i256) {
+    block0:
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        mstore v2 v0 i256;
+        mstore v3 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v3 i256;
+        evm_revert v4 v5;
+}
+
+func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_2b5d(v0.i256, v1.i256) {
+    block0:
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        mstore v2 v0 i256;
+        mstore v3 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v3 i256;
+        evm_revert v4 v5;
+}
+
+func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_2efa(v0.i256, v1.i256) {
+    block0:
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        mstore v2 v0 i256;
+        mstore v3 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v3 i256;
+        evm_revert v4 v5;
+}
+
+func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_34f1(v0.i256, v1.i256) {
+    block0:
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        mstore v2 v0 i256;
+        mstore v3 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v3 i256;
+        evm_revert v4 v5;
+}
+
+func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_35af(v0.i256, v1.i256) {
+    block0:
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        mstore v2 v0 i256;
+        mstore v3 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v3 i256;
+        evm_revert v4 v5;
+}
+
+func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_3bd1(v0.i256, v1.i256) {
+    block0:
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        mstore v2 v0 i256;
+        mstore v3 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v3 i256;
+        evm_revert v4 v5;
+}
+
+func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_41e6(v0.i256, v1.i256) {
+    block0:
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        mstore v2 v0 i256;
+        mstore v3 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v3 i256;
+        evm_revert v4 v5;
+}
+
+func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_62f4(v0.i256, v1.i256) {
+    block0:
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        mstore v2 v0 i256;
+        mstore v3 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v3 i256;
+        evm_revert v4 v5;
+}
+
+func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_6471(v0.i256, v1.i256) {
+    block0:
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        mstore v2 v0 i256;
+        mstore v3 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v3 i256;
+        evm_revert v4 v5;
+}
+
+func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_9e6f(v0.i256, v1.i256) {
+    block0:
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        mstore v2 v0 i256;
+        mstore v3 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v3 i256;
+        evm_revert v4 v5;
+}
+
+func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_9fb4(v0.i256, v1.i256) {
+    block0:
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        mstore v2 v0 i256;
+        mstore v3 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v3 i256;
+        evm_revert v4 v5;
+}
+
+func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_a28f(v0.i256, v1.i256) {
+    block0:
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        mstore v2 v0 i256;
+        mstore v3 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v3 i256;
+        evm_revert v4 v5;
+}
+
+func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_cab9(v0.i256, v1.i256) {
+    block0:
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        mstore v2 v0 i256;
+        mstore v3 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v3 i256;
+        evm_revert v4 v5;
+}
+
+func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_cb12(v0.i256, v1.i256) {
+    block0:
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        mstore v2 v0 i256;
+        mstore v3 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v3 i256;
+        evm_revert v4 v5;
 }
 
 func private %core__lib__abi__round_up_words_a41d(v0.i256) -> i256 {
@@ -10441,146 +7489,6 @@ func private %core__lib__abi__round_up_words_b13c_0(v0.i256) -> i256 {
         return v20;
 }
 
-func inline(always) private %core__lib__contracts__trait_ContractHost__runtime_decoder__g736d_0a0b() -> @layout_4 {
-    block0:
-        jump block1;
-
-    block1:
-        v0.@layout_2 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_d0c9;
-        v2.@layout_4 = call %std__lib__abi__sol__impl_trait_Sol_1f5f__decoder_with_base__gd20d_c673 v0 4.i256;
-        return v2;
-}
-
-func inline(always) private %core__lib__contracts__trait_ContractHost__runtime_decoder__g736d_3d42() -> @layout_4 {
-    block0:
-        jump block1;
-
-    block1:
-        v0.@layout_2 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_5a78;
-        v2.@layout_4 = call %std__lib__abi__sol__impl_trait_Sol_1f5f__decoder_with_base__gd20d_db7f v0 4.i256;
-        return v2;
-}
-
-func inline(always) private %core__lib__contracts__trait_ContractHost__runtime_decoder__g736d_56dd() -> @layout_4 {
-    block0:
-        jump block1;
-
-    block1:
-        v0.@layout_2 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_fd52;
-        v2.@layout_4 = call %std__lib__abi__sol__impl_trait_Sol_1f5f__decoder_with_base__gd20d_372b v0 4.i256;
-        return v2;
-}
-
-func inline(always) private %core__lib__contracts__trait_ContractHost__runtime_decoder__g736d_5b9b() -> @layout_4 {
-    block0:
-        jump block1;
-
-    block1:
-        v0.@layout_2 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_b348;
-        v2.@layout_4 = call %std__lib__abi__sol__impl_trait_Sol_1f5f__decoder_with_base__gd20d_41f6 v0 4.i256;
-        return v2;
-}
-
-func inline(always) private %core__lib__contracts__trait_ContractHost__runtime_decoder__g736d_69cd() -> @layout_4 {
-    block0:
-        jump block1;
-
-    block1:
-        v0.@layout_2 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_3f88;
-        v2.@layout_4 = call %std__lib__abi__sol__impl_trait_Sol_1f5f__decoder_with_base__gd20d_691a v0 4.i256;
-        return v2;
-}
-
-func inline(always) private %core__lib__contracts__trait_ContractHost__runtime_decoder__g736d_90a6() -> @layout_4 {
-    block0:
-        jump block1;
-
-    block1:
-        v0.@layout_2 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_2d6f;
-        v2.@layout_4 = call %std__lib__abi__sol__impl_trait_Sol_1f5f__decoder_with_base__gd20d_911d v0 4.i256;
-        return v2;
-}
-
-func inline(always) private %core__lib__contracts__trait_ContractHost__runtime_decoder__g736d_a8b6() -> @layout_4 {
-    block0:
-        jump block1;
-
-    block1:
-        v0.@layout_2 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_bf4c;
-        v2.@layout_4 = call %std__lib__abi__sol__impl_trait_Sol_1f5f__decoder_with_base__gd20d_9b9c v0 4.i256;
-        return v2;
-}
-
-func inline(always) private %core__lib__contracts__trait_ContractHost__runtime_decoder__g736d_a9a1() -> @layout_4 {
-    block0:
-        jump block1;
-
-    block1:
-        v0.@layout_2 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_1aa7;
-        v2.@layout_4 = call %std__lib__abi__sol__impl_trait_Sol_1f5f__decoder_with_base__gd20d_1790 v0 4.i256;
-        return v2;
-}
-
-func inline(always) private %core__lib__contracts__trait_ContractHost__runtime_decoder__g736d_ccfe() -> @layout_4 {
-    block0:
-        jump block1;
-
-    block1:
-        v0.@layout_2 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_1ba1;
-        v2.@layout_4 = call %std__lib__abi__sol__impl_trait_Sol_1f5f__decoder_with_base__gd20d_9aa7 v0 4.i256;
-        return v2;
-}
-
-func inline(always) private %core__lib__contracts__trait_ContractHost__runtime_decoder__g736d_d57b() -> @layout_4 {
-    block0:
-        jump block1;
-
-    block1:
-        v0.@layout_2 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_7b84;
-        v2.@layout_4 = call %std__lib__abi__sol__impl_trait_Sol_1f5f__decoder_with_base__gd20d_dc77 v0 4.i256;
-        return v2;
-}
-
-func inline(always) private %core__lib__contracts__trait_ContractHost__runtime_decoder__g736d_dcc2() -> @layout_4 {
-    block0:
-        jump block1;
-
-    block1:
-        v0.@layout_2 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_0e0b;
-        v2.@layout_4 = call %std__lib__abi__sol__impl_trait_Sol_1f5f__decoder_with_base__gd20d_b2fb v0 4.i256;
-        return v2;
-}
-
-func inline(always) private %core__lib__contracts__trait_ContractHost__runtime_decoder__g736d_e77a() -> @layout_4 {
-    block0:
-        jump block1;
-
-    block1:
-        v0.@layout_2 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_938b;
-        v2.@layout_4 = call %std__lib__abi__sol__impl_trait_Sol_1f5f__decoder_with_base__gd20d_2089 v0 4.i256;
-        return v2;
-}
-
-func inline(always) private %core__lib__contracts__trait_ContractHost__runtime_decoder__g736d_f123() -> @layout_4 {
-    block0:
-        jump block1;
-
-    block1:
-        v0.@layout_2 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_015b;
-        v2.@layout_4 = call %std__lib__abi__sol__impl_trait_Sol_1f5f__decoder_with_base__gd20d_7ee4 v0 4.i256;
-        return v2;
-}
-
-func inline(always) private %core__lib__contracts__trait_ContractHost__runtime_decoder__g736d_f38f() -> @layout_4 {
-    block0:
-        jump block1;
-
-    block1:
-        v0.@layout_2 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_b9f8;
-        v2.@layout_4 = call %std__lib__abi__sol__impl_trait_Sol_1f5f__decoder_with_base__gd20d_46bc v0 4.i256;
-        return v2;
-}
-
 func inline(always) private %set__g2163(v0.@layout_0, v1.i256) {
     block0:
         jump block1;
@@ -10588,123 +7496,6 @@ func inline(always) private %set__g2163(v0.@layout_0, v1.i256) {
     block1:
         v4.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__to_word_3e9f v1;
         call %storagemap_set_word_with_salt__g67a8 v0 0.i256 v4;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_08ad(v0.objref<@layout_4>, v1.i256) {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 1.i256;
-        obj.store v6 v3;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_2047(v0.objref<@layout_4>, v1.i256) {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 1.i256;
-        obj.store v6 v3;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_2c03(v0.objref<@layout_4>, v1.i256) {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 1.i256;
-        obj.store v6 v3;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_3353(v0.objref<@layout_4>, v1.i256) {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 1.i256;
-        obj.store v6 v3;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_37ba(v0.objref<@layout_4>, v1.i256) {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 1.i256;
-        obj.store v6 v3;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_5e07(v0.objref<@layout_4>, v1.i256) {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 1.i256;
-        obj.store v6 v3;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_6069(v0.objref<@layout_4>, v1.i256) {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 1.i256;
-        obj.store v6 v3;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_625a(v0.objref<@layout_4>, v1.i256) {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 1.i256;
-        obj.store v6 v3;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_71fe(v0.objref<@layout_4>, v1.i256) {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 1.i256;
-        obj.store v6 v3;
         return;
 }
 
@@ -10717,19 +7508,6 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_750c(v0.o
     block1:
         v3.i256 = mload v2 i256;
         v6.objref<i256> = obj.proj v0 0.i256;
-        obj.store v6 v3;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_8271(v0.objref<@layout_4>, v1.i256) {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 1.i256;
         obj.store v6 v3;
         return;
 }
@@ -10747,71 +7525,6 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_844b(v0.o
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_88e6(v0.objref<@layout_4>, v1.i256) {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 1.i256;
-        obj.store v6 v3;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_8f23(v0.objref<@layout_4>, v1.i256) {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 1.i256;
-        obj.store v6 v3;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_abec(v0.objref<@layout_4>, v1.i256) {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 1.i256;
-        obj.store v6 v3;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_b0be(v0.objref<@layout_4>, v1.i256) {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 1.i256;
-        obj.store v6 v3;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_b760(v0.objref<@layout_4>, v1.i256) {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 1.i256;
-        obj.store v6 v3;
-        return;
-}
-
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_c5ff(v0.objref<@layout_1>, v1.i256) {
     block0:
         v2.*i256 = alloca i256;
@@ -10821,19 +7534,6 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_c5ff(v0.o
     block1:
         v3.i256 = mload v2 i256;
         v6.objref<i256> = obj.proj v0 0.i256;
-        obj.store v6 v3;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_cbf7(v0.objref<@layout_4>, v1.i256) {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 1.i256;
         obj.store v6 v3;
         return;
 }
@@ -10851,7 +7551,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_cc2c(v0.o
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_d49b(v0.objref<@layout_7>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_d49b(v0.objref<@layout_4>, v1.i256) {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -10864,20 +7564,7 @@ func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_d4
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_d49b_0(v0.objref<@layout_7>, v1.i256) {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 1.i256;
-        obj.store v6 v3;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g8f43_f70c(v0.objref<@layout_4>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_d49b_0(v0.objref<@layout_4>, v1.i256) {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -10903,7 +7590,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_fa20(v0.o
         return;
 }
 
-func inline(always) private %set__gc9ba(v0.@layout_15, v1.i1) {
+func inline(always) private %set__gc9ba(v0.@layout_16, v1.i1) {
     block0:
         jump block1;
 
@@ -10913,7 +7600,7 @@ func inline(always) private %set__gc9ba(v0.@layout_15, v1.i1) {
         return;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__set__ga15b_f7f7(v0.@layout_24, v1.i256) {
+func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__set__ga15b_f7f7(v0.@layout_22, v1.i256) {
     block0:
         jump block1;
 
@@ -10923,27 +7610,13 @@ func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__s
         return;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__set__ga15b_f7f7_0(v0.@layout_24, v1.i256) {
+func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__set__ga15b_f7f7_0(v0.@layout_22, v1.i256) {
     block0:
         jump block1;
 
     block1:
         v4.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__to_word_05d2_0 v1;
         call %std__lib__evm__storage_map__storagemap_set_word_with_salt__g7bf4_7aa4_0 v0 1.i256 v4;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_04a3(v0.objref<@layout_4>, v1.i256) {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<@layout_3> = obj.proj v0 0.i256;
-        v8.objref<i256> = obj.proj v6 1.i256;
-        obj.store v8 v3;
         return;
 }
 
@@ -10960,76 +7633,6 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_0f4a(v0.ob
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_0f8a(v0.objref<@layout_4>, v1.i256) {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<@layout_3> = obj.proj v0 0.i256;
-        v8.objref<i256> = obj.proj v6 1.i256;
-        obj.store v8 v3;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_1627(v0.objref<@layout_4>, v1.i256) {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<@layout_3> = obj.proj v0 0.i256;
-        v8.objref<i256> = obj.proj v6 1.i256;
-        obj.store v8 v3;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_3496(v0.objref<@layout_4>, v1.i256) {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<@layout_3> = obj.proj v0 0.i256;
-        v8.objref<i256> = obj.proj v6 1.i256;
-        obj.store v8 v3;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_34da(v0.objref<@layout_4>, v1.i256) {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<@layout_3> = obj.proj v0 0.i256;
-        v8.objref<i256> = obj.proj v6 1.i256;
-        obj.store v8 v3;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_3709(v0.objref<@layout_4>, v1.i256) {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<@layout_3> = obj.proj v0 0.i256;
-        v8.objref<i256> = obj.proj v6 1.i256;
-        obj.store v8 v3;
-        return;
-}
-
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_3857(v0.objref<@layout_1>, v1.i256) {
     block0:
         v2.*i256 = alloca i256;
@@ -11040,48 +7643,6 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_3857(v0.ob
         v3.i256 = mload v2 i256;
         v6.objref<i256> = obj.proj v0 1.i256;
         obj.store v6 v3;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_3c9e(v0.objref<@layout_4>, v1.i256) {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<@layout_3> = obj.proj v0 0.i256;
-        v8.objref<i256> = obj.proj v6 1.i256;
-        obj.store v8 v3;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_499d(v0.objref<@layout_4>, v1.i256) {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<@layout_3> = obj.proj v0 0.i256;
-        v8.objref<i256> = obj.proj v6 1.i256;
-        obj.store v8 v3;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_592f(v0.objref<@layout_4>, v1.i256) {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<@layout_3> = obj.proj v0 0.i256;
-        v8.objref<i256> = obj.proj v6 1.i256;
-        obj.store v8 v3;
         return;
 }
 
@@ -11111,62 +7672,6 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_7410(v0.ob
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_763e(v0.objref<@layout_4>, v1.i256) {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<@layout_3> = obj.proj v0 0.i256;
-        v8.objref<i256> = obj.proj v6 1.i256;
-        obj.store v8 v3;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_79da(v0.objref<@layout_4>, v1.i256) {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<@layout_3> = obj.proj v0 0.i256;
-        v8.objref<i256> = obj.proj v6 1.i256;
-        obj.store v8 v3;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_a284(v0.objref<@layout_4>, v1.i256) {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<@layout_3> = obj.proj v0 0.i256;
-        v8.objref<i256> = obj.proj v6 1.i256;
-        obj.store v8 v3;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_a5d2(v0.objref<@layout_4>, v1.i256) {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<@layout_3> = obj.proj v0 0.i256;
-        v8.objref<i256> = obj.proj v6 1.i256;
-        obj.store v8 v3;
-        return;
-}
-
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_b6ef(v0.objref<@layout_1>, v1.i256) {
     block0:
         v2.*i256 = alloca i256;
@@ -11180,7 +7685,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_b6ef(v0.ob
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_c11e(v0.objref<@layout_4>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_d790(v0.objref<@layout_4>, v1.i256) {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -11194,63 +7699,7 @@ func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_c11
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_cfe1(v0.objref<@layout_4>, v1.i256) {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<@layout_3> = obj.proj v0 0.i256;
-        v8.objref<i256> = obj.proj v6 1.i256;
-        obj.store v8 v3;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_d790(v0.objref<@layout_7>, v1.i256) {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<@layout_6> = obj.proj v0 0.i256;
-        v8.objref<i256> = obj.proj v6 1.i256;
-        obj.store v8 v3;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_d790_0(v0.objref<@layout_7>, v1.i256) {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<@layout_6> = obj.proj v0 0.i256;
-        v8.objref<i256> = obj.proj v6 1.i256;
-        obj.store v8 v3;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_de99(v0.objref<@layout_4>, v1.i256) {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<@layout_3> = obj.proj v0 0.i256;
-        v8.objref<i256> = obj.proj v6 1.i256;
-        obj.store v8 v3;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g8f43_ec24(v0.objref<@layout_4>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_d790_0(v0.objref<@layout_4>, v1.i256) {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -11271,7 +7720,7 @@ func private %standalone_erc20__erc20__spend_allowance__ga033_1943(v0.@layout_0,
         jump block1;
 
     block1:
-        v7.objref<@layout_24> = obj.alloc @layout_24;
+        v7.objref<@layout_22> = obj.alloc @layout_22;
         v9.objref<@layout_0> = obj.proj v7 0.i256;
         v10.objref<i256> = obj.proj v9 0.i256;
         v11.i256 = extract_value v0 0.i256;
@@ -11280,7 +7729,7 @@ func private %standalone_erc20__erc20__spend_allowance__ga033_1943(v0.@layout_0,
         v14.objref<i256> = obj.proj v13 0.i256;
         v15.i256 = extract_value v1 0.i256;
         obj.store v14 v15;
-        v16.@layout_24 = obj.load v7;
+        v16.@layout_22 = obj.load v7;
         v17.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get__ga15b_b5d5 v16;
         v18.i256 = mload v4 i256;
         v19.i1 = lt v17 v18;
@@ -11298,7 +7747,7 @@ func private %standalone_erc20__erc20__spend_allowance__ga033_1943(v0.@layout_0,
         br v29 block5 block6;
 
     block4:
-        v38.objref<@layout_24> = obj.alloc @layout_24;
+        v38.objref<@layout_22> = obj.alloc @layout_22;
         v39.objref<@layout_0> = obj.proj v38 0.i256;
         v40.objref<i256> = obj.proj v39 0.i256;
         v41.i256 = extract_value v0 0.i256;
@@ -11307,7 +7756,7 @@ func private %standalone_erc20__erc20__spend_allowance__ga033_1943(v0.@layout_0,
         v43.objref<i256> = obj.proj v42 0.i256;
         v44.i256 = extract_value v1 0.i256;
         obj.store v43 v44;
-        v45.@layout_24 = obj.load v38;
+        v45.@layout_22 = obj.load v38;
         v46.i256 = mload v4 i256;
         (v48.i256, v49.i1) = usubo v17 v46;
         br v49 block5 block7;
@@ -11333,7 +7782,7 @@ func private %standalone_erc20__erc20__spend_allowance__ga033_1943_0(v0.@layout_
         jump block1;
 
     block1:
-        v7.objref<@layout_24> = obj.alloc @layout_24;
+        v7.objref<@layout_22> = obj.alloc @layout_22;
         v9.objref<@layout_0> = obj.proj v7 0.i256;
         v10.objref<i256> = obj.proj v9 0.i256;
         v11.i256 = extract_value v0 0.i256;
@@ -11342,7 +7791,7 @@ func private %standalone_erc20__erc20__spend_allowance__ga033_1943_0(v0.@layout_
         v14.objref<i256> = obj.proj v13 0.i256;
         v15.i256 = extract_value v1 0.i256;
         obj.store v14 v15;
-        v16.@layout_24 = obj.load v7;
+        v16.@layout_22 = obj.load v7;
         v17.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get__ga15b_b5d5 v16;
         v18.i256 = mload v4 i256;
         v19.i1 = lt v17 v18;
@@ -11360,7 +7809,7 @@ func private %standalone_erc20__erc20__spend_allowance__ga033_1943_0(v0.@layout_
         br v29 block5 block6;
 
     block4:
-        v38.objref<@layout_24> = obj.alloc @layout_24;
+        v38.objref<@layout_22> = obj.alloc @layout_22;
         v39.objref<@layout_0> = obj.proj v38 0.i256;
         v40.objref<i256> = obj.proj v39 0.i256;
         v41.i256 = extract_value v0 0.i256;
@@ -11369,7 +7818,7 @@ func private %standalone_erc20__erc20__spend_allowance__ga033_1943_0(v0.@layout_
         v43.objref<i256> = obj.proj v42 0.i256;
         v44.i256 = extract_value v1 0.i256;
         obj.store v43 v44;
-        v45.@layout_24 = obj.load v38;
+        v45.@layout_22 = obj.load v38;
         v46.i256 = mload v4 i256;
         (v48.i256, v49.i1) = usubo v17 v46;
         br v49 block5 block7;
@@ -11388,7 +7837,7 @@ func private %standalone_erc20__erc20__spend_allowance__ga033_1943_0(v0.@layout_
         return;
 }
 
-func inline(always) private %std__lib__evm__storage_map__storagemap_get_word_with_salt__g7bf4_09af(v0.@layout_24, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__storagemap_get_word_with_salt__g7bf4_09af(v0.@layout_22, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -11401,7 +7850,7 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_get_word_wit
         return v6;
 }
 
-func inline(always) private %std__lib__evm__storage_map__storagemap_get_word_with_salt__g7bf4_09af_0(v0.@layout_24, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__storagemap_get_word_with_salt__g7bf4_09af_0(v0.@layout_22, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -11427,7 +7876,7 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_get_word_wit
         return v6;
 }
 
-func inline(always) private %storagemap_get_word_with_salt__g9379(v0.@layout_15, v1.i256) -> i256 {
+func inline(always) private %storagemap_get_word_with_salt__g9379(v0.@layout_16, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -11453,7 +7902,7 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_get_word_wit
         return v6;
 }
 
-func inline(always) private %std__lib__evm__storage_map__storagemap_get_word_with_salt__g7bf4_af75(v0.@layout_24, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__storagemap_get_word_with_salt__g7bf4_af75(v0.@layout_22, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -11482,7 +7931,7 @@ func inline(always) private %storagemap_set_word_with_salt__g67a8(v0.@layout_0, 
         return;
 }
 
-func inline(always) private %std__lib__evm__storage_map__storagemap_set_word_with_salt__g7bf4_7aa4(v0.@layout_24, v1.i256, v2.i256) {
+func inline(always) private %std__lib__evm__storage_map__storagemap_set_word_with_salt__g7bf4_7aa4(v0.@layout_22, v1.i256, v2.i256) {
     block0:
         v3.*i256 = alloca i256;
         v4.*i256 = alloca i256;
@@ -11498,7 +7947,7 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_set_word_wit
         return;
 }
 
-func inline(always) private %std__lib__evm__storage_map__storagemap_set_word_with_salt__g7bf4_7aa4_0(v0.@layout_24, v1.i256, v2.i256) {
+func inline(always) private %std__lib__evm__storage_map__storagemap_set_word_with_salt__g7bf4_7aa4_0(v0.@layout_22, v1.i256, v2.i256) {
     block0:
         v3.*i256 = alloca i256;
         v4.*i256 = alloca i256;
@@ -11514,7 +7963,7 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_set_word_wit
         return;
 }
 
-func inline(always) private %storagemap_set_word_with_salt__g9379(v0.@layout_15, v1.i256, v2.i256) {
+func inline(always) private %storagemap_set_word_with_salt__g9379(v0.@layout_16, v1.i256, v2.i256) {
     block0:
         v3.*i256 = alloca i256;
         v4.*i256 = alloca i256;
@@ -11530,7 +7979,7 @@ func inline(always) private %storagemap_set_word_with_salt__g9379(v0.@layout_15,
         return;
 }
 
-func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_2a19(v0.@layout_24, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_2a19(v0.@layout_22, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -11617,7 +8066,7 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot
         return v21;
 }
 
-func inline(always) private %storagemap_storage_slot_with_salt__g9379(v0.@layout_15, v1.i256) -> i256 {
+func inline(always) private %storagemap_storage_slot_with_salt__g9379(v0.@layout_16, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -11646,7 +8095,7 @@ func inline(always) private %storagemap_storage_slot_with_salt__g9379(v0.@layout
         return v21;
 }
 
-func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_e3d6(v0.@layout_24, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_e3d6(v0.@layout_22, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -11675,7 +8124,7 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot
         return v21;
 }
 
-func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_e3d6_0(v0.@layout_24, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_e3d6_0(v0.@layout_22, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -11704,7 +8153,7 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot
         return v21;
 }
 
-func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_e3d6_1(v0.@layout_24, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_e3d6_1(v0.@layout_22, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -11987,7 +8436,7 @@ func private %standalone_erc20__erc20__transfer__g5c3f_3bfd(v0.@layout_0, v1.@la
     block16:
         call %set__g2163 v1 v66;
         v72.i256 = mload v4 i256;
-        v73.objref<@layout_21> = obj.alloc @layout_21;
+        v73.objref<@layout_19> = obj.alloc @layout_19;
         v74.objref<@layout_0> = obj.proj v73 0.i256;
         v75.objref<i256> = obj.proj v74 0.i256;
         v76.i256 = extract_value v0 0.i256;
@@ -11998,7 +8447,7 @@ func private %standalone_erc20__erc20__transfer__g5c3f_3bfd(v0.@layout_0, v1.@la
         obj.store v79 v80;
         v82.objref<i256> = obj.proj v73 2.i256;
         obj.store v82 v72;
-        v83.@layout_21 = obj.load v73;
+        v83.@layout_19 = obj.load v73;
         call %emit__g4c3d v83;
         return;
 }
@@ -12098,7 +8547,7 @@ func private %standalone_erc20__erc20__transfer__g5c3f_d8a9(v0.@layout_0, v1.@la
     block16:
         call %set__g2163 v1 v66;
         v72.i256 = mload v4 i256;
-        v73.objref<@layout_21> = obj.alloc @layout_21;
+        v73.objref<@layout_19> = obj.alloc @layout_19;
         v74.objref<@layout_0> = obj.proj v73 0.i256;
         v75.objref<i256> = obj.proj v74 0.i256;
         v76.i256 = extract_value v0 0.i256;
@@ -12109,450 +8558,26 @@ func private %standalone_erc20__erc20__transfer__g5c3f_d8a9(v0.@layout_0, v1.@la
         obj.store v79 v80;
         v82.objref<i256> = obj.proj v73 2.i256;
         obj.store v82 v72;
-        v83.@layout_21 = obj.load v73;
+        v83.@layout_19 = obj.load v73;
         call %emit__g4c3d v83;
         return;
 }
 
-func inline(always) private %std__lib__abi__sol__impl_SolDecoder_113c__with_base__gd20d_1583(v0.@layout_2, v1.i256) -> @layout_4 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_0f5c(v0.@layout_5, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.@layout_3 = call %core__lib__abi__impl_Cursor_1a04__new__gd20d_4240 v0;
-        v5.i256 = mload v2 i256;
-        v6.@layout_3 = call %core__lib__abi__impl_Cursor_1a04__fork__gd20d_ace8 v4 v5;
-        v7.i256 = mload v2 i256;
-        v8.objref<@layout_4> = obj.alloc @layout_4;
-        v10.objref<@layout_3> = obj.proj v8 0.i256;
-        v11.objref<@layout_2> = obj.proj v10 0.i256;
-        v12.@layout_2 = extract_value v6 0.i256;
-        v13.objref<i256> = obj.proj v11 0.i256;
-        v14.i256 = extract_value v12 0.i256;
-        obj.store v13 v14;
-        v16.objref<i256> = obj.proj v10 1.i256;
-        v17.i256 = extract_value v6 1.i256;
-        obj.store v16 v17;
-        v18.objref<i256> = obj.proj v8 1.i256;
-        obj.store v18 v7;
-        v19.@layout_4 = obj.load v8;
-        return v19;
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
 }
 
-func inline(always) private %std__lib__abi__sol__impl_SolDecoder_113c__with_base__gd20d_3cb6(v0.@layout_2, v1.i256) -> @layout_4 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v4.@layout_3 = call %core__lib__abi__impl_Cursor_1a04__new__gd20d_2e66 v0;
-        v5.i256 = mload v2 i256;
-        v6.@layout_3 = call %core__lib__abi__impl_Cursor_1a04__fork__gd20d_d4d6 v4 v5;
-        v7.i256 = mload v2 i256;
-        v8.objref<@layout_4> = obj.alloc @layout_4;
-        v10.objref<@layout_3> = obj.proj v8 0.i256;
-        v11.objref<@layout_2> = obj.proj v10 0.i256;
-        v12.@layout_2 = extract_value v6 0.i256;
-        v13.objref<i256> = obj.proj v11 0.i256;
-        v14.i256 = extract_value v12 0.i256;
-        obj.store v13 v14;
-        v16.objref<i256> = obj.proj v10 1.i256;
-        v17.i256 = extract_value v6 1.i256;
-        obj.store v16 v17;
-        v18.objref<i256> = obj.proj v8 1.i256;
-        obj.store v18 v7;
-        v19.@layout_4 = obj.load v8;
-        return v19;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_SolDecoder_113c__with_base__gd20d_4009(v0.@layout_2, v1.i256) -> @layout_4 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v4.@layout_3 = call %core__lib__abi__impl_Cursor_1a04__new__gd20d_200e v0;
-        v5.i256 = mload v2 i256;
-        v6.@layout_3 = call %core__lib__abi__impl_Cursor_1a04__fork__gd20d_542f v4 v5;
-        v7.i256 = mload v2 i256;
-        v8.objref<@layout_4> = obj.alloc @layout_4;
-        v10.objref<@layout_3> = obj.proj v8 0.i256;
-        v11.objref<@layout_2> = obj.proj v10 0.i256;
-        v12.@layout_2 = extract_value v6 0.i256;
-        v13.objref<i256> = obj.proj v11 0.i256;
-        v14.i256 = extract_value v12 0.i256;
-        obj.store v13 v14;
-        v16.objref<i256> = obj.proj v10 1.i256;
-        v17.i256 = extract_value v6 1.i256;
-        obj.store v16 v17;
-        v18.objref<i256> = obj.proj v8 1.i256;
-        obj.store v18 v7;
-        v19.@layout_4 = obj.load v8;
-        return v19;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_SolDecoder_113c__with_base__gd20d_43fc(v0.@layout_2, v1.i256) -> @layout_4 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v4.@layout_3 = call %core__lib__abi__impl_Cursor_1a04__new__gd20d_3ec1 v0;
-        v5.i256 = mload v2 i256;
-        v6.@layout_3 = call %core__lib__abi__impl_Cursor_1a04__fork__gd20d_f9b8 v4 v5;
-        v7.i256 = mload v2 i256;
-        v8.objref<@layout_4> = obj.alloc @layout_4;
-        v10.objref<@layout_3> = obj.proj v8 0.i256;
-        v11.objref<@layout_2> = obj.proj v10 0.i256;
-        v12.@layout_2 = extract_value v6 0.i256;
-        v13.objref<i256> = obj.proj v11 0.i256;
-        v14.i256 = extract_value v12 0.i256;
-        obj.store v13 v14;
-        v16.objref<i256> = obj.proj v10 1.i256;
-        v17.i256 = extract_value v6 1.i256;
-        obj.store v16 v17;
-        v18.objref<i256> = obj.proj v8 1.i256;
-        obj.store v18 v7;
-        v19.@layout_4 = obj.load v8;
-        return v19;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_SolDecoder_113c__with_base__gd20d_56ca(v0.@layout_2, v1.i256) -> @layout_4 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v4.@layout_3 = call %core__lib__abi__impl_Cursor_1a04__new__gd20d_232c v0;
-        v5.i256 = mload v2 i256;
-        v6.@layout_3 = call %core__lib__abi__impl_Cursor_1a04__fork__gd20d_cd99 v4 v5;
-        v7.i256 = mload v2 i256;
-        v8.objref<@layout_4> = obj.alloc @layout_4;
-        v10.objref<@layout_3> = obj.proj v8 0.i256;
-        v11.objref<@layout_2> = obj.proj v10 0.i256;
-        v12.@layout_2 = extract_value v6 0.i256;
-        v13.objref<i256> = obj.proj v11 0.i256;
-        v14.i256 = extract_value v12 0.i256;
-        obj.store v13 v14;
-        v16.objref<i256> = obj.proj v10 1.i256;
-        v17.i256 = extract_value v6 1.i256;
-        obj.store v16 v17;
-        v18.objref<i256> = obj.proj v8 1.i256;
-        obj.store v18 v7;
-        v19.@layout_4 = obj.load v8;
-        return v19;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_SolDecoder_113c__with_base__gd20d_57e7(v0.@layout_2, v1.i256) -> @layout_4 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v4.@layout_3 = call %core__lib__abi__impl_Cursor_1a04__new__gd20d_edc0 v0;
-        v5.i256 = mload v2 i256;
-        v6.@layout_3 = call %core__lib__abi__impl_Cursor_1a04__fork__gd20d_320d v4 v5;
-        v7.i256 = mload v2 i256;
-        v8.objref<@layout_4> = obj.alloc @layout_4;
-        v10.objref<@layout_3> = obj.proj v8 0.i256;
-        v11.objref<@layout_2> = obj.proj v10 0.i256;
-        v12.@layout_2 = extract_value v6 0.i256;
-        v13.objref<i256> = obj.proj v11 0.i256;
-        v14.i256 = extract_value v12 0.i256;
-        obj.store v13 v14;
-        v16.objref<i256> = obj.proj v10 1.i256;
-        v17.i256 = extract_value v6 1.i256;
-        obj.store v16 v17;
-        v18.objref<i256> = obj.proj v8 1.i256;
-        obj.store v18 v7;
-        v19.@layout_4 = obj.load v8;
-        return v19;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_SolDecoder_113c__with_base__gd20d_6cde(v0.@layout_2, v1.i256) -> @layout_4 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v4.@layout_3 = call %core__lib__abi__impl_Cursor_1a04__new__gd20d_8b54 v0;
-        v5.i256 = mload v2 i256;
-        v6.@layout_3 = call %core__lib__abi__impl_Cursor_1a04__fork__gd20d_64b6 v4 v5;
-        v7.i256 = mload v2 i256;
-        v8.objref<@layout_4> = obj.alloc @layout_4;
-        v10.objref<@layout_3> = obj.proj v8 0.i256;
-        v11.objref<@layout_2> = obj.proj v10 0.i256;
-        v12.@layout_2 = extract_value v6 0.i256;
-        v13.objref<i256> = obj.proj v11 0.i256;
-        v14.i256 = extract_value v12 0.i256;
-        obj.store v13 v14;
-        v16.objref<i256> = obj.proj v10 1.i256;
-        v17.i256 = extract_value v6 1.i256;
-        obj.store v16 v17;
-        v18.objref<i256> = obj.proj v8 1.i256;
-        obj.store v18 v7;
-        v19.@layout_4 = obj.load v8;
-        return v19;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_SolDecoder_113c__with_base__gd20d_7c6f(v0.@layout_2, v1.i256) -> @layout_4 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v4.@layout_3 = call %core__lib__abi__impl_Cursor_1a04__new__gd20d_4eb9 v0;
-        v5.i256 = mload v2 i256;
-        v6.@layout_3 = call %core__lib__abi__impl_Cursor_1a04__fork__gd20d_84e3 v4 v5;
-        v7.i256 = mload v2 i256;
-        v8.objref<@layout_4> = obj.alloc @layout_4;
-        v10.objref<@layout_3> = obj.proj v8 0.i256;
-        v11.objref<@layout_2> = obj.proj v10 0.i256;
-        v12.@layout_2 = extract_value v6 0.i256;
-        v13.objref<i256> = obj.proj v11 0.i256;
-        v14.i256 = extract_value v12 0.i256;
-        obj.store v13 v14;
-        v16.objref<i256> = obj.proj v10 1.i256;
-        v17.i256 = extract_value v6 1.i256;
-        obj.store v16 v17;
-        v18.objref<i256> = obj.proj v8 1.i256;
-        obj.store v18 v7;
-        v19.@layout_4 = obj.load v8;
-        return v19;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_SolDecoder_113c__with_base__gd20d_a45d(v0.@layout_2, v1.i256) -> @layout_4 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v4.@layout_3 = call %core__lib__abi__impl_Cursor_1a04__new__gd20d_cb66 v0;
-        v5.i256 = mload v2 i256;
-        v6.@layout_3 = call %core__lib__abi__impl_Cursor_1a04__fork__gd20d_3257 v4 v5;
-        v7.i256 = mload v2 i256;
-        v8.objref<@layout_4> = obj.alloc @layout_4;
-        v10.objref<@layout_3> = obj.proj v8 0.i256;
-        v11.objref<@layout_2> = obj.proj v10 0.i256;
-        v12.@layout_2 = extract_value v6 0.i256;
-        v13.objref<i256> = obj.proj v11 0.i256;
-        v14.i256 = extract_value v12 0.i256;
-        obj.store v13 v14;
-        v16.objref<i256> = obj.proj v10 1.i256;
-        v17.i256 = extract_value v6 1.i256;
-        obj.store v16 v17;
-        v18.objref<i256> = obj.proj v8 1.i256;
-        obj.store v18 v7;
-        v19.@layout_4 = obj.load v8;
-        return v19;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_SolDecoder_113c__with_base__gd20d_b4c9(v0.@layout_2, v1.i256) -> @layout_4 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v4.@layout_3 = call %core__lib__abi__impl_Cursor_1a04__new__gd20d_6e18 v0;
-        v5.i256 = mload v2 i256;
-        v6.@layout_3 = call %core__lib__abi__impl_Cursor_1a04__fork__gd20d_08b4 v4 v5;
-        v7.i256 = mload v2 i256;
-        v8.objref<@layout_4> = obj.alloc @layout_4;
-        v10.objref<@layout_3> = obj.proj v8 0.i256;
-        v11.objref<@layout_2> = obj.proj v10 0.i256;
-        v12.@layout_2 = extract_value v6 0.i256;
-        v13.objref<i256> = obj.proj v11 0.i256;
-        v14.i256 = extract_value v12 0.i256;
-        obj.store v13 v14;
-        v16.objref<i256> = obj.proj v10 1.i256;
-        v17.i256 = extract_value v6 1.i256;
-        obj.store v16 v17;
-        v18.objref<i256> = obj.proj v8 1.i256;
-        obj.store v18 v7;
-        v19.@layout_4 = obj.load v8;
-        return v19;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_SolDecoder_113c__with_base__gd20d_dba1(v0.@layout_2, v1.i256) -> @layout_4 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v4.@layout_3 = call %core__lib__abi__impl_Cursor_1a04__new__gd20d_c3a0 v0;
-        v5.i256 = mload v2 i256;
-        v6.@layout_3 = call %core__lib__abi__impl_Cursor_1a04__fork__gd20d_d620 v4 v5;
-        v7.i256 = mload v2 i256;
-        v8.objref<@layout_4> = obj.alloc @layout_4;
-        v10.objref<@layout_3> = obj.proj v8 0.i256;
-        v11.objref<@layout_2> = obj.proj v10 0.i256;
-        v12.@layout_2 = extract_value v6 0.i256;
-        v13.objref<i256> = obj.proj v11 0.i256;
-        v14.i256 = extract_value v12 0.i256;
-        obj.store v13 v14;
-        v16.objref<i256> = obj.proj v10 1.i256;
-        v17.i256 = extract_value v6 1.i256;
-        obj.store v16 v17;
-        v18.objref<i256> = obj.proj v8 1.i256;
-        obj.store v18 v7;
-        v19.@layout_4 = obj.load v8;
-        return v19;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_SolDecoder_113c__with_base__gd20d_dd64(v0.@layout_2, v1.i256) -> @layout_4 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v4.@layout_3 = call %core__lib__abi__impl_Cursor_1a04__new__gd20d_0a92 v0;
-        v5.i256 = mload v2 i256;
-        v6.@layout_3 = call %core__lib__abi__impl_Cursor_1a04__fork__gd20d_7e69 v4 v5;
-        v7.i256 = mload v2 i256;
-        v8.objref<@layout_4> = obj.alloc @layout_4;
-        v10.objref<@layout_3> = obj.proj v8 0.i256;
-        v11.objref<@layout_2> = obj.proj v10 0.i256;
-        v12.@layout_2 = extract_value v6 0.i256;
-        v13.objref<i256> = obj.proj v11 0.i256;
-        v14.i256 = extract_value v12 0.i256;
-        obj.store v13 v14;
-        v16.objref<i256> = obj.proj v10 1.i256;
-        v17.i256 = extract_value v6 1.i256;
-        obj.store v16 v17;
-        v18.objref<i256> = obj.proj v8 1.i256;
-        obj.store v18 v7;
-        v19.@layout_4 = obj.load v8;
-        return v19;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_SolDecoder_113c__with_base__gd20d_df78(v0.@layout_2, v1.i256) -> @layout_4 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v4.@layout_3 = call %core__lib__abi__impl_Cursor_1a04__new__gd20d_cc0f v0;
-        v5.i256 = mload v2 i256;
-        v6.@layout_3 = call %core__lib__abi__impl_Cursor_1a04__fork__gd20d_5db0 v4 v5;
-        v7.i256 = mload v2 i256;
-        v8.objref<@layout_4> = obj.alloc @layout_4;
-        v10.objref<@layout_3> = obj.proj v8 0.i256;
-        v11.objref<@layout_2> = obj.proj v10 0.i256;
-        v12.@layout_2 = extract_value v6 0.i256;
-        v13.objref<i256> = obj.proj v11 0.i256;
-        v14.i256 = extract_value v12 0.i256;
-        obj.store v13 v14;
-        v16.objref<i256> = obj.proj v10 1.i256;
-        v17.i256 = extract_value v6 1.i256;
-        obj.store v16 v17;
-        v18.objref<i256> = obj.proj v8 1.i256;
-        obj.store v18 v7;
-        v19.@layout_4 = obj.load v8;
-        return v19;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_SolDecoder_113c__with_base__gd20d_f665(v0.@layout_2, v1.i256) -> @layout_4 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v4.@layout_3 = call %core__lib__abi__impl_Cursor_1a04__new__gd20d_d550 v0;
-        v5.i256 = mload v2 i256;
-        v6.@layout_3 = call %core__lib__abi__impl_Cursor_1a04__fork__gd20d_baad v4 v5;
-        v7.i256 = mload v2 i256;
-        v8.objref<@layout_4> = obj.alloc @layout_4;
-        v10.objref<@layout_3> = obj.proj v8 0.i256;
-        v11.objref<@layout_2> = obj.proj v10 0.i256;
-        v12.@layout_2 = extract_value v6 0.i256;
-        v13.objref<i256> = obj.proj v11 0.i256;
-        v14.i256 = extract_value v12 0.i256;
-        obj.store v13 v14;
-        v16.objref<i256> = obj.proj v10 1.i256;
-        v17.i256 = extract_value v6 1.i256;
-        obj.store v16 v17;
-        v18.objref<i256> = obj.proj v8 1.i256;
-        obj.store v18 v7;
-        v19.@layout_4 = obj.load v8;
-        return v19;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_013b(v0.objref<@layout_2>, v1.i256) -> i256 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = evm_calldata_load v8;
-        return v9;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_0b94(v0.objref<@layout_2>, v1.i256) -> i256 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = evm_calldata_load v8;
-        return v9;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_0de0(v0.objref<@layout_2>, v1.i256) -> i256 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = evm_calldata_load v8;
-        return v9;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_0fd5(v0.objref<@layout_2>, v1.i256) -> i256 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = evm_calldata_load v8;
-        return v9;
-}
-
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_20e1(v0.objref<@layout_5>, v1.i256) -> i256 {
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_20e1(v0.objref<@layout_2>, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -12567,7 +8592,7 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_
         return v9;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_20e1_0(v0.objref<@layout_5>, v1.i256) -> i256 {
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_20e1_0(v0.objref<@layout_2>, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -12582,37 +8607,35 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_
         return v9;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_2cde(v0.objref<@layout_2>, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_27ad(v0.@layout_5, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = evm_calldata_load v8;
-        return v9;
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_321e(v0.objref<@layout_2>, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3a1f(v0.@layout_5, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = evm_calldata_load v8;
-        return v9;
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_3a7f(v0.objref<@layout_5>, v1.i256) -> i256 {
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_3a7f(v0.objref<@layout_2>, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -12627,307 +8650,343 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_
         return v9;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3a89(v0.objref<@layout_2>, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3ba3(v0.@layout_5, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = evm_calldata_load v8;
-        return v9;
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3f26(v0.objref<@layout_2>, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3bad(v0.@layout_5, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = evm_calldata_load v8;
-        return v9;
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_4724(v0.objref<@layout_2>, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_40a0(v0.@layout_5, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = evm_calldata_load v8;
-        return v9;
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_4e61(v0.objref<@layout_2>, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_49c5(v0.@layout_5, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = evm_calldata_load v8;
-        return v9;
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_509a(v0.objref<@layout_2>, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_5ce9(v0.@layout_5, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = evm_calldata_load v8;
-        return v9;
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_553d(v0.objref<@layout_2>, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_69bf(v0.@layout_5, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = evm_calldata_load v8;
-        return v9;
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_59f2(v0.objref<@layout_2>, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_6dae(v0.@layout_5, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = evm_calldata_load v8;
-        return v9;
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_60f2(v0.objref<@layout_2>, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_780b(v0.@layout_5, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = evm_calldata_load v8;
-        return v9;
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_698d(v0.objref<@layout_2>, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_790f(v0.@layout_5, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = evm_calldata_load v8;
-        return v9;
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_712d(v0.objref<@layout_2>, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_7946(v0.@layout_5, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = evm_calldata_load v8;
-        return v9;
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_7244(v0.objref<@layout_2>, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_8736(v0.@layout_5, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = evm_calldata_load v8;
-        return v9;
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_7f0e(v0.objref<@layout_2>, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_88a1(v0.@layout_5, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = evm_calldata_load v8;
-        return v9;
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_7f8f(v0.objref<@layout_2>, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_9725(v0.@layout_5, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = evm_calldata_load v8;
-        return v9;
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_81ff(v0.objref<@layout_2>, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_9757(v0.@layout_5, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = evm_calldata_load v8;
-        return v9;
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_9376(v0.objref<@layout_2>, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_a6b2(v0.@layout_5, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = evm_calldata_load v8;
-        return v9;
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_add5(v0.objref<@layout_2>, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_a8d6(v0.@layout_5, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = evm_calldata_load v8;
-        return v9;
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_aed6(v0.objref<@layout_2>, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b461(v0.@layout_5, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = evm_calldata_load v8;
-        return v9;
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b2c9(v0.objref<@layout_2>, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b705(v0.@layout_5, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = evm_calldata_load v8;
-        return v9;
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b9f2(v0.objref<@layout_2>, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b870(v0.@layout_5, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = evm_calldata_load v8;
-        return v9;
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c2fe(v0.objref<@layout_2>, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b9ca(v0.@layout_5, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = evm_calldata_load v8;
-        return v9;
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_c66d(v0.objref<@layout_5>, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_bae8(v0.@layout_5, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
+}
+
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c259(v0.@layout_5, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
+}
+
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c2d4(v0.@layout_5, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
+}
+
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c32c(v0.@layout_5, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
+}
+
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_c66d(v0.objref<@layout_2>, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -12942,124 +9001,102 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_
         return v9;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c912(v0.objref<@layout_2>, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c700(v0.@layout_5, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = evm_calldata_load v8;
-        return v9;
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_d42e(v0.objref<@layout_2>, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_ce64(v0.@layout_5, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = evm_calldata_load v8;
-        return v9;
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_d5b3(v0.objref<@layout_2>, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_d831(v0.@layout_5, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = evm_calldata_load v8;
-        return v9;
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_dbd0(v0.objref<@layout_2>, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_e134(v0.@layout_5, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = evm_calldata_load v8;
-        return v9;
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_dc0f(v0.objref<@layout_2>, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_faf2(v0.@layout_5, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = evm_calldata_load v8;
-        return v9;
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_e224(v0.objref<@layout_2>, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_fdcb(v0.@layout_5, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = evm_calldata_load v8;
-        return v9;
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_e6fd(v0.objref<@layout_2>, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_fec2(v0.@layout_5, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = evm_calldata_load v8;
-        return v9;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_ee40(v0.objref<@layout_2>, v1.i256) -> i256 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = evm_calldata_load v8;
-        return v9;
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
 }
 
 func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_1cfc(v0.i256, v1.@layout_0) -> i256 {
@@ -13075,7 +9112,7 @@ func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e
         return v7;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_2c8a(v0.i256, v1.@layout_24) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_2c8a(v0.i256, v1.@layout_22) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v0 i256;
@@ -13218,7 +9255,7 @@ func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__w
         return 32.i256;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_ba59(v0.i256, v1.@layout_24) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_ba59(v0.i256, v1.@layout_22) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v0 i256;
@@ -13247,7 +9284,7 @@ func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__wri
         return v20;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_ba59_0(v0.i256, v1.@layout_24) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_ba59_0(v0.i256, v1.@layout_22) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v0 i256;
@@ -13276,7 +9313,7 @@ func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__wri
         return v20;
 }
 
-func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_ba59_1(v0.i256, v1.@layout_24) -> i256 {
+func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_ba59_1(v0.i256, v1.@layout_22) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v0 i256;
@@ -13305,7 +9342,7 @@ func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__wri
         return v20;
 }
 
-func inline(always) private %write_key__g6d15(v0.i256, v1.@layout_15) -> i256 {
+func inline(always) private %write_key__g6d15(v0.i256, v1.@layout_16) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v0 i256;

--- a/crates/codegen/tests/fixtures/sonatina_ir/erc20.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/erc20.snap
@@ -7461,7 +7461,7 @@ func private %impl_trait_u8__encode__g426c(v0.i8, v1.objref<@layout_1>) {
         return;
 }
 
-func private %core__lib__abi__encode_alloc__gac80_492c(v0.i256) -> @layout_21 {
+func inline(always) private %core__lib__abi__encode_alloc__gac80_492c(v0.i256) -> @layout_21 {
     block0:
         jump block1;
 
@@ -7486,7 +7486,7 @@ func private %core__lib__abi__encode_alloc__gac80_492c(v0.i256) -> @layout_21 {
         return v16;
 }
 
-func private %core__lib__abi__encode_alloc__gac80_c438(v0.i256) -> @layout_21 {
+func inline(always) private %core__lib__abi__encode_alloc__gac80_c438(v0.i256) -> @layout_21 {
     block0:
         jump block1;
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/erc20.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/erc20.snap
@@ -3090,6 +3090,216 @@ func inline(always) private %impl_trait_TransferFrom__decode_from__gd20d(v0.@lay
         return v42;
 }
 
+func inline(always) private %decode_from_checked_head__g76d6(v0.@layout_5, v1.i256, v2.i256) -> @layout_8 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v4 i256;
+        v7.i256 = mload v3 i256;
+        v8.@layout_8 = call %impl_trait_Mint__decode_from__gd20d v0 v7;
+        return v8;
+}
+
+func inline(always) private %decode_from_checked_head__g051e(v0.@layout_5, v1.i256, v2.i256) {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v4 i256;
+        v7.i256 = mload v3 i256;
+        call %impl_trait_TotalSupply__decode_from__gd20d v0 v7;
+        return;
+}
+
+func inline(always) private %decode_from_checked_head__g6690(v0.@layout_5, v1.i256, v2.i256) -> @layout_13 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v4 i256;
+        v7.i256 = mload v3 i256;
+        v8.@layout_13 = call %impl_trait_TransferFrom__decode_from__gd20d v0 v7;
+        return v8;
+}
+
+func inline(always) private %decode_from_checked_head__g7ea0(v0.@layout_5, v1.i256, v2.i256) -> @layout_11 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v4 i256;
+        v7.i256 = mload v3 i256;
+        v8.@layout_11 = call %impl_trait_BalanceOf__decode_from__gd20d v0 v7;
+        return v8;
+}
+
+func inline(always) private %decode_from_checked_head__g4997(v0.@layout_5, v1.i256, v2.i256) {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v4 i256;
+        v7.i256 = mload v3 i256;
+        call %impl_trait_Decimals__decode_from__gd20d v0 v7;
+        return;
+}
+
+func inline(always) private %decode_from_checked_head__g205f(v0.@layout_5, v1.i256, v2.i256) -> @layout_14 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v4 i256;
+        v7.i256 = mload v3 i256;
+        v8.@layout_14 = call %impl_trait_Transfer__decode_from__gd20d v0 v7;
+        return v8;
+}
+
+func inline(always) private %decode_from_checked_head__gbd88(v0.@layout_5, v1.i256, v2.i256) {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v4 i256;
+        v7.i256 = mload v3 i256;
+        call %impl_trait_Name__decode_from__gd20d v0 v7;
+        return;
+}
+
+func inline(always) private %decode_from_checked_head__g7d8c(v0.@layout_5, v1.i256, v2.i256) -> @layout_12 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v4 i256;
+        v7.i256 = mload v3 i256;
+        v8.@layout_12 = call %impl_trait_IncreaseAllowance__decode_from__gd20d v0 v7;
+        return v8;
+}
+
+func inline(always) private %decode_from_checked_head__g5470(v0.@layout_5, v1.i256, v2.i256) -> @layout_6 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v4 i256;
+        v7.i256 = mload v3 i256;
+        v8.@layout_6 = call %impl_trait_Allowance__decode_from__gd20d v0 v7;
+        return v8;
+}
+
+func inline(always) private %decode_from_checked_head__g691a(v0.@layout_5, v1.i256, v2.i256) {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v4 i256;
+        v7.i256 = mload v3 i256;
+        call %impl_trait_Symbol__decode_from__gd20d v0 v7;
+        return;
+}
+
+func inline(always) private %decode_from_checked_head__g41f8(v0.@layout_5, v1.i256, v2.i256) -> @layout_9 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v4 i256;
+        v7.i256 = mload v3 i256;
+        v8.@layout_9 = call %impl_trait_Burn__decode_from__gd20d v0 v7;
+        return v8;
+}
+
+func inline(always) private %decode_from_checked_head__gad59(v0.@layout_5, v1.i256, v2.i256) -> @layout_10 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v4 i256;
+        v7.i256 = mload v3 i256;
+        v8.@layout_10 = call %impl_trait_BurnFrom__decode_from__gd20d v0 v7;
+        return v8;
+}
+
+func inline(always) private %decode_from_checked_head__gab8c(v0.@layout_5, v1.i256, v2.i256) -> @layout_7 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v4 i256;
+        v7.i256 = mload v3 i256;
+        v8.@layout_7 = call %impl_trait_Approve__decode_from__gd20d v0 v7;
+        return v8;
+}
+
+func inline(always) private %decode_from_checked_head__g383e(v0.@layout_5, v1.i256, v2.i256) -> @layout_15 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v4 i256;
+        v7.i256 = mload v3 i256;
+        v8.@layout_15 = call %impl_trait_DecreaseAllowance__decode_from__gd20d v0 v7;
+        return v8;
+}
+
 func inline(always) private %impl_trait_Transfer__decode_from__gd20d(v0.@layout_5, v1.i256) -> @layout_14 {
     block0:
         v2.*i256 = alloca i256;
@@ -3279,18 +3489,14 @@ func inline(always) private %decode_runtime_args__g5a0b(v0.objref<@layout_18>) {
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
         v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v5.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_cd56;
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_fc14 v5;
-        mstore v1 v7 i256;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt 4.i256 v9;
-        br v10 block2 block3;
+        v4.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_cd56;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_fc14 v4;
+        mstore v1 v6 i256;
+        mstore v2 4.i256 i256;
+        br 0.i1 block2 block5;
 
     block2:
         call %std__lib__evm__effects__impl_trait_Evm_c913__abort_57a6;
@@ -3300,35 +3506,16 @@ func inline(always) private %decode_runtime_args__g5a0b(v0.objref<@layout_18>) {
         jump block4;
 
     block4:
-        br 1.i1 block5 block6;
-
-    block5:
-        mstore v3 4.i256 i256;
-        br 0.i1 block8 block11;
-
-    block6:
-        jump block7;
-
-    block7:
-        call %impl_trait_Decimals__decode_from__gd20d v5 4.i256;
+        v11.i256 = mload v1 i256;
+        call %decode_from_checked_head__g4997 v4 4.i256 v11;
         return;
 
-    block8:
-        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_57a6;
-        unreachable;
-
-    block9:
-        jump block10;
-
-    block10:
-        jump block7;
-
-    block11:
-        v17.i256 = mload v1 i256;
-        mstore v4 v17 i256;
-        v19.i256 = mload v4 i256;
-        v20.i1 = gt 4.i256 v19;
-        br v20 block8 block9;
+    block5:
+        v13.i256 = mload v1 i256;
+        mstore v3 v13 i256;
+        v15.i256 = mload v3 i256;
+        v16.i1 = gt 4.i256 v15;
+        br v16 block2 block3;
 }
 
 func inline(always) private %decode_runtime_args__g6a7c(v0.objref<@layout_18>) -> @layout_15 {
@@ -3336,18 +3523,14 @@ func inline(always) private %decode_runtime_args__g6a7c(v0.objref<@layout_18>) -
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
         v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v5.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_663b;
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_5dcb v5;
-        mstore v1 v7 i256;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt 4.i256 v9;
-        br v10 block2 block3;
+        v4.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_663b;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_5dcb v4;
+        mstore v1 v6 i256;
+        mstore v2 4.i256 i256;
+        br 0.i1 block2 block5;
 
     block2:
         call %std__lib__evm__effects__impl_trait_Evm_c913__abort_20f2;
@@ -3357,35 +3540,16 @@ func inline(always) private %decode_runtime_args__g6a7c(v0.objref<@layout_18>) -
         jump block4;
 
     block4:
-        br 1.i1 block5 block6;
+        v12.i256 = mload v1 i256;
+        v13.@layout_15 = call %decode_from_checked_head__g383e v4 4.i256 v12;
+        return v13;
 
     block5:
-        mstore v3 4.i256 i256;
-        br 0.i1 block8 block11;
-
-    block6:
-        jump block7;
-
-    block7:
-        v17.@layout_15 = call %impl_trait_DecreaseAllowance__decode_from__gd20d v5 4.i256;
-        return v17;
-
-    block8:
-        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_20f2;
-        unreachable;
-
-    block9:
-        jump block10;
-
-    block10:
-        jump block7;
-
-    block11:
-        v18.i256 = mload v1 i256;
-        mstore v4 v18 i256;
-        v20.i256 = mload v4 i256;
-        v21.i1 = gt 68.i256 v20;
-        br v21 block8 block9;
+        v14.i256 = mload v1 i256;
+        mstore v3 v14 i256;
+        v16.i256 = mload v3 i256;
+        v17.i1 = gt 68.i256 v16;
+        br v17 block2 block3;
 }
 
 func inline(always) private %decode_runtime_args__g7a2c(v0.objref<@layout_18>) -> @layout_7 {
@@ -3393,18 +3557,14 @@ func inline(always) private %decode_runtime_args__g7a2c(v0.objref<@layout_18>) -
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
         v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v5.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_a580;
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_22ff v5;
-        mstore v1 v7 i256;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt 4.i256 v9;
-        br v10 block2 block3;
+        v4.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_a580;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_22ff v4;
+        mstore v1 v6 i256;
+        mstore v2 4.i256 i256;
+        br 0.i1 block2 block5;
 
     block2:
         call %std__lib__evm__effects__impl_trait_Evm_c913__abort_ce6e;
@@ -3414,35 +3574,16 @@ func inline(always) private %decode_runtime_args__g7a2c(v0.objref<@layout_18>) -
         jump block4;
 
     block4:
-        br 1.i1 block5 block6;
+        v12.i256 = mload v1 i256;
+        v13.@layout_7 = call %decode_from_checked_head__gab8c v4 4.i256 v12;
+        return v13;
 
     block5:
-        mstore v3 4.i256 i256;
-        br 0.i1 block8 block11;
-
-    block6:
-        jump block7;
-
-    block7:
-        v17.@layout_7 = call %impl_trait_Approve__decode_from__gd20d v5 4.i256;
-        return v17;
-
-    block8:
-        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_ce6e;
-        unreachable;
-
-    block9:
-        jump block10;
-
-    block10:
-        jump block7;
-
-    block11:
-        v18.i256 = mload v1 i256;
-        mstore v4 v18 i256;
-        v20.i256 = mload v4 i256;
-        v21.i1 = gt 68.i256 v20;
-        br v21 block8 block9;
+        v14.i256 = mload v1 i256;
+        mstore v3 v14 i256;
+        v16.i256 = mload v3 i256;
+        v17.i1 = gt 68.i256 v16;
+        br v17 block2 block3;
 }
 
 func inline(always) private %decode_runtime_args__g295c(v0.objref<@layout_18>) {
@@ -3450,18 +3591,14 @@ func inline(always) private %decode_runtime_args__g295c(v0.objref<@layout_18>) {
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
         v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v5.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_5bd8;
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_ae2f v5;
-        mstore v1 v7 i256;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt 4.i256 v9;
-        br v10 block2 block3;
+        v4.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_5bd8;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_ae2f v4;
+        mstore v1 v6 i256;
+        mstore v2 4.i256 i256;
+        br 0.i1 block2 block5;
 
     block2:
         call %std__lib__evm__effects__impl_trait_Evm_c913__abort_9941;
@@ -3471,35 +3608,16 @@ func inline(always) private %decode_runtime_args__g295c(v0.objref<@layout_18>) {
         jump block4;
 
     block4:
-        br 1.i1 block5 block6;
-
-    block5:
-        mstore v3 4.i256 i256;
-        br 0.i1 block8 block11;
-
-    block6:
-        jump block7;
-
-    block7:
-        call %impl_trait_Symbol__decode_from__gd20d v5 4.i256;
+        v11.i256 = mload v1 i256;
+        call %decode_from_checked_head__g691a v4 4.i256 v11;
         return;
 
-    block8:
-        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_9941;
-        unreachable;
-
-    block9:
-        jump block10;
-
-    block10:
-        jump block7;
-
-    block11:
-        v17.i256 = mload v1 i256;
-        mstore v4 v17 i256;
-        v19.i256 = mload v4 i256;
-        v20.i1 = gt 4.i256 v19;
-        br v20 block8 block9;
+    block5:
+        v13.i256 = mload v1 i256;
+        mstore v3 v13 i256;
+        v15.i256 = mload v3 i256;
+        v16.i1 = gt 4.i256 v15;
+        br v16 block2 block3;
 }
 
 func inline(always) private %decode_runtime_args__gce7d(v0.objref<@layout_18>) {
@@ -3507,18 +3625,14 @@ func inline(always) private %decode_runtime_args__gce7d(v0.objref<@layout_18>) {
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
         v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v5.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_88e5;
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_9efd v5;
-        mstore v1 v7 i256;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt 4.i256 v9;
-        br v10 block2 block3;
+        v4.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_88e5;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_9efd v4;
+        mstore v1 v6 i256;
+        mstore v2 4.i256 i256;
+        br 0.i1 block2 block5;
 
     block2:
         call %std__lib__evm__effects__impl_trait_Evm_c913__abort_b229;
@@ -3528,35 +3642,16 @@ func inline(always) private %decode_runtime_args__gce7d(v0.objref<@layout_18>) {
         jump block4;
 
     block4:
-        br 1.i1 block5 block6;
-
-    block5:
-        mstore v3 4.i256 i256;
-        br 0.i1 block8 block11;
-
-    block6:
-        jump block7;
-
-    block7:
-        call %impl_trait_TotalSupply__decode_from__gd20d v5 4.i256;
+        v11.i256 = mload v1 i256;
+        call %decode_from_checked_head__g051e v4 4.i256 v11;
         return;
 
-    block8:
-        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_b229;
-        unreachable;
-
-    block9:
-        jump block10;
-
-    block10:
-        jump block7;
-
-    block11:
-        v17.i256 = mload v1 i256;
-        mstore v4 v17 i256;
-        v19.i256 = mload v4 i256;
-        v20.i1 = gt 4.i256 v19;
-        br v20 block8 block9;
+    block5:
+        v13.i256 = mload v1 i256;
+        mstore v3 v13 i256;
+        v15.i256 = mload v3 i256;
+        v16.i1 = gt 4.i256 v15;
+        br v16 block2 block3;
 }
 
 func inline(always) private %decode_runtime_args__g2273(v0.objref<@layout_18>) -> @layout_8 {
@@ -3564,18 +3659,14 @@ func inline(always) private %decode_runtime_args__g2273(v0.objref<@layout_18>) -
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
         v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v5.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_f89e;
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_5742 v5;
-        mstore v1 v7 i256;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt 4.i256 v9;
-        br v10 block2 block3;
+        v4.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_f89e;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_5742 v4;
+        mstore v1 v6 i256;
+        mstore v2 4.i256 i256;
+        br 0.i1 block2 block5;
 
     block2:
         call %std__lib__evm__effects__impl_trait_Evm_c913__abort_0a69;
@@ -3585,35 +3676,16 @@ func inline(always) private %decode_runtime_args__g2273(v0.objref<@layout_18>) -
         jump block4;
 
     block4:
-        br 1.i1 block5 block6;
+        v12.i256 = mload v1 i256;
+        v13.@layout_8 = call %decode_from_checked_head__g76d6 v4 4.i256 v12;
+        return v13;
 
     block5:
-        mstore v3 4.i256 i256;
-        br 0.i1 block8 block11;
-
-    block6:
-        jump block7;
-
-    block7:
-        v17.@layout_8 = call %impl_trait_Mint__decode_from__gd20d v5 4.i256;
-        return v17;
-
-    block8:
-        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_0a69;
-        unreachable;
-
-    block9:
-        jump block10;
-
-    block10:
-        jump block7;
-
-    block11:
-        v18.i256 = mload v1 i256;
-        mstore v4 v18 i256;
-        v20.i256 = mload v4 i256;
-        v21.i1 = gt 68.i256 v20;
-        br v21 block8 block9;
+        v14.i256 = mload v1 i256;
+        mstore v3 v14 i256;
+        v16.i256 = mload v3 i256;
+        v17.i1 = gt 68.i256 v16;
+        br v17 block2 block3;
 }
 
 func inline(always) private %decode_runtime_args__g4e54(v0.objref<@layout_18>) -> @layout_13 {
@@ -3621,18 +3693,14 @@ func inline(always) private %decode_runtime_args__g4e54(v0.objref<@layout_18>) -
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
         v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v5.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_3dc9;
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_ce93 v5;
-        mstore v1 v7 i256;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt 4.i256 v9;
-        br v10 block2 block3;
+        v4.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_3dc9;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_ce93 v4;
+        mstore v1 v6 i256;
+        mstore v2 4.i256 i256;
+        br 0.i1 block2 block5;
 
     block2:
         call %std__lib__evm__effects__impl_trait_Evm_c913__abort_2f36;
@@ -3642,35 +3710,16 @@ func inline(always) private %decode_runtime_args__g4e54(v0.objref<@layout_18>) -
         jump block4;
 
     block4:
-        br 1.i1 block5 block6;
+        v12.i256 = mload v1 i256;
+        v13.@layout_13 = call %decode_from_checked_head__g6690 v4 4.i256 v12;
+        return v13;
 
     block5:
-        mstore v3 4.i256 i256;
-        br 0.i1 block8 block11;
-
-    block6:
-        jump block7;
-
-    block7:
-        v17.@layout_13 = call %impl_trait_TransferFrom__decode_from__gd20d v5 4.i256;
-        return v17;
-
-    block8:
-        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_2f36;
-        unreachable;
-
-    block9:
-        jump block10;
-
-    block10:
-        jump block7;
-
-    block11:
-        v18.i256 = mload v1 i256;
-        mstore v4 v18 i256;
-        v20.i256 = mload v4 i256;
-        v21.i1 = gt 100.i256 v20;
-        br v21 block8 block9;
+        v14.i256 = mload v1 i256;
+        mstore v3 v14 i256;
+        v16.i256 = mload v3 i256;
+        v17.i1 = gt 100.i256 v16;
+        br v17 block2 block3;
 }
 
 func inline(always) private %decode_runtime_args__g698d(v0.objref<@layout_18>) -> @layout_12 {
@@ -3678,18 +3727,14 @@ func inline(always) private %decode_runtime_args__g698d(v0.objref<@layout_18>) -
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
         v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v5.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_d673;
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_f03b v5;
-        mstore v1 v7 i256;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt 4.i256 v9;
-        br v10 block2 block3;
+        v4.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_d673;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_f03b v4;
+        mstore v1 v6 i256;
+        mstore v2 4.i256 i256;
+        br 0.i1 block2 block5;
 
     block2:
         call %std__lib__evm__effects__impl_trait_Evm_c913__abort_cb5c;
@@ -3699,35 +3744,16 @@ func inline(always) private %decode_runtime_args__g698d(v0.objref<@layout_18>) -
         jump block4;
 
     block4:
-        br 1.i1 block5 block6;
+        v12.i256 = mload v1 i256;
+        v13.@layout_12 = call %decode_from_checked_head__g7d8c v4 4.i256 v12;
+        return v13;
 
     block5:
-        mstore v3 4.i256 i256;
-        br 0.i1 block8 block11;
-
-    block6:
-        jump block7;
-
-    block7:
-        v17.@layout_12 = call %impl_trait_IncreaseAllowance__decode_from__gd20d v5 4.i256;
-        return v17;
-
-    block8:
-        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_cb5c;
-        unreachable;
-
-    block9:
-        jump block10;
-
-    block10:
-        jump block7;
-
-    block11:
-        v18.i256 = mload v1 i256;
-        mstore v4 v18 i256;
-        v20.i256 = mload v4 i256;
-        v21.i1 = gt 68.i256 v20;
-        br v21 block8 block9;
+        v14.i256 = mload v1 i256;
+        mstore v3 v14 i256;
+        v16.i256 = mload v3 i256;
+        v17.i1 = gt 68.i256 v16;
+        br v17 block2 block3;
 }
 
 func inline(always) private %decode_runtime_args__gc772(v0.objref<@layout_18>) -> @layout_6 {
@@ -3735,18 +3761,14 @@ func inline(always) private %decode_runtime_args__gc772(v0.objref<@layout_18>) -
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
         v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v5.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_3347;
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_4a91 v5;
-        mstore v1 v7 i256;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt 4.i256 v9;
-        br v10 block2 block3;
+        v4.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_3347;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_4a91 v4;
+        mstore v1 v6 i256;
+        mstore v2 4.i256 i256;
+        br 0.i1 block2 block5;
 
     block2:
         call %std__lib__evm__effects__impl_trait_Evm_c913__abort_12ed;
@@ -3756,35 +3778,16 @@ func inline(always) private %decode_runtime_args__gc772(v0.objref<@layout_18>) -
         jump block4;
 
     block4:
-        br 1.i1 block5 block6;
+        v12.i256 = mload v1 i256;
+        v13.@layout_6 = call %decode_from_checked_head__g5470 v4 4.i256 v12;
+        return v13;
 
     block5:
-        mstore v3 4.i256 i256;
-        br 0.i1 block8 block11;
-
-    block6:
-        jump block7;
-
-    block7:
-        v17.@layout_6 = call %impl_trait_Allowance__decode_from__gd20d v5 4.i256;
-        return v17;
-
-    block8:
-        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_12ed;
-        unreachable;
-
-    block9:
-        jump block10;
-
-    block10:
-        jump block7;
-
-    block11:
-        v18.i256 = mload v1 i256;
-        mstore v4 v18 i256;
-        v20.i256 = mload v4 i256;
-        v21.i1 = gt 68.i256 v20;
-        br v21 block8 block9;
+        v14.i256 = mload v1 i256;
+        mstore v3 v14 i256;
+        v16.i256 = mload v3 i256;
+        v17.i1 = gt 68.i256 v16;
+        br v17 block2 block3;
 }
 
 func inline(always) private %decode_runtime_args__g953d(v0.objref<@layout_18>) -> @layout_11 {
@@ -3792,18 +3795,14 @@ func inline(always) private %decode_runtime_args__g953d(v0.objref<@layout_18>) -
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
         v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v5.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_b73f;
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_6107 v5;
-        mstore v1 v7 i256;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt 4.i256 v9;
-        br v10 block2 block3;
+        v4.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_b73f;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_6107 v4;
+        mstore v1 v6 i256;
+        mstore v2 4.i256 i256;
+        br 0.i1 block2 block5;
 
     block2:
         call %std__lib__evm__effects__impl_trait_Evm_c913__abort_6993;
@@ -3813,35 +3812,16 @@ func inline(always) private %decode_runtime_args__g953d(v0.objref<@layout_18>) -
         jump block4;
 
     block4:
-        br 1.i1 block5 block6;
+        v12.i256 = mload v1 i256;
+        v13.@layout_11 = call %decode_from_checked_head__g7ea0 v4 4.i256 v12;
+        return v13;
 
     block5:
-        mstore v3 4.i256 i256;
-        br 0.i1 block8 block11;
-
-    block6:
-        jump block7;
-
-    block7:
-        v17.@layout_11 = call %impl_trait_BalanceOf__decode_from__gd20d v5 4.i256;
-        return v17;
-
-    block8:
-        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_6993;
-        unreachable;
-
-    block9:
-        jump block10;
-
-    block10:
-        jump block7;
-
-    block11:
-        v18.i256 = mload v1 i256;
-        mstore v4 v18 i256;
-        v20.i256 = mload v4 i256;
-        v21.i1 = gt 36.i256 v20;
-        br v21 block8 block9;
+        v14.i256 = mload v1 i256;
+        mstore v3 v14 i256;
+        v16.i256 = mload v3 i256;
+        v17.i1 = gt 36.i256 v16;
+        br v17 block2 block3;
 }
 
 func inline(always) private %decode_runtime_args__g216b(v0.objref<@layout_18>) -> @layout_10 {
@@ -3849,18 +3829,14 @@ func inline(always) private %decode_runtime_args__g216b(v0.objref<@layout_18>) -
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
         v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v5.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_6a54;
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_7388 v5;
-        mstore v1 v7 i256;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt 4.i256 v9;
-        br v10 block2 block3;
+        v4.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_6a54;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_7388 v4;
+        mstore v1 v6 i256;
+        mstore v2 4.i256 i256;
+        br 0.i1 block2 block5;
 
     block2:
         call %std__lib__evm__effects__impl_trait_Evm_c913__abort_cf57;
@@ -3870,35 +3846,16 @@ func inline(always) private %decode_runtime_args__g216b(v0.objref<@layout_18>) -
         jump block4;
 
     block4:
-        br 1.i1 block5 block6;
+        v12.i256 = mload v1 i256;
+        v13.@layout_10 = call %decode_from_checked_head__gad59 v4 4.i256 v12;
+        return v13;
 
     block5:
-        mstore v3 4.i256 i256;
-        br 0.i1 block8 block11;
-
-    block6:
-        jump block7;
-
-    block7:
-        v17.@layout_10 = call %impl_trait_BurnFrom__decode_from__gd20d v5 4.i256;
-        return v17;
-
-    block8:
-        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_cf57;
-        unreachable;
-
-    block9:
-        jump block10;
-
-    block10:
-        jump block7;
-
-    block11:
-        v18.i256 = mload v1 i256;
-        mstore v4 v18 i256;
-        v20.i256 = mload v4 i256;
-        v21.i1 = gt 68.i256 v20;
-        br v21 block8 block9;
+        v14.i256 = mload v1 i256;
+        mstore v3 v14 i256;
+        v16.i256 = mload v3 i256;
+        v17.i1 = gt 68.i256 v16;
+        br v17 block2 block3;
 }
 
 func inline(always) private %decode_runtime_args__gf629(v0.objref<@layout_18>) -> @layout_9 {
@@ -3906,18 +3863,14 @@ func inline(always) private %decode_runtime_args__gf629(v0.objref<@layout_18>) -
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
         v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v5.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_e029;
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_c018 v5;
-        mstore v1 v7 i256;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt 4.i256 v9;
-        br v10 block2 block3;
+        v4.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_e029;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_c018 v4;
+        mstore v1 v6 i256;
+        mstore v2 4.i256 i256;
+        br 0.i1 block2 block5;
 
     block2:
         call %std__lib__evm__effects__impl_trait_Evm_c913__abort_98a8;
@@ -3927,35 +3880,16 @@ func inline(always) private %decode_runtime_args__gf629(v0.objref<@layout_18>) -
         jump block4;
 
     block4:
-        br 1.i1 block5 block6;
+        v12.i256 = mload v1 i256;
+        v13.@layout_9 = call %decode_from_checked_head__g41f8 v4 4.i256 v12;
+        return v13;
 
     block5:
-        mstore v3 4.i256 i256;
-        br 0.i1 block8 block11;
-
-    block6:
-        jump block7;
-
-    block7:
-        v17.@layout_9 = call %impl_trait_Burn__decode_from__gd20d v5 4.i256;
-        return v17;
-
-    block8:
-        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_98a8;
-        unreachable;
-
-    block9:
-        jump block10;
-
-    block10:
-        jump block7;
-
-    block11:
-        v18.i256 = mload v1 i256;
-        mstore v4 v18 i256;
-        v20.i256 = mload v4 i256;
-        v21.i1 = gt 36.i256 v20;
-        br v21 block8 block9;
+        v14.i256 = mload v1 i256;
+        mstore v3 v14 i256;
+        v16.i256 = mload v3 i256;
+        v17.i1 = gt 36.i256 v16;
+        br v17 block2 block3;
 }
 
 func inline(always) private %decode_runtime_args__gce2e(v0.objref<@layout_18>) {
@@ -3963,18 +3897,14 @@ func inline(always) private %decode_runtime_args__gce2e(v0.objref<@layout_18>) {
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
         v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v5.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_844a;
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_b318 v5;
-        mstore v1 v7 i256;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt 4.i256 v9;
-        br v10 block2 block3;
+        v4.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_844a;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_b318 v4;
+        mstore v1 v6 i256;
+        mstore v2 4.i256 i256;
+        br 0.i1 block2 block5;
 
     block2:
         call %std__lib__evm__effects__impl_trait_Evm_c913__abort_66b1;
@@ -3984,35 +3914,16 @@ func inline(always) private %decode_runtime_args__gce2e(v0.objref<@layout_18>) {
         jump block4;
 
     block4:
-        br 1.i1 block5 block6;
-
-    block5:
-        mstore v3 4.i256 i256;
-        br 0.i1 block8 block11;
-
-    block6:
-        jump block7;
-
-    block7:
-        call %impl_trait_Name__decode_from__gd20d v5 4.i256;
+        v11.i256 = mload v1 i256;
+        call %decode_from_checked_head__gbd88 v4 4.i256 v11;
         return;
 
-    block8:
-        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_66b1;
-        unreachable;
-
-    block9:
-        jump block10;
-
-    block10:
-        jump block7;
-
-    block11:
-        v17.i256 = mload v1 i256;
-        mstore v4 v17 i256;
-        v19.i256 = mload v4 i256;
-        v20.i1 = gt 4.i256 v19;
-        br v20 block8 block9;
+    block5:
+        v13.i256 = mload v1 i256;
+        mstore v3 v13 i256;
+        v15.i256 = mload v3 i256;
+        v16.i1 = gt 4.i256 v15;
+        br v16 block2 block3;
 }
 
 func inline(always) private %decode_runtime_args__ge035(v0.objref<@layout_18>) -> @layout_14 {
@@ -4020,18 +3931,14 @@ func inline(always) private %decode_runtime_args__ge035(v0.objref<@layout_18>) -
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
         v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v5.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_dac7;
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_1a14 v5;
-        mstore v1 v7 i256;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt 4.i256 v9;
-        br v10 block2 block3;
+        v4.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_dac7;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_1a14 v4;
+        mstore v1 v6 i256;
+        mstore v2 4.i256 i256;
+        br 0.i1 block2 block5;
 
     block2:
         call %std__lib__evm__effects__impl_trait_Evm_c913__abort_a20a;
@@ -4041,35 +3948,16 @@ func inline(always) private %decode_runtime_args__ge035(v0.objref<@layout_18>) -
         jump block4;
 
     block4:
-        br 1.i1 block5 block6;
+        v12.i256 = mload v1 i256;
+        v13.@layout_14 = call %decode_from_checked_head__g205f v4 4.i256 v12;
+        return v13;
 
     block5:
-        mstore v3 4.i256 i256;
-        br 0.i1 block8 block11;
-
-    block6:
-        jump block7;
-
-    block7:
-        v17.@layout_14 = call %impl_trait_Transfer__decode_from__gd20d v5 4.i256;
-        return v17;
-
-    block8:
-        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_a20a;
-        unreachable;
-
-    block9:
-        jump block10;
-
-    block10:
-        jump block7;
-
-    block11:
-        v18.i256 = mload v1 i256;
-        mstore v4 v18 i256;
-        v20.i256 = mload v4 i256;
-        v21.i1 = gt 68.i256 v20;
-        br v21 block8 block9;
+        v14.i256 = mload v1 i256;
+        mstore v3 v14 i256;
+        v16.i256 = mload v3 i256;
+        v17.i1 = gt 68.i256 v16;
+        br v17 block2 block3;
 }
 
 func private %decoder_new(v0.@layout_2) -> @layout_4 {

--- a/crates/codegen/tests/fixtures/sonatina_ir/erc20.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/erc20.snap
@@ -914,6 +914,132 @@ func private %std__lib__abi__sol__types__impl_trait_Address_0a07__as_topic_c497(
         return v4;
 }
 
+func inline(always) private %std__lib__abi__sol__impl_SolEncoder_ce34__at_0e5a(v0.i256) -> @layout_1 {
+    block0:
+        v1.*i256 = alloca i256;
+        mstore v1 v0 i256;
+        jump block1;
+
+    block1:
+        v2.i256 = mload v1 i256;
+        v3.i256 = mload v1 i256;
+        v4.objref<@layout_1> = obj.alloc @layout_1;
+        v6.objref<i256> = obj.proj v4 0.i256;
+        obj.store v6 v2;
+        v8.objref<i256> = obj.proj v4 1.i256;
+        obj.store v8 v3;
+        v9.@layout_1 = obj.load v4;
+        return v9;
+}
+
+func inline(always) private %std__lib__abi__sol__impl_SolEncoder_ce34__at_31d5(v0.i256) -> @layout_1 {
+    block0:
+        v1.*i256 = alloca i256;
+        mstore v1 v0 i256;
+        jump block1;
+
+    block1:
+        v2.i256 = mload v1 i256;
+        v3.i256 = mload v1 i256;
+        v4.objref<@layout_1> = obj.alloc @layout_1;
+        v6.objref<i256> = obj.proj v4 0.i256;
+        obj.store v6 v2;
+        v8.objref<i256> = obj.proj v4 1.i256;
+        obj.store v8 v3;
+        v9.@layout_1 = obj.load v4;
+        return v9;
+}
+
+func inline(always) private %std__lib__abi__sol__impl_SolEncoder_ce34__at_3361(v0.i256) -> @layout_1 {
+    block0:
+        v1.*i256 = alloca i256;
+        mstore v1 v0 i256;
+        jump block1;
+
+    block1:
+        v2.i256 = mload v1 i256;
+        v3.i256 = mload v1 i256;
+        v4.objref<@layout_1> = obj.alloc @layout_1;
+        v6.objref<i256> = obj.proj v4 0.i256;
+        obj.store v6 v2;
+        v8.objref<i256> = obj.proj v4 1.i256;
+        obj.store v8 v3;
+        v9.@layout_1 = obj.load v4;
+        return v9;
+}
+
+func inline(always) private %std__lib__abi__sol__impl_SolEncoder_ce34__at_65fb(v0.i256) -> @layout_1 {
+    block0:
+        v1.*i256 = alloca i256;
+        mstore v1 v0 i256;
+        jump block1;
+
+    block1:
+        v2.i256 = mload v1 i256;
+        v3.i256 = mload v1 i256;
+        v4.objref<@layout_1> = obj.alloc @layout_1;
+        v6.objref<i256> = obj.proj v4 0.i256;
+        obj.store v6 v2;
+        v8.objref<i256> = obj.proj v4 1.i256;
+        obj.store v8 v3;
+        v9.@layout_1 = obj.load v4;
+        return v9;
+}
+
+func inline(always) private %std__lib__abi__sol__impl_SolEncoder_ce34__at_6792(v0.i256) -> @layout_1 {
+    block0:
+        v1.*i256 = alloca i256;
+        mstore v1 v0 i256;
+        jump block1;
+
+    block1:
+        v2.i256 = mload v1 i256;
+        v3.i256 = mload v1 i256;
+        v4.objref<@layout_1> = obj.alloc @layout_1;
+        v6.objref<i256> = obj.proj v4 0.i256;
+        obj.store v6 v2;
+        v8.objref<i256> = obj.proj v4 1.i256;
+        obj.store v8 v3;
+        v9.@layout_1 = obj.load v4;
+        return v9;
+}
+
+func inline(always) private %std__lib__abi__sol__impl_SolEncoder_ce34__at_69c8(v0.i256) -> @layout_1 {
+    block0:
+        v1.*i256 = alloca i256;
+        mstore v1 v0 i256;
+        jump block1;
+
+    block1:
+        v2.i256 = mload v1 i256;
+        v3.i256 = mload v1 i256;
+        v4.objref<@layout_1> = obj.alloc @layout_1;
+        v6.objref<i256> = obj.proj v4 0.i256;
+        obj.store v6 v2;
+        v8.objref<i256> = obj.proj v4 1.i256;
+        obj.store v8 v3;
+        v9.@layout_1 = obj.load v4;
+        return v9;
+}
+
+func inline(always) private %std__lib__abi__sol__impl_SolEncoder_ce34__at_fb00(v0.i256) -> @layout_1 {
+    block0:
+        v1.*i256 = alloca i256;
+        mstore v1 v0 i256;
+        jump block1;
+
+    block1:
+        v2.i256 = mload v1 i256;
+        v3.i256 = mload v1 i256;
+        v4.objref<@layout_1> = obj.alloc @layout_1;
+        v6.objref<i256> = obj.proj v4 0.i256;
+        obj.store v6 v2;
+        v8.objref<i256> = obj.proj v4 1.i256;
+        obj.store v8 v3;
+        v9.@layout_1 = obj.load v4;
+        return v9;
+}
+
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_009f(v0.objref<@layout_1>) -> i256 {
     block0:
         jump block1;
@@ -5930,13 +6056,8 @@ func private %std__lib__abi__sol__impl_SolEncoder_ce34__new_1301(v0.i256) -> @la
 
     block4:
         v8.i256 = phi (0.i256 block2) (v7 block3);
-        v9.objref<@layout_1> = obj.alloc @layout_1;
-        v10.objref<i256> = obj.proj v9 0.i256;
-        obj.store v10 v8;
-        v12.objref<i256> = obj.proj v9 1.i256;
-        obj.store v12 v8;
-        v13.@layout_1 = obj.load v9;
-        return v13;
+        v9.@layout_1 = call %std__lib__abi__sol__impl_SolEncoder_ce34__at_6792 v8;
+        return v9;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_147c() -> @layout_5 {
@@ -5973,13 +6094,8 @@ func private %std__lib__abi__sol__impl_SolEncoder_ce34__new_24a6(v0.i256) -> @la
 
     block4:
         v8.i256 = phi (0.i256 block2) (v7 block3);
-        v9.objref<@layout_1> = obj.alloc @layout_1;
-        v10.objref<i256> = obj.proj v9 0.i256;
-        obj.store v10 v8;
-        v12.objref<i256> = obj.proj v9 1.i256;
-        obj.store v12 v8;
-        v13.@layout_1 = obj.load v9;
-        return v13;
+        v9.@layout_1 = call %std__lib__abi__sol__impl_SolEncoder_ce34__at_0e5a v8;
+        return v9;
 }
 
 func inline(always) private %impl_SolDecoder__new__g463e(v0.@layout_2) -> @layout_4 {
@@ -6065,13 +6181,8 @@ func private %std__lib__abi__sol__impl_SolEncoder_ce34__new_8670(v0.i256) -> @la
 
     block4:
         v8.i256 = phi (0.i256 block2) (v7 block3);
-        v9.objref<@layout_1> = obj.alloc @layout_1;
-        v10.objref<i256> = obj.proj v9 0.i256;
-        obj.store v10 v8;
-        v12.objref<i256> = obj.proj v9 1.i256;
-        obj.store v12 v8;
-        v13.@layout_1 = obj.load v9;
-        return v13;
+        v9.@layout_1 = call %std__lib__abi__sol__impl_SolEncoder_ce34__at_65fb v8;
+        return v9;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_923b() -> @layout_5 {
@@ -6108,13 +6219,8 @@ func private %std__lib__abi__sol__impl_SolEncoder_ce34__new_978f(v0.i256) -> @la
 
     block4:
         v8.i256 = phi (0.i256 block2) (v7 block3);
-        v9.objref<@layout_1> = obj.alloc @layout_1;
-        v10.objref<i256> = obj.proj v9 0.i256;
-        obj.store v10 v8;
-        v12.objref<i256> = obj.proj v9 1.i256;
-        obj.store v12 v8;
-        v13.@layout_1 = obj.load v9;
-        return v13;
+        v9.@layout_1 = call %std__lib__abi__sol__impl_SolEncoder_ce34__at_fb00 v8;
+        return v9;
 }
 
 func inline(always) private %impl_Cursor__new__g463e(v0.@layout_2) -> @layout_3 {
@@ -6194,13 +6300,8 @@ func private %std__lib__abi__sol__impl_SolEncoder_ce34__new_c2ff(v0.i256) -> @la
 
     block4:
         v8.i256 = phi (0.i256 block2) (v7 block3);
-        v9.objref<@layout_1> = obj.alloc @layout_1;
-        v10.objref<i256> = obj.proj v9 0.i256;
-        obj.store v10 v8;
-        v12.objref<i256> = obj.proj v9 1.i256;
-        obj.store v12 v8;
-        v13.@layout_1 = obj.load v9;
-        return v13;
+        v9.@layout_1 = call %std__lib__abi__sol__impl_SolEncoder_ce34__at_69c8 v8;
+        return v9;
 }
 
 func private %std__lib__abi__sol__impl_SolEncoder_ce34__new_c575(v0.i256) -> @layout_1 {
@@ -6225,13 +6326,8 @@ func private %std__lib__abi__sol__impl_SolEncoder_ce34__new_c575(v0.i256) -> @la
 
     block4:
         v8.i256 = phi (0.i256 block2) (v7 block3);
-        v9.objref<@layout_1> = obj.alloc @layout_1;
-        v10.objref<i256> = obj.proj v9 0.i256;
-        obj.store v10 v8;
-        v12.objref<i256> = obj.proj v9 1.i256;
-        obj.store v12 v8;
-        v13.@layout_1 = obj.load v9;
-        return v13;
+        v9.@layout_1 = call %std__lib__abi__sol__impl_SolEncoder_ce34__at_3361 v8;
+        return v9;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_d306() -> @layout_5 {
@@ -6268,13 +6364,8 @@ func private %std__lib__abi__sol__impl_SolEncoder_ce34__new_f042(v0.i256) -> @la
 
     block4:
         v8.i256 = phi (0.i256 block2) (v7 block3);
-        v9.objref<@layout_1> = obj.alloc @layout_1;
-        v10.objref<i256> = obj.proj v9 0.i256;
-        obj.store v10 v8;
-        v12.objref<i256> = obj.proj v9 1.i256;
-        obj.store v12 v8;
-        v13.@layout_1 = obj.load v9;
-        return v13;
+        v9.@layout_1 = call %std__lib__abi__sol__impl_SolEncoder_ce34__at_31d5 v8;
+        return v9;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_f11a() -> @layout_5 {

--- a/crates/codegen/tests/fixtures/sonatina_ir/erc20.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/erc20.snap
@@ -1060,26 +1060,6 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_25d4(v0.objre
         return v4;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_2c1b(v0.objref<@layout_4>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 1.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_2c1b_0(v0.objref<@layout_4>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 1.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_6030(v0.objref<@layout_1>) -> i256 {
     block0:
         jump block1;
@@ -1096,6 +1076,26 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_8751(v0.objre
 
     block1:
         v3.objref<i256> = obj.proj v0 0.i256;
+        v4.i256 = obj.load v3;
+        return v4;
+}
+
+func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_91bf(v0.objref<@layout_4>) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v3.objref<i256> = obj.proj v0 1.i256;
+        v4.i256 = obj.load v3;
+        return v4;
+}
+
+func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_91bf_0(v0.objref<@layout_4>) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v3.objref<i256> = obj.proj v0 1.i256;
         v4.i256 = obj.load v3;
         return v4;
 }
@@ -1337,6 +1337,1315 @@ func private %caller() -> @layout_0 {
         obj.store v3 v0;
         v4.@layout_0 = obj.load v1;
         return v4;
+}
+
+func inline(always) private %core__lib__abi__checked_frame_end__gf13e_01a8(v0.i256, v1.i256, v2.i256) -> i256 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        mstore v3 v0 i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        jump block1;
+
+    block1:
+        v6.i256 = mload v3 i256;
+        v7.i256 = mload v4 i256;
+        (v8.i256, v9.i1) = uaddo v6 v7;
+        br v9 block6 block7;
+
+    block2:
+        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_947f;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        return v8;
+
+    block5:
+        v19.i256 = mload v5 i256;
+        v20.i1 = gt v8 v19;
+        br v20 block2 block3;
+
+    block6:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block7:
+        v15.i256 = mload v3 i256;
+        v16.i1 = lt v8 v15;
+        br v16 block2 block5;
+}
+
+func inline(always) private %core__lib__abi__checked_frame_end__gf13e_4689(v0.i256, v1.i256, v2.i256) -> i256 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        mstore v3 v0 i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        jump block1;
+
+    block1:
+        v6.i256 = mload v3 i256;
+        v7.i256 = mload v4 i256;
+        (v8.i256, v9.i1) = uaddo v6 v7;
+        br v9 block6 block7;
+
+    block2:
+        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_733d;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        return v8;
+
+    block5:
+        v19.i256 = mload v5 i256;
+        v20.i1 = gt v8 v19;
+        br v20 block2 block3;
+
+    block6:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block7:
+        v15.i256 = mload v3 i256;
+        v16.i1 = lt v8 v15;
+        br v16 block2 block5;
+}
+
+func inline(always) private %core__lib__abi__checked_frame_end__gf13e_60b4(v0.i256, v1.i256, v2.i256) -> i256 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        mstore v3 v0 i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        jump block1;
+
+    block1:
+        v6.i256 = mload v3 i256;
+        v7.i256 = mload v4 i256;
+        (v8.i256, v9.i1) = uaddo v6 v7;
+        br v9 block6 block7;
+
+    block2:
+        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_a0e7;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        return v8;
+
+    block5:
+        v19.i256 = mload v5 i256;
+        v20.i1 = gt v8 v19;
+        br v20 block2 block3;
+
+    block6:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block7:
+        v15.i256 = mload v3 i256;
+        v16.i1 = lt v8 v15;
+        br v16 block2 block5;
+}
+
+func inline(always) private %core__lib__abi__checked_frame_end__gf13e_6403(v0.i256, v1.i256, v2.i256) -> i256 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        mstore v3 v0 i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        jump block1;
+
+    block1:
+        v6.i256 = mload v3 i256;
+        v7.i256 = mload v4 i256;
+        (v8.i256, v9.i1) = uaddo v6 v7;
+        br v9 block6 block7;
+
+    block2:
+        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_2004;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        return v8;
+
+    block5:
+        v19.i256 = mload v5 i256;
+        v20.i1 = gt v8 v19;
+        br v20 block2 block3;
+
+    block6:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block7:
+        v15.i256 = mload v3 i256;
+        v16.i1 = lt v8 v15;
+        br v16 block2 block5;
+}
+
+func inline(always) private %core__lib__abi__checked_frame_end__gf13e_9284(v0.i256, v1.i256, v2.i256) -> i256 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        mstore v3 v0 i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        jump block1;
+
+    block1:
+        v6.i256 = mload v3 i256;
+        v7.i256 = mload v4 i256;
+        (v8.i256, v9.i1) = uaddo v6 v7;
+        br v9 block6 block7;
+
+    block2:
+        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_929c;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        return v8;
+
+    block5:
+        v19.i256 = mload v5 i256;
+        v20.i1 = gt v8 v19;
+        br v20 block2 block3;
+
+    block6:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block7:
+        v15.i256 = mload v3 i256;
+        v16.i1 = lt v8 v15;
+        br v16 block2 block5;
+}
+
+func inline(always) private %core__lib__abi__checked_frame_end__gf13e_9888(v0.i256, v1.i256, v2.i256) -> i256 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        mstore v3 v0 i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        jump block1;
+
+    block1:
+        v6.i256 = mload v3 i256;
+        v7.i256 = mload v4 i256;
+        (v8.i256, v9.i1) = uaddo v6 v7;
+        br v9 block6 block7;
+
+    block2:
+        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_7414;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        return v8;
+
+    block5:
+        v19.i256 = mload v5 i256;
+        v20.i1 = gt v8 v19;
+        br v20 block2 block3;
+
+    block6:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block7:
+        v15.i256 = mload v3 i256;
+        v16.i1 = lt v8 v15;
+        br v16 block2 block5;
+}
+
+func inline(always) private %core__lib__abi__checked_frame_end__gf13e_9b12(v0.i256, v1.i256, v2.i256) -> i256 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        mstore v3 v0 i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        jump block1;
+
+    block1:
+        v6.i256 = mload v3 i256;
+        v7.i256 = mload v4 i256;
+        (v8.i256, v9.i1) = uaddo v6 v7;
+        br v9 block6 block7;
+
+    block2:
+        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_dc07;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        return v8;
+
+    block5:
+        v19.i256 = mload v5 i256;
+        v20.i1 = gt v8 v19;
+        br v20 block2 block3;
+
+    block6:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block7:
+        v15.i256 = mload v3 i256;
+        v16.i1 = lt v8 v15;
+        br v16 block2 block5;
+}
+
+func inline(always) private %core__lib__abi__checked_frame_end__gf13e_a584(v0.i256, v1.i256, v2.i256) -> i256 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        mstore v3 v0 i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        jump block1;
+
+    block1:
+        v6.i256 = mload v3 i256;
+        v7.i256 = mload v4 i256;
+        (v8.i256, v9.i1) = uaddo v6 v7;
+        br v9 block6 block7;
+
+    block2:
+        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_4ce8;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        return v8;
+
+    block5:
+        v19.i256 = mload v5 i256;
+        v20.i1 = gt v8 v19;
+        br v20 block2 block3;
+
+    block6:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block7:
+        v15.i256 = mload v3 i256;
+        v16.i1 = lt v8 v15;
+        br v16 block2 block5;
+}
+
+func inline(always) private %core__lib__abi__checked_frame_end__gf13e_aaf5(v0.i256, v1.i256, v2.i256) -> i256 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        mstore v3 v0 i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        jump block1;
+
+    block1:
+        v6.i256 = mload v3 i256;
+        v7.i256 = mload v4 i256;
+        (v8.i256, v9.i1) = uaddo v6 v7;
+        br v9 block6 block7;
+
+    block2:
+        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_39f6;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        return v8;
+
+    block5:
+        v19.i256 = mload v5 i256;
+        v20.i1 = gt v8 v19;
+        br v20 block2 block3;
+
+    block6:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block7:
+        v15.i256 = mload v3 i256;
+        v16.i1 = lt v8 v15;
+        br v16 block2 block5;
+}
+
+func inline(always) private %core__lib__abi__checked_frame_end__gf13e_b8aa(v0.i256, v1.i256, v2.i256) -> i256 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        mstore v3 v0 i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        jump block1;
+
+    block1:
+        v6.i256 = mload v3 i256;
+        v7.i256 = mload v4 i256;
+        (v8.i256, v9.i1) = uaddo v6 v7;
+        br v9 block6 block7;
+
+    block2:
+        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_0b81;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        return v8;
+
+    block5:
+        v19.i256 = mload v5 i256;
+        v20.i1 = gt v8 v19;
+        br v20 block2 block3;
+
+    block6:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block7:
+        v15.i256 = mload v3 i256;
+        v16.i1 = lt v8 v15;
+        br v16 block2 block5;
+}
+
+func inline(always) private %core__lib__abi__checked_frame_end__gf13e_c0b4(v0.i256, v1.i256, v2.i256) -> i256 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        mstore v3 v0 i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        jump block1;
+
+    block1:
+        v6.i256 = mload v3 i256;
+        v7.i256 = mload v4 i256;
+        (v8.i256, v9.i1) = uaddo v6 v7;
+        br v9 block6 block7;
+
+    block2:
+        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_12a9;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        return v8;
+
+    block5:
+        v19.i256 = mload v5 i256;
+        v20.i1 = gt v8 v19;
+        br v20 block2 block3;
+
+    block6:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block7:
+        v15.i256 = mload v3 i256;
+        v16.i1 = lt v8 v15;
+        br v16 block2 block5;
+}
+
+func inline(always) private %core__lib__abi__checked_frame_end__gf13e_c3cb(v0.i256, v1.i256, v2.i256) -> i256 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        mstore v3 v0 i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        jump block1;
+
+    block1:
+        v6.i256 = mload v3 i256;
+        v7.i256 = mload v4 i256;
+        (v8.i256, v9.i1) = uaddo v6 v7;
+        br v9 block6 block7;
+
+    block2:
+        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_a63d;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        return v8;
+
+    block5:
+        v19.i256 = mload v5 i256;
+        v20.i1 = gt v8 v19;
+        br v20 block2 block3;
+
+    block6:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block7:
+        v15.i256 = mload v3 i256;
+        v16.i1 = lt v8 v15;
+        br v16 block2 block5;
+}
+
+func inline(always) private %core__lib__abi__checked_frame_end__gf13e_cc78(v0.i256, v1.i256, v2.i256) -> i256 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        mstore v3 v0 i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        jump block1;
+
+    block1:
+        v6.i256 = mload v3 i256;
+        v7.i256 = mload v4 i256;
+        (v8.i256, v9.i1) = uaddo v6 v7;
+        br v9 block6 block7;
+
+    block2:
+        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_6a0c;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        return v8;
+
+    block5:
+        v19.i256 = mload v5 i256;
+        v20.i1 = gt v8 v19;
+        br v20 block2 block3;
+
+    block6:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block7:
+        v15.i256 = mload v3 i256;
+        v16.i1 = lt v8 v15;
+        br v16 block2 block5;
+}
+
+func inline(always) private %core__lib__abi__checked_frame_end__gf13e_d1eb(v0.i256, v1.i256, v2.i256) -> i256 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        mstore v3 v0 i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        jump block1;
+
+    block1:
+        v6.i256 = mload v3 i256;
+        v7.i256 = mload v4 i256;
+        (v8.i256, v9.i1) = uaddo v6 v7;
+        br v9 block6 block7;
+
+    block2:
+        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_f9e7;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        return v8;
+
+    block5:
+        v19.i256 = mload v5 i256;
+        v20.i1 = gt v8 v19;
+        br v20 block2 block3;
+
+    block6:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block7:
+        v15.i256 = mload v3 i256;
+        v16.i1 = lt v8 v15;
+        br v16 block2 block5;
+}
+
+func inline(always) private %core__lib__abi__checked_frame_end__gf13e_de97(v0.i256, v1.i256, v2.i256) -> i256 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        mstore v3 v0 i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        jump block1;
+
+    block1:
+        v6.i256 = mload v3 i256;
+        v7.i256 = mload v4 i256;
+        (v8.i256, v9.i1) = uaddo v6 v7;
+        br v9 block6 block7;
+
+    block2:
+        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_0d37;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        return v8;
+
+    block5:
+        v19.i256 = mload v5 i256;
+        v20.i1 = gt v8 v19;
+        br v20 block2 block3;
+
+    block6:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block7:
+        v15.i256 = mload v3 i256;
+        v16.i1 = lt v8 v15;
+        br v16 block2 block5;
+}
+
+func inline(always) private %core__lib__abi__checked_frame_end__gf13e_e706(v0.i256, v1.i256, v2.i256) -> i256 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        mstore v3 v0 i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        jump block1;
+
+    block1:
+        v6.i256 = mload v3 i256;
+        v7.i256 = mload v4 i256;
+        (v8.i256, v9.i1) = uaddo v6 v7;
+        br v9 block6 block7;
+
+    block2:
+        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_27a8;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        return v8;
+
+    block5:
+        v19.i256 = mload v5 i256;
+        v20.i1 = gt v8 v19;
+        br v20 block2 block3;
+
+    block6:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block7:
+        v15.i256 = mload v3 i256;
+        v16.i1 = lt v8 v15;
+        br v16 block2 block5;
+}
+
+func inline(always) private %core__lib__abi__checked_frame_end__gf13e_f40a(v0.i256, v1.i256, v2.i256) -> i256 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        mstore v3 v0 i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        jump block1;
+
+    block1:
+        v6.i256 = mload v3 i256;
+        v7.i256 = mload v4 i256;
+        (v8.i256, v9.i1) = uaddo v6 v7;
+        br v9 block6 block7;
+
+    block2:
+        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_23e2;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        return v8;
+
+    block5:
+        v19.i256 = mload v5 i256;
+        v20.i1 = gt v8 v19;
+        br v20 block2 block3;
+
+    block6:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block7:
+        v15.i256 = mload v3 i256;
+        v16.i1 = lt v8 v15;
+        br v16 block2 block5;
+}
+
+func inline(always) private %core__lib__abi__checked_tail__gf13e_134e(v0.i256, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        mstore v2 v0 i256;
+        mstore v3 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v3 i256;
+        (v6.i256, v7.i1) = uaddo v4 v5;
+        br v7 block5 block6;
+
+    block2:
+        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_fe05;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        return v6;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        v13.i256 = mload v2 i256;
+        v14.i1 = lt v6 v13;
+        br v14 block2 block3;
+}
+
+func inline(always) private %core__lib__abi__checked_tail__gf13e_15b4(v0.i256, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        mstore v2 v0 i256;
+        mstore v3 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v3 i256;
+        (v6.i256, v7.i1) = uaddo v4 v5;
+        br v7 block5 block6;
+
+    block2:
+        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_d2b1;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        return v6;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        v13.i256 = mload v2 i256;
+        v14.i1 = lt v6 v13;
+        br v14 block2 block3;
+}
+
+func inline(always) private %core__lib__abi__checked_tail__gf13e_2af0(v0.i256, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        mstore v2 v0 i256;
+        mstore v3 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v3 i256;
+        (v6.i256, v7.i1) = uaddo v4 v5;
+        br v7 block5 block6;
+
+    block2:
+        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_eb20;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        return v6;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        v13.i256 = mload v2 i256;
+        v14.i1 = lt v6 v13;
+        br v14 block2 block3;
+}
+
+func inline(always) private %core__lib__abi__checked_tail__gf13e_2d1a(v0.i256, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        mstore v2 v0 i256;
+        mstore v3 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v3 i256;
+        (v6.i256, v7.i1) = uaddo v4 v5;
+        br v7 block5 block6;
+
+    block2:
+        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_85bb;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        return v6;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        v13.i256 = mload v2 i256;
+        v14.i1 = lt v6 v13;
+        br v14 block2 block3;
+}
+
+func inline(always) private %core__lib__abi__checked_tail__gf13e_3749(v0.i256, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        mstore v2 v0 i256;
+        mstore v3 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v3 i256;
+        (v6.i256, v7.i1) = uaddo v4 v5;
+        br v7 block5 block6;
+
+    block2:
+        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_e087;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        return v6;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        v13.i256 = mload v2 i256;
+        v14.i1 = lt v6 v13;
+        br v14 block2 block3;
+}
+
+func inline(always) private %core__lib__abi__checked_tail__gf13e_45b0(v0.i256, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        mstore v2 v0 i256;
+        mstore v3 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v3 i256;
+        (v6.i256, v7.i1) = uaddo v4 v5;
+        br v7 block5 block6;
+
+    block2:
+        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_57f0;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        return v6;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        v13.i256 = mload v2 i256;
+        v14.i1 = lt v6 v13;
+        br v14 block2 block3;
+}
+
+func inline(always) private %core__lib__abi__checked_tail__gf13e_46df(v0.i256, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        mstore v2 v0 i256;
+        mstore v3 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v3 i256;
+        (v6.i256, v7.i1) = uaddo v4 v5;
+        br v7 block5 block6;
+
+    block2:
+        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_9af2;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        return v6;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        v13.i256 = mload v2 i256;
+        v14.i1 = lt v6 v13;
+        br v14 block2 block3;
+}
+
+func inline(always) private %core__lib__abi__checked_tail__gf13e_50a2(v0.i256, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        mstore v2 v0 i256;
+        mstore v3 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v3 i256;
+        (v6.i256, v7.i1) = uaddo v4 v5;
+        br v7 block5 block6;
+
+    block2:
+        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_60d9;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        return v6;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        v13.i256 = mload v2 i256;
+        v14.i1 = lt v6 v13;
+        br v14 block2 block3;
+}
+
+func inline(always) private %core__lib__abi__checked_tail__gf13e_7a36(v0.i256, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        mstore v2 v0 i256;
+        mstore v3 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v3 i256;
+        (v6.i256, v7.i1) = uaddo v4 v5;
+        br v7 block5 block6;
+
+    block2:
+        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_fd54;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        return v6;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        v13.i256 = mload v2 i256;
+        v14.i1 = lt v6 v13;
+        br v14 block2 block3;
+}
+
+func inline(always) private %core__lib__abi__checked_tail__gf13e_8bdb(v0.i256, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        mstore v2 v0 i256;
+        mstore v3 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v3 i256;
+        (v6.i256, v7.i1) = uaddo v4 v5;
+        br v7 block5 block6;
+
+    block2:
+        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_bf37;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        return v6;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        v13.i256 = mload v2 i256;
+        v14.i1 = lt v6 v13;
+        br v14 block2 block3;
+}
+
+func inline(always) private %core__lib__abi__checked_tail__gf13e_9611(v0.i256, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        mstore v2 v0 i256;
+        mstore v3 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v3 i256;
+        (v6.i256, v7.i1) = uaddo v4 v5;
+        br v7 block5 block6;
+
+    block2:
+        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_2515;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        return v6;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        v13.i256 = mload v2 i256;
+        v14.i1 = lt v6 v13;
+        br v14 block2 block3;
+}
+
+func inline(always) private %core__lib__abi__checked_tail__gf13e_9794(v0.i256, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        mstore v2 v0 i256;
+        mstore v3 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v3 i256;
+        (v6.i256, v7.i1) = uaddo v4 v5;
+        br v7 block5 block6;
+
+    block2:
+        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_6332;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        return v6;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        v13.i256 = mload v2 i256;
+        v14.i1 = lt v6 v13;
+        br v14 block2 block3;
+}
+
+func inline(always) private %core__lib__abi__checked_tail__gf13e_9c13(v0.i256, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        mstore v2 v0 i256;
+        mstore v3 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v3 i256;
+        (v6.i256, v7.i1) = uaddo v4 v5;
+        br v7 block5 block6;
+
+    block2:
+        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_7fdc;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        return v6;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        v13.i256 = mload v2 i256;
+        v14.i1 = lt v6 v13;
+        br v14 block2 block3;
+}
+
+func inline(always) private %core__lib__abi__checked_tail__gf13e_ad42(v0.i256, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        mstore v2 v0 i256;
+        mstore v3 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v3 i256;
+        (v6.i256, v7.i1) = uaddo v4 v5;
+        br v7 block5 block6;
+
+    block2:
+        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_3f2a;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        return v6;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        v13.i256 = mload v2 i256;
+        v14.i1 = lt v6 v13;
+        br v14 block2 block3;
+}
+
+func inline(always) private %core__lib__abi__checked_tail__gf13e_b743(v0.i256, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        mstore v2 v0 i256;
+        mstore v3 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v3 i256;
+        (v6.i256, v7.i1) = uaddo v4 v5;
+        br v7 block5 block6;
+
+    block2:
+        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_509b;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        return v6;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        v13.i256 = mload v2 i256;
+        v14.i1 = lt v6 v13;
+        br v14 block2 block3;
+}
+
+func inline(always) private %core__lib__abi__checked_tail__gf13e_c3ce(v0.i256, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        mstore v2 v0 i256;
+        mstore v3 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v3 i256;
+        (v6.i256, v7.i1) = uaddo v4 v5;
+        br v7 block5 block6;
+
+    block2:
+        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_2546;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        return v6;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        v13.i256 = mload v2 i256;
+        v14.i1 = lt v6 v13;
+        br v14 block2 block3;
+}
+
+func inline(always) private %core__lib__abi__checked_tail__gf13e_c89e(v0.i256, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        mstore v2 v0 i256;
+        mstore v3 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v3 i256;
+        (v6.i256, v7.i1) = uaddo v4 v5;
+        br v7 block5 block6;
+
+    block2:
+        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_def1;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        return v6;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        v13.i256 = mload v2 i256;
+        v14.i1 = lt v6 v13;
+        br v14 block2 block3;
 }
 
 func private %contract_init_abi_CoolCoin() {
@@ -1833,40 +3142,276 @@ func private %contract_runtime_root_CoolCoin() {
         unreachable;
 }
 
-func inline(always) private %decode_field__g8463(v0.objref<@layout_4>) -> @layout_0 {
+func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_0b81() {
     block0:
         jump block1;
 
     block1:
-        br 0.i1 block2 block3;
+        evm_revert 0.i256 0.i256;
+}
 
-    block2:
-        v3.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_8be4 v0;
-        v4.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_2c1b v0;
-        v5.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g463e_1f4c v0;
-        (v6.i256, v7.i1) = uaddo v4 v3;
-        br v7 block5 block6;
+func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_0d37() {
+    block0:
+        jump block1;
 
-    block3:
-        jump block4;
+    block1:
+        evm_revert 0.i256 0.i256;
+}
 
-    block4:
-        v23.@layout_0 = call %impl_trait_Address__decode_payload__g407e v0;
-        return v23;
+func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_12a9() {
+    block0:
+        jump block1;
 
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
+    block1:
+        evm_revert 0.i256 0.i256;
+}
 
-    block6:
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_d49b v0 v6;
-        v15.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_2c1b v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_d790 v0 v15;
-        v17.@layout_0 = call %impl_trait_Address__decode_payload__g407e v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_d49b v0 v4;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_d790 v0 v5;
-        return v17;
+func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_2004() {
+    block0:
+        jump block1;
+
+    block1:
+        evm_revert 0.i256 0.i256;
+}
+
+func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_23e2() {
+    block0:
+        jump block1;
+
+    block1:
+        evm_revert 0.i256 0.i256;
+}
+
+func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_2515() {
+    block0:
+        jump block1;
+
+    block1:
+        evm_revert 0.i256 0.i256;
+}
+
+func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_2546() {
+    block0:
+        jump block1;
+
+    block1:
+        evm_revert 0.i256 0.i256;
+}
+
+func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_27a8() {
+    block0:
+        jump block1;
+
+    block1:
+        evm_revert 0.i256 0.i256;
+}
+
+func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_39f6() {
+    block0:
+        jump block1;
+
+    block1:
+        evm_revert 0.i256 0.i256;
+}
+
+func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_3f2a() {
+    block0:
+        jump block1;
+
+    block1:
+        evm_revert 0.i256 0.i256;
+}
+
+func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_4ce8() {
+    block0:
+        jump block1;
+
+    block1:
+        evm_revert 0.i256 0.i256;
+}
+
+func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_509b() {
+    block0:
+        jump block1;
+
+    block1:
+        evm_revert 0.i256 0.i256;
+}
+
+func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_57f0() {
+    block0:
+        jump block1;
+
+    block1:
+        evm_revert 0.i256 0.i256;
+}
+
+func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_60d9() {
+    block0:
+        jump block1;
+
+    block1:
+        evm_revert 0.i256 0.i256;
+}
+
+func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_6332() {
+    block0:
+        jump block1;
+
+    block1:
+        evm_revert 0.i256 0.i256;
+}
+
+func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_6a0c() {
+    block0:
+        jump block1;
+
+    block1:
+        evm_revert 0.i256 0.i256;
+}
+
+func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_733d() {
+    block0:
+        jump block1;
+
+    block1:
+        evm_revert 0.i256 0.i256;
+}
+
+func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_7414() {
+    block0:
+        jump block1;
+
+    block1:
+        evm_revert 0.i256 0.i256;
+}
+
+func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_7fdc() {
+    block0:
+        jump block1;
+
+    block1:
+        evm_revert 0.i256 0.i256;
+}
+
+func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_85bb() {
+    block0:
+        jump block1;
+
+    block1:
+        evm_revert 0.i256 0.i256;
+}
+
+func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_929c() {
+    block0:
+        jump block1;
+
+    block1:
+        evm_revert 0.i256 0.i256;
+}
+
+func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_947f() {
+    block0:
+        jump block1;
+
+    block1:
+        evm_revert 0.i256 0.i256;
+}
+
+func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_9af2() {
+    block0:
+        jump block1;
+
+    block1:
+        evm_revert 0.i256 0.i256;
+}
+
+func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_a0e7() {
+    block0:
+        jump block1;
+
+    block1:
+        evm_revert 0.i256 0.i256;
+}
+
+func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_a63d() {
+    block0:
+        jump block1;
+
+    block1:
+        evm_revert 0.i256 0.i256;
+}
+
+func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_bf37() {
+    block0:
+        jump block1;
+
+    block1:
+        evm_revert 0.i256 0.i256;
+}
+
+func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_d2b1() {
+    block0:
+        jump block1;
+
+    block1:
+        evm_revert 0.i256 0.i256;
+}
+
+func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_dc07() {
+    block0:
+        jump block1;
+
+    block1:
+        evm_revert 0.i256 0.i256;
+}
+
+func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_def1() {
+    block0:
+        jump block1;
+
+    block1:
+        evm_revert 0.i256 0.i256;
+}
+
+func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_e087() {
+    block0:
+        jump block1;
+
+    block1:
+        evm_revert 0.i256 0.i256;
+}
+
+func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_eb20() {
+    block0:
+        jump block1;
+
+    block1:
+        evm_revert 0.i256 0.i256;
+}
+
+func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_f9e7() {
+    block0:
+        jump block1;
+
+    block1:
+        evm_revert 0.i256 0.i256;
+}
+
+func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_fd54() {
+    block0:
+        jump block1;
+
+    block1:
+        evm_revert 0.i256 0.i256;
+}
+
+func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_fe05() {
+    block0:
+        jump block1;
+
+    block1:
+        evm_revert 0.i256 0.i256;
 }
 
 func inline(always) private %decode_field__g3854(v0.objref<@layout_4>) -> i256 {
@@ -1877,9 +3422,9 @@ func inline(always) private %decode_field__g3854(v0.objref<@layout_4>) -> i256 {
         br 0.i1 block2 block3;
 
     block2:
-        v3.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_8be4_0 v0;
-        v4.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_2c1b_0 v0;
-        v5.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g463e_1f4c_0 v0;
+        v3.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_0a1c_0 v0;
+        v4.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_91bf_0 v0;
+        v5.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g463e_3f42_0 v0;
         (v6.i256, v7.i1) = uaddo v4 v3;
         br v7 block5 block6;
 
@@ -1896,40 +3441,35 @@ func inline(always) private %decode_field__g3854(v0.objref<@layout_4>) -> i256 {
         evm_revert 0.i256 36.i256;
 
     block6:
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_d49b_0 v0 v6;
-        v15.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_2c1b_0 v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_d790_0 v0 v15;
+        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_4735_0 v0 v6;
+        v15.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_91bf_0 v0;
+        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_ae9c_0 v0 v15;
         v17.i256 = call %impl_trait_u256__decode_payload__g407e v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_d49b_0 v0 v4;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_d790_0 v0 v5;
+        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_4735_0 v0 v4;
+        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_ae9c_0 v0 v5;
         return v17;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from__gcfb5_05e1(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
+func inline(always) private %decode_field__g8463(v0.objref<@layout_4>) -> @layout_0 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v7.i256 = mload v4 i256;
-        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c2d4 v0 v7;
-        v9.i256 = mload v3 i256;
-        (v10.i256, v11.i1) = uaddo v9 v8;
-        br v11 block5 block6;
+        v3.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_0a1c v0;
+        v4.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_91bf v0;
+        v5.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g463e_3f42 v0;
+        (v6.i256, v7.i1) = uaddo v4 v3;
+        br v7 block5 block6;
 
     block3:
         jump block4;
 
     block4:
-        v20.i256 = mload v4 i256;
-        v21.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_4e5e v0 v20;
-        return v21;
+        v23.@layout_0 = call %impl_trait_Address__decode_payload__g407e v0;
+        return v23;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -1937,83 +3477,16 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_05e1(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v18.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_4e5e v0 v10;
-        return v18;
+        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_4735 v0 v6;
+        v15.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_91bf v0;
+        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_ae9c v0 v15;
+        v17.@layout_0 = call %impl_trait_Address__decode_payload__g407e v0;
+        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_4735 v0 v4;
+        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_ae9c v0 v5;
+        return v17;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from__gcfb5_1aba(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
-    block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
-        jump block1;
-
-    block1:
-        br 0.i1 block2 block3;
-
-    block2:
-        v7.i256 = mload v4 i256;
-        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_88a1 v0 v7;
-        v9.i256 = mload v3 i256;
-        (v10.i256, v11.i1) = uaddo v9 v8;
-        br v11 block5 block6;
-
-    block3:
-        jump block4;
-
-    block4:
-        v20.i256 = mload v4 i256;
-        v21.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_9286 v0 v20;
-        return v21;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        v18.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_9286 v0 v10;
-        return v18;
-}
-
-func inline(always) private %core__lib__abi__decode_field_from__gcfb5_2b31(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
-    block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
-        jump block1;
-
-    block1:
-        br 0.i1 block2 block3;
-
-    block2:
-        v7.i256 = mload v4 i256;
-        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_fdcb v0 v7;
-        v9.i256 = mload v3 i256;
-        (v10.i256, v11.i1) = uaddo v9 v8;
-        br v11 block5 block6;
-
-    block3:
-        jump block4;
-
-    block4:
-        v20.i256 = mload v4 i256;
-        v21.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_db93 v0 v20;
-        return v21;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        v18.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_db93 v0 v10;
-        return v18;
-}
-
-func inline(always) private %core__lib__abi__decode_field_from__g5385_30a1(v0.@layout_5, v1.i256, v2.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_field_from__g5385_03a7(v0.@layout_5, v1.i256, v2.i256) -> i256 {
     block0:
         v3.*i256 = alloca i256;
         v4.*i256 = alloca i256;
@@ -2036,7 +3509,7 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_30a1(v0.@l
 
     block4:
         v20.i256 = mload v4 i256;
-        v21.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_3a7c v0 v20;
+        v21.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_3a7c_0 v0 v20;
         return v21;
 
     block5:
@@ -2045,299 +3518,11 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_30a1(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v18.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_3a7c v0 v10;
+        v18.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_3a7c_0 v0 v10;
         return v18;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from__g5385_4478(v0.@layout_5, v1.i256, v2.i256) -> i256 {
-    block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
-        jump block1;
-
-    block1:
-        br 0.i1 block2 block3;
-
-    block2:
-        v7.i256 = mload v4 i256;
-        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_5ce9 v0 v7;
-        v9.i256 = mload v3 i256;
-        (v10.i256, v11.i1) = uaddo v9 v8;
-        br v11 block5 block6;
-
-    block3:
-        jump block4;
-
-    block4:
-        v20.i256 = mload v4 i256;
-        v21.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_b39f v0 v20;
-        return v21;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        v18.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_b39f v0 v10;
-        return v18;
-}
-
-func inline(always) private %core__lib__abi__decode_field_from__gcfb5_6a4b(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
-    block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
-        jump block1;
-
-    block1:
-        br 0.i1 block2 block3;
-
-    block2:
-        v7.i256 = mload v4 i256;
-        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_ce64 v0 v7;
-        v9.i256 = mload v3 i256;
-        (v10.i256, v11.i1) = uaddo v9 v8;
-        br v11 block5 block6;
-
-    block3:
-        jump block4;
-
-    block4:
-        v20.i256 = mload v4 i256;
-        v21.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_2519 v0 v20;
-        return v21;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        v18.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_2519 v0 v10;
-        return v18;
-}
-
-func inline(always) private %core__lib__abi__decode_field_from__g5385_7d9f(v0.@layout_5, v1.i256, v2.i256) -> i256 {
-    block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
-        jump block1;
-
-    block1:
-        br 0.i1 block2 block3;
-
-    block2:
-        v7.i256 = mload v4 i256;
-        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_27ad v0 v7;
-        v9.i256 = mload v3 i256;
-        (v10.i256, v11.i1) = uaddo v9 v8;
-        br v11 block5 block6;
-
-    block3:
-        jump block4;
-
-    block4:
-        v20.i256 = mload v4 i256;
-        v21.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8d9f v0 v20;
-        return v21;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        v18.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8d9f v0 v10;
-        return v18;
-}
-
-func inline(always) private %core__lib__abi__decode_field_from__g5385_8921(v0.@layout_5, v1.i256, v2.i256) -> i256 {
-    block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
-        jump block1;
-
-    block1:
-        br 0.i1 block2 block3;
-
-    block2:
-        v7.i256 = mload v4 i256;
-        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c32c v0 v7;
-        v9.i256 = mload v3 i256;
-        (v10.i256, v11.i1) = uaddo v9 v8;
-        br v11 block5 block6;
-
-    block3:
-        jump block4;
-
-    block4:
-        v20.i256 = mload v4 i256;
-        v21.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_5c31 v0 v20;
-        return v21;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        v18.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_5c31 v0 v10;
-        return v18;
-}
-
-func inline(always) private %core__lib__abi__decode_field_from__gcfb5_8ab8(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
-    block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
-        jump block1;
-
-    block1:
-        br 0.i1 block2 block3;
-
-    block2:
-        v7.i256 = mload v4 i256;
-        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_faf2 v0 v7;
-        v9.i256 = mload v3 i256;
-        (v10.i256, v11.i1) = uaddo v9 v8;
-        br v11 block5 block6;
-
-    block3:
-        jump block4;
-
-    block4:
-        v20.i256 = mload v4 i256;
-        v21.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_5535 v0 v20;
-        return v21;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        v18.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_5535 v0 v10;
-        return v18;
-}
-
-func inline(always) private %core__lib__abi__decode_field_from__g5385_9c75(v0.@layout_5, v1.i256, v2.i256) -> i256 {
-    block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
-        jump block1;
-
-    block1:
-        br 0.i1 block2 block3;
-
-    block2:
-        v7.i256 = mload v4 i256;
-        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_780b v0 v7;
-        v9.i256 = mload v3 i256;
-        (v10.i256, v11.i1) = uaddo v9 v8;
-        br v11 block5 block6;
-
-    block3:
-        jump block4;
-
-    block4:
-        v20.i256 = mload v4 i256;
-        v21.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_0a95 v0 v20;
-        return v21;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        v18.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_0a95 v0 v10;
-        return v18;
-}
-
-func inline(always) private %core__lib__abi__decode_field_from__gcfb5_b81d(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
-    block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
-        jump block1;
-
-    block1:
-        br 0.i1 block2 block3;
-
-    block2:
-        v7.i256 = mload v4 i256;
-        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_0f5c v0 v7;
-        v9.i256 = mload v3 i256;
-        (v10.i256, v11.i1) = uaddo v9 v8;
-        br v11 block5 block6;
-
-    block3:
-        jump block4;
-
-    block4:
-        v20.i256 = mload v4 i256;
-        v21.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_f4e0 v0 v20;
-        return v21;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        v18.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_f4e0 v0 v10;
-        return v18;
-}
-
-func inline(always) private %core__lib__abi__decode_field_from__g5385_c0de(v0.@layout_5, v1.i256, v2.i256) -> i256 {
-    block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
-        jump block1;
-
-    block1:
-        br 0.i1 block2 block3;
-
-    block2:
-        v7.i256 = mload v4 i256;
-        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c259 v0 v7;
-        v9.i256 = mload v3 i256;
-        (v10.i256, v11.i1) = uaddo v9 v8;
-        br v11 block5 block6;
-
-    block3:
-        jump block4;
-
-    block4:
-        v20.i256 = mload v4 i256;
-        v21.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_4e52 v0 v20;
-        return v21;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        v18.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_4e52 v0 v10;
-        return v18;
-}
-
-func inline(always) private %core__lib__abi__decode_field_from__gcfb5_c63b(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
+func inline(always) private %core__lib__abi__decode_field_from__gcfb5_2692(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
     block0:
         v3.*i256 = alloca i256;
         v4.*i256 = alloca i256;
@@ -2360,7 +3545,7 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_c63b(v0.@l
 
     block4:
         v20.i256 = mload v4 i256;
-        v21.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_3716 v0 v20;
+        v21.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_3716_0 v0 v20;
         return v21;
 
     block5:
@@ -2369,11 +3554,11 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_c63b(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v18.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_3716 v0 v10;
+        v18.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_3716_0 v0 v10;
         return v18;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from__g5385_c71a(v0.@layout_5, v1.i256, v2.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_field_from__gcfb5_2eef(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
     block0:
         v3.*i256 = alloca i256;
         v4.*i256 = alloca i256;
@@ -2386,7 +3571,7 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_c71a(v0.@l
 
     block2:
         v7.i256 = mload v4 i256;
-        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_49c5 v0 v7;
+        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_ce64 v0 v7;
         v9.i256 = mload v3 i256;
         (v10.i256, v11.i1) = uaddo v9 v8;
         br v11 block5 block6;
@@ -2396,7 +3581,7 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_c71a(v0.@l
 
     block4:
         v20.i256 = mload v4 i256;
-        v21.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_18e6 v0 v20;
+        v21.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_2519_0 v0 v20;
         return v21;
 
     block5:
@@ -2405,11 +3590,11 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_c71a(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v18.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_18e6 v0 v10;
+        v18.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_2519_0 v0 v10;
         return v18;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from__gcfb5_cd1a(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
+func inline(always) private %core__lib__abi__decode_field_from__g5385_4796(v0.@layout_5, v1.i256, v2.i256) -> i256 {
     block0:
         v3.*i256 = alloca i256;
         v4.*i256 = alloca i256;
@@ -2422,7 +3607,7 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_cd1a(v0.@l
 
     block2:
         v7.i256 = mload v4 i256;
-        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_7946 v0 v7;
+        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_27ad v0 v7;
         v9.i256 = mload v3 i256;
         (v10.i256, v11.i1) = uaddo v9 v8;
         br v11 block5 block6;
@@ -2432,7 +3617,7 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_cd1a(v0.@l
 
     block4:
         v20.i256 = mload v4 i256;
-        v21.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_b822 v0 v20;
+        v21.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8d9f_0 v0 v20;
         return v21;
 
     block5:
@@ -2441,11 +3626,155 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_cd1a(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v18.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_b822 v0 v10;
+        v18.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8d9f_0 v0 v10;
         return v18;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from__g5385_d823(v0.@layout_5, v1.i256, v2.i256) -> i256 {
+func inline(always) private %core__lib__abi__decode_field_from__g5385_5cc4(v0.@layout_5, v1.i256, v2.i256) -> i256 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v7.i256 = mload v4 i256;
+        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_5ce9 v0 v7;
+        v9.i256 = mload v3 i256;
+        (v10.i256, v11.i1) = uaddo v9 v8;
+        br v11 block5 block6;
+
+    block3:
+        jump block4;
+
+    block4:
+        v20.i256 = mload v4 i256;
+        v21.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_b39f_0 v0 v20;
+        return v21;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        v18.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_b39f_0 v0 v10;
+        return v18;
+}
+
+func inline(always) private %core__lib__abi__decode_field_from__gcfb5_7143(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v7.i256 = mload v4 i256;
+        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_faf2 v0 v7;
+        v9.i256 = mload v3 i256;
+        (v10.i256, v11.i1) = uaddo v9 v8;
+        br v11 block5 block6;
+
+    block3:
+        jump block4;
+
+    block4:
+        v20.i256 = mload v4 i256;
+        v21.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_5535_0 v0 v20;
+        return v21;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        v18.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_5535_0 v0 v10;
+        return v18;
+}
+
+func inline(always) private %core__lib__abi__decode_field_from__g5385_7366(v0.@layout_5, v1.i256, v2.i256) -> i256 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v7.i256 = mload v4 i256;
+        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c32c v0 v7;
+        v9.i256 = mload v3 i256;
+        (v10.i256, v11.i1) = uaddo v9 v8;
+        br v11 block5 block6;
+
+    block3:
+        jump block4;
+
+    block4:
+        v20.i256 = mload v4 i256;
+        v21.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_5c31_0 v0 v20;
+        return v21;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        v18.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_5c31_0 v0 v10;
+        return v18;
+}
+
+func inline(always) private %core__lib__abi__decode_field_from__gcfb5_786c(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v7.i256 = mload v4 i256;
+        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c2d4 v0 v7;
+        v9.i256 = mload v3 i256;
+        (v10.i256, v11.i1) = uaddo v9 v8;
+        br v11 block5 block6;
+
+    block3:
+        jump block4;
+
+    block4:
+        v20.i256 = mload v4 i256;
+        v21.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_4e5e_0 v0 v20;
+        return v21;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        v18.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_4e5e_0 v0 v10;
+        return v18;
+}
+
+func inline(always) private %core__lib__abi__decode_field_from__g5385_79b2(v0.@layout_5, v1.i256, v2.i256) -> i256 {
     block0:
         v3.*i256 = alloca i256;
         v4.*i256 = alloca i256;
@@ -2468,7 +3797,7 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_d823(v0.@l
 
     block4:
         v20.i256 = mload v4 i256;
-        v21.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_251a v0 v20;
+        v21.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_251a_0 v0 v20;
         return v21;
 
     block5:
@@ -2477,11 +3806,191 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_d823(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v18.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_251a v0 v10;
+        v18.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_251a_0 v0 v10;
         return v18;
 }
 
-func inline(always) private %core__lib__abi__decode_field_from__gcfb5_fd62(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
+func inline(always) private %core__lib__abi__decode_field_from__gcfb5_7fa7(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v7.i256 = mload v4 i256;
+        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_fdcb v0 v7;
+        v9.i256 = mload v3 i256;
+        (v10.i256, v11.i1) = uaddo v9 v8;
+        br v11 block5 block6;
+
+    block3:
+        jump block4;
+
+    block4:
+        v20.i256 = mload v4 i256;
+        v21.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_db93_0 v0 v20;
+        return v21;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        v18.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_db93_0 v0 v10;
+        return v18;
+}
+
+func inline(always) private %core__lib__abi__decode_field_from__g5385_9270(v0.@layout_5, v1.i256, v2.i256) -> i256 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v7.i256 = mload v4 i256;
+        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_780b v0 v7;
+        v9.i256 = mload v3 i256;
+        (v10.i256, v11.i1) = uaddo v9 v8;
+        br v11 block5 block6;
+
+    block3:
+        jump block4;
+
+    block4:
+        v20.i256 = mload v4 i256;
+        v21.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_0a95_0 v0 v20;
+        return v21;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        v18.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_0a95_0 v0 v10;
+        return v18;
+}
+
+func inline(always) private %core__lib__abi__decode_field_from__gcfb5_b564(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v7.i256 = mload v4 i256;
+        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_88a1 v0 v7;
+        v9.i256 = mload v3 i256;
+        (v10.i256, v11.i1) = uaddo v9 v8;
+        br v11 block5 block6;
+
+    block3:
+        jump block4;
+
+    block4:
+        v20.i256 = mload v4 i256;
+        v21.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_9286_0 v0 v20;
+        return v21;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        v18.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_9286_0 v0 v10;
+        return v18;
+}
+
+func inline(always) private %core__lib__abi__decode_field_from__g5385_cb05(v0.@layout_5, v1.i256, v2.i256) -> i256 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v7.i256 = mload v4 i256;
+        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_49c5 v0 v7;
+        v9.i256 = mload v3 i256;
+        (v10.i256, v11.i1) = uaddo v9 v8;
+        br v11 block5 block6;
+
+    block3:
+        jump block4;
+
+    block4:
+        v20.i256 = mload v4 i256;
+        v21.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_18e6_0 v0 v20;
+        return v21;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        v18.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_18e6_0 v0 v10;
+        return v18;
+}
+
+func inline(always) private %core__lib__abi__decode_field_from__gcfb5_d5a0(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v7.i256 = mload v4 i256;
+        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_0f5c v0 v7;
+        v9.i256 = mload v3 i256;
+        (v10.i256, v11.i1) = uaddo v9 v8;
+        br v11 block5 block6;
+
+    block3:
+        jump block4;
+
+    block4:
+        v20.i256 = mload v4 i256;
+        v21.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_f4e0_0 v0 v20;
+        return v21;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        v18.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_f4e0_0 v0 v10;
+        return v18;
+}
+
+func inline(always) private %core__lib__abi__decode_field_from__gcfb5_d5c8(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
     block0:
         v3.*i256 = alloca i256;
         v4.*i256 = alloca i256;
@@ -2504,7 +4013,7 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_fd62(v0.@l
 
     block4:
         v20.i256 = mload v4 i256;
-        v21.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_3641 v0 v20;
+        v21.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_3641_0 v0 v20;
         return v21;
 
     block5:
@@ -2513,8 +4022,607 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_fd62(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v18.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_3641 v0 v10;
+        v18.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_3641_0 v0 v10;
         return v18;
+}
+
+func inline(always) private %core__lib__abi__decode_field_from__g5385_d887(v0.@layout_5, v1.i256, v2.i256) -> i256 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v7.i256 = mload v4 i256;
+        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c259 v0 v7;
+        v9.i256 = mload v3 i256;
+        (v10.i256, v11.i1) = uaddo v9 v8;
+        br v11 block5 block6;
+
+    block3:
+        jump block4;
+
+    block4:
+        v20.i256 = mload v4 i256;
+        v21.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_4e52_0 v0 v20;
+        return v21;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        v18.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_4e52_0 v0 v10;
+        return v18;
+}
+
+func inline(always) private %core__lib__abi__decode_field_from__gcfb5_e784(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v7.i256 = mload v4 i256;
+        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_7946 v0 v7;
+        v9.i256 = mload v3 i256;
+        (v10.i256, v11.i1) = uaddo v9 v8;
+        br v11 block5 block6;
+
+    block3:
+        jump block4;
+
+    block4:
+        v20.i256 = mload v4 i256;
+        v21.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_b822_0 v0 v20;
+        return v21;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        v18.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_b822_0 v0 v10;
+        return v18;
+}
+
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__gcfb5_07a0(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> @layout_0 {
+    block0:
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        v6.*i256 = alloca i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        mstore v6 v3 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v9.i256 = mload v5 i256;
+        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_88a1 v0 v9;
+        v11.i256 = mload v4 i256;
+        v12.i256 = call %core__lib__abi__checked_tail__gf13e_9794 v11 v10;
+        v13.i256 = mload v6 i256;
+        v14.@layout_0 = call %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_3fea v0 v12 v13;
+        return v14;
+
+    block3:
+        jump block4;
+
+    block4:
+        v16.i256 = mload v5 i256;
+        v17.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_9286_0 v0 v16;
+        return v17;
+}
+
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__gcfb5_18ef(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> @layout_0 {
+    block0:
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        v6.*i256 = alloca i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        mstore v6 v3 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v9.i256 = mload v5 i256;
+        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_69bf v0 v9;
+        v11.i256 = mload v4 i256;
+        v12.i256 = call %core__lib__abi__checked_tail__gf13e_46df v11 v10;
+        v13.i256 = mload v6 i256;
+        v14.@layout_0 = call %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_978c v0 v12 v13;
+        return v14;
+
+    block3:
+        jump block4;
+
+    block4:
+        v16.i256 = mload v5 i256;
+        v17.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_3716_0 v0 v16;
+        return v17;
+}
+
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__gcfb5_2207(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> @layout_0 {
+    block0:
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        v6.*i256 = alloca i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        mstore v6 v3 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v9.i256 = mload v5 i256;
+        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_fdcb v0 v9;
+        v11.i256 = mload v4 i256;
+        v12.i256 = call %core__lib__abi__checked_tail__gf13e_45b0 v11 v10;
+        v13.i256 = mload v6 i256;
+        v14.@layout_0 = call %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_d676 v0 v12 v13;
+        return v14;
+
+    block3:
+        jump block4;
+
+    block4:
+        v16.i256 = mload v5 i256;
+        v17.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_db93_0 v0 v16;
+        return v17;
+}
+
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__gcfb5_2724(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> @layout_0 {
+    block0:
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        v6.*i256 = alloca i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        mstore v6 v3 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v9.i256 = mload v5 i256;
+        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c2d4 v0 v9;
+        v11.i256 = mload v4 i256;
+        v12.i256 = call %core__lib__abi__checked_tail__gf13e_ad42 v11 v10;
+        v13.i256 = mload v6 i256;
+        v14.@layout_0 = call %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_64e6 v0 v12 v13;
+        return v14;
+
+    block3:
+        jump block4;
+
+    block4:
+        v16.i256 = mload v5 i256;
+        v17.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_4e5e_0 v0 v16;
+        return v17;
+}
+
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_34fc(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> i256 {
+    block0:
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        v6.*i256 = alloca i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        mstore v6 v3 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v9.i256 = mload v5 i256;
+        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c32c v0 v9;
+        v11.i256 = mload v4 i256;
+        v12.i256 = call %core__lib__abi__checked_tail__gf13e_b743 v11 v10;
+        v13.i256 = mload v6 i256;
+        v14.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_d01b v0 v12 v13;
+        return v14;
+
+    block3:
+        jump block4;
+
+    block4:
+        v16.i256 = mload v5 i256;
+        v17.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_5c31_0 v0 v16;
+        return v17;
+}
+
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_5db0(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> i256 {
+    block0:
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        v6.*i256 = alloca i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        mstore v6 v3 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v9.i256 = mload v5 i256;
+        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_27ad v0 v9;
+        v11.i256 = mload v4 i256;
+        v12.i256 = call %core__lib__abi__checked_tail__gf13e_9611 v11 v10;
+        v13.i256 = mload v6 i256;
+        v14.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_2374 v0 v12 v13;
+        return v14;
+
+    block3:
+        jump block4;
+
+    block4:
+        v16.i256 = mload v5 i256;
+        v17.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8d9f_0 v0 v16;
+        return v17;
+}
+
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__gcfb5_764c(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> @layout_0 {
+    block0:
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        v6.*i256 = alloca i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        mstore v6 v3 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v9.i256 = mload v5 i256;
+        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_ce64 v0 v9;
+        v11.i256 = mload v4 i256;
+        v12.i256 = call %core__lib__abi__checked_tail__gf13e_3749 v11 v10;
+        v13.i256 = mload v6 i256;
+        v14.@layout_0 = call %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_3639 v0 v12 v13;
+        return v14;
+
+    block3:
+        jump block4;
+
+    block4:
+        v16.i256 = mload v5 i256;
+        v17.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_2519_0 v0 v16;
+        return v17;
+}
+
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_7760(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> i256 {
+    block0:
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        v6.*i256 = alloca i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        mstore v6 v3 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v9.i256 = mload v5 i256;
+        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_780b v0 v9;
+        v11.i256 = mload v4 i256;
+        v12.i256 = call %core__lib__abi__checked_tail__gf13e_8bdb v11 v10;
+        v13.i256 = mload v6 i256;
+        v14.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_1972 v0 v12 v13;
+        return v14;
+
+    block3:
+        jump block4;
+
+    block4:
+        v16.i256 = mload v5 i256;
+        v17.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_0a95_0 v0 v16;
+        return v17;
+}
+
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_839e(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> i256 {
+    block0:
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        v6.*i256 = alloca i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        mstore v6 v3 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v9.i256 = mload v5 i256;
+        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_9725 v0 v9;
+        v11.i256 = mload v4 i256;
+        v12.i256 = call %core__lib__abi__checked_tail__gf13e_2af0 v11 v10;
+        v13.i256 = mload v6 i256;
+        v14.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_43c7 v0 v12 v13;
+        return v14;
+
+    block3:
+        jump block4;
+
+    block4:
+        v16.i256 = mload v5 i256;
+        v17.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_3a7c_0 v0 v16;
+        return v17;
+}
+
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_847c(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> i256 {
+    block0:
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        v6.*i256 = alloca i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        mstore v6 v3 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v9.i256 = mload v5 i256;
+        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b870 v0 v9;
+        v11.i256 = mload v4 i256;
+        v12.i256 = call %core__lib__abi__checked_tail__gf13e_9c13 v11 v10;
+        v13.i256 = mload v6 i256;
+        v14.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_8823 v0 v12 v13;
+        return v14;
+
+    block3:
+        jump block4;
+
+    block4:
+        v16.i256 = mload v5 i256;
+        v17.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_251a_0 v0 v16;
+        return v17;
+}
+
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__gcfb5_a4f7(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> @layout_0 {
+    block0:
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        v6.*i256 = alloca i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        mstore v6 v3 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v9.i256 = mload v5 i256;
+        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_faf2 v0 v9;
+        v11.i256 = mload v4 i256;
+        v12.i256 = call %core__lib__abi__checked_tail__gf13e_2d1a v11 v10;
+        v13.i256 = mload v6 i256;
+        v14.@layout_0 = call %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_2c09 v0 v12 v13;
+        return v14;
+
+    block3:
+        jump block4;
+
+    block4:
+        v16.i256 = mload v5 i256;
+        v17.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_5535_0 v0 v16;
+        return v17;
+}
+
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_b51a(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> i256 {
+    block0:
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        v6.*i256 = alloca i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        mstore v6 v3 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v9.i256 = mload v5 i256;
+        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_5ce9 v0 v9;
+        v11.i256 = mload v4 i256;
+        v12.i256 = call %core__lib__abi__checked_tail__gf13e_134e v11 v10;
+        v13.i256 = mload v6 i256;
+        v14.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_2360 v0 v12 v13;
+        return v14;
+
+    block3:
+        jump block4;
+
+    block4:
+        v16.i256 = mload v5 i256;
+        v17.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_b39f_0 v0 v16;
+        return v17;
+}
+
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_c7d5(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> i256 {
+    block0:
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        v6.*i256 = alloca i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        mstore v6 v3 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v9.i256 = mload v5 i256;
+        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_49c5 v0 v9;
+        v11.i256 = mload v4 i256;
+        v12.i256 = call %core__lib__abi__checked_tail__gf13e_15b4 v11 v10;
+        v13.i256 = mload v6 i256;
+        v14.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_38c3 v0 v12 v13;
+        return v14;
+
+    block3:
+        jump block4;
+
+    block4:
+        v16.i256 = mload v5 i256;
+        v17.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_18e6_0 v0 v16;
+        return v17;
+}
+
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_d4dc(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> i256 {
+    block0:
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        v6.*i256 = alloca i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        mstore v6 v3 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v9.i256 = mload v5 i256;
+        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c259 v0 v9;
+        v11.i256 = mload v4 i256;
+        v12.i256 = call %core__lib__abi__checked_tail__gf13e_50a2 v11 v10;
+        v13.i256 = mload v6 i256;
+        v14.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_6ea9 v0 v12 v13;
+        return v14;
+
+    block3:
+        jump block4;
+
+    block4:
+        v16.i256 = mload v5 i256;
+        v17.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_4e52_0 v0 v16;
+        return v17;
+}
+
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__gcfb5_ed91(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> @layout_0 {
+    block0:
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        v6.*i256 = alloca i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        mstore v6 v3 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v9.i256 = mload v5 i256;
+        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_7946 v0 v9;
+        v11.i256 = mload v4 i256;
+        v12.i256 = call %core__lib__abi__checked_tail__gf13e_c3ce v11 v10;
+        v13.i256 = mload v6 i256;
+        v14.@layout_0 = call %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_8e68 v0 v12 v13;
+        return v14;
+
+    block3:
+        jump block4;
+
+    block4:
+        v16.i256 = mload v5 i256;
+        v17.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_b822_0 v0 v16;
+        return v17;
+}
+
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__gcfb5_ef75(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> @layout_0 {
+    block0:
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        v6.*i256 = alloca i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        mstore v6 v3 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v9.i256 = mload v5 i256;
+        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_0f5c v0 v9;
+        v11.i256 = mload v4 i256;
+        v12.i256 = call %core__lib__abi__checked_tail__gf13e_7a36 v11 v10;
+        v13.i256 = mload v6 i256;
+        v14.@layout_0 = call %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_29bc v0 v12 v13;
+        return v14;
+
+    block3:
+        jump block4;
+
+    block4:
+        v16.i256 = mload v5 i256;
+        v17.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_f4e0_0 v0 v16;
+        return v17;
+}
+
+func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__gcfb5_faf8(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> @layout_0 {
+    block0:
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        v6.*i256 = alloca i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        mstore v6 v3 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v9.i256 = mload v5 i256;
+        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_6dae v0 v9;
+        v11.i256 = mload v4 i256;
+        v12.i256 = call %core__lib__abi__checked_tail__gf13e_c89e v11 v10;
+        v13.i256 = mload v6 i256;
+        v14.@layout_0 = call %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_a883 v0 v12 v13;
+        return v14;
+
+    block3:
+        jump block4;
+
+    block4:
+        v16.i256 = mload v5 i256;
+        v17.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_3641_0 v0 v16;
+        return v17;
 }
 
 func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_0a95(v0.@layout_5, v1.i256) -> i256 {
@@ -2529,6 +4637,18 @@ func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__
         return v5;
 }
 
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_0a95_0(v0.@layout_5, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c700_0 v0 v4;
+        return v5;
+}
+
 func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_18e6(v0.@layout_5, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
@@ -2538,6 +4658,18 @@ func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__
     block1:
         v4.i256 = mload v2 i256;
         v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b705 v0 v4;
+        return v5;
+}
+
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_18e6_0(v0.@layout_5, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b705_0 v0 v4;
         return v5;
 }
 
@@ -2569,6 +4701,34 @@ func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__de
         return v14;
 }
 
+func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_2519_0(v0.@layout_5, v1.i256) -> @layout_0 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_8736_0 v0 v4;
+        v7.i256 = shr 160.i256 v5;
+        v9.i1 = eq v7 0.i256;
+        v10.i1 = is_zero v9;
+        br v10 block2 block3;
+
+    block2:
+        evm_revert 0.i256 0.i256;
+
+    block3:
+        jump block4;
+
+    block4:
+        v11.objref<@layout_0> = obj.alloc @layout_0;
+        v13.objref<i256> = obj.proj v11 0.i256;
+        obj.store v13 v5;
+        v14.@layout_0 = obj.load v11;
+        return v14;
+}
+
 func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_251a(v0.@layout_5, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
@@ -2578,6 +4738,18 @@ func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__
     block1:
         v4.i256 = mload v2 i256;
         v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3bad v0 v4;
+        return v5;
+}
+
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_251a_0(v0.@layout_5, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3bad_0 v0 v4;
         return v5;
 }
 
@@ -2600,6 +4772,34 @@ func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__de
     block1:
         v4.i256 = mload v2 i256;
         v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b9ca v0 v4;
+        v7.i256 = shr 160.i256 v5;
+        v9.i1 = eq v7 0.i256;
+        v10.i1 = is_zero v9;
+        br v10 block2 block3;
+
+    block2:
+        evm_revert 0.i256 0.i256;
+
+    block3:
+        jump block4;
+
+    block4:
+        v11.objref<@layout_0> = obj.alloc @layout_0;
+        v13.objref<i256> = obj.proj v11 0.i256;
+        obj.store v13 v5;
+        v14.@layout_0 = obj.load v11;
+        return v14;
+}
+
+func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_3641_0(v0.@layout_5, v1.i256) -> @layout_0 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b9ca_0 v0 v4;
         v7.i256 = shr 160.i256 v5;
         v9.i1 = eq v7 0.i256;
         v10.i1 = is_zero v9;
@@ -2647,6 +4847,34 @@ func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__de
         return v14;
 }
 
+func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_3716_0(v0.@layout_5, v1.i256) -> @layout_0 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_d831_0 v0 v4;
+        v7.i256 = shr 160.i256 v5;
+        v9.i1 = eq v7 0.i256;
+        v10.i1 = is_zero v9;
+        br v10 block2 block3;
+
+    block2:
+        evm_revert 0.i256 0.i256;
+
+    block3:
+        jump block4;
+
+    block4:
+        v11.objref<@layout_0> = obj.alloc @layout_0;
+        v13.objref<i256> = obj.proj v11 0.i256;
+        obj.store v13 v5;
+        v14.@layout_0 = obj.load v11;
+        return v14;
+}
+
 func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_3a7c(v0.@layout_5, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
@@ -2656,6 +4884,18 @@ func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__
     block1:
         v4.i256 = mload v2 i256;
         v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_9757 v0 v4;
+        return v5;
+}
+
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_3a7c_0(v0.@layout_5, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_9757_0 v0 v4;
         return v5;
 }
 
@@ -2671,6 +4911,18 @@ func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__
         return v5;
 }
 
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_4e52_0(v0.@layout_5, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_790f_0 v0 v4;
+        return v5;
+}
+
 func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_4e5e(v0.@layout_5, v1.i256) -> @layout_0 {
     block0:
         v2.*i256 = alloca i256;
@@ -2680,6 +4932,34 @@ func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__de
     block1:
         v4.i256 = mload v2 i256;
         v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_fec2 v0 v4;
+        v7.i256 = shr 160.i256 v5;
+        v9.i1 = eq v7 0.i256;
+        v10.i1 = is_zero v9;
+        br v10 block2 block3;
+
+    block2:
+        evm_revert 0.i256 0.i256;
+
+    block3:
+        jump block4;
+
+    block4:
+        v11.objref<@layout_0> = obj.alloc @layout_0;
+        v13.objref<i256> = obj.proj v11 0.i256;
+        obj.store v13 v5;
+        v14.@layout_0 = obj.load v11;
+        return v14;
+}
+
+func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_4e5e_0(v0.@layout_5, v1.i256) -> @layout_0 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_fec2_0 v0 v4;
         v7.i256 = shr 160.i256 v5;
         v9.i1 = eq v7 0.i256;
         v10.i1 = is_zero v9;
@@ -2727,6 +5007,34 @@ func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__de
         return v14;
 }
 
+func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_5535_0(v0.@layout_5, v1.i256) -> @layout_0 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_a6b2_0 v0 v4;
+        v7.i256 = shr 160.i256 v5;
+        v9.i1 = eq v7 0.i256;
+        v10.i1 = is_zero v9;
+        br v10 block2 block3;
+
+    block2:
+        evm_revert 0.i256 0.i256;
+
+    block3:
+        jump block4;
+
+    block4:
+        v11.objref<@layout_0> = obj.alloc @layout_0;
+        v13.objref<i256> = obj.proj v11 0.i256;
+        obj.store v13 v5;
+        v14.@layout_0 = obj.load v11;
+        return v14;
+}
+
 func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_5c31(v0.@layout_5, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
@@ -2739,7 +5047,7 @@ func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__
         return v5;
 }
 
-func inline(always) private %impl_trait_Allowance__decode_from__gd20d(v0.@layout_5, v1.i256) -> @layout_6 {
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_5c31_0(v0.@layout_5, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -2747,12 +5055,25 @@ func inline(always) private %impl_trait_Allowance__decode_from__gd20d(v0.@layout
 
     block1:
         v4.i256 = mload v2 i256;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3a1f_0 v0 v4;
+        return v5;
+}
+
+func inline(always) private %impl_trait_Allowance__decode_from__gd20d(v0.@layout_5, v1.i256) -> @layout_6 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_e949 v0;
         v5.i256 = mload v2 i256;
-        v6.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_1aba v0 v4 v5;
-        v7.i256 = mload v2 i256;
+        v6.i256 = mload v2 i256;
+        v7.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_6698 v0 v5 v6 v4;
         v8.i256 = mload v2 i256;
-        (v10.i256, v11.i1) = uaddo v8 32.i256;
-        br v11 block2 block3;
+        v9.i256 = mload v2 i256;
+        (v11.i256, v12.i1) = uaddo v9 32.i256;
+        br v12 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -2760,18 +5081,18 @@ func inline(always) private %impl_trait_Allowance__decode_from__gd20d(v0.@layout
         evm_revert 0.i256 36.i256;
 
     block3:
-        v19.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_1aba v0 v7 v10;
-        v20.objref<@layout_6> = obj.alloc @layout_6;
-        v22.objref<@layout_0> = obj.proj v20 0.i256;
-        v23.objref<i256> = obj.proj v22 0.i256;
-        v24.i256 = extract_value v6 0.i256;
-        obj.store v23 v24;
-        v26.objref<@layout_0> = obj.proj v20 1.i256;
-        v27.objref<i256> = obj.proj v26 0.i256;
-        v28.i256 = extract_value v19 0.i256;
-        obj.store v27 v28;
-        v29.@layout_6 = obj.load v20;
-        return v29;
+        v21.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_6698 v0 v8 v11 v4;
+        v22.objref<@layout_6> = obj.alloc @layout_6;
+        v24.objref<@layout_0> = obj.proj v22 0.i256;
+        v25.objref<i256> = obj.proj v24 0.i256;
+        v26.i256 = extract_value v7 0.i256;
+        obj.store v25 v26;
+        v28.objref<@layout_0> = obj.proj v22 1.i256;
+        v29.objref<i256> = obj.proj v28 0.i256;
+        v30.i256 = extract_value v21 0.i256;
+        obj.store v29 v30;
+        v31.@layout_6 = obj.load v22;
+        return v31;
 }
 
 func inline(always) private %impl_trait_Approve__decode_from__gd20d(v0.@layout_5, v1.i256) -> @layout_7 {
@@ -2781,13 +5102,14 @@ func inline(always) private %impl_trait_Approve__decode_from__gd20d(v0.@layout_5
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_aa47 v0;
         v5.i256 = mload v2 i256;
-        v6.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_2b31 v0 v4 v5;
-        v7.i256 = mload v2 i256;
+        v6.i256 = mload v2 i256;
+        v7.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_329a v0 v5 v6 v4;
         v8.i256 = mload v2 i256;
-        (v10.i256, v11.i1) = uaddo v8 32.i256;
-        br v11 block2 block3;
+        v9.i256 = mload v2 i256;
+        (v11.i256, v12.i1) = uaddo v9 32.i256;
+        br v12 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -2795,16 +5117,16 @@ func inline(always) private %impl_trait_Approve__decode_from__gd20d(v0.@layout_5
         evm_revert 0.i256 36.i256;
 
     block3:
-        v19.i256 = call %core__lib__abi__decode_field_from__g5385_7d9f v0 v7 v10;
-        v20.objref<@layout_7> = obj.alloc @layout_7;
-        v22.objref<@layout_0> = obj.proj v20 0.i256;
-        v23.objref<i256> = obj.proj v22 0.i256;
-        v24.i256 = extract_value v6 0.i256;
-        obj.store v23 v24;
-        v26.objref<i256> = obj.proj v20 1.i256;
-        obj.store v26 v19;
-        v27.@layout_7 = obj.load v20;
-        return v27;
+        v21.i256 = call %core__lib__abi__decode_msg_field_from__g5385_0219 v0 v8 v11 v4;
+        v22.objref<@layout_7> = obj.alloc @layout_7;
+        v24.objref<@layout_0> = obj.proj v22 0.i256;
+        v25.objref<i256> = obj.proj v24 0.i256;
+        v26.i256 = extract_value v7 0.i256;
+        obj.store v25 v26;
+        v28.objref<i256> = obj.proj v22 1.i256;
+        obj.store v28 v21;
+        v29.@layout_7 = obj.load v22;
+        return v29;
 }
 
 func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8d9f(v0.@layout_5, v1.i256) -> i256 {
@@ -2816,6 +5138,18 @@ func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__
     block1:
         v4.i256 = mload v2 i256;
         v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b461 v0 v4;
+        return v5;
+}
+
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8d9f_0(v0.@layout_5, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b461_0 v0 v4;
         return v5;
 }
 
@@ -2847,7 +5181,7 @@ func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__de
         return v14;
 }
 
-func inline(always) private %impl_trait_Mint__decode_from__gd20d(v0.@layout_5, v1.i256) -> @layout_8 {
+func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_9286_0(v0.@layout_5, v1.i256) -> @layout_0 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -2855,12 +5189,41 @@ func inline(always) private %impl_trait_Mint__decode_from__gd20d(v0.@layout_5, v
 
     block1:
         v4.i256 = mload v2 i256;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_a8d6_0 v0 v4;
+        v7.i256 = shr 160.i256 v5;
+        v9.i1 = eq v7 0.i256;
+        v10.i1 = is_zero v9;
+        br v10 block2 block3;
+
+    block2:
+        evm_revert 0.i256 0.i256;
+
+    block3:
+        jump block4;
+
+    block4:
+        v11.objref<@layout_0> = obj.alloc @layout_0;
+        v13.objref<i256> = obj.proj v11 0.i256;
+        obj.store v13 v5;
+        v14.@layout_0 = obj.load v11;
+        return v14;
+}
+
+func inline(always) private %impl_trait_Mint__decode_from__gd20d(v0.@layout_5, v1.i256) -> @layout_8 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_779e v0;
         v5.i256 = mload v2 i256;
-        v6.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_c63b v0 v4 v5;
-        v7.i256 = mload v2 i256;
+        v6.i256 = mload v2 i256;
+        v7.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_0358 v0 v5 v6 v4;
         v8.i256 = mload v2 i256;
-        (v10.i256, v11.i1) = uaddo v8 32.i256;
-        br v11 block2 block3;
+        v9.i256 = mload v2 i256;
+        (v11.i256, v12.i1) = uaddo v9 32.i256;
+        br v12 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -2868,16 +5231,16 @@ func inline(always) private %impl_trait_Mint__decode_from__gd20d(v0.@layout_5, v
         evm_revert 0.i256 36.i256;
 
     block3:
-        v19.i256 = call %core__lib__abi__decode_field_from__g5385_8921 v0 v7 v10;
-        v20.objref<@layout_8> = obj.alloc @layout_8;
-        v22.objref<@layout_0> = obj.proj v20 0.i256;
-        v23.objref<i256> = obj.proj v22 0.i256;
-        v24.i256 = extract_value v6 0.i256;
-        obj.store v23 v24;
-        v26.objref<i256> = obj.proj v20 1.i256;
-        obj.store v26 v19;
-        v27.@layout_8 = obj.load v20;
-        return v27;
+        v21.i256 = call %core__lib__abi__decode_msg_field_from__g5385_9796 v0 v8 v11 v4;
+        v22.objref<@layout_8> = obj.alloc @layout_8;
+        v24.objref<@layout_0> = obj.proj v22 0.i256;
+        v25.objref<i256> = obj.proj v24 0.i256;
+        v26.i256 = extract_value v7 0.i256;
+        obj.store v25 v26;
+        v28.objref<i256> = obj.proj v22 1.i256;
+        obj.store v28 v21;
+        v29.@layout_8 = obj.load v22;
+        return v29;
 }
 
 func inline(always) private %impl_trait_Burn__decode_from__gd20d(v0.@layout_5, v1.i256) -> @layout_9 {
@@ -2887,14 +5250,15 @@ func inline(always) private %impl_trait_Burn__decode_from__gd20d(v0.@layout_5, v
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_6f43 v0;
         v5.i256 = mload v2 i256;
-        v6.i256 = call %core__lib__abi__decode_field_from__g5385_c0de v0 v4 v5;
-        v7.objref<@layout_9> = obj.alloc @layout_9;
-        v9.objref<i256> = obj.proj v7 0.i256;
-        obj.store v9 v6;
-        v10.@layout_9 = obj.load v7;
-        return v10;
+        v6.i256 = mload v2 i256;
+        v7.i256 = call %core__lib__abi__decode_msg_field_from__g5385_ce42 v0 v5 v6 v4;
+        v8.objref<@layout_9> = obj.alloc @layout_9;
+        v10.objref<i256> = obj.proj v8 0.i256;
+        obj.store v10 v7;
+        v11.@layout_9 = obj.load v8;
+        return v11;
 }
 
 func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_b39f(v0.@layout_5, v1.i256) -> i256 {
@@ -2906,6 +5270,18 @@ func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__
     block1:
         v4.i256 = mload v2 i256;
         v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_e134 v0 v4;
+        return v5;
+}
+
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_b39f_0(v0.@layout_5, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_e134_0 v0 v4;
         return v5;
 }
 
@@ -2937,7 +5313,7 @@ func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__de
         return v14;
 }
 
-func inline(always) private %impl_trait_BurnFrom__decode_from__gd20d(v0.@layout_5, v1.i256) -> @layout_10 {
+func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_b822_0(v0.@layout_5, v1.i256) -> @layout_0 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -2945,12 +5321,41 @@ func inline(always) private %impl_trait_BurnFrom__decode_from__gd20d(v0.@layout_
 
     block1:
         v4.i256 = mload v2 i256;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_40a0_0 v0 v4;
+        v7.i256 = shr 160.i256 v5;
+        v9.i1 = eq v7 0.i256;
+        v10.i1 = is_zero v9;
+        br v10 block2 block3;
+
+    block2:
+        evm_revert 0.i256 0.i256;
+
+    block3:
+        jump block4;
+
+    block4:
+        v11.objref<@layout_0> = obj.alloc @layout_0;
+        v13.objref<i256> = obj.proj v11 0.i256;
+        obj.store v13 v5;
+        v14.@layout_0 = obj.load v11;
+        return v14;
+}
+
+func inline(always) private %impl_trait_BurnFrom__decode_from__gd20d(v0.@layout_5, v1.i256) -> @layout_10 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_e065 v0;
         v5.i256 = mload v2 i256;
-        v6.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_05e1 v0 v4 v5;
-        v7.i256 = mload v2 i256;
+        v6.i256 = mload v2 i256;
+        v7.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_059c v0 v5 v6 v4;
         v8.i256 = mload v2 i256;
-        (v10.i256, v11.i1) = uaddo v8 32.i256;
-        br v11 block2 block3;
+        v9.i256 = mload v2 i256;
+        (v11.i256, v12.i1) = uaddo v9 32.i256;
+        br v12 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -2958,16 +5363,305 @@ func inline(always) private %impl_trait_BurnFrom__decode_from__gd20d(v0.@layout_
         evm_revert 0.i256 36.i256;
 
     block3:
-        v19.i256 = call %core__lib__abi__decode_field_from__g5385_c71a v0 v7 v10;
-        v20.objref<@layout_10> = obj.alloc @layout_10;
-        v22.objref<@layout_0> = obj.proj v20 0.i256;
-        v23.objref<i256> = obj.proj v22 0.i256;
-        v24.i256 = extract_value v6 0.i256;
-        obj.store v23 v24;
-        v26.objref<i256> = obj.proj v20 1.i256;
-        obj.store v26 v19;
-        v27.@layout_10 = obj.load v20;
-        return v27;
+        v21.i256 = call %core__lib__abi__decode_msg_field_from__g5385_745e v0 v8 v11 v4;
+        v22.objref<@layout_10> = obj.alloc @layout_10;
+        v24.objref<@layout_0> = obj.proj v22 0.i256;
+        v25.objref<i256> = obj.proj v24 0.i256;
+        v26.i256 = extract_value v7 0.i256;
+        obj.store v25 v26;
+        v28.objref<i256> = obj.proj v22 1.i256;
+        obj.store v28 v21;
+        v29.@layout_10 = obj.load v22;
+        return v29;
+}
+
+func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_1972(v0.@layout_5, v1.i256, v2.i256) -> i256 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v3 i256;
+        v7.i256 = mload v4 i256;
+        v8.i256 = call %core__lib__abi__checked_frame_end__gf13e_aaf5 v5 32.i256 v7;
+        v10.i256 = mload v3 i256;
+        v11.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_0a95 v0 v10;
+        return v11;
+}
+
+func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_2360(v0.@layout_5, v1.i256, v2.i256) -> i256 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v3 i256;
+        v7.i256 = mload v4 i256;
+        v8.i256 = call %core__lib__abi__checked_frame_end__gf13e_01a8 v5 32.i256 v7;
+        v10.i256 = mload v3 i256;
+        v11.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_b39f v0 v10;
+        return v11;
+}
+
+func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_2374(v0.@layout_5, v1.i256, v2.i256) -> i256 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v3 i256;
+        v7.i256 = mload v4 i256;
+        v8.i256 = call %core__lib__abi__checked_frame_end__gf13e_a584 v5 32.i256 v7;
+        v10.i256 = mload v3 i256;
+        v11.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8d9f v0 v10;
+        return v11;
+}
+
+func private %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_29bc(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v3 i256;
+        v7.i256 = mload v4 i256;
+        v8.i256 = call %core__lib__abi__checked_frame_end__gf13e_e706 v5 32.i256 v7;
+        v10.i256 = mload v3 i256;
+        v11.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_f4e0 v0 v10;
+        return v11;
+}
+
+func private %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_2c09(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v3 i256;
+        v7.i256 = mload v4 i256;
+        v8.i256 = call %core__lib__abi__checked_frame_end__gf13e_cc78 v5 32.i256 v7;
+        v10.i256 = mload v3 i256;
+        v11.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_5535 v0 v10;
+        return v11;
+}
+
+func private %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_3639(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v3 i256;
+        v7.i256 = mload v4 i256;
+        v8.i256 = call %core__lib__abi__checked_frame_end__gf13e_4689 v5 32.i256 v7;
+        v10.i256 = mload v3 i256;
+        v11.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_2519 v0 v10;
+        return v11;
+}
+
+func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_38c3(v0.@layout_5, v1.i256, v2.i256) -> i256 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v3 i256;
+        v7.i256 = mload v4 i256;
+        v8.i256 = call %core__lib__abi__checked_frame_end__gf13e_c0b4 v5 32.i256 v7;
+        v10.i256 = mload v3 i256;
+        v11.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_18e6 v0 v10;
+        return v11;
+}
+
+func private %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_3fea(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v3 i256;
+        v7.i256 = mload v4 i256;
+        v8.i256 = call %core__lib__abi__checked_frame_end__gf13e_de97 v5 32.i256 v7;
+        v10.i256 = mload v3 i256;
+        v11.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_9286 v0 v10;
+        return v11;
+}
+
+func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_43c7(v0.@layout_5, v1.i256, v2.i256) -> i256 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v3 i256;
+        v7.i256 = mload v4 i256;
+        v8.i256 = call %core__lib__abi__checked_frame_end__gf13e_f40a v5 32.i256 v7;
+        v10.i256 = mload v3 i256;
+        v11.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_3a7c v0 v10;
+        return v11;
+}
+
+func private %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_64e6(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v3 i256;
+        v7.i256 = mload v4 i256;
+        v8.i256 = call %core__lib__abi__checked_frame_end__gf13e_6403 v5 32.i256 v7;
+        v10.i256 = mload v3 i256;
+        v11.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_4e5e v0 v10;
+        return v11;
+}
+
+func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_6ea9(v0.@layout_5, v1.i256, v2.i256) -> i256 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v3 i256;
+        v7.i256 = mload v4 i256;
+        v8.i256 = call %core__lib__abi__checked_frame_end__gf13e_9888 v5 32.i256 v7;
+        v10.i256 = mload v3 i256;
+        v11.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_4e52 v0 v10;
+        return v11;
+}
+
+func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_8823(v0.@layout_5, v1.i256, v2.i256) -> i256 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v3 i256;
+        v7.i256 = mload v4 i256;
+        v8.i256 = call %core__lib__abi__checked_frame_end__gf13e_9284 v5 32.i256 v7;
+        v10.i256 = mload v3 i256;
+        v11.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_251a v0 v10;
+        return v11;
+}
+
+func private %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_8e68(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v3 i256;
+        v7.i256 = mload v4 i256;
+        v8.i256 = call %core__lib__abi__checked_frame_end__gf13e_c3cb v5 32.i256 v7;
+        v10.i256 = mload v3 i256;
+        v11.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_b822 v0 v10;
+        return v11;
+}
+
+func private %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_978c(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v3 i256;
+        v7.i256 = mload v4 i256;
+        v8.i256 = call %core__lib__abi__checked_frame_end__gf13e_60b4 v5 32.i256 v7;
+        v10.i256 = mload v3 i256;
+        v11.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_3716 v0 v10;
+        return v11;
+}
+
+func private %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_a883(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v3 i256;
+        v7.i256 = mload v4 i256;
+        v8.i256 = call %core__lib__abi__checked_frame_end__gf13e_9b12 v5 32.i256 v7;
+        v10.i256 = mload v3 i256;
+        v11.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_3641 v0 v10;
+        return v11;
+}
+
+func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_d01b(v0.@layout_5, v1.i256, v2.i256) -> i256 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v3 i256;
+        v7.i256 = mload v4 i256;
+        v8.i256 = call %core__lib__abi__checked_frame_end__gf13e_d1eb v5 32.i256 v7;
+        v10.i256 = mload v3 i256;
+        v11.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_5c31 v0 v10;
+        return v11;
+}
+
+func private %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_d676(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v3 i256;
+        v7.i256 = mload v4 i256;
+        v8.i256 = call %core__lib__abi__checked_frame_end__gf13e_b8aa v5 32.i256 v7;
+        v10.i256 = mload v3 i256;
+        v11.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_db93 v0 v10;
+        return v11;
 }
 
 func inline(always) private %impl_trait_Decimals__decode_from__gd20d(v0.@layout_5, v1.i256) {
@@ -2987,16 +5681,17 @@ func inline(always) private %impl_trait_BalanceOf__decode_from__gd20d(v0.@layout
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_e9e0 v0;
         v5.i256 = mload v2 i256;
-        v6.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_fd62 v0 v4 v5;
-        v7.objref<@layout_11> = obj.alloc @layout_11;
-        v9.objref<@layout_0> = obj.proj v7 0.i256;
-        v10.objref<i256> = obj.proj v9 0.i256;
-        v11.i256 = extract_value v6 0.i256;
-        obj.store v10 v11;
-        v12.@layout_11 = obj.load v7;
-        return v12;
+        v6.i256 = mload v2 i256;
+        v7.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_6f66 v0 v5 v6 v4;
+        v8.objref<@layout_11> = obj.alloc @layout_11;
+        v10.objref<@layout_0> = obj.proj v8 0.i256;
+        v11.objref<i256> = obj.proj v10 0.i256;
+        v12.i256 = extract_value v7 0.i256;
+        obj.store v11 v12;
+        v13.@layout_11 = obj.load v8;
+        return v13;
 }
 
 func inline(always) private %impl_trait_Name__decode_from__gd20d(v0.@layout_5, v1.i256) {
@@ -3016,13 +5711,14 @@ func inline(always) private %impl_trait_IncreaseAllowance__decode_from__gd20d(v0
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_de6d v0;
         v5.i256 = mload v2 i256;
-        v6.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_6a4b v0 v4 v5;
-        v7.i256 = mload v2 i256;
+        v6.i256 = mload v2 i256;
+        v7.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_f58a v0 v5 v6 v4;
         v8.i256 = mload v2 i256;
-        (v10.i256, v11.i1) = uaddo v8 32.i256;
-        br v11 block2 block3;
+        v9.i256 = mload v2 i256;
+        (v11.i256, v12.i1) = uaddo v9 32.i256;
+        br v12 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -3030,16 +5726,16 @@ func inline(always) private %impl_trait_IncreaseAllowance__decode_from__gd20d(v0
         evm_revert 0.i256 36.i256;
 
     block3:
-        v19.i256 = call %core__lib__abi__decode_field_from__g5385_9c75 v0 v7 v10;
-        v20.objref<@layout_12> = obj.alloc @layout_12;
-        v22.objref<@layout_0> = obj.proj v20 0.i256;
-        v23.objref<i256> = obj.proj v22 0.i256;
-        v24.i256 = extract_value v6 0.i256;
-        obj.store v23 v24;
-        v26.objref<i256> = obj.proj v20 1.i256;
-        obj.store v26 v19;
-        v27.@layout_12 = obj.load v20;
-        return v27;
+        v21.i256 = call %core__lib__abi__decode_msg_field_from__g5385_0929 v0 v8 v11 v4;
+        v22.objref<@layout_12> = obj.alloc @layout_12;
+        v24.objref<@layout_0> = obj.proj v22 0.i256;
+        v25.objref<i256> = obj.proj v24 0.i256;
+        v26.i256 = extract_value v7 0.i256;
+        obj.store v25 v26;
+        v28.objref<i256> = obj.proj v22 1.i256;
+        obj.store v28 v21;
+        v29.@layout_12 = obj.load v22;
+        return v29;
 }
 
 func inline(always) private %impl_trait_TransferFrom__decode_from__gd20d(v0.@layout_5, v1.i256) -> @layout_13 {
@@ -3049,13 +5745,14 @@ func inline(always) private %impl_trait_TransferFrom__decode_from__gd20d(v0.@lay
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_36c4 v0;
         v5.i256 = mload v2 i256;
-        v6.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_8ab8 v0 v4 v5;
-        v7.i256 = mload v2 i256;
+        v6.i256 = mload v2 i256;
+        v7.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_3b80 v0 v5 v6 v4;
         v8.i256 = mload v2 i256;
-        (v10.i256, v11.i1) = uaddo v8 32.i256;
-        br v11 block2 block3;
+        v9.i256 = mload v2 i256;
+        (v11.i256, v12.i1) = uaddo v9 32.i256;
+        br v12 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -3063,31 +5760,31 @@ func inline(always) private %impl_trait_TransferFrom__decode_from__gd20d(v0.@lay
         evm_revert 0.i256 36.i256;
 
     block3:
-        v19.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_8ab8 v0 v7 v10;
-        v21.i256 = mload v2 i256;
-        v22.i256 = mload v2 i256;
-        (v23.i256, v24.i1) = uaddo v22 32.i256;
-        br v24 block2 block4;
+        v21.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_3b80 v0 v8 v11 v4;
+        v23.i256 = mload v2 i256;
+        v24.i256 = mload v2 i256;
+        (v25.i256, v26.i1) = uaddo v24 32.i256;
+        br v26 block2 block4;
 
     block4:
-        (v25.i256, v26.i1) = uaddo v23 32.i256;
-        br v26 block2 block5;
+        (v27.i256, v28.i1) = uaddo v25 32.i256;
+        br v28 block2 block5;
 
     block5:
-        v29.i256 = call %core__lib__abi__decode_field_from__g5385_30a1 v0 v21 v25;
-        v30.objref<@layout_13> = obj.alloc @layout_13;
-        v32.objref<@layout_0> = obj.proj v30 0.i256;
-        v33.objref<i256> = obj.proj v32 0.i256;
-        v34.i256 = extract_value v6 0.i256;
-        obj.store v33 v34;
-        v37.objref<@layout_0> = obj.proj v30 1.i256;
-        v38.objref<i256> = obj.proj v37 0.i256;
-        v39.i256 = extract_value v19 0.i256;
-        obj.store v38 v39;
-        v41.objref<i256> = obj.proj v30 2.i256;
-        obj.store v41 v29;
-        v42.@layout_13 = obj.load v30;
-        return v42;
+        v32.i256 = call %core__lib__abi__decode_msg_field_from__g5385_2a48 v0 v23 v27 v4;
+        v33.objref<@layout_13> = obj.alloc @layout_13;
+        v35.objref<@layout_0> = obj.proj v33 0.i256;
+        v36.objref<i256> = obj.proj v35 0.i256;
+        v37.i256 = extract_value v7 0.i256;
+        obj.store v36 v37;
+        v40.objref<@layout_0> = obj.proj v33 1.i256;
+        v41.objref<i256> = obj.proj v40 0.i256;
+        v42.i256 = extract_value v21 0.i256;
+        obj.store v41 v42;
+        v44.objref<i256> = obj.proj v33 2.i256;
+        obj.store v44 v32;
+        v45.@layout_13 = obj.load v33;
+        return v45;
 }
 
 func inline(always) private %impl_trait_Transfer__decode_from__gd20d(v0.@layout_5, v1.i256) -> @layout_14 {
@@ -3097,13 +5794,14 @@ func inline(always) private %impl_trait_Transfer__decode_from__gd20d(v0.@layout_
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_0eff v0;
         v5.i256 = mload v2 i256;
-        v6.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_cd1a v0 v4 v5;
-        v7.i256 = mload v2 i256;
+        v6.i256 = mload v2 i256;
+        v7.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_bede v0 v5 v6 v4;
         v8.i256 = mload v2 i256;
-        (v10.i256, v11.i1) = uaddo v8 32.i256;
-        br v11 block2 block3;
+        v9.i256 = mload v2 i256;
+        (v11.i256, v12.i1) = uaddo v9 32.i256;
+        br v12 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -3111,16 +5809,16 @@ func inline(always) private %impl_trait_Transfer__decode_from__gd20d(v0.@layout_
         evm_revert 0.i256 36.i256;
 
     block3:
-        v19.i256 = call %core__lib__abi__decode_field_from__g5385_d823 v0 v7 v10;
-        v20.objref<@layout_14> = obj.alloc @layout_14;
-        v22.objref<@layout_0> = obj.proj v20 0.i256;
-        v23.objref<i256> = obj.proj v22 0.i256;
-        v24.i256 = extract_value v6 0.i256;
-        obj.store v23 v24;
-        v26.objref<i256> = obj.proj v20 1.i256;
-        obj.store v26 v19;
-        v27.@layout_14 = obj.load v20;
-        return v27;
+        v21.i256 = call %core__lib__abi__decode_msg_field_from__g5385_252f v0 v8 v11 v4;
+        v22.objref<@layout_14> = obj.alloc @layout_14;
+        v24.objref<@layout_0> = obj.proj v22 0.i256;
+        v25.objref<i256> = obj.proj v24 0.i256;
+        v26.i256 = extract_value v7 0.i256;
+        obj.store v25 v26;
+        v28.objref<i256> = obj.proj v22 1.i256;
+        obj.store v28 v21;
+        v29.@layout_14 = obj.load v22;
+        return v29;
 }
 
 func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_db93(v0.@layout_5, v1.i256) -> @layout_0 {
@@ -3151,7 +5849,7 @@ func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__de
         return v14;
 }
 
-func inline(always) private %impl_trait_DecreaseAllowance__decode_from__gd20d(v0.@layout_5, v1.i256) -> @layout_15 {
+func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_db93_0(v0.@layout_5, v1.i256) -> @layout_0 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -3159,12 +5857,41 @@ func inline(always) private %impl_trait_DecreaseAllowance__decode_from__gd20d(v0
 
     block1:
         v4.i256 = mload v2 i256;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3ba3_0 v0 v4;
+        v7.i256 = shr 160.i256 v5;
+        v9.i1 = eq v7 0.i256;
+        v10.i1 = is_zero v9;
+        br v10 block2 block3;
+
+    block2:
+        evm_revert 0.i256 0.i256;
+
+    block3:
+        jump block4;
+
+    block4:
+        v11.objref<@layout_0> = obj.alloc @layout_0;
+        v13.objref<i256> = obj.proj v11 0.i256;
+        obj.store v13 v5;
+        v14.@layout_0 = obj.load v11;
+        return v14;
+}
+
+func inline(always) private %impl_trait_DecreaseAllowance__decode_from__gd20d(v0.@layout_5, v1.i256) -> @layout_15 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_e83e v0;
         v5.i256 = mload v2 i256;
-        v6.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_b81d v0 v4 v5;
-        v7.i256 = mload v2 i256;
+        v6.i256 = mload v2 i256;
+        v7.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_7904 v0 v5 v6 v4;
         v8.i256 = mload v2 i256;
-        (v10.i256, v11.i1) = uaddo v8 32.i256;
-        br v11 block2 block3;
+        v9.i256 = mload v2 i256;
+        (v11.i256, v12.i1) = uaddo v9 32.i256;
+        br v12 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -3172,16 +5899,16 @@ func inline(always) private %impl_trait_DecreaseAllowance__decode_from__gd20d(v0
         evm_revert 0.i256 36.i256;
 
     block3:
-        v19.i256 = call %core__lib__abi__decode_field_from__g5385_4478 v0 v7 v10;
-        v20.objref<@layout_15> = obj.alloc @layout_15;
-        v22.objref<@layout_0> = obj.proj v20 0.i256;
-        v23.objref<i256> = obj.proj v22 0.i256;
-        v24.i256 = extract_value v6 0.i256;
-        obj.store v23 v24;
-        v26.objref<i256> = obj.proj v20 1.i256;
-        obj.store v26 v19;
-        v27.@layout_15 = obj.load v20;
-        return v27;
+        v21.i256 = call %core__lib__abi__decode_msg_field_from__g5385_9aa8 v0 v8 v11 v4;
+        v22.objref<@layout_15> = obj.alloc @layout_15;
+        v24.objref<@layout_0> = obj.proj v22 0.i256;
+        v25.objref<i256> = obj.proj v24 0.i256;
+        v26.i256 = extract_value v7 0.i256;
+        obj.store v25 v26;
+        v28.objref<i256> = obj.proj v22 1.i256;
+        obj.store v28 v21;
+        v29.@layout_15 = obj.load v22;
+        return v29;
 }
 
 func inline(always) private %impl_trait_TotalSupply__decode_from__gd20d(v0.@layout_5, v1.i256) {
@@ -3203,6 +5930,34 @@ func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__de
     block1:
         v4.i256 = mload v2 i256;
         v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_bae8 v0 v4;
+        v7.i256 = shr 160.i256 v5;
+        v9.i1 = eq v7 0.i256;
+        v10.i1 = is_zero v9;
+        br v10 block2 block3;
+
+    block2:
+        evm_revert 0.i256 0.i256;
+
+    block3:
+        jump block4;
+
+    block4:
+        v11.objref<@layout_0> = obj.alloc @layout_0;
+        v13.objref<i256> = obj.proj v11 0.i256;
+        obj.store v13 v5;
+        v14.@layout_0 = obj.load v11;
+        return v14;
+}
+
+func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_f4e0_0(v0.@layout_5, v1.i256) -> @layout_0 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_bae8_0 v0 v4;
         v7.i256 = shr 160.i256 v5;
         v9.i1 = eq v7 0.i256;
         v10.i1 = is_zero v9;
@@ -3432,12 +6187,548 @@ func inline(always) private %decode_from_prechecked_head__g383e(v0.@layout_5, v1
         return v8;
 }
 
+func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_0219(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> i256 {
+    block0:
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        v6.*i256 = alloca i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        mstore v6 v3 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v9.i256 = mload v4 i256;
+        v10.i256 = mload v5 i256;
+        v11.i256 = mload v6 i256;
+        v12.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_5db0 v0 v9 v10 v11;
+        return v12;
+
+    block3:
+        jump block4;
+
+    block4:
+        v13.i256 = mload v6 i256;
+        v15.i256 = mload v4 i256;
+        v16.i256 = mload v5 i256;
+        v17.i256 = call %core__lib__abi__decode_field_from__g5385_4796 v0 v15 v16;
+        return v17;
+}
+
+func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_0358(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> @layout_0 {
+    block0:
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        v6.*i256 = alloca i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        mstore v6 v3 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v9.i256 = mload v4 i256;
+        v10.i256 = mload v5 i256;
+        v11.i256 = mload v6 i256;
+        v12.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_18ef v0 v9 v10 v11;
+        return v12;
+
+    block3:
+        jump block4;
+
+    block4:
+        v13.i256 = mload v6 i256;
+        v15.i256 = mload v4 i256;
+        v16.i256 = mload v5 i256;
+        v17.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_2692 v0 v15 v16;
+        return v17;
+}
+
+func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_059c(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> @layout_0 {
+    block0:
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        v6.*i256 = alloca i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        mstore v6 v3 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v9.i256 = mload v4 i256;
+        v10.i256 = mload v5 i256;
+        v11.i256 = mload v6 i256;
+        v12.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_2724 v0 v9 v10 v11;
+        return v12;
+
+    block3:
+        jump block4;
+
+    block4:
+        v13.i256 = mload v6 i256;
+        v15.i256 = mload v4 i256;
+        v16.i256 = mload v5 i256;
+        v17.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_786c v0 v15 v16;
+        return v17;
+}
+
+func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_0929(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> i256 {
+    block0:
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        v6.*i256 = alloca i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        mstore v6 v3 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v9.i256 = mload v4 i256;
+        v10.i256 = mload v5 i256;
+        v11.i256 = mload v6 i256;
+        v12.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_7760 v0 v9 v10 v11;
+        return v12;
+
+    block3:
+        jump block4;
+
+    block4:
+        v13.i256 = mload v6 i256;
+        v15.i256 = mload v4 i256;
+        v16.i256 = mload v5 i256;
+        v17.i256 = call %core__lib__abi__decode_field_from__g5385_9270 v0 v15 v16;
+        return v17;
+}
+
+func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_252f(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> i256 {
+    block0:
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        v6.*i256 = alloca i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        mstore v6 v3 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v9.i256 = mload v4 i256;
+        v10.i256 = mload v5 i256;
+        v11.i256 = mload v6 i256;
+        v12.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_847c v0 v9 v10 v11;
+        return v12;
+
+    block3:
+        jump block4;
+
+    block4:
+        v13.i256 = mload v6 i256;
+        v15.i256 = mload v4 i256;
+        v16.i256 = mload v5 i256;
+        v17.i256 = call %core__lib__abi__decode_field_from__g5385_79b2 v0 v15 v16;
+        return v17;
+}
+
+func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_2a48(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> i256 {
+    block0:
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        v6.*i256 = alloca i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        mstore v6 v3 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v9.i256 = mload v4 i256;
+        v10.i256 = mload v5 i256;
+        v11.i256 = mload v6 i256;
+        v12.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_839e v0 v9 v10 v11;
+        return v12;
+
+    block3:
+        jump block4;
+
+    block4:
+        v13.i256 = mload v6 i256;
+        v15.i256 = mload v4 i256;
+        v16.i256 = mload v5 i256;
+        v17.i256 = call %core__lib__abi__decode_field_from__g5385_03a7 v0 v15 v16;
+        return v17;
+}
+
+func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_329a(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> @layout_0 {
+    block0:
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        v6.*i256 = alloca i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        mstore v6 v3 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v9.i256 = mload v4 i256;
+        v10.i256 = mload v5 i256;
+        v11.i256 = mload v6 i256;
+        v12.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_2207 v0 v9 v10 v11;
+        return v12;
+
+    block3:
+        jump block4;
+
+    block4:
+        v13.i256 = mload v6 i256;
+        v15.i256 = mload v4 i256;
+        v16.i256 = mload v5 i256;
+        v17.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_7fa7 v0 v15 v16;
+        return v17;
+}
+
+func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_3b80(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> @layout_0 {
+    block0:
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        v6.*i256 = alloca i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        mstore v6 v3 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v9.i256 = mload v4 i256;
+        v10.i256 = mload v5 i256;
+        v11.i256 = mload v6 i256;
+        v12.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_a4f7 v0 v9 v10 v11;
+        return v12;
+
+    block3:
+        jump block4;
+
+    block4:
+        v13.i256 = mload v6 i256;
+        v15.i256 = mload v4 i256;
+        v16.i256 = mload v5 i256;
+        v17.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_7143 v0 v15 v16;
+        return v17;
+}
+
+func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_6698(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> @layout_0 {
+    block0:
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        v6.*i256 = alloca i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        mstore v6 v3 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v9.i256 = mload v4 i256;
+        v10.i256 = mload v5 i256;
+        v11.i256 = mload v6 i256;
+        v12.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_07a0 v0 v9 v10 v11;
+        return v12;
+
+    block3:
+        jump block4;
+
+    block4:
+        v13.i256 = mload v6 i256;
+        v15.i256 = mload v4 i256;
+        v16.i256 = mload v5 i256;
+        v17.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_b564 v0 v15 v16;
+        return v17;
+}
+
+func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_6f66(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> @layout_0 {
+    block0:
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        v6.*i256 = alloca i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        mstore v6 v3 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v9.i256 = mload v4 i256;
+        v10.i256 = mload v5 i256;
+        v11.i256 = mload v6 i256;
+        v12.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_faf8 v0 v9 v10 v11;
+        return v12;
+
+    block3:
+        jump block4;
+
+    block4:
+        v13.i256 = mload v6 i256;
+        v15.i256 = mload v4 i256;
+        v16.i256 = mload v5 i256;
+        v17.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_d5c8 v0 v15 v16;
+        return v17;
+}
+
+func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_745e(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> i256 {
+    block0:
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        v6.*i256 = alloca i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        mstore v6 v3 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v9.i256 = mload v4 i256;
+        v10.i256 = mload v5 i256;
+        v11.i256 = mload v6 i256;
+        v12.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_c7d5 v0 v9 v10 v11;
+        return v12;
+
+    block3:
+        jump block4;
+
+    block4:
+        v13.i256 = mload v6 i256;
+        v15.i256 = mload v4 i256;
+        v16.i256 = mload v5 i256;
+        v17.i256 = call %core__lib__abi__decode_field_from__g5385_cb05 v0 v15 v16;
+        return v17;
+}
+
+func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_7904(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> @layout_0 {
+    block0:
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        v6.*i256 = alloca i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        mstore v6 v3 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v9.i256 = mload v4 i256;
+        v10.i256 = mload v5 i256;
+        v11.i256 = mload v6 i256;
+        v12.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_ef75 v0 v9 v10 v11;
+        return v12;
+
+    block3:
+        jump block4;
+
+    block4:
+        v13.i256 = mload v6 i256;
+        v15.i256 = mload v4 i256;
+        v16.i256 = mload v5 i256;
+        v17.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_d5a0 v0 v15 v16;
+        return v17;
+}
+
+func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_9796(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> i256 {
+    block0:
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        v6.*i256 = alloca i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        mstore v6 v3 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v9.i256 = mload v4 i256;
+        v10.i256 = mload v5 i256;
+        v11.i256 = mload v6 i256;
+        v12.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_34fc v0 v9 v10 v11;
+        return v12;
+
+    block3:
+        jump block4;
+
+    block4:
+        v13.i256 = mload v6 i256;
+        v15.i256 = mload v4 i256;
+        v16.i256 = mload v5 i256;
+        v17.i256 = call %core__lib__abi__decode_field_from__g5385_7366 v0 v15 v16;
+        return v17;
+}
+
+func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_9aa8(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> i256 {
+    block0:
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        v6.*i256 = alloca i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        mstore v6 v3 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v9.i256 = mload v4 i256;
+        v10.i256 = mload v5 i256;
+        v11.i256 = mload v6 i256;
+        v12.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_b51a v0 v9 v10 v11;
+        return v12;
+
+    block3:
+        jump block4;
+
+    block4:
+        v13.i256 = mload v6 i256;
+        v15.i256 = mload v4 i256;
+        v16.i256 = mload v5 i256;
+        v17.i256 = call %core__lib__abi__decode_field_from__g5385_5cc4 v0 v15 v16;
+        return v17;
+}
+
+func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_bede(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> @layout_0 {
+    block0:
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        v6.*i256 = alloca i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        mstore v6 v3 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v9.i256 = mload v4 i256;
+        v10.i256 = mload v5 i256;
+        v11.i256 = mload v6 i256;
+        v12.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_ed91 v0 v9 v10 v11;
+        return v12;
+
+    block3:
+        jump block4;
+
+    block4:
+        v13.i256 = mload v6 i256;
+        v15.i256 = mload v4 i256;
+        v16.i256 = mload v5 i256;
+        v17.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_e784 v0 v15 v16;
+        return v17;
+}
+
+func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_ce42(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> i256 {
+    block0:
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        v6.*i256 = alloca i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        mstore v6 v3 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v9.i256 = mload v4 i256;
+        v10.i256 = mload v5 i256;
+        v11.i256 = mload v6 i256;
+        v12.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_d4dc v0 v9 v10 v11;
+        return v12;
+
+    block3:
+        jump block4;
+
+    block4:
+        v13.i256 = mload v6 i256;
+        v15.i256 = mload v4 i256;
+        v16.i256 = mload v5 i256;
+        v17.i256 = call %core__lib__abi__decode_field_from__g5385_d887 v0 v15 v16;
+        return v17;
+}
+
+func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_f58a(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> @layout_0 {
+    block0:
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        v6.*i256 = alloca i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        mstore v6 v3 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v9.i256 = mload v4 i256;
+        v10.i256 = mload v5 i256;
+        v11.i256 = mload v6 i256;
+        v12.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_764c v0 v9 v10 v11;
+        return v12;
+
+    block3:
+        jump block4;
+
+    block4:
+        v13.i256 = mload v6 i256;
+        v15.i256 = mload v4 i256;
+        v16.i256 = mload v5 i256;
+        v17.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_2eef v0 v15 v16;
+        return v17;
+}
+
+func inline(always) private %impl_trait_u256__decode_payload__g407e(v0.objref<@layout_4>) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v2.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_85d9 v0;
+        return v2;
+}
+
 func inline(always) private %impl_trait_Address__decode_payload__g407e(v0.objref<@layout_4>) -> @layout_0 {
     block0:
         jump block1;
 
     block1:
-        v2.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_83b2 v0;
+        v2.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_87b3 v0;
         v4.i256 = shr 160.i256 v2;
         v6.i1 = eq v4 0.i256;
         v7.i1 = is_zero v6;
@@ -3473,15 +6764,6 @@ func private %decode_payload__gf566(v0.objref<@layout_4>) -> @layout_16 {
         obj.store v9 v10;
         v11.@layout_16 = obj.load v4;
         return v11;
-}
-
-func inline(always) private %impl_trait_u256__decode_payload__g407e(v0.objref<@layout_4>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_44f9 v0;
-        return v2;
 }
 
 func inline(always) private %decode_runtime_args__g5a0b(v0.objref<@layout_18>) {
@@ -5120,14 +8402,42 @@ func private %std__lib__evm__effects__impl_trait_Evm_c913__input_f89e() -> @layo
         return v0;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_01a6(v0.objref<@layout_2>) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_0eff(v0.@layout_5) -> i256 {
     block0:
+        v1.*i256 = alloca i256;
+        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.objref<i256> = obj.proj v0 1.i256;
-        v4.i256 = obj.load v3;
-        return v4;
+        v3.i256 = evm_calldata_size;
+        mstore v1 v3 i256;
+        v6.i256 = extract_value v0 0.i256;
+        v7.i256 = mload v1 i256;
+        mstore v2 v7 i256;
+        v8.i256 = mload v2 i256;
+        v9.i1 = gt v6 v8;
+        br v9 block2 block3;
+
+    block2:
+        jump block4;
+
+    block3:
+        v11.i256 = extract_value v0 0.i256;
+        v12.i256 = mload v1 i256;
+        (v13.i256, v14.i1) = usubo v12 v11;
+        br v14 block5 block6;
+
+    block4:
+        v19.i256 = phi (0.i256 block2) (v13 block6);
+        return v19;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        jump block4;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_1a14(v0.@layout_5) -> i256 {
@@ -5204,6 +8514,54 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
 
     block6:
         jump block4;
+}
+
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_36c4(v0.@layout_5) -> i256 {
+    block0:
+        v1.*i256 = alloca i256;
+        v2.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v3.i256 = evm_calldata_size;
+        mstore v1 v3 i256;
+        v6.i256 = extract_value v0 0.i256;
+        v7.i256 = mload v1 i256;
+        mstore v2 v7 i256;
+        v8.i256 = mload v2 i256;
+        v9.i1 = gt v6 v8;
+        br v9 block2 block3;
+
+    block2:
+        jump block4;
+
+    block3:
+        v11.i256 = extract_value v0 0.i256;
+        v12.i256 = mload v1 i256;
+        (v13.i256, v14.i1) = usubo v12 v11;
+        br v14 block5 block6;
+
+    block4:
+        v19.i256 = phi (0.i256 block2) (v13 block6);
+        return v19;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        jump block4;
+}
+
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_48ab(v0.objref<@layout_2>) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v3.objref<i256> = obj.proj v0 1.i256;
+        v4.i256 = obj.load v3;
+        return v4;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_4a91(v0.@layout_5) -> i256 {
@@ -5358,6 +8716,44 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         jump block4;
 }
 
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_6f43(v0.@layout_5) -> i256 {
+    block0:
+        v1.*i256 = alloca i256;
+        v2.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v3.i256 = evm_calldata_size;
+        mstore v1 v3 i256;
+        v6.i256 = extract_value v0 0.i256;
+        v7.i256 = mload v1 i256;
+        mstore v2 v7 i256;
+        v8.i256 = mload v2 i256;
+        v9.i1 = gt v6 v8;
+        br v9 block2 block3;
+
+    block2:
+        jump block4;
+
+    block3:
+        v11.i256 = extract_value v0 0.i256;
+        v12.i256 = mload v1 i256;
+        (v13.i256, v14.i1) = usubo v12 v11;
+        br v14 block5 block6;
+
+    block4:
+        v19.i256 = phi (0.i256 block2) (v13 block6);
+        return v19;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        jump block4;
+}
+
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_7388(v0.@layout_5) -> i256 {
     block0:
         v1.*i256 = alloca i256;
@@ -5396,7 +8792,113 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         jump block4;
 }
 
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_779e(v0.@layout_5) -> i256 {
+    block0:
+        v1.*i256 = alloca i256;
+        v2.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v3.i256 = evm_calldata_size;
+        mstore v1 v3 i256;
+        v6.i256 = extract_value v0 0.i256;
+        v7.i256 = mload v1 i256;
+        mstore v2 v7 i256;
+        v8.i256 = mload v2 i256;
+        v9.i1 = gt v6 v8;
+        br v9 block2 block3;
+
+    block2:
+        jump block4;
+
+    block3:
+        v11.i256 = extract_value v0 0.i256;
+        v12.i256 = mload v1 i256;
+        (v13.i256, v14.i1) = usubo v12 v11;
+        br v14 block5 block6;
+
+    block4:
+        v19.i256 = phi (0.i256 block2) (v13 block6);
+        return v19;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        jump block4;
+}
+
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_7b50(v0.objref<@layout_2>) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v3.objref<i256> = obj.proj v0 1.i256;
+        v4.i256 = obj.load v3;
+        return v4;
+}
+
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_7b50_0(v0.objref<@layout_2>) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v3.objref<i256> = obj.proj v0 1.i256;
+        v4.i256 = obj.load v3;
+        return v4;
+}
+
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_9efd(v0.@layout_5) -> i256 {
+    block0:
+        v1.*i256 = alloca i256;
+        v2.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v3.i256 = evm_calldata_size;
+        mstore v1 v3 i256;
+        v6.i256 = extract_value v0 0.i256;
+        v7.i256 = mload v1 i256;
+        mstore v2 v7 i256;
+        v8.i256 = mload v2 i256;
+        v9.i1 = gt v6 v8;
+        br v9 block2 block3;
+
+    block2:
+        jump block4;
+
+    block3:
+        v11.i256 = extract_value v0 0.i256;
+        v12.i256 = mload v1 i256;
+        (v13.i256, v14.i1) = usubo v12 v11;
+        br v14 block5 block6;
+
+    block4:
+        v19.i256 = phi (0.i256 block2) (v13 block6);
+        return v19;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        jump block4;
+}
+
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_a4fa(v0.objref<@layout_2>) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v3.objref<i256> = obj.proj v0 1.i256;
+        v4.i256 = obj.load v3;
+        return v4;
+}
+
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_aa47(v0.@layout_5) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
@@ -5510,26 +9012,6 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         jump block4;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_be96(v0.objref<@layout_2>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 1.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_be96_0(v0.objref<@layout_2>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 1.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_c018(v0.@layout_5) -> i256 {
     block0:
         v1.*i256 = alloca i256;
@@ -5606,14 +9088,194 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         jump block4;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_e00f(v0.objref<@layout_2>) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_de6d(v0.@layout_5) -> i256 {
     block0:
+        v1.*i256 = alloca i256;
+        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.objref<i256> = obj.proj v0 1.i256;
-        v4.i256 = obj.load v3;
-        return v4;
+        v3.i256 = evm_calldata_size;
+        mstore v1 v3 i256;
+        v6.i256 = extract_value v0 0.i256;
+        v7.i256 = mload v1 i256;
+        mstore v2 v7 i256;
+        v8.i256 = mload v2 i256;
+        v9.i1 = gt v6 v8;
+        br v9 block2 block3;
+
+    block2:
+        jump block4;
+
+    block3:
+        v11.i256 = extract_value v0 0.i256;
+        v12.i256 = mload v1 i256;
+        (v13.i256, v14.i1) = usubo v12 v11;
+        br v14 block5 block6;
+
+    block4:
+        v19.i256 = phi (0.i256 block2) (v13 block6);
+        return v19;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        jump block4;
+}
+
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_e065(v0.@layout_5) -> i256 {
+    block0:
+        v1.*i256 = alloca i256;
+        v2.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v3.i256 = evm_calldata_size;
+        mstore v1 v3 i256;
+        v6.i256 = extract_value v0 0.i256;
+        v7.i256 = mload v1 i256;
+        mstore v2 v7 i256;
+        v8.i256 = mload v2 i256;
+        v9.i1 = gt v6 v8;
+        br v9 block2 block3;
+
+    block2:
+        jump block4;
+
+    block3:
+        v11.i256 = extract_value v0 0.i256;
+        v12.i256 = mload v1 i256;
+        (v13.i256, v14.i1) = usubo v12 v11;
+        br v14 block5 block6;
+
+    block4:
+        v19.i256 = phi (0.i256 block2) (v13 block6);
+        return v19;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        jump block4;
+}
+
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_e83e(v0.@layout_5) -> i256 {
+    block0:
+        v1.*i256 = alloca i256;
+        v2.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v3.i256 = evm_calldata_size;
+        mstore v1 v3 i256;
+        v6.i256 = extract_value v0 0.i256;
+        v7.i256 = mload v1 i256;
+        mstore v2 v7 i256;
+        v8.i256 = mload v2 i256;
+        v9.i1 = gt v6 v8;
+        br v9 block2 block3;
+
+    block2:
+        jump block4;
+
+    block3:
+        v11.i256 = extract_value v0 0.i256;
+        v12.i256 = mload v1 i256;
+        (v13.i256, v14.i1) = usubo v12 v11;
+        br v14 block5 block6;
+
+    block4:
+        v19.i256 = phi (0.i256 block2) (v13 block6);
+        return v19;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        jump block4;
+}
+
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_e949(v0.@layout_5) -> i256 {
+    block0:
+        v1.*i256 = alloca i256;
+        v2.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v3.i256 = evm_calldata_size;
+        mstore v1 v3 i256;
+        v6.i256 = extract_value v0 0.i256;
+        v7.i256 = mload v1 i256;
+        mstore v2 v7 i256;
+        v8.i256 = mload v2 i256;
+        v9.i1 = gt v6 v8;
+        br v9 block2 block3;
+
+    block2:
+        jump block4;
+
+    block3:
+        v11.i256 = extract_value v0 0.i256;
+        v12.i256 = mload v1 i256;
+        (v13.i256, v14.i1) = usubo v12 v11;
+        br v14 block5 block6;
+
+    block4:
+        v19.i256 = phi (0.i256 block2) (v13 block6);
+        return v19;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        jump block4;
+}
+
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_e9e0(v0.@layout_5) -> i256 {
+    block0:
+        v1.*i256 = alloca i256;
+        v2.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v3.i256 = evm_calldata_size;
+        mstore v1 v3 i256;
+        v6.i256 = extract_value v0 0.i256;
+        v7.i256 = mload v1 i256;
+        mstore v2 v7 i256;
+        v8.i256 = mload v2 i256;
+        v9.i1 = gt v6 v8;
+        br v9 block2 block3;
+
+    block2:
+        jump block4;
+
+    block3:
+        v11.i256 = extract_value v0 0.i256;
+        v12.i256 = mload v1 i256;
+        (v13.i256, v14.i1) = usubo v12 v11;
+        br v14 block5 block6;
+
+    block4:
+        v19.i256 = phi (0.i256 block2) (v13 block6);
+        return v19;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        jump block4;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_f03b(v0.@layout_5) -> i256 {
@@ -6714,28 +10376,6 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_0de4(v0.objref
         return v4;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g463e_1f4c(v0.objref<@layout_4>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<@layout_3> = obj.proj v0 0.i256;
-        v5.objref<i256> = obj.proj v3 1.i256;
-        v6.i256 = obj.load v5;
-        return v6;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g463e_1f4c_0(v0.objref<@layout_4>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<@layout_3> = obj.proj v0 0.i256;
-        v5.objref<i256> = obj.proj v3 1.i256;
-        v6.i256 = obj.load v5;
-        return v6;
-}
-
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_324d(v0.objref<@layout_1>) -> i256 {
     block0:
         jump block1;
@@ -6744,6 +10384,28 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_324d(v0.objref
         v3.objref<i256> = obj.proj v0 1.i256;
         v4.i256 = obj.load v3;
         return v4;
+}
+
+func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g463e_3f42(v0.objref<@layout_4>) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v3.objref<@layout_3> = obj.proj v0 0.i256;
+        v5.objref<i256> = obj.proj v3 1.i256;
+        v6.i256 = obj.load v5;
+        return v6;
+}
+
+func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g463e_3f42_0(v0.objref<@layout_4>) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v3.objref<@layout_3> = obj.proj v0 0.i256;
+        v5.objref<i256> = obj.proj v3 1.i256;
+        v6.i256 = obj.load v5;
+        return v6;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_6cac(v0.objref<@layout_1>) -> i256 {
@@ -6776,7 +10438,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_d8ed(v0.objref
         return v4;
 }
 
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_44f9(v0.objref<@layout_4>) -> i256 {
+func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_0a1c(v0.objref<@layout_4>) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
@@ -6788,7 +10450,7 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         v7.@layout_2 = obj.load v6;
         v8.objref<@layout_3> = obj.proj v0 0.i256;
         v9.objref<@layout_2> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_e00f v9;
+        v10.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_7b50 v9;
         mstore v1 v10 i256;
         v11.objref<@layout_3> = obj.proj v0 0.i256;
         v13.objref<i256> = obj.proj v11 1.i256;
@@ -6811,7 +10473,7 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         v33.i256 = obj.load v32;
         v34.objref<@layout_3> = obj.proj v0 0.i256;
         v35.objref<@layout_2> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_c66d v35 v33;
+        v36.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_7f19 v35 v33;
         v38.objref<@layout_3> = obj.proj v0 0.i256;
         v39.objref<i256> = obj.proj v38 1.i256;
         obj.store v39 v16;
@@ -6837,7 +10499,7 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         br v26 block2 block5;
 }
 
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_83b2(v0.objref<@layout_4>) -> i256 {
+func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_0a1c_0(v0.objref<@layout_4>) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
@@ -6849,7 +10511,7 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         v7.@layout_2 = obj.load v6;
         v8.objref<@layout_3> = obj.proj v0 0.i256;
         v9.objref<@layout_2> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_01a6 v9;
+        v10.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_7b50_0 v9;
         mstore v1 v10 i256;
         v11.objref<@layout_3> = obj.proj v0 0.i256;
         v13.objref<i256> = obj.proj v11 1.i256;
@@ -6872,7 +10534,7 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         v33.i256 = obj.load v32;
         v34.objref<@layout_3> = obj.proj v0 0.i256;
         v35.objref<@layout_2> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_3a7f v35 v33;
+        v36.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_7f19_0 v35 v33;
         v38.objref<@layout_3> = obj.proj v0 0.i256;
         v39.objref<i256> = obj.proj v38 1.i256;
         obj.store v39 v16;
@@ -6898,7 +10560,7 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         br v26 block2 block5;
 }
 
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_8be4(v0.objref<@layout_4>) -> i256 {
+func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_85d9(v0.objref<@layout_4>) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
@@ -6910,7 +10572,7 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         v7.@layout_2 = obj.load v6;
         v8.objref<@layout_3> = obj.proj v0 0.i256;
         v9.objref<@layout_2> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_be96 v9;
+        v10.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_48ab v9;
         mstore v1 v10 i256;
         v11.objref<@layout_3> = obj.proj v0 0.i256;
         v13.objref<i256> = obj.proj v11 1.i256;
@@ -6933,7 +10595,7 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         v33.i256 = obj.load v32;
         v34.objref<@layout_3> = obj.proj v0 0.i256;
         v35.objref<@layout_2> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_20e1 v35 v33;
+        v36.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_6576 v35 v33;
         v38.objref<@layout_3> = obj.proj v0 0.i256;
         v39.objref<i256> = obj.proj v38 1.i256;
         obj.store v39 v16;
@@ -6959,7 +10621,7 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         br v26 block2 block5;
 }
 
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_8be4_0(v0.objref<@layout_4>) -> i256 {
+func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_87b3(v0.objref<@layout_4>) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
@@ -6971,7 +10633,7 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         v7.@layout_2 = obj.load v6;
         v8.objref<@layout_3> = obj.proj v0 0.i256;
         v9.objref<@layout_2> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_be96_0 v9;
+        v10.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_a4fa v9;
         mstore v1 v10 i256;
         v11.objref<@layout_3> = obj.proj v0 0.i256;
         v13.objref<i256> = obj.proj v11 1.i256;
@@ -6994,7 +10656,7 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         v33.i256 = obj.load v32;
         v34.objref<@layout_3> = obj.proj v0 0.i256;
         v35.objref<@layout_2> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_20e1_0 v35 v33;
+        v36.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_fb71 v35 v33;
         v38.objref<@layout_3> = obj.proj v0 0.i256;
         v39.objref<i256> = obj.proj v38 1.i256;
         obj.store v39 v16;
@@ -7478,6 +11140,32 @@ func inline(always) private %set__g2163(v0.@layout_0, v1.i256) {
         return;
 }
 
+func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_4735(v0.objref<@layout_4>, v1.i256) {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v3.i256 = mload v2 i256;
+        v6.objref<i256> = obj.proj v0 1.i256;
+        obj.store v6 v3;
+        return;
+}
+
+func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_4735_0(v0.objref<@layout_4>, v1.i256) {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v3.i256 = mload v2 i256;
+        v6.objref<i256> = obj.proj v0 1.i256;
+        obj.store v6 v3;
+        return;
+}
+
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_750c(v0.objref<@layout_1>, v1.i256) {
     block0:
         v2.*i256 = alloca i256;
@@ -7526,32 +11214,6 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_cc2c(v0.o
     block1:
         v3.i256 = mload v2 i256;
         v6.objref<i256> = obj.proj v0 0.i256;
-        obj.store v6 v3;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_d49b(v0.objref<@layout_4>, v1.i256) {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 1.i256;
-        obj.store v6 v3;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_d49b_0(v0.objref<@layout_4>, v1.i256) {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 1.i256;
         obj.store v6 v3;
         return;
 }
@@ -7651,6 +11313,34 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_7410(v0.ob
         return;
 }
 
+func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_ae9c(v0.objref<@layout_4>, v1.i256) {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v3.i256 = mload v2 i256;
+        v6.objref<@layout_3> = obj.proj v0 0.i256;
+        v8.objref<i256> = obj.proj v6 1.i256;
+        obj.store v8 v3;
+        return;
+}
+
+func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_ae9c_0(v0.objref<@layout_4>, v1.i256) {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v3.i256 = mload v2 i256;
+        v6.objref<@layout_3> = obj.proj v0 0.i256;
+        v8.objref<i256> = obj.proj v6 1.i256;
+        obj.store v8 v3;
+        return;
+}
+
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_b6ef(v0.objref<@layout_1>, v1.i256) {
     block0:
         v2.*i256 = alloca i256;
@@ -7661,34 +11351,6 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_b6ef(v0.ob
         v3.i256 = mload v2 i256;
         v6.objref<i256> = obj.proj v0 1.i256;
         obj.store v6 v3;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_d790(v0.objref<@layout_4>, v1.i256) {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<@layout_3> = obj.proj v0 0.i256;
-        v8.objref<i256> = obj.proj v6 1.i256;
-        obj.store v8 v3;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_d790_0(v0.objref<@layout_4>, v1.i256) {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<@layout_3> = obj.proj v0 0.i256;
-        v8.objref<i256> = obj.proj v6 1.i256;
-        obj.store v8 v3;
         return;
 }
 
@@ -8556,36 +12218,6 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v8;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_20e1(v0.objref<@layout_2>, v1.i256) -> i256 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = mload v8 i256;
-        return v9;
-}
-
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_20e1_0(v0.objref<@layout_2>, v1.i256) -> i256 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = mload v8 i256;
-        return v9;
-}
-
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_27ad(v0.@layout_5, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
@@ -8614,22 +12246,35 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v8;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_3a7f(v0.objref<@layout_2>, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3a1f_0(v0.@layout_5, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = mload v8 i256;
-        return v9;
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3ba3(v0.@layout_5, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
+}
+
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3ba3_0(v0.@layout_5, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -8657,7 +12302,35 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v8;
 }
 
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3bad_0(v0.@layout_5, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
+}
+
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_40a0(v0.@layout_5, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
+}
+
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_40a0_0(v0.@layout_5, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -8697,6 +12370,21 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         v7.i256 = add v5 v6;
         v8.i256 = evm_calldata_load v7;
         return v8;
+}
+
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_6576(v0.objref<@layout_2>, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v5.objref<i256> = obj.proj v0 0.i256;
+        v6.i256 = obj.load v5;
+        v7.i256 = mload v2 i256;
+        v8.i256 = add v6 v7;
+        v9.i256 = mload v8 i256;
+        return v9;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_69bf(v0.@layout_5, v1.i256) -> i256 {
@@ -8755,6 +12443,20 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v8;
 }
 
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_790f_0(v0.@layout_5, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
+}
+
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_7946(v0.@layout_5, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
@@ -8769,7 +12471,51 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v8;
 }
 
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_7f19(v0.objref<@layout_2>, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v5.objref<i256> = obj.proj v0 0.i256;
+        v6.i256 = obj.load v5;
+        v7.i256 = mload v2 i256;
+        v8.i256 = add v6 v7;
+        v9.i256 = mload v8 i256;
+        return v9;
+}
+
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_7f19_0(v0.objref<@layout_2>, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v5.objref<i256> = obj.proj v0 0.i256;
+        v6.i256 = obj.load v5;
+        v7.i256 = mload v2 i256;
+        v8.i256 = add v6 v7;
+        v9.i256 = mload v8 i256;
+        return v9;
+}
+
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_8736(v0.@layout_5, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
+}
+
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_8736_0(v0.@layout_5, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -8825,7 +12571,35 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v8;
 }
 
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_9757_0(v0.@layout_5, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
+}
+
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_a6b2(v0.@layout_5, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
+}
+
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_a6b2_0(v0.@layout_5, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -8853,6 +12627,20 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v8;
 }
 
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_a8d6_0(v0.@layout_5, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
+}
+
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b461(v0.@layout_5, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
@@ -8867,7 +12655,35 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v8;
 }
 
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b461_0(v0.@layout_5, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
+}
+
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b705(v0.@layout_5, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
+}
+
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b705_0(v0.@layout_5, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -8909,7 +12725,35 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v8;
 }
 
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b9ca_0(v0.@layout_5, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
+}
+
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_bae8(v0.@layout_5, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
+}
+
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_bae8_0(v0.@layout_5, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -8965,22 +12809,21 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v8;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_c66d(v0.objref<@layout_2>, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c700(v0.@layout_5, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = mload v8 i256;
-        return v9;
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c700(v0.@layout_5, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c700_0(v0.@layout_5, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -9022,7 +12865,35 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v8;
 }
 
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_d831_0(v0.@layout_5, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
+}
+
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_e134(v0.@layout_5, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
+}
+
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_e134_0(v0.@layout_5, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -9050,6 +12921,21 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v8;
 }
 
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_fb71(v0.objref<@layout_2>, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v5.objref<i256> = obj.proj v0 0.i256;
+        v6.i256 = obj.load v5;
+        v7.i256 = mload v2 i256;
+        v8.i256 = add v6 v7;
+        v9.i256 = mload v8 i256;
+        return v9;
+}
+
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_fdcb(v0.@layout_5, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
@@ -9065,6 +12951,20 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_fec2(v0.@layout_5, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
+}
+
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_fec2_0(v0.@layout_5, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;

--- a/crates/codegen/tests/fixtures/sonatina_ir/erc20.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/erc20.snap
@@ -3090,216 +3090,6 @@ func inline(always) private %impl_trait_TransferFrom__decode_from__gd20d(v0.@lay
         return v42;
 }
 
-func inline(always) private %decode_from_checked_head__g76d6(v0.@layout_5, v1.i256, v2.i256) -> @layout_8 {
-    block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
-        jump block1;
-
-    block1:
-        v5.i256 = mload v4 i256;
-        v7.i256 = mload v3 i256;
-        v8.@layout_8 = call %impl_trait_Mint__decode_from__gd20d v0 v7;
-        return v8;
-}
-
-func inline(always) private %decode_from_checked_head__g051e(v0.@layout_5, v1.i256, v2.i256) {
-    block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
-        jump block1;
-
-    block1:
-        v5.i256 = mload v4 i256;
-        v7.i256 = mload v3 i256;
-        call %impl_trait_TotalSupply__decode_from__gd20d v0 v7;
-        return;
-}
-
-func inline(always) private %decode_from_checked_head__g6690(v0.@layout_5, v1.i256, v2.i256) -> @layout_13 {
-    block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
-        jump block1;
-
-    block1:
-        v5.i256 = mload v4 i256;
-        v7.i256 = mload v3 i256;
-        v8.@layout_13 = call %impl_trait_TransferFrom__decode_from__gd20d v0 v7;
-        return v8;
-}
-
-func inline(always) private %decode_from_checked_head__g7ea0(v0.@layout_5, v1.i256, v2.i256) -> @layout_11 {
-    block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
-        jump block1;
-
-    block1:
-        v5.i256 = mload v4 i256;
-        v7.i256 = mload v3 i256;
-        v8.@layout_11 = call %impl_trait_BalanceOf__decode_from__gd20d v0 v7;
-        return v8;
-}
-
-func inline(always) private %decode_from_checked_head__g4997(v0.@layout_5, v1.i256, v2.i256) {
-    block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
-        jump block1;
-
-    block1:
-        v5.i256 = mload v4 i256;
-        v7.i256 = mload v3 i256;
-        call %impl_trait_Decimals__decode_from__gd20d v0 v7;
-        return;
-}
-
-func inline(always) private %decode_from_checked_head__g205f(v0.@layout_5, v1.i256, v2.i256) -> @layout_14 {
-    block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
-        jump block1;
-
-    block1:
-        v5.i256 = mload v4 i256;
-        v7.i256 = mload v3 i256;
-        v8.@layout_14 = call %impl_trait_Transfer__decode_from__gd20d v0 v7;
-        return v8;
-}
-
-func inline(always) private %decode_from_checked_head__gbd88(v0.@layout_5, v1.i256, v2.i256) {
-    block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
-        jump block1;
-
-    block1:
-        v5.i256 = mload v4 i256;
-        v7.i256 = mload v3 i256;
-        call %impl_trait_Name__decode_from__gd20d v0 v7;
-        return;
-}
-
-func inline(always) private %decode_from_checked_head__g7d8c(v0.@layout_5, v1.i256, v2.i256) -> @layout_12 {
-    block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
-        jump block1;
-
-    block1:
-        v5.i256 = mload v4 i256;
-        v7.i256 = mload v3 i256;
-        v8.@layout_12 = call %impl_trait_IncreaseAllowance__decode_from__gd20d v0 v7;
-        return v8;
-}
-
-func inline(always) private %decode_from_checked_head__g5470(v0.@layout_5, v1.i256, v2.i256) -> @layout_6 {
-    block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
-        jump block1;
-
-    block1:
-        v5.i256 = mload v4 i256;
-        v7.i256 = mload v3 i256;
-        v8.@layout_6 = call %impl_trait_Allowance__decode_from__gd20d v0 v7;
-        return v8;
-}
-
-func inline(always) private %decode_from_checked_head__g691a(v0.@layout_5, v1.i256, v2.i256) {
-    block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
-        jump block1;
-
-    block1:
-        v5.i256 = mload v4 i256;
-        v7.i256 = mload v3 i256;
-        call %impl_trait_Symbol__decode_from__gd20d v0 v7;
-        return;
-}
-
-func inline(always) private %decode_from_checked_head__g41f8(v0.@layout_5, v1.i256, v2.i256) -> @layout_9 {
-    block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
-        jump block1;
-
-    block1:
-        v5.i256 = mload v4 i256;
-        v7.i256 = mload v3 i256;
-        v8.@layout_9 = call %impl_trait_Burn__decode_from__gd20d v0 v7;
-        return v8;
-}
-
-func inline(always) private %decode_from_checked_head__gad59(v0.@layout_5, v1.i256, v2.i256) -> @layout_10 {
-    block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
-        jump block1;
-
-    block1:
-        v5.i256 = mload v4 i256;
-        v7.i256 = mload v3 i256;
-        v8.@layout_10 = call %impl_trait_BurnFrom__decode_from__gd20d v0 v7;
-        return v8;
-}
-
-func inline(always) private %decode_from_checked_head__gab8c(v0.@layout_5, v1.i256, v2.i256) -> @layout_7 {
-    block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
-        jump block1;
-
-    block1:
-        v5.i256 = mload v4 i256;
-        v7.i256 = mload v3 i256;
-        v8.@layout_7 = call %impl_trait_Approve__decode_from__gd20d v0 v7;
-        return v8;
-}
-
-func inline(always) private %decode_from_checked_head__g383e(v0.@layout_5, v1.i256, v2.i256) -> @layout_15 {
-    block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
-        jump block1;
-
-    block1:
-        v5.i256 = mload v4 i256;
-        v7.i256 = mload v3 i256;
-        v8.@layout_15 = call %impl_trait_DecreaseAllowance__decode_from__gd20d v0 v7;
-        return v8;
-}
-
 func inline(always) private %impl_trait_Transfer__decode_from__gd20d(v0.@layout_5, v1.i256) -> @layout_14 {
     block0:
         v2.*i256 = alloca i256;
@@ -3432,6 +3222,216 @@ func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__de
         return v14;
 }
 
+func inline(always) private %decode_from_prechecked_head__gbd88(v0.@layout_5, v1.i256, v2.i256) {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v4 i256;
+        v7.i256 = mload v3 i256;
+        call %impl_trait_Name__decode_from__gd20d v0 v7;
+        return;
+}
+
+func inline(always) private %decode_from_prechecked_head__g76d6(v0.@layout_5, v1.i256, v2.i256) -> @layout_8 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v4 i256;
+        v7.i256 = mload v3 i256;
+        v8.@layout_8 = call %impl_trait_Mint__decode_from__gd20d v0 v7;
+        return v8;
+}
+
+func inline(always) private %decode_from_prechecked_head__g41f8(v0.@layout_5, v1.i256, v2.i256) -> @layout_9 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v4 i256;
+        v7.i256 = mload v3 i256;
+        v8.@layout_9 = call %impl_trait_Burn__decode_from__gd20d v0 v7;
+        return v8;
+}
+
+func inline(always) private %decode_from_prechecked_head__g205f(v0.@layout_5, v1.i256, v2.i256) -> @layout_14 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v4 i256;
+        v7.i256 = mload v3 i256;
+        v8.@layout_14 = call %impl_trait_Transfer__decode_from__gd20d v0 v7;
+        return v8;
+}
+
+func inline(always) private %decode_from_prechecked_head__g5470(v0.@layout_5, v1.i256, v2.i256) -> @layout_6 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v4 i256;
+        v7.i256 = mload v3 i256;
+        v8.@layout_6 = call %impl_trait_Allowance__decode_from__gd20d v0 v7;
+        return v8;
+}
+
+func inline(always) private %decode_from_prechecked_head__g6690(v0.@layout_5, v1.i256, v2.i256) -> @layout_13 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v4 i256;
+        v7.i256 = mload v3 i256;
+        v8.@layout_13 = call %impl_trait_TransferFrom__decode_from__gd20d v0 v7;
+        return v8;
+}
+
+func inline(always) private %decode_from_prechecked_head__g7ea0(v0.@layout_5, v1.i256, v2.i256) -> @layout_11 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v4 i256;
+        v7.i256 = mload v3 i256;
+        v8.@layout_11 = call %impl_trait_BalanceOf__decode_from__gd20d v0 v7;
+        return v8;
+}
+
+func inline(always) private %decode_from_prechecked_head__g691a(v0.@layout_5, v1.i256, v2.i256) {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v4 i256;
+        v7.i256 = mload v3 i256;
+        call %impl_trait_Symbol__decode_from__gd20d v0 v7;
+        return;
+}
+
+func inline(always) private %decode_from_prechecked_head__g7d8c(v0.@layout_5, v1.i256, v2.i256) -> @layout_12 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v4 i256;
+        v7.i256 = mload v3 i256;
+        v8.@layout_12 = call %impl_trait_IncreaseAllowance__decode_from__gd20d v0 v7;
+        return v8;
+}
+
+func inline(always) private %decode_from_prechecked_head__gab8c(v0.@layout_5, v1.i256, v2.i256) -> @layout_7 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v4 i256;
+        v7.i256 = mload v3 i256;
+        v8.@layout_7 = call %impl_trait_Approve__decode_from__gd20d v0 v7;
+        return v8;
+}
+
+func inline(always) private %decode_from_prechecked_head__g4997(v0.@layout_5, v1.i256, v2.i256) {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v4 i256;
+        v7.i256 = mload v3 i256;
+        call %impl_trait_Decimals__decode_from__gd20d v0 v7;
+        return;
+}
+
+func inline(always) private %decode_from_prechecked_head__gad59(v0.@layout_5, v1.i256, v2.i256) -> @layout_10 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v4 i256;
+        v7.i256 = mload v3 i256;
+        v8.@layout_10 = call %impl_trait_BurnFrom__decode_from__gd20d v0 v7;
+        return v8;
+}
+
+func inline(always) private %decode_from_prechecked_head__g051e(v0.@layout_5, v1.i256, v2.i256) {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v4 i256;
+        v7.i256 = mload v3 i256;
+        call %impl_trait_TotalSupply__decode_from__gd20d v0 v7;
+        return;
+}
+
+func inline(always) private %decode_from_prechecked_head__g383e(v0.@layout_5, v1.i256, v2.i256) -> @layout_15 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v4 i256;
+        v7.i256 = mload v3 i256;
+        v8.@layout_15 = call %impl_trait_DecreaseAllowance__decode_from__gd20d v0 v7;
+        return v8;
+}
+
 func inline(always) private %impl_trait_Address__decode_payload__g407e(v0.objref<@layout_4>) -> @layout_0 {
     block0:
         jump block1;
@@ -3507,7 +3507,7 @@ func inline(always) private %decode_runtime_args__g5a0b(v0.objref<@layout_18>) {
 
     block4:
         v11.i256 = mload v1 i256;
-        call %decode_from_checked_head__g4997 v4 4.i256 v11;
+        call %decode_from_prechecked_head__g4997 v4 4.i256 v11;
         return;
 
     block5:
@@ -3541,7 +3541,7 @@ func inline(always) private %decode_runtime_args__g6a7c(v0.objref<@layout_18>) -
 
     block4:
         v12.i256 = mload v1 i256;
-        v13.@layout_15 = call %decode_from_checked_head__g383e v4 4.i256 v12;
+        v13.@layout_15 = call %decode_from_prechecked_head__g383e v4 4.i256 v12;
         return v13;
 
     block5:
@@ -3575,7 +3575,7 @@ func inline(always) private %decode_runtime_args__g7a2c(v0.objref<@layout_18>) -
 
     block4:
         v12.i256 = mload v1 i256;
-        v13.@layout_7 = call %decode_from_checked_head__gab8c v4 4.i256 v12;
+        v13.@layout_7 = call %decode_from_prechecked_head__gab8c v4 4.i256 v12;
         return v13;
 
     block5:
@@ -3609,7 +3609,7 @@ func inline(always) private %decode_runtime_args__g295c(v0.objref<@layout_18>) {
 
     block4:
         v11.i256 = mload v1 i256;
-        call %decode_from_checked_head__g691a v4 4.i256 v11;
+        call %decode_from_prechecked_head__g691a v4 4.i256 v11;
         return;
 
     block5:
@@ -3643,7 +3643,7 @@ func inline(always) private %decode_runtime_args__gce7d(v0.objref<@layout_18>) {
 
     block4:
         v11.i256 = mload v1 i256;
-        call %decode_from_checked_head__g051e v4 4.i256 v11;
+        call %decode_from_prechecked_head__g051e v4 4.i256 v11;
         return;
 
     block5:
@@ -3677,7 +3677,7 @@ func inline(always) private %decode_runtime_args__g2273(v0.objref<@layout_18>) -
 
     block4:
         v12.i256 = mload v1 i256;
-        v13.@layout_8 = call %decode_from_checked_head__g76d6 v4 4.i256 v12;
+        v13.@layout_8 = call %decode_from_prechecked_head__g76d6 v4 4.i256 v12;
         return v13;
 
     block5:
@@ -3711,7 +3711,7 @@ func inline(always) private %decode_runtime_args__g4e54(v0.objref<@layout_18>) -
 
     block4:
         v12.i256 = mload v1 i256;
-        v13.@layout_13 = call %decode_from_checked_head__g6690 v4 4.i256 v12;
+        v13.@layout_13 = call %decode_from_prechecked_head__g6690 v4 4.i256 v12;
         return v13;
 
     block5:
@@ -3745,7 +3745,7 @@ func inline(always) private %decode_runtime_args__g698d(v0.objref<@layout_18>) -
 
     block4:
         v12.i256 = mload v1 i256;
-        v13.@layout_12 = call %decode_from_checked_head__g7d8c v4 4.i256 v12;
+        v13.@layout_12 = call %decode_from_prechecked_head__g7d8c v4 4.i256 v12;
         return v13;
 
     block5:
@@ -3779,7 +3779,7 @@ func inline(always) private %decode_runtime_args__gc772(v0.objref<@layout_18>) -
 
     block4:
         v12.i256 = mload v1 i256;
-        v13.@layout_6 = call %decode_from_checked_head__g5470 v4 4.i256 v12;
+        v13.@layout_6 = call %decode_from_prechecked_head__g5470 v4 4.i256 v12;
         return v13;
 
     block5:
@@ -3813,7 +3813,7 @@ func inline(always) private %decode_runtime_args__g953d(v0.objref<@layout_18>) -
 
     block4:
         v12.i256 = mload v1 i256;
-        v13.@layout_11 = call %decode_from_checked_head__g7ea0 v4 4.i256 v12;
+        v13.@layout_11 = call %decode_from_prechecked_head__g7ea0 v4 4.i256 v12;
         return v13;
 
     block5:
@@ -3847,7 +3847,7 @@ func inline(always) private %decode_runtime_args__g216b(v0.objref<@layout_18>) -
 
     block4:
         v12.i256 = mload v1 i256;
-        v13.@layout_10 = call %decode_from_checked_head__gad59 v4 4.i256 v12;
+        v13.@layout_10 = call %decode_from_prechecked_head__gad59 v4 4.i256 v12;
         return v13;
 
     block5:
@@ -3881,7 +3881,7 @@ func inline(always) private %decode_runtime_args__gf629(v0.objref<@layout_18>) -
 
     block4:
         v12.i256 = mload v1 i256;
-        v13.@layout_9 = call %decode_from_checked_head__g41f8 v4 4.i256 v12;
+        v13.@layout_9 = call %decode_from_prechecked_head__g41f8 v4 4.i256 v12;
         return v13;
 
     block5:
@@ -3915,7 +3915,7 @@ func inline(always) private %decode_runtime_args__gce2e(v0.objref<@layout_18>) {
 
     block4:
         v11.i256 = mload v1 i256;
-        call %decode_from_checked_head__gbd88 v4 4.i256 v11;
+        call %decode_from_prechecked_head__gbd88 v4 4.i256 v11;
         return;
 
     block5:
@@ -3949,7 +3949,7 @@ func inline(always) private %decode_runtime_args__ge035(v0.objref<@layout_18>) -
 
     block4:
         v12.i256 = mload v1 i256;
-        v13.@layout_14 = call %decode_from_checked_head__g205f v4 4.i256 v12;
+        v13.@layout_14 = call %decode_from_prechecked_head__g205f v4 4.i256 v12;
         return v13;
 
     block5:

--- a/crates/codegen/tests/fixtures/sonatina_ir/event_logging.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/event_logging.snap
@@ -156,7 +156,7 @@ func private %encode_abi_payload(v0.i256) -> @layout_3 {
         return v2;
 }
 
-func private %encode_alloc(v0.i256) -> @layout_3 {
+func inline(always) private %encode_alloc(v0.i256) -> @layout_3 {
     block0:
         jump block1;
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/event_logging.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/event_logging.snap
@@ -35,6 +35,24 @@ func private %as_topic(v0.objref<@layout_0>) -> i256 {
         return v4;
 }
 
+func inline(always) private %at(v0.i256) -> @layout_1 {
+    block0:
+        v1.*i256 = alloca i256;
+        mstore v1 v0 i256;
+        jump block1;
+
+    block1:
+        v2.i256 = mload v1 i256;
+        v3.i256 = mload v1 i256;
+        v4.objref<@layout_1> = obj.alloc @layout_1;
+        v6.objref<i256> = obj.proj v4 0.i256;
+        obj.store v6 v2;
+        v8.objref<i256> = obj.proj v4 1.i256;
+        obj.store v8 v3;
+        v9.@layout_1 = obj.load v4;
+        return v9;
+}
+
 func private %base(v0.objref<@layout_1>) -> i256 {
     block0:
         jump block1;
@@ -241,13 +259,8 @@ func private %new(v0.i256) -> @layout_1 {
 
     block4:
         v8.i256 = phi (0.i256 block2) (v7 block3);
-        v9.objref<@layout_1> = obj.alloc @layout_1;
-        v10.objref<i256> = obj.proj v9 0.i256;
-        obj.store v10 v8;
-        v12.objref<i256> = obj.proj v9 1.i256;
-        obj.store v12 v8;
-        v13.@layout_1 = obj.load v9;
-        return v13;
+        v9.@layout_1 = call %at v8;
+        return v9;
 }
 
 func private %payload_size(v0.i256) -> i256 {

--- a/crates/codegen/tests/fixtures/sonatina_ir/event_logging_via_log.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/event_logging_via_log.snap
@@ -35,6 +35,24 @@ func private %as_topic(v0.objref<@layout_0>) -> i256 {
         return v4;
 }
 
+func inline(always) private %at(v0.i256) -> @layout_1 {
+    block0:
+        v1.*i256 = alloca i256;
+        mstore v1 v0 i256;
+        jump block1;
+
+    block1:
+        v2.i256 = mload v1 i256;
+        v3.i256 = mload v1 i256;
+        v4.objref<@layout_1> = obj.alloc @layout_1;
+        v6.objref<i256> = obj.proj v4 0.i256;
+        obj.store v6 v2;
+        v8.objref<i256> = obj.proj v4 1.i256;
+        obj.store v8 v3;
+        v9.@layout_1 = obj.load v4;
+        return v9;
+}
+
 func private %base(v0.objref<@layout_1>) -> i256 {
     block0:
         jump block1;
@@ -250,13 +268,8 @@ func private %new(v0.i256) -> @layout_1 {
 
     block4:
         v8.i256 = phi (0.i256 block2) (v7 block3);
-        v9.objref<@layout_1> = obj.alloc @layout_1;
-        v10.objref<i256> = obj.proj v9 0.i256;
-        obj.store v10 v8;
-        v12.objref<i256> = obj.proj v9 1.i256;
-        obj.store v12 v8;
-        v13.@layout_1 = obj.load v9;
-        return v13;
+        v9.@layout_1 = call %at v8;
+        return v9;
 }
 
 func private %payload_size(v0.i256) -> i256 {

--- a/crates/codegen/tests/fixtures/sonatina_ir/event_logging_via_log.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/event_logging_via_log.snap
@@ -165,7 +165,7 @@ func private %encode_abi_payload(v0.i256) -> @layout_3 {
         return v2;
 }
 
-func private %encode_alloc(v0.i256) -> @layout_3 {
+func inline(always) private %encode_alloc(v0.i256) -> @layout_3 {
     block0:
         jump block1;
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/high_level_contract.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/high_level_contract.snap
@@ -466,7 +466,22 @@ func inline(always) private %decode_from__g72ab(v0.@layout_4, v1.i256) -> i256 {
         return v5;
 }
 
-func inline(always) private %decode_from_checked_head__g2f3f(v0.@layout_4, v1.i256, v2.i256) {
+func inline(always) private %decode_from_prechecked_head__g2d0f(v0.@layout_4, v1.i256, v2.i256) {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v4 i256;
+        v7.i256 = mload v3 i256;
+        call %impl_trait_GetX__decode_from__gd20d v0 v7;
+        return;
+}
+
+func inline(always) private %decode_from_prechecked_head__g2f3f(v0.@layout_4, v1.i256, v2.i256) {
     block0:
         v3.*i256 = alloca i256;
         v4.*i256 = alloca i256;
@@ -481,7 +496,7 @@ func inline(always) private %decode_from_checked_head__g2f3f(v0.@layout_4, v1.i2
         return;
 }
 
-func inline(always) private %decode_from_checked_head__g6fcf(v0.@layout_4, v1.i256, v2.i256) -> @layout_5 {
+func inline(always) private %decode_from_prechecked_head__g6fcf(v0.@layout_4, v1.i256, v2.i256) -> @layout_5 {
     block0:
         v3.*i256 = alloca i256;
         v4.*i256 = alloca i256;
@@ -494,21 +509,6 @@ func inline(always) private %decode_from_checked_head__g6fcf(v0.@layout_4, v1.i2
         v7.i256 = mload v3 i256;
         v8.@layout_5 = call %impl_trait_Echo__decode_from__gd20d v0 v7;
         return v8;
-}
-
-func inline(always) private %decode_from_checked_head__g2d0f(v0.@layout_4, v1.i256, v2.i256) {
-    block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
-        jump block1;
-
-    block1:
-        v5.i256 = mload v4 i256;
-        v7.i256 = mload v3 i256;
-        call %impl_trait_GetX__decode_from__gd20d v0 v7;
-        return;
 }
 
 func private %decode_payload__g4770(v0.objref<@layout_3>) -> @layout_6 {
@@ -559,7 +559,7 @@ func inline(always) private %decode_runtime_args__g9e33(v0.objref<@layout_8>) ->
 
     block4:
         v12.i256 = mload v1 i256;
-        v13.@layout_5 = call %decode_from_checked_head__g6fcf v4 4.i256 v12;
+        v13.@layout_5 = call %decode_from_prechecked_head__g6fcf v4 4.i256 v12;
         return v13;
 
     block5:
@@ -593,7 +593,7 @@ func inline(always) private %decode_runtime_args__gf173(v0.objref<@layout_8>) {
 
     block4:
         v11.i256 = mload v1 i256;
-        call %decode_from_checked_head__g2d0f v4 4.i256 v11;
+        call %decode_from_prechecked_head__g2d0f v4 4.i256 v11;
         return;
 
     block5:
@@ -627,7 +627,7 @@ func inline(always) private %decode_runtime_args__g235a(v0.objref<@layout_8>) {
 
     block4:
         v11.i256 = mload v1 i256;
-        call %decode_from_checked_head__g2f3f v4 4.i256 v11;
+        call %decode_from_prechecked_head__g2f3f v4 4.i256 v11;
         return;
 
     block5:

--- a/crates/codegen/tests/fixtures/sonatina_ir/high_level_contract.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/high_level_contract.snap
@@ -6,9 +6,9 @@ input_file: crates/codegen/tests/fixtures/high_level_contract.fe
 target = "evm-ethereum-osaka"
 
 type @layout_0 = {i256, i256};
-type @layout_1 = {@layout_0, i256};
+type @layout_1 = {i256, i256};
 type @layout_2 = {@layout_1, i256};
-type @layout_3 = {i256, i256};
+type @layout_3 = {@layout_2, i256};
 type @layout_4 = {i256};
 type @layout_5 = {i256};
 type @layout_6 = {i256, i256};
@@ -128,7 +128,25 @@ func private %std__lib__evm__effects__impl_trait_Evm_c913__abort_ee4e() {
         unreachable;
 }
 
-func private %base__g463e(v0.objref<@layout_2>) -> i256 {
+func inline(always) private %at(v0.i256) -> @layout_0 {
+    block0:
+        v1.*i256 = alloca i256;
+        mstore v1 v0 i256;
+        jump block1;
+
+    block1:
+        v2.i256 = mload v1 i256;
+        v3.i256 = mload v1 i256;
+        v4.objref<@layout_0> = obj.alloc @layout_0;
+        v6.objref<i256> = obj.proj v4 0.i256;
+        obj.store v6 v2;
+        v8.objref<i256> = obj.proj v4 1.i256;
+        obj.store v8 v3;
+        v9.@layout_0 = obj.load v4;
+        return v9;
+}
+
+func private %base__g463e(v0.objref<@layout_3>) -> i256 {
     block0:
         jump block1;
 
@@ -138,7 +156,7 @@ func private %base__g463e(v0.objref<@layout_2>) -> i256 {
         return v4;
 }
 
-func private %impl_trait_SolEncoder__base(v0.objref<@layout_3>) -> i256 {
+func private %impl_trait_SolEncoder__base(v0.objref<@layout_0>) -> i256 {
     block0:
         jump block1;
 
@@ -150,8 +168,8 @@ func private %impl_trait_SolEncoder__base(v0.objref<@layout_3>) -> i256 {
 
 func private %contract_init_abi_EchoContract() {
     block0:
-        v0.objref<@layout_0> = obj.alloc @layout_0;
-        v1.objref<@layout_2> = obj.alloc @layout_2;
+        v0.objref<@layout_1> = obj.alloc @layout_1;
+        v1.objref<@layout_3> = obj.alloc @layout_3;
         jump block1;
 
     block1:
@@ -189,12 +207,12 @@ func private %contract_init_abi_EchoContract() {
         obj.store v23 v20;
         v25.objref<i256> = obj.proj v0 1.i256;
         obj.store v25 v13;
-        v26.@layout_0 = obj.load v0;
-        v27.@layout_2 = call %decoder_new v26;
-        v28.objref<@layout_1> = obj.proj v1 0.i256;
-        v29.@layout_1 = extract_value v27 0.i256;
-        v30.objref<@layout_0> = obj.proj v28 0.i256;
-        v31.@layout_0 = extract_value v29 0.i256;
+        v26.@layout_1 = obj.load v0;
+        v27.@layout_3 = call %decoder_new v26;
+        v28.objref<@layout_2> = obj.proj v1 0.i256;
+        v29.@layout_2 = extract_value v27 0.i256;
+        v30.objref<@layout_1> = obj.proj v28 0.i256;
+        v31.@layout_1 = extract_value v29 0.i256;
         v32.objref<i256> = obj.proj v30 0.i256;
         v33.i256 = extract_value v31 0.i256;
         obj.store v32 v33;
@@ -327,7 +345,7 @@ func private %contract_runtime_root_EchoContract() {
         unreachable;
 }
 
-func inline(always) private %decode_field(v0.objref<@layout_2>) -> i256 {
+func inline(always) private %decode_field(v0.objref<@layout_3>) -> i256 {
     block0:
         jump block1;
 
@@ -448,7 +466,7 @@ func inline(always) private %decode_from__g72ab(v0.@layout_4, v1.i256) -> i256 {
         return v5;
 }
 
-func private %decode_payload__g4770(v0.objref<@layout_2>) -> @layout_6 {
+func private %decode_payload__g4770(v0.objref<@layout_3>) -> @layout_6 {
     block0:
         jump block1;
 
@@ -464,7 +482,7 @@ func private %decode_payload__g4770(v0.objref<@layout_2>) -> @layout_6 {
         return v9;
 }
 
-func inline(always) private %decode_payload__g407e(v0.objref<@layout_2>) -> i256 {
+func inline(always) private %decode_payload__g407e(v0.objref<@layout_3>) -> i256 {
     block0:
         jump block1;
 
@@ -644,16 +662,16 @@ func inline(always) private %decode_runtime_args__g235a(v0.objref<@layout_8>) {
         br v20 block8 block9;
 }
 
-func private %decoder_new(v0.@layout_0) -> @layout_2 {
+func private %decoder_new(v0.@layout_1) -> @layout_3 {
     block0:
         jump block1;
 
     block1:
-        v2.@layout_2 = call %impl_SolDecoder__new__g463e v0;
+        v2.@layout_3 = call %impl_SolDecoder__new__g463e v0;
         return v2;
 }
 
-func private %encode(v0.i256, v1.objref<@layout_3>) {
+func private %encode(v0.i256, v1.objref<@layout_0>) {
     block0:
         jump block1;
 
@@ -662,7 +680,7 @@ func private %encode(v0.i256, v1.objref<@layout_3>) {
         return;
 }
 
-func private %encode_field(v0.i256, v1.objref<@layout_3>, v2.i256) {
+func private %encode_field(v0.i256, v1.objref<@layout_0>, v2.i256) {
     block0:
         jump block1;
 
@@ -709,7 +727,7 @@ func private %encode_field(v0.i256, v1.objref<@layout_3>, v2.i256) {
         return;
 }
 
-func private %encode_single_root(v0.i256, v1.objref<@layout_3>) {
+func private %encode_single_root(v0.i256, v1.objref<@layout_0>) {
     block0:
         v2.*i256 = alloca i256;
         jump block1;
@@ -729,8 +747,8 @@ func private %encode_single_root_alloc(v0.i256) -> @layout_6 {
 
     block1:
         v2.i256 = call %abi_single_root_size v0;
-        v3.@layout_3 = call %encoder_new v2;
-        v4.objref<@layout_3> = obj.alloc @layout_3;
+        v3.@layout_0 = call %encoder_new v2;
+        v4.objref<@layout_0> = obj.alloc @layout_0;
         v6.objref<i256> = obj.proj v4 0.i256;
         v7.i256 = extract_value v3 0.i256;
         obj.store v6 v7;
@@ -760,7 +778,7 @@ func private %encode_to_ptr(v0.i256, v1.i256) {
         return;
 }
 
-func private %encoder_new(v0.i256) -> @layout_3 {
+func private %encoder_new(v0.i256) -> @layout_0 {
     block0:
         v1.*i256 = alloca i256;
         mstore v1 v0 i256;
@@ -768,7 +786,7 @@ func private %encoder_new(v0.i256) -> @layout_3 {
 
     block1:
         v2.i256 = mload v1 i256;
-        v3.@layout_3 = call %impl_SolEncoder__new v2;
+        v3.@layout_0 = call %impl_SolEncoder__new v2;
         return v3;
 }
 
@@ -875,7 +893,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         jump block4;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_56e9(v0.objref<@layout_0>) -> i256 {
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_56e9(v0.objref<@layout_1>) -> i256 {
     block0:
         jump block1;
 
@@ -923,7 +941,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         jump block4;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_9d6b(v0.objref<@layout_0>) -> i256 {
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_9d6b(v0.objref<@layout_1>) -> i256 {
     block0:
         jump block1;
 
@@ -933,7 +951,7 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_9d6b
         return v4;
 }
 
-func private %impl_SolEncoder__new(v0.i256) -> @layout_3 {
+func private %impl_SolEncoder__new(v0.i256) -> @layout_0 {
     block0:
         v1.*i256 = alloca i256;
         mstore v1 v0 i256;
@@ -955,13 +973,8 @@ func private %impl_SolEncoder__new(v0.i256) -> @layout_3 {
 
     block4:
         v8.i256 = phi (0.i256 block2) (v7 block3);
-        v9.objref<@layout_3> = obj.alloc @layout_3;
-        v10.objref<i256> = obj.proj v9 0.i256;
-        obj.store v10 v8;
-        v12.objref<i256> = obj.proj v9 1.i256;
-        obj.store v12 v8;
-        v13.@layout_3 = obj.load v9;
-        return v13;
+        v9.@layout_0 = call %at v8;
+        return v9;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_45d4() -> @layout_4 {
@@ -976,13 +989,13 @@ func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_45
         return v3;
 }
 
-func inline(always) private %impl_Cursor__new__g463e(v0.@layout_0) -> @layout_1 {
+func inline(always) private %impl_Cursor__new__g463e(v0.@layout_1) -> @layout_2 {
     block0:
         jump block1;
 
     block1:
-        v2.objref<@layout_1> = obj.alloc @layout_1;
-        v4.objref<@layout_0> = obj.proj v2 0.i256;
+        v2.objref<@layout_2> = obj.alloc @layout_2;
+        v4.objref<@layout_1> = obj.proj v2 0.i256;
         v5.objref<i256> = obj.proj v4 0.i256;
         v6.i256 = extract_value v0 0.i256;
         obj.store v5 v6;
@@ -991,7 +1004,7 @@ func inline(always) private %impl_Cursor__new__g463e(v0.@layout_0) -> @layout_1 
         obj.store v8 v9;
         v10.objref<i256> = obj.proj v2 1.i256;
         obj.store v10 0.i256;
-        v11.@layout_1 = obj.load v2;
+        v11.@layout_2 = obj.load v2;
         return v11;
 }
 
@@ -1019,16 +1032,16 @@ func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_c0
         return v3;
 }
 
-func inline(always) private %impl_SolDecoder__new__g463e(v0.@layout_0) -> @layout_2 {
+func inline(always) private %impl_SolDecoder__new__g463e(v0.@layout_1) -> @layout_3 {
     block0:
         jump block1;
 
     block1:
-        v2.@layout_1 = call %impl_Cursor__new__g463e v0;
-        v4.objref<@layout_2> = obj.alloc @layout_2;
-        v5.objref<@layout_1> = obj.proj v4 0.i256;
-        v6.objref<@layout_0> = obj.proj v5 0.i256;
-        v7.@layout_0 = extract_value v2 0.i256;
+        v2.@layout_2 = call %impl_Cursor__new__g463e v0;
+        v4.objref<@layout_3> = obj.alloc @layout_3;
+        v5.objref<@layout_2> = obj.proj v4 0.i256;
+        v6.objref<@layout_1> = obj.proj v5 0.i256;
+        v7.@layout_1 = extract_value v2 0.i256;
         v8.objref<i256> = obj.proj v6 0.i256;
         v9.i256 = extract_value v7 0.i256;
         obj.store v8 v9;
@@ -1040,7 +1053,7 @@ func inline(always) private %impl_SolDecoder__new__g463e(v0.@layout_0) -> @layou
         obj.store v13 v14;
         v15.objref<i256> = obj.proj v4 1.i256;
         obj.store v15 0.i256;
-        v16.@layout_2 = obj.load v4;
+        v16.@layout_3 = obj.load v4;
         return v16;
 }
 
@@ -1064,7 +1077,7 @@ func private %core__lib__abi__trait_AbiSize__payload_size__ge513_9950_0(v0.i256)
         return 32.i256;
 }
 
-func private %impl_trait_SolEncoder__pos(v0.objref<@layout_3>) -> i256 {
+func private %impl_trait_SolEncoder__pos(v0.objref<@layout_0>) -> i256 {
     block0:
         jump block1;
 
@@ -1074,32 +1087,32 @@ func private %impl_trait_SolEncoder__pos(v0.objref<@layout_3>) -> i256 {
         return v4;
 }
 
-func private %pos__g463e(v0.objref<@layout_2>) -> i256 {
+func private %pos__g463e(v0.objref<@layout_3>) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v3.objref<@layout_1> = obj.proj v0 0.i256;
+        v3.objref<@layout_2> = obj.proj v0 0.i256;
         v5.objref<i256> = obj.proj v3 1.i256;
         v6.i256 = obj.load v5;
         return v6;
 }
 
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_16c3(v0.objref<@layout_2>) -> i256 {
+func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_16c3(v0.objref<@layout_3>) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v5.objref<@layout_1> = obj.proj v0 0.i256;
-        v6.objref<@layout_0> = obj.proj v5 0.i256;
-        v7.@layout_0 = obj.load v6;
-        v8.objref<@layout_1> = obj.proj v0 0.i256;
-        v9.objref<@layout_0> = obj.proj v8 0.i256;
+        v5.objref<@layout_2> = obj.proj v0 0.i256;
+        v6.objref<@layout_1> = obj.proj v5 0.i256;
+        v7.@layout_1 = obj.load v6;
+        v8.objref<@layout_2> = obj.proj v0 0.i256;
+        v9.objref<@layout_1> = obj.proj v8 0.i256;
         v10.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_9d6b v9;
         mstore v1 v10 i256;
-        v11.objref<@layout_1> = obj.proj v0 0.i256;
+        v11.objref<@layout_2> = obj.proj v0 0.i256;
         v13.objref<i256> = obj.proj v11 1.i256;
         v14.i256 = obj.load v13;
         (v16.i256, v17.i1) = uaddo v14 32.i256;
@@ -1112,16 +1125,16 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         jump block4;
 
     block4:
-        v28.objref<@layout_1> = obj.proj v0 0.i256;
-        v29.objref<@layout_0> = obj.proj v28 0.i256;
-        v30.@layout_0 = obj.load v29;
-        v31.objref<@layout_1> = obj.proj v0 0.i256;
+        v28.objref<@layout_2> = obj.proj v0 0.i256;
+        v29.objref<@layout_1> = obj.proj v28 0.i256;
+        v30.@layout_1 = obj.load v29;
+        v31.objref<@layout_2> = obj.proj v0 0.i256;
         v32.objref<i256> = obj.proj v31 1.i256;
         v33.i256 = obj.load v32;
-        v34.objref<@layout_1> = obj.proj v0 0.i256;
-        v35.objref<@layout_0> = obj.proj v34 0.i256;
+        v34.objref<@layout_2> = obj.proj v0 0.i256;
+        v35.objref<@layout_1> = obj.proj v34 0.i256;
         v36.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_33be v35 v33;
-        v38.objref<@layout_1> = obj.proj v0 0.i256;
+        v38.objref<@layout_2> = obj.proj v0 0.i256;
         v39.objref<i256> = obj.proj v38 1.i256;
         obj.store v39 v16;
         return v36;
@@ -1139,28 +1152,28 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         evm_revert 0.i256 36.i256;
 
     block7:
-        v23.objref<@layout_1> = obj.proj v0 0.i256;
+        v23.objref<@layout_2> = obj.proj v0 0.i256;
         v24.objref<i256> = obj.proj v23 1.i256;
         v25.i256 = obj.load v24;
         v26.i1 = lt v16 v25;
         br v26 block2 block5;
 }
 
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_1759(v0.objref<@layout_2>) -> i256 {
+func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_1759(v0.objref<@layout_3>) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v5.objref<@layout_1> = obj.proj v0 0.i256;
-        v6.objref<@layout_0> = obj.proj v5 0.i256;
-        v7.@layout_0 = obj.load v6;
-        v8.objref<@layout_1> = obj.proj v0 0.i256;
-        v9.objref<@layout_0> = obj.proj v8 0.i256;
+        v5.objref<@layout_2> = obj.proj v0 0.i256;
+        v6.objref<@layout_1> = obj.proj v5 0.i256;
+        v7.@layout_1 = obj.load v6;
+        v8.objref<@layout_2> = obj.proj v0 0.i256;
+        v9.objref<@layout_1> = obj.proj v8 0.i256;
         v10.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_56e9 v9;
         mstore v1 v10 i256;
-        v11.objref<@layout_1> = obj.proj v0 0.i256;
+        v11.objref<@layout_2> = obj.proj v0 0.i256;
         v13.objref<i256> = obj.proj v11 1.i256;
         v14.i256 = obj.load v13;
         (v16.i256, v17.i1) = uaddo v14 32.i256;
@@ -1173,16 +1186,16 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         jump block4;
 
     block4:
-        v28.objref<@layout_1> = obj.proj v0 0.i256;
-        v29.objref<@layout_0> = obj.proj v28 0.i256;
-        v30.@layout_0 = obj.load v29;
-        v31.objref<@layout_1> = obj.proj v0 0.i256;
+        v28.objref<@layout_2> = obj.proj v0 0.i256;
+        v29.objref<@layout_1> = obj.proj v28 0.i256;
+        v30.@layout_1 = obj.load v29;
+        v31.objref<@layout_2> = obj.proj v0 0.i256;
         v32.objref<i256> = obj.proj v31 1.i256;
         v33.i256 = obj.load v32;
-        v34.objref<@layout_1> = obj.proj v0 0.i256;
-        v35.objref<@layout_0> = obj.proj v34 0.i256;
+        v34.objref<@layout_2> = obj.proj v0 0.i256;
+        v35.objref<@layout_1> = obj.proj v34 0.i256;
         v36.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_52f5 v35 v33;
-        v38.objref<@layout_1> = obj.proj v0 0.i256;
+        v38.objref<@layout_2> = obj.proj v0 0.i256;
         v39.objref<i256> = obj.proj v38 1.i256;
         obj.store v39 v16;
         return v36;
@@ -1200,7 +1213,7 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         evm_revert 0.i256 36.i256;
 
     block7:
-        v23.objref<@layout_1> = obj.proj v0 0.i256;
+        v23.objref<@layout_2> = obj.proj v0 0.i256;
         v24.objref<i256> = obj.proj v23 1.i256;
         v25.i256 = obj.load v24;
         v26.i1 = lt v16 v25;
@@ -1249,7 +1262,7 @@ func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_f892(v0.i256, 
         evm_revert v4 v5;
 }
 
-func private %set_base__g463e(v0.objref<@layout_2>, v1.i256) {
+func private %set_base__g463e(v0.objref<@layout_3>, v1.i256) {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -1262,7 +1275,7 @@ func private %set_base__g463e(v0.objref<@layout_2>, v1.i256) {
         return;
 }
 
-func private %impl_trait_SolEncoder__set_base(v0.objref<@layout_3>, v1.i256) {
+func private %impl_trait_SolEncoder__set_base(v0.objref<@layout_0>, v1.i256) {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -1275,7 +1288,7 @@ func private %impl_trait_SolEncoder__set_base(v0.objref<@layout_3>, v1.i256) {
         return;
 }
 
-func private %set_pos__g463e(v0.objref<@layout_2>, v1.i256) {
+func private %set_pos__g463e(v0.objref<@layout_3>, v1.i256) {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -1283,13 +1296,13 @@ func private %set_pos__g463e(v0.objref<@layout_2>, v1.i256) {
 
     block1:
         v3.i256 = mload v2 i256;
-        v6.objref<@layout_1> = obj.proj v0 0.i256;
+        v6.objref<@layout_2> = obj.proj v0 0.i256;
         v8.objref<i256> = obj.proj v6 1.i256;
         obj.store v8 v3;
         return;
 }
 
-func private %impl_trait_SolEncoder__set_pos(v0.objref<@layout_3>, v1.i256) {
+func private %impl_trait_SolEncoder__set_pos(v0.objref<@layout_0>, v1.i256) {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -1331,7 +1344,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v8;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_33be(v0.objref<@layout_0>, v1.i256) -> i256 {
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_33be(v0.objref<@layout_1>, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -1346,7 +1359,7 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_
         return v9;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_52f5(v0.objref<@layout_0>, v1.i256) -> i256 {
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_52f5(v0.objref<@layout_1>, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -1375,7 +1388,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v8;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_6213(v0.objref<@layout_3>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_6213(v0.objref<@layout_0>, v1.i256) {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -1392,7 +1405,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_6213(v0
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_d116(v0.objref<@layout_3>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_d116(v0.objref<@layout_0>, v1.i256) {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;

--- a/crates/codegen/tests/fixtures/sonatina_ir/high_level_contract.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/high_level_contract.snap
@@ -8,16 +8,14 @@ target = "evm-ethereum-osaka"
 type @layout_0 = {i256, i256};
 type @layout_1 = {@layout_0, i256};
 type @layout_2 = {@layout_1, i256};
-type @layout_3 = {i256};
-type @layout_4 = {@layout_3, i256};
-type @layout_5 = {@layout_4, i256};
+type @layout_3 = {i256, i256};
+type @layout_4 = {i256};
+type @layout_5 = {i256};
 type @layout_6 = {i256, i256};
-type @layout_7 = {i256};
-type @layout_8 = {i256, i256};
-type @layout_9 = {};
-type @layout_10 = {@layout_9};
+type @layout_7 = {};
+type @layout_8 = {@layout_7};
 
-global private const @layout_3 $const_region_0 = {0};
+global private const @layout_4 $const_region_0 = {0};
 
 func private %__EchoContract_init(v0.i256, v1.i256, v2.i256) {
     block0:
@@ -103,6 +101,33 @@ func private %abi_single_root_size(v0.i256) -> i256 {
         return v3;
 }
 
+func private %std__lib__evm__effects__impl_trait_Evm_c913__abort_2725() {
+    block0:
+        jump block1;
+
+    block1:
+        call %std__lib__evm__effects__impl_trait_Evm_0098__revert_a97d 0.i256 0.i256;
+        unreachable;
+}
+
+func private %std__lib__evm__effects__impl_trait_Evm_c913__abort_87bf() {
+    block0:
+        jump block1;
+
+    block1:
+        call %std__lib__evm__effects__impl_trait_Evm_0098__revert_f892 0.i256 0.i256;
+        unreachable;
+}
+
+func private %std__lib__evm__effects__impl_trait_Evm_c913__abort_ee4e() {
+    block0:
+        jump block1;
+
+    block1:
+        call %std__lib__evm__effects__impl_trait_Evm_0098__revert_6da5 0.i256 0.i256;
+        unreachable;
+}
+
 func private %base__g463e(v0.objref<@layout_2>) -> i256 {
     block0:
         jump block1;
@@ -113,17 +138,7 @@ func private %base__g463e(v0.objref<@layout_2>) -> i256 {
         return v4;
 }
 
-func private %base__g8f43(v0.objref<@layout_5>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 1.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
-func private %impl_trait_SolEncoder__base(v0.objref<@layout_6>) -> i256 {
+func private %impl_trait_SolEncoder__base(v0.objref<@layout_3>) -> i256 {
     block0:
         jump block1;
 
@@ -192,7 +207,7 @@ func private %contract_init_abi_EchoContract() {
         v38.objref<i256> = obj.proj v1 1.i256;
         v39.i256 = extract_value v27 1.i256;
         obj.store v38 v39;
-        v40.@layout_8 = call %decode_payload__g4770 v1;
+        v40.@layout_6 = call %decode_payload__g4770 v1;
         v41.i256 = extract_value v40 0.i256;
         v42.i256 = extract_value v40 1.i256;
         call %__EchoContract_init v41 v42 0.i256;
@@ -225,10 +240,10 @@ func private %contract_recv_abi_EchoContract_1() {
         evm_revert 0.i256 0.i256;
 
     block3:
-        v5.objref<@layout_10> = obj.alloc @layout_10;
+        v5.objref<@layout_8> = obj.alloc @layout_8;
         call %decode_runtime_args__g235a v5;
         v7.i256 = call %__EchoContract_recv_0_0;
-        v8.@layout_8 = call %encode_single_root_alloc v7;
+        v8.@layout_6 = call %encode_single_root_alloc v7;
         v9.i256 = extract_value v8 0.i256;
         v11.i256 = extract_value v8 1.i256;
         evm_return v9 v11;
@@ -248,11 +263,11 @@ func private %contract_recv_abi_EchoContract_2() {
         evm_revert 0.i256 0.i256;
 
     block3:
-        v5.objref<@layout_10> = obj.alloc @layout_10;
-        v6.@layout_7 = call %decode_runtime_args__g9e33 v5;
+        v5.objref<@layout_8> = obj.alloc @layout_8;
+        v6.@layout_5 = call %decode_runtime_args__g9e33 v5;
         v7.i256 = extract_value v6 0.i256;
         v8.i256 = call %__EchoContract_recv_0_1 v7;
-        v9.@layout_8 = call %encode_single_root_alloc v8;
+        v9.@layout_6 = call %encode_single_root_alloc v8;
         v10.i256 = extract_value v9 0.i256;
         v12.i256 = extract_value v9 1.i256;
         evm_return v10 v12;
@@ -272,10 +287,10 @@ func private %contract_recv_abi_EchoContract_3() {
         evm_revert 0.i256 0.i256;
 
     block3:
-        v5.objref<@layout_10> = obj.alloc @layout_10;
+        v5.objref<@layout_8> = obj.alloc @layout_8;
         call %decode_runtime_args__gf173 v5;
         v7.i256 = call %__EchoContract_recv_0_2 0.i256;
-        v8.@layout_8 = call %encode_single_root_alloc v7;
+        v8.@layout_6 = call %encode_single_root_alloc v7;
         v9.i256 = extract_value v8 0.i256;
         v11.i256 = extract_value v8 1.i256;
         evm_return v9 v11;
@@ -312,43 +327,7 @@ func private %contract_runtime_root_EchoContract() {
         unreachable;
 }
 
-func inline(always) private %decode_field__g7400(v0.objref<@layout_5>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        br 0.i1 block2 block3;
-
-    block2:
-        v3.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_b0fa v0;
-        v4.i256 = call %base__g8f43 v0;
-        v5.i256 = call %pos__g8f43 v0;
-        (v6.i256, v7.i1) = uaddo v4 v3;
-        br v7 block5 block6;
-
-    block3:
-        jump block4;
-
-    block4:
-        v23.i256 = call %decode_payload__g574e v0;
-        return v23;
-
-    block5:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block6:
-        call %set_base__g8f43 v0 v6;
-        v15.i256 = call %base__g8f43 v0;
-        call %set_pos__g8f43 v0 v15;
-        v17.i256 = call %decode_payload__g574e v0;
-        call %set_base__g8f43 v0 v4;
-        call %set_pos__g8f43 v0 v5;
-        return v17;
-}
-
-func inline(always) private %decode_field__g3854(v0.objref<@layout_2>) -> i256 {
+func inline(always) private %decode_field(v0.objref<@layout_2>) -> i256 {
     block0:
         jump block1;
 
@@ -384,50 +363,105 @@ func inline(always) private %decode_field__g3854(v0.objref<@layout_2>) -> i256 {
         return v17;
 }
 
-func inline(always) private %impl_trait_Answer__decode_payload__g3a69(v0.objref<@layout_5>) {
+func inline(always) private %decode_field_from(v0.@layout_4, v1.i256, v2.i256) -> i256 {
     block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v7.i256 = mload v4 i256;
+        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_1f7f v0 v7;
+        v9.i256 = mload v3 i256;
+        (v10.i256, v11.i1) = uaddo v9 v8;
+        br v11 block5 block6;
+
+    block3:
+        jump block4;
+
+    block4:
+        v20.i256 = mload v4 i256;
+        v21.i256 = call %decode_from__g72ab v0 v20;
+        return v21;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        v18.i256 = call %decode_from__g72ab v0 v10;
+        return v18;
+}
+
+func inline(always) private %impl_trait_Echo__decode_from__gd20d(v0.@layout_4, v1.i256) -> @layout_5 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v2 i256;
+        v6.i256 = call %decode_field_from v0 v4 v5;
+        v7.objref<@layout_5> = obj.alloc @layout_5;
+        v9.objref<i256> = obj.proj v7 0.i256;
+        obj.store v9 v6;
+        v10.@layout_5 = obj.load v7;
+        return v10;
+}
+
+func inline(always) private %impl_trait_Answer__decode_from__gd20d(v0.@layout_4, v1.i256) {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
         jump block1;
 
     block1:
         return;
 }
 
-func inline(always) private %impl_trait_Echo__decode_payload__g3a69(v0.objref<@layout_5>) -> @layout_7 {
+func inline(always) private %impl_trait_GetX__decode_from__gd20d(v0.@layout_4, v1.i256) {
     block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v2.i256 = call %decode_field__g7400 v0;
-        v3.objref<@layout_7> = obj.alloc @layout_7;
-        v5.objref<i256> = obj.proj v3 0.i256;
-        obj.store v5 v2;
-        v6.@layout_7 = obj.load v3;
-        return v6;
+        return;
 }
 
-func private %decode_payload__g4770(v0.objref<@layout_2>) -> @layout_8 {
+func inline(always) private %decode_from__g72ab(v0.@layout_4, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_81b2 v0 v4;
+        return v5;
+}
+
+func private %decode_payload__g4770(v0.objref<@layout_2>) -> @layout_6 {
     block0:
         jump block1;
 
     block1:
-        v2.i256 = call %decode_field__g3854 v0;
-        v3.i256 = call %decode_field__g3854 v0;
-        v4.objref<@layout_8> = obj.alloc @layout_8;
+        v2.i256 = call %decode_field v0;
+        v3.i256 = call %decode_field v0;
+        v4.objref<@layout_6> = obj.alloc @layout_6;
         v6.objref<i256> = obj.proj v4 0.i256;
         obj.store v6 v2;
         v8.objref<i256> = obj.proj v4 1.i256;
         obj.store v8 v3;
-        v9.@layout_8 = obj.load v4;
+        v9.@layout_6 = obj.load v4;
         return v9;
-}
-
-func inline(always) private %decode_payload__g574e(v0.objref<@layout_5>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_2f0d v0;
-        return v2;
 }
 
 func inline(always) private %decode_payload__g407e(v0.objref<@layout_2>) -> i256 {
@@ -439,84 +473,175 @@ func inline(always) private %decode_payload__g407e(v0.objref<@layout_2>) -> i256
         return v2;
 }
 
-func inline(always) private %impl_trait_GetX__decode_payload__g3a69(v0.objref<@layout_5>) {
+func inline(always) private %decode_runtime_args__g9e33(v0.objref<@layout_8>) -> @layout_5 {
     block0:
+        v1.*i256 = alloca i256;
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
         jump block1;
 
     block1:
-        return;
+        v5.@layout_4 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_024f;
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_7c2f v5;
+        mstore v1 v7 i256;
+        v8.i256 = mload v1 i256;
+        mstore v2 v8 i256;
+        v9.i256 = mload v2 i256;
+        v10.i1 = gt 4.i256 v9;
+        br v10 block2 block3;
+
+    block2:
+        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_87bf;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        br 1.i1 block5 block6;
+
+    block5:
+        mstore v3 4.i256 i256;
+        br 0.i1 block8 block11;
+
+    block6:
+        jump block7;
+
+    block7:
+        v17.@layout_5 = call %impl_trait_Echo__decode_from__gd20d v5 4.i256;
+        return v17;
+
+    block8:
+        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_87bf;
+        unreachable;
+
+    block9:
+        jump block10;
+
+    block10:
+        jump block7;
+
+    block11:
+        v18.i256 = mload v1 i256;
+        mstore v4 v18 i256;
+        v20.i256 = mload v4 i256;
+        v21.i1 = gt 36.i256 v20;
+        br v21 block8 block9;
 }
 
-func inline(always) private %decode_runtime_args__g9e33(v0.objref<@layout_10>) -> @layout_7 {
+func inline(always) private %decode_runtime_args__gf173(v0.objref<@layout_8>) {
     block0:
+        v1.*i256 = alloca i256;
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v1.@layout_5 = call %core__lib__contracts__trait_ContractHost__runtime_decoder__g736d_aa0c;
-        v2.objref<@layout_5> = obj.alloc @layout_5;
-        v4.objref<@layout_4> = obj.proj v2 0.i256;
-        v5.@layout_4 = extract_value v1 0.i256;
-        v6.objref<@layout_3> = obj.proj v4 0.i256;
-        v7.@layout_3 = extract_value v5 0.i256;
-        v8.objref<i256> = obj.proj v6 0.i256;
-        v9.i256 = extract_value v7 0.i256;
-        obj.store v8 v9;
-        v11.objref<i256> = obj.proj v4 1.i256;
-        v12.i256 = extract_value v5 1.i256;
-        obj.store v11 v12;
-        v13.objref<i256> = obj.proj v2 1.i256;
-        v14.i256 = extract_value v1 1.i256;
-        obj.store v13 v14;
-        v15.@layout_7 = call %impl_trait_Echo__decode_payload__g3a69 v2;
-        return v15;
+        v5.@layout_4 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_58ca;
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_34dc v5;
+        mstore v1 v7 i256;
+        v8.i256 = mload v1 i256;
+        mstore v2 v8 i256;
+        v9.i256 = mload v2 i256;
+        v10.i1 = gt 4.i256 v9;
+        br v10 block2 block3;
+
+    block2:
+        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_2725;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        br 1.i1 block5 block6;
+
+    block5:
+        mstore v3 4.i256 i256;
+        br 0.i1 block8 block11;
+
+    block6:
+        jump block7;
+
+    block7:
+        call %impl_trait_GetX__decode_from__gd20d v5 4.i256;
+        return;
+
+    block8:
+        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_2725;
+        unreachable;
+
+    block9:
+        jump block10;
+
+    block10:
+        jump block7;
+
+    block11:
+        v17.i256 = mload v1 i256;
+        mstore v4 v17 i256;
+        v19.i256 = mload v4 i256;
+        v20.i1 = gt 4.i256 v19;
+        br v20 block8 block9;
 }
 
-func inline(always) private %decode_runtime_args__gf173(v0.objref<@layout_10>) {
+func inline(always) private %decode_runtime_args__g235a(v0.objref<@layout_8>) {
     block0:
+        v1.*i256 = alloca i256;
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v1.@layout_5 = call %core__lib__contracts__trait_ContractHost__runtime_decoder__g736d_d20c;
-        v2.objref<@layout_5> = obj.alloc @layout_5;
-        v4.objref<@layout_4> = obj.proj v2 0.i256;
-        v5.@layout_4 = extract_value v1 0.i256;
-        v6.objref<@layout_3> = obj.proj v4 0.i256;
-        v7.@layout_3 = extract_value v5 0.i256;
-        v8.objref<i256> = obj.proj v6 0.i256;
-        v9.i256 = extract_value v7 0.i256;
-        obj.store v8 v9;
-        v11.objref<i256> = obj.proj v4 1.i256;
-        v12.i256 = extract_value v5 1.i256;
-        obj.store v11 v12;
-        v13.objref<i256> = obj.proj v2 1.i256;
-        v14.i256 = extract_value v1 1.i256;
-        obj.store v13 v14;
-        call %impl_trait_GetX__decode_payload__g3a69 v2;
-        return;
-}
+        v5.@layout_4 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_414c;
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_1779 v5;
+        mstore v1 v7 i256;
+        v8.i256 = mload v1 i256;
+        mstore v2 v8 i256;
+        v9.i256 = mload v2 i256;
+        v10.i1 = gt 4.i256 v9;
+        br v10 block2 block3;
 
-func inline(always) private %decode_runtime_args__g235a(v0.objref<@layout_10>) {
-    block0:
-        jump block1;
+    block2:
+        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_ee4e;
+        unreachable;
 
-    block1:
-        v1.@layout_5 = call %core__lib__contracts__trait_ContractHost__runtime_decoder__g736d_4e5a;
-        v2.objref<@layout_5> = obj.alloc @layout_5;
-        v4.objref<@layout_4> = obj.proj v2 0.i256;
-        v5.@layout_4 = extract_value v1 0.i256;
-        v6.objref<@layout_3> = obj.proj v4 0.i256;
-        v7.@layout_3 = extract_value v5 0.i256;
-        v8.objref<i256> = obj.proj v6 0.i256;
-        v9.i256 = extract_value v7 0.i256;
-        obj.store v8 v9;
-        v11.objref<i256> = obj.proj v4 1.i256;
-        v12.i256 = extract_value v5 1.i256;
-        obj.store v11 v12;
-        v13.objref<i256> = obj.proj v2 1.i256;
-        v14.i256 = extract_value v1 1.i256;
-        obj.store v13 v14;
-        call %impl_trait_Answer__decode_payload__g3a69 v2;
+    block3:
+        jump block4;
+
+    block4:
+        br 1.i1 block5 block6;
+
+    block5:
+        mstore v3 4.i256 i256;
+        br 0.i1 block8 block11;
+
+    block6:
+        jump block7;
+
+    block7:
+        call %impl_trait_Answer__decode_from__gd20d v5 4.i256;
         return;
+
+    block8:
+        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_ee4e;
+        unreachable;
+
+    block9:
+        jump block10;
+
+    block10:
+        jump block7;
+
+    block11:
+        v17.i256 = mload v1 i256;
+        mstore v4 v17 i256;
+        v19.i256 = mload v4 i256;
+        v20.i1 = gt 4.i256 v19;
+        br v20 block8 block9;
 }
 
 func private %decoder_new(v0.@layout_0) -> @layout_2 {
@@ -528,43 +653,7 @@ func private %decoder_new(v0.@layout_0) -> @layout_2 {
         return v2;
 }
 
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decoder_with_base__gd20d_5e6e(v0.@layout_3, v1.i256) -> @layout_5 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v5.@layout_5 = call %std__lib__abi__sol__impl_SolDecoder_113c__with_base__gd20d_dced v0 v3;
-        return v5;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decoder_with_base__gd20d_a557(v0.@layout_3, v1.i256) -> @layout_5 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v5.@layout_5 = call %std__lib__abi__sol__impl_SolDecoder_113c__with_base__gd20d_a4b0 v0 v3;
-        return v5;
-}
-
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decoder_with_base__gd20d_f86d(v0.@layout_3, v1.i256) -> @layout_5 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v5.@layout_5 = call %std__lib__abi__sol__impl_SolDecoder_113c__with_base__gd20d_15d8 v0 v3;
-        return v5;
-}
-
-func private %encode(v0.i256, v1.objref<@layout_6>) {
+func private %encode(v0.i256, v1.objref<@layout_3>) {
     block0:
         jump block1;
 
@@ -573,7 +662,7 @@ func private %encode(v0.i256, v1.objref<@layout_6>) {
         return;
 }
 
-func private %encode_field(v0.i256, v1.objref<@layout_6>, v2.i256) {
+func private %encode_field(v0.i256, v1.objref<@layout_3>, v2.i256) {
     block0:
         jump block1;
 
@@ -620,7 +709,7 @@ func private %encode_field(v0.i256, v1.objref<@layout_6>, v2.i256) {
         return;
 }
 
-func private %encode_single_root(v0.i256, v1.objref<@layout_6>) {
+func private %encode_single_root(v0.i256, v1.objref<@layout_3>) {
     block0:
         v2.*i256 = alloca i256;
         jump block1;
@@ -634,14 +723,14 @@ func private %encode_single_root(v0.i256, v1.objref<@layout_6>) {
         return;
 }
 
-func private %encode_single_root_alloc(v0.i256) -> @layout_8 {
+func private %encode_single_root_alloc(v0.i256) -> @layout_6 {
     block0:
         jump block1;
 
     block1:
         v2.i256 = call %abi_single_root_size v0;
-        v3.@layout_6 = call %encoder_new v2;
-        v4.objref<@layout_6> = obj.alloc @layout_6;
+        v3.@layout_3 = call %encoder_new v2;
+        v4.objref<@layout_3> = obj.alloc @layout_3;
         v6.objref<i256> = obj.proj v4 0.i256;
         v7.i256 = extract_value v3 0.i256;
         obj.store v6 v7;
@@ -650,12 +739,12 @@ func private %encode_single_root_alloc(v0.i256) -> @layout_8 {
         obj.store v9 v10;
         v11.i256 = call %impl_trait_SolEncoder__base v4;
         call %encode_single_root v0 v4;
-        v13.objref<@layout_8> = obj.alloc @layout_8;
+        v13.objref<@layout_6> = obj.alloc @layout_6;
         v14.objref<i256> = obj.proj v13 0.i256;
         obj.store v14 v11;
         v15.objref<i256> = obj.proj v13 1.i256;
         obj.store v15 v2;
-        v16.@layout_8 = obj.load v13;
+        v16.@layout_6 = obj.load v13;
         return v16;
 }
 
@@ -671,7 +760,7 @@ func private %encode_to_ptr(v0.i256, v1.i256) {
         return;
 }
 
-func private %encoder_new(v0.i256) -> @layout_6 {
+func private %encoder_new(v0.i256) -> @layout_3 {
     block0:
         v1.*i256 = alloca i256;
         mstore v1 v0 i256;
@@ -679,98 +768,38 @@ func private %encoder_new(v0.i256) -> @layout_6 {
 
     block1:
         v2.i256 = mload v1 i256;
-        v3.@layout_6 = call %impl_SolEncoder__new v2;
+        v3.@layout_3 = call %impl_SolEncoder__new v2;
         return v3;
 }
 
-func inline(always) private %core__lib__abi__impl_Cursor_1a04__fork__gd20d_12dd(v0.@layout_4, v1.i256) -> @layout_4 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v5.@layout_3 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.objref<@layout_4> = obj.alloc @layout_4;
-        v8.objref<@layout_3> = obj.proj v7 0.i256;
-        v9.objref<i256> = obj.proj v8 0.i256;
-        v10.i256 = extract_value v5 0.i256;
-        obj.store v9 v10;
-        v12.objref<i256> = obj.proj v7 1.i256;
-        obj.store v12 v6;
-        v13.@layout_4 = obj.load v7;
-        return v13;
-}
-
-func inline(always) private %core__lib__abi__impl_Cursor_1a04__fork__gd20d_9251(v0.@layout_4, v1.i256) -> @layout_4 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v5.@layout_3 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.objref<@layout_4> = obj.alloc @layout_4;
-        v8.objref<@layout_3> = obj.proj v7 0.i256;
-        v9.objref<i256> = obj.proj v8 0.i256;
-        v10.i256 = extract_value v5 0.i256;
-        obj.store v9 v10;
-        v12.objref<i256> = obj.proj v7 1.i256;
-        obj.store v12 v6;
-        v13.@layout_4 = obj.load v7;
-        return v13;
-}
-
-func inline(always) private %core__lib__abi__impl_Cursor_1a04__fork__gd20d_ce1d(v0.@layout_4, v1.i256) -> @layout_4 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v5.@layout_3 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.objref<@layout_4> = obj.alloc @layout_4;
-        v8.objref<@layout_3> = obj.proj v7 0.i256;
-        v9.objref<i256> = obj.proj v8 0.i256;
-        v10.i256 = extract_value v5 0.i256;
-        obj.store v9 v10;
-        v12.objref<i256> = obj.proj v7 1.i256;
-        obj.store v12 v6;
-        v13.@layout_4 = obj.load v7;
-        return v13;
-}
-
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_04c6() -> @layout_3 {
+func private %std__lib__evm__effects__impl_trait_Evm_c913__input_024f() -> @layout_4 {
     block0:
         jump block1;
 
     block1:
-        v0.@layout_3 = call %std__lib__evm__calldata__impl_CallData_8f43__new_5a55;
+        v0.@layout_4 = call %std__lib__evm__calldata__impl_CallData_8f43__new_45d4;
         return v0;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_1b01() -> @layout_3 {
+func private %std__lib__evm__effects__impl_trait_Evm_c913__input_414c() -> @layout_4 {
     block0:
         jump block1;
 
     block1:
-        v0.@layout_3 = call %std__lib__evm__calldata__impl_CallData_8f43__new_ad08;
+        v0.@layout_4 = call %std__lib__evm__calldata__impl_CallData_8f43__new_c043;
         return v0;
 }
 
-func private %std__lib__evm__effects__impl_trait_Evm_c913__input_cf60() -> @layout_3 {
+func private %std__lib__evm__effects__impl_trait_Evm_c913__input_58ca() -> @layout_4 {
     block0:
         jump block1;
 
     block1:
-        v0.@layout_3 = call %std__lib__evm__calldata__impl_CallData_8f43__new_a74d;
+        v0.@layout_4 = call %std__lib__evm__calldata__impl_CallData_8f43__new_bdf6;
         return v0;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_19cc(v0.objref<@layout_3>) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_1779(v0.@layout_4) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
@@ -779,27 +808,25 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
     block1:
         v3.i256 = evm_calldata_size;
         mstore v1 v3 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        v7.i256 = obj.load v6;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt v7 v9;
-        br v10 block2 block3;
+        v6.i256 = extract_value v0 0.i256;
+        v7.i256 = mload v1 i256;
+        mstore v2 v7 i256;
+        v8.i256 = mload v2 i256;
+        v9.i1 = gt v6 v8;
+        br v9 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v12.objref<i256> = obj.proj v0 0.i256;
-        v13.i256 = obj.load v12;
-        v14.i256 = mload v1 i256;
-        (v15.i256, v16.i1) = usubo v14 v13;
-        br v16 block5 block6;
+        v11.i256 = extract_value v0 0.i256;
+        v12.i256 = mload v1 i256;
+        (v13.i256, v14.i1) = usubo v12 v11;
+        br v14 block5 block6;
 
     block4:
-        v21.i256 = phi (0.i256 block2) (v15 block6);
-        return v21;
+        v19.i256 = phi (0.i256 block2) (v13 block6);
+        return v19;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -810,7 +837,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         jump block4;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_30aa(v0.objref<@layout_3>) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_34dc(v0.@layout_4) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
@@ -819,27 +846,25 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
     block1:
         v3.i256 = evm_calldata_size;
         mstore v1 v3 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        v7.i256 = obj.load v6;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt v7 v9;
-        br v10 block2 block3;
+        v6.i256 = extract_value v0 0.i256;
+        v7.i256 = mload v1 i256;
+        mstore v2 v7 i256;
+        v8.i256 = mload v2 i256;
+        v9.i1 = gt v6 v8;
+        br v9 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v12.objref<i256> = obj.proj v0 0.i256;
-        v13.i256 = obj.load v12;
-        v14.i256 = mload v1 i256;
-        (v15.i256, v16.i1) = usubo v14 v13;
-        br v16 block5 block6;
+        v11.i256 = extract_value v0 0.i256;
+        v12.i256 = mload v1 i256;
+        (v13.i256, v14.i1) = usubo v12 v11;
+        br v14 block5 block6;
 
     block4:
-        v21.i256 = phi (0.i256 block2) (v15 block6);
-        return v21;
+        v19.i256 = phi (0.i256 block2) (v13 block6);
+        return v19;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -860,6 +885,44 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_56e9
         return v4;
 }
 
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_7c2f(v0.@layout_4) -> i256 {
+    block0:
+        v1.*i256 = alloca i256;
+        v2.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v3.i256 = evm_calldata_size;
+        mstore v1 v3 i256;
+        v6.i256 = extract_value v0 0.i256;
+        v7.i256 = mload v1 i256;
+        mstore v2 v7 i256;
+        v8.i256 = mload v2 i256;
+        v9.i1 = gt v6 v8;
+        br v9 block2 block3;
+
+    block2:
+        jump block4;
+
+    block3:
+        v11.i256 = extract_value v0 0.i256;
+        v12.i256 = mload v1 i256;
+        (v13.i256, v14.i1) = usubo v12 v11;
+        br v14 block5 block6;
+
+    block4:
+        v19.i256 = phi (0.i256 block2) (v13 block6);
+        return v19;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        jump block4;
+}
+
 func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_9d6b(v0.objref<@layout_0>) -> i256 {
     block0:
         jump block1;
@@ -870,7 +933,7 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_9d6b
         return v4;
 }
 
-func private %impl_SolEncoder__new(v0.i256) -> @layout_6 {
+func private %impl_SolEncoder__new(v0.i256) -> @layout_3 {
     block0:
         v1.*i256 = alloca i256;
         mstore v1 v0 i256;
@@ -892,24 +955,24 @@ func private %impl_SolEncoder__new(v0.i256) -> @layout_6 {
 
     block4:
         v8.i256 = phi (0.i256 block2) (v7 block3);
-        v9.objref<@layout_6> = obj.alloc @layout_6;
+        v9.objref<@layout_3> = obj.alloc @layout_3;
         v10.objref<i256> = obj.proj v9 0.i256;
         obj.store v10 v8;
         v12.objref<i256> = obj.proj v9 1.i256;
         obj.store v12 v8;
-        v13.@layout_6 = obj.load v9;
+        v13.@layout_3 = obj.load v9;
         return v13;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_5a55() -> @layout_3 {
+func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_45d4() -> @layout_4 {
     block0:
         jump block1;
 
     block1:
-        v1.constref<@layout_3> = const.ref $const_region_0;
-        v2.objref<@layout_3> = obj.alloc @layout_3;
+        v1.constref<@layout_4> = const.ref $const_region_0;
+        v2.objref<@layout_4> = obj.alloc @layout_4;
         obj.init.const v2 v1;
-        v3.@layout_3 = obj.load v2;
+        v3.@layout_4 = obj.load v2;
         return v3;
 }
 
@@ -932,44 +995,28 @@ func inline(always) private %impl_Cursor__new__g463e(v0.@layout_0) -> @layout_1 
         return v11;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_a74d() -> @layout_3 {
+func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_bdf6() -> @layout_4 {
     block0:
         jump block1;
 
     block1:
-        v1.constref<@layout_3> = const.ref $const_region_0;
-        v2.objref<@layout_3> = obj.alloc @layout_3;
-        obj.init.const v2 v1;
-        v3.@layout_3 = obj.load v2;
-        return v3;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_ad08() -> @layout_3 {
-    block0:
-        jump block1;
-
-    block1:
-        v1.constref<@layout_3> = const.ref $const_region_0;
-        v2.objref<@layout_3> = obj.alloc @layout_3;
-        obj.init.const v2 v1;
-        v3.@layout_3 = obj.load v2;
-        return v3;
-}
-
-func inline(always) private %core__lib__abi__impl_Cursor_1a04__new__gd20d_d058(v0.@layout_3) -> @layout_4 {
-    block0:
-        jump block1;
-
-    block1:
+        v1.constref<@layout_4> = const.ref $const_region_0;
         v2.objref<@layout_4> = obj.alloc @layout_4;
-        v4.objref<@layout_3> = obj.proj v2 0.i256;
-        v5.objref<i256> = obj.proj v4 0.i256;
-        v6.i256 = extract_value v0 0.i256;
-        obj.store v5 v6;
-        v8.objref<i256> = obj.proj v2 1.i256;
-        obj.store v8 0.i256;
-        v9.@layout_4 = obj.load v2;
-        return v9;
+        obj.init.const v2 v1;
+        v3.@layout_4 = obj.load v2;
+        return v3;
+}
+
+func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_c043() -> @layout_4 {
+    block0:
+        jump block1;
+
+    block1:
+        v1.constref<@layout_4> = const.ref $const_region_0;
+        v2.objref<@layout_4> = obj.alloc @layout_4;
+        obj.init.const v2 v1;
+        v3.@layout_4 = obj.load v2;
+        return v3;
 }
 
 func inline(always) private %impl_SolDecoder__new__g463e(v0.@layout_0) -> @layout_2 {
@@ -997,38 +1044,6 @@ func inline(always) private %impl_SolDecoder__new__g463e(v0.@layout_0) -> @layou
         return v16;
 }
 
-func inline(always) private %core__lib__abi__impl_Cursor_1a04__new__gd20d_f1be(v0.@layout_3) -> @layout_4 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.objref<@layout_4> = obj.alloc @layout_4;
-        v4.objref<@layout_3> = obj.proj v2 0.i256;
-        v5.objref<i256> = obj.proj v4 0.i256;
-        v6.i256 = extract_value v0 0.i256;
-        obj.store v5 v6;
-        v8.objref<i256> = obj.proj v2 1.i256;
-        obj.store v8 0.i256;
-        v9.@layout_4 = obj.load v2;
-        return v9;
-}
-
-func inline(always) private %core__lib__abi__impl_Cursor_1a04__new__gd20d_f33a(v0.@layout_3) -> @layout_4 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.objref<@layout_4> = obj.alloc @layout_4;
-        v4.objref<@layout_3> = obj.proj v2 0.i256;
-        v5.objref<i256> = obj.proj v4 0.i256;
-        v6.i256 = extract_value v0 0.i256;
-        obj.store v5 v6;
-        v8.objref<i256> = obj.proj v2 1.i256;
-        obj.store v8 0.i256;
-        v9.@layout_4 = obj.load v2;
-        return v9;
-}
-
 func private %core__lib__abi__trait_AbiSize__payload_size__ge513_9950(v0.i256) -> i256 {
     block0:
         v1.*i256 = alloca i256;
@@ -1049,7 +1064,7 @@ func private %core__lib__abi__trait_AbiSize__payload_size__ge513_9950_0(v0.i256)
         return 32.i256;
 }
 
-func private %impl_trait_SolEncoder__pos(v0.objref<@layout_6>) -> i256 {
+func private %impl_trait_SolEncoder__pos(v0.objref<@layout_3>) -> i256 {
     block0:
         jump block1;
 
@@ -1057,17 +1072,6 @@ func private %impl_trait_SolEncoder__pos(v0.objref<@layout_6>) -> i256 {
         v3.objref<i256> = obj.proj v0 1.i256;
         v4.i256 = obj.load v3;
         return v4;
-}
-
-func private %pos__g8f43(v0.objref<@layout_5>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<@layout_4> = obj.proj v0 0.i256;
-        v5.objref<i256> = obj.proj v3 1.i256;
-        v6.i256 = obj.load v5;
-        return v6;
 }
 
 func private %pos__g463e(v0.objref<@layout_2>) -> i256 {
@@ -1203,156 +1207,46 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         br v26 block2 block5;
 }
 
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_2f0d(v0.objref<@layout_5>) -> i256 {
+func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_6da5(v0.i256, v1.i256) {
     block0:
-        v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        mstore v2 v0 i256;
+        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<@layout_4> = obj.proj v0 0.i256;
-        v6.objref<@layout_3> = obj.proj v5 0.i256;
-        v7.@layout_3 = obj.load v6;
-        v8.objref<@layout_4> = obj.proj v0 0.i256;
-        v9.objref<@layout_3> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_30aa v9;
-        mstore v1 v10 i256;
-        v11.objref<@layout_4> = obj.proj v0 0.i256;
-        v13.objref<i256> = obj.proj v11 1.i256;
-        v14.i256 = obj.load v13;
-        (v16.i256, v17.i1) = uaddo v14 32.i256;
-        br v17 block6 block7;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v28.objref<@layout_4> = obj.proj v0 0.i256;
-        v29.objref<@layout_3> = obj.proj v28 0.i256;
-        v30.@layout_3 = obj.load v29;
-        v31.objref<@layout_4> = obj.proj v0 0.i256;
-        v32.objref<i256> = obj.proj v31 1.i256;
-        v33.i256 = obj.load v32;
-        v34.objref<@layout_4> = obj.proj v0 0.i256;
-        v35.objref<@layout_3> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_61b2 v35 v33;
-        v38.objref<@layout_4> = obj.proj v0 0.i256;
-        v39.objref<i256> = obj.proj v38 1.i256;
-        obj.store v39 v16;
-        return v36;
-
-    block5:
-        v40.i256 = mload v1 i256;
-        mstore v2 v40 i256;
-        v42.i256 = mload v2 i256;
-        v43.i1 = gt v16 v42;
-        br v43 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v23.objref<@layout_4> = obj.proj v0 0.i256;
-        v24.objref<i256> = obj.proj v23 1.i256;
-        v25.i256 = obj.load v24;
-        v26.i1 = lt v16 v25;
-        br v26 block2 block5;
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v3 i256;
+        evm_revert v4 v5;
 }
 
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g8f43_b0fa(v0.objref<@layout_5>) -> i256 {
+func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_a97d(v0.i256, v1.i256) {
     block0:
-        v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        mstore v2 v0 i256;
+        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<@layout_4> = obj.proj v0 0.i256;
-        v6.objref<@layout_3> = obj.proj v5 0.i256;
-        v7.@layout_3 = obj.load v6;
-        v8.objref<@layout_4> = obj.proj v0 0.i256;
-        v9.objref<@layout_3> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_19cc v9;
-        mstore v1 v10 i256;
-        v11.objref<@layout_4> = obj.proj v0 0.i256;
-        v13.objref<i256> = obj.proj v11 1.i256;
-        v14.i256 = obj.load v13;
-        (v16.i256, v17.i1) = uaddo v14 32.i256;
-        br v17 block6 block7;
-
-    block2:
-        evm_revert 0.i256 0.i256;
-
-    block3:
-        jump block4;
-
-    block4:
-        v28.objref<@layout_4> = obj.proj v0 0.i256;
-        v29.objref<@layout_3> = obj.proj v28 0.i256;
-        v30.@layout_3 = obj.load v29;
-        v31.objref<@layout_4> = obj.proj v0 0.i256;
-        v32.objref<i256> = obj.proj v31 1.i256;
-        v33.i256 = obj.load v32;
-        v34.objref<@layout_4> = obj.proj v0 0.i256;
-        v35.objref<@layout_3> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_39d8 v35 v33;
-        v38.objref<@layout_4> = obj.proj v0 0.i256;
-        v39.objref<i256> = obj.proj v38 1.i256;
-        obj.store v39 v16;
-        return v36;
-
-    block5:
-        v40.i256 = mload v1 i256;
-        mstore v2 v40 i256;
-        v42.i256 = mload v2 i256;
-        v43.i1 = gt v16 v42;
-        br v43 block2 block3;
-
-    block6:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block7:
-        v23.objref<@layout_4> = obj.proj v0 0.i256;
-        v24.objref<i256> = obj.proj v23 1.i256;
-        v25.i256 = obj.load v24;
-        v26.i1 = lt v16 v25;
-        br v26 block2 block5;
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v3 i256;
+        evm_revert v4 v5;
 }
 
-func inline(always) private %core__lib__contracts__trait_ContractHost__runtime_decoder__g736d_4e5a() -> @layout_5 {
+func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_f892(v0.i256, v1.i256) {
     block0:
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        mstore v2 v0 i256;
+        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v0.@layout_3 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_04c6;
-        v2.@layout_5 = call %std__lib__abi__sol__impl_trait_Sol_1f5f__decoder_with_base__gd20d_5e6e v0 4.i256;
-        return v2;
-}
-
-func inline(always) private %core__lib__contracts__trait_ContractHost__runtime_decoder__g736d_aa0c() -> @layout_5 {
-    block0:
-        jump block1;
-
-    block1:
-        v0.@layout_3 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_1b01;
-        v2.@layout_5 = call %std__lib__abi__sol__impl_trait_Sol_1f5f__decoder_with_base__gd20d_f86d v0 4.i256;
-        return v2;
-}
-
-func inline(always) private %core__lib__contracts__trait_ContractHost__runtime_decoder__g736d_d20c() -> @layout_5 {
-    block0:
-        jump block1;
-
-    block1:
-        v0.@layout_3 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_cf60;
-        v2.@layout_5 = call %std__lib__abi__sol__impl_trait_Sol_1f5f__decoder_with_base__gd20d_a557 v0 4.i256;
-        return v2;
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v3 i256;
+        evm_revert v4 v5;
 }
 
 func private %set_base__g463e(v0.objref<@layout_2>, v1.i256) {
@@ -1368,20 +1262,7 @@ func private %set_base__g463e(v0.objref<@layout_2>, v1.i256) {
         return;
 }
 
-func private %set_base__g8f43(v0.objref<@layout_5>, v1.i256) {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 1.i256;
-        obj.store v6 v3;
-        return;
-}
-
-func private %impl_trait_SolEncoder__set_base(v0.objref<@layout_6>, v1.i256) {
+func private %impl_trait_SolEncoder__set_base(v0.objref<@layout_3>, v1.i256) {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -1391,20 +1272,6 @@ func private %impl_trait_SolEncoder__set_base(v0.objref<@layout_6>, v1.i256) {
         v3.i256 = mload v2 i256;
         v6.objref<i256> = obj.proj v0 0.i256;
         obj.store v6 v3;
-        return;
-}
-
-func private %set_pos__g8f43(v0.objref<@layout_5>, v1.i256) {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<@layout_4> = obj.proj v0 0.i256;
-        v8.objref<i256> = obj.proj v6 1.i256;
-        obj.store v8 v3;
         return;
 }
 
@@ -1422,7 +1289,7 @@ func private %set_pos__g463e(v0.objref<@layout_2>, v1.i256) {
         return;
 }
 
-func private %impl_trait_SolEncoder__set_pos(v0.objref<@layout_6>, v1.i256) {
+func private %impl_trait_SolEncoder__set_pos(v0.objref<@layout_3>, v1.i256) {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -1450,85 +1317,18 @@ func private %store_word(v0.i256, v1.i256) {
         return;
 }
 
-func inline(always) private %std__lib__abi__sol__impl_SolDecoder_113c__with_base__gd20d_15d8(v0.@layout_3, v1.i256) -> @layout_5 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_1f7f(v0.@layout_4, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.@layout_4 = call %core__lib__abi__impl_Cursor_1a04__new__gd20d_d058 v0;
-        v5.i256 = mload v2 i256;
-        v6.@layout_4 = call %core__lib__abi__impl_Cursor_1a04__fork__gd20d_ce1d v4 v5;
-        v7.i256 = mload v2 i256;
-        v8.objref<@layout_5> = obj.alloc @layout_5;
-        v10.objref<@layout_4> = obj.proj v8 0.i256;
-        v11.objref<@layout_3> = obj.proj v10 0.i256;
-        v12.@layout_3 = extract_value v6 0.i256;
-        v13.objref<i256> = obj.proj v11 0.i256;
-        v14.i256 = extract_value v12 0.i256;
-        obj.store v13 v14;
-        v16.objref<i256> = obj.proj v10 1.i256;
-        v17.i256 = extract_value v6 1.i256;
-        obj.store v16 v17;
-        v18.objref<i256> = obj.proj v8 1.i256;
-        obj.store v18 v7;
-        v19.@layout_5 = obj.load v8;
-        return v19;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_SolDecoder_113c__with_base__gd20d_a4b0(v0.@layout_3, v1.i256) -> @layout_5 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v4.@layout_4 = call %core__lib__abi__impl_Cursor_1a04__new__gd20d_f33a v0;
-        v5.i256 = mload v2 i256;
-        v6.@layout_4 = call %core__lib__abi__impl_Cursor_1a04__fork__gd20d_12dd v4 v5;
-        v7.i256 = mload v2 i256;
-        v8.objref<@layout_5> = obj.alloc @layout_5;
-        v10.objref<@layout_4> = obj.proj v8 0.i256;
-        v11.objref<@layout_3> = obj.proj v10 0.i256;
-        v12.@layout_3 = extract_value v6 0.i256;
-        v13.objref<i256> = obj.proj v11 0.i256;
-        v14.i256 = extract_value v12 0.i256;
-        obj.store v13 v14;
-        v16.objref<i256> = obj.proj v10 1.i256;
-        v17.i256 = extract_value v6 1.i256;
-        obj.store v16 v17;
-        v18.objref<i256> = obj.proj v8 1.i256;
-        obj.store v18 v7;
-        v19.@layout_5 = obj.load v8;
-        return v19;
-}
-
-func inline(always) private %std__lib__abi__sol__impl_SolDecoder_113c__with_base__gd20d_dced(v0.@layout_3, v1.i256) -> @layout_5 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v4.@layout_4 = call %core__lib__abi__impl_Cursor_1a04__new__gd20d_f1be v0;
-        v5.i256 = mload v2 i256;
-        v6.@layout_4 = call %core__lib__abi__impl_Cursor_1a04__fork__gd20d_9251 v4 v5;
-        v7.i256 = mload v2 i256;
-        v8.objref<@layout_5> = obj.alloc @layout_5;
-        v10.objref<@layout_4> = obj.proj v8 0.i256;
-        v11.objref<@layout_3> = obj.proj v10 0.i256;
-        v12.@layout_3 = extract_value v6 0.i256;
-        v13.objref<i256> = obj.proj v11 0.i256;
-        v14.i256 = extract_value v12 0.i256;
-        obj.store v13 v14;
-        v16.objref<i256> = obj.proj v10 1.i256;
-        v17.i256 = extract_value v6 1.i256;
-        obj.store v16 v17;
-        v18.objref<i256> = obj.proj v8 1.i256;
-        obj.store v18 v7;
-        v19.@layout_5 = obj.load v8;
-        return v19;
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
 }
 
 func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_33be(v0.objref<@layout_0>, v1.i256) -> i256 {
@@ -1543,21 +1343,6 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_
         v7.i256 = mload v2 i256;
         v8.i256 = add v6 v7;
         v9.i256 = mload v8 i256;
-        return v9;
-}
-
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_39d8(v0.objref<@layout_3>, v1.i256) -> i256 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = evm_calldata_load v8;
         return v9;
 }
 
@@ -1576,22 +1361,21 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_
         return v9;
 }
 
-func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_61b2(v0.objref<@layout_3>, v1.i256) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_81b2(v0.@layout_4, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = evm_calldata_load v8;
-        return v9;
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_6213(v0.objref<@layout_6>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_6213(v0.objref<@layout_3>, v1.i256) {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -1608,7 +1392,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_6213(v0
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_d116(v0.objref<@layout_6>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_d116(v0.objref<@layout_3>, v1.i256) {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;

--- a/crates/codegen/tests/fixtures/sonatina_ir/high_level_contract.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/high_level_contract.snap
@@ -466,6 +466,51 @@ func inline(always) private %decode_from__g72ab(v0.@layout_4, v1.i256) -> i256 {
         return v5;
 }
 
+func inline(always) private %decode_from_checked_head__g2f3f(v0.@layout_4, v1.i256, v2.i256) {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v4 i256;
+        v7.i256 = mload v3 i256;
+        call %impl_trait_Answer__decode_from__gd20d v0 v7;
+        return;
+}
+
+func inline(always) private %decode_from_checked_head__g6fcf(v0.@layout_4, v1.i256, v2.i256) -> @layout_5 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v4 i256;
+        v7.i256 = mload v3 i256;
+        v8.@layout_5 = call %impl_trait_Echo__decode_from__gd20d v0 v7;
+        return v8;
+}
+
+func inline(always) private %decode_from_checked_head__g2d0f(v0.@layout_4, v1.i256, v2.i256) {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v4 i256;
+        v7.i256 = mload v3 i256;
+        call %impl_trait_GetX__decode_from__gd20d v0 v7;
+        return;
+}
+
 func private %decode_payload__g4770(v0.objref<@layout_3>) -> @layout_6 {
     block0:
         jump block1;
@@ -496,18 +541,14 @@ func inline(always) private %decode_runtime_args__g9e33(v0.objref<@layout_8>) ->
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
         v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v5.@layout_4 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_024f;
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_7c2f v5;
-        mstore v1 v7 i256;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt 4.i256 v9;
-        br v10 block2 block3;
+        v4.@layout_4 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_024f;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_7c2f v4;
+        mstore v1 v6 i256;
+        mstore v2 4.i256 i256;
+        br 0.i1 block2 block5;
 
     block2:
         call %std__lib__evm__effects__impl_trait_Evm_c913__abort_87bf;
@@ -517,35 +558,16 @@ func inline(always) private %decode_runtime_args__g9e33(v0.objref<@layout_8>) ->
         jump block4;
 
     block4:
-        br 1.i1 block5 block6;
+        v12.i256 = mload v1 i256;
+        v13.@layout_5 = call %decode_from_checked_head__g6fcf v4 4.i256 v12;
+        return v13;
 
     block5:
-        mstore v3 4.i256 i256;
-        br 0.i1 block8 block11;
-
-    block6:
-        jump block7;
-
-    block7:
-        v17.@layout_5 = call %impl_trait_Echo__decode_from__gd20d v5 4.i256;
-        return v17;
-
-    block8:
-        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_87bf;
-        unreachable;
-
-    block9:
-        jump block10;
-
-    block10:
-        jump block7;
-
-    block11:
-        v18.i256 = mload v1 i256;
-        mstore v4 v18 i256;
-        v20.i256 = mload v4 i256;
-        v21.i1 = gt 36.i256 v20;
-        br v21 block8 block9;
+        v14.i256 = mload v1 i256;
+        mstore v3 v14 i256;
+        v16.i256 = mload v3 i256;
+        v17.i1 = gt 36.i256 v16;
+        br v17 block2 block3;
 }
 
 func inline(always) private %decode_runtime_args__gf173(v0.objref<@layout_8>) {
@@ -553,18 +575,14 @@ func inline(always) private %decode_runtime_args__gf173(v0.objref<@layout_8>) {
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
         v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v5.@layout_4 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_58ca;
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_34dc v5;
-        mstore v1 v7 i256;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt 4.i256 v9;
-        br v10 block2 block3;
+        v4.@layout_4 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_58ca;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_34dc v4;
+        mstore v1 v6 i256;
+        mstore v2 4.i256 i256;
+        br 0.i1 block2 block5;
 
     block2:
         call %std__lib__evm__effects__impl_trait_Evm_c913__abort_2725;
@@ -574,35 +592,16 @@ func inline(always) private %decode_runtime_args__gf173(v0.objref<@layout_8>) {
         jump block4;
 
     block4:
-        br 1.i1 block5 block6;
-
-    block5:
-        mstore v3 4.i256 i256;
-        br 0.i1 block8 block11;
-
-    block6:
-        jump block7;
-
-    block7:
-        call %impl_trait_GetX__decode_from__gd20d v5 4.i256;
+        v11.i256 = mload v1 i256;
+        call %decode_from_checked_head__g2d0f v4 4.i256 v11;
         return;
 
-    block8:
-        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_2725;
-        unreachable;
-
-    block9:
-        jump block10;
-
-    block10:
-        jump block7;
-
-    block11:
-        v17.i256 = mload v1 i256;
-        mstore v4 v17 i256;
-        v19.i256 = mload v4 i256;
-        v20.i1 = gt 4.i256 v19;
-        br v20 block8 block9;
+    block5:
+        v13.i256 = mload v1 i256;
+        mstore v3 v13 i256;
+        v15.i256 = mload v3 i256;
+        v16.i1 = gt 4.i256 v15;
+        br v16 block2 block3;
 }
 
 func inline(always) private %decode_runtime_args__g235a(v0.objref<@layout_8>) {
@@ -610,18 +609,14 @@ func inline(always) private %decode_runtime_args__g235a(v0.objref<@layout_8>) {
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
         v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v5.@layout_4 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_414c;
-        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_1779 v5;
-        mstore v1 v7 i256;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt 4.i256 v9;
-        br v10 block2 block3;
+        v4.@layout_4 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_414c;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_1779 v4;
+        mstore v1 v6 i256;
+        mstore v2 4.i256 i256;
+        br 0.i1 block2 block5;
 
     block2:
         call %std__lib__evm__effects__impl_trait_Evm_c913__abort_ee4e;
@@ -631,35 +626,16 @@ func inline(always) private %decode_runtime_args__g235a(v0.objref<@layout_8>) {
         jump block4;
 
     block4:
-        br 1.i1 block5 block6;
-
-    block5:
-        mstore v3 4.i256 i256;
-        br 0.i1 block8 block11;
-
-    block6:
-        jump block7;
-
-    block7:
-        call %impl_trait_Answer__decode_from__gd20d v5 4.i256;
+        v11.i256 = mload v1 i256;
+        call %decode_from_checked_head__g2f3f v4 4.i256 v11;
         return;
 
-    block8:
-        call %std__lib__evm__effects__impl_trait_Evm_c913__abort_ee4e;
-        unreachable;
-
-    block9:
-        jump block10;
-
-    block10:
-        jump block7;
-
-    block11:
-        v17.i256 = mload v1 i256;
-        mstore v4 v17 i256;
-        v19.i256 = mload v4 i256;
-        v20.i1 = gt 4.i256 v19;
-        br v20 block8 block9;
+    block5:
+        v13.i256 = mload v1 i256;
+        mstore v3 v13 i256;
+        v15.i256 = mload v3 i256;
+        v16.i1 = gt 4.i256 v15;
+        br v16 block2 block3;
 }
 
 func private %decoder_new(v0.@layout_1) -> @layout_3 {

--- a/crates/codegen/tests/fixtures/sonatina_ir/high_level_contract.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/high_level_contract.snap
@@ -166,6 +166,83 @@ func private %impl_trait_SolEncoder__base(v0.objref<@layout_0>) -> i256 {
         return v4;
 }
 
+func inline(always) private %checked_frame_end(v0.i256, v1.i256, v2.i256) -> i256 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        mstore v3 v0 i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        jump block1;
+
+    block1:
+        v6.i256 = mload v3 i256;
+        v7.i256 = mload v4 i256;
+        (v8.i256, v9.i1) = uaddo v6 v7;
+        br v9 block6 block7;
+
+    block2:
+        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_f5d2;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        return v8;
+
+    block5:
+        v19.i256 = mload v5 i256;
+        v20.i1 = gt v8 v19;
+        br v20 block2 block3;
+
+    block6:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block7:
+        v15.i256 = mload v3 i256;
+        v16.i1 = lt v8 v15;
+        br v16 block2 block5;
+}
+
+func inline(always) private %checked_tail(v0.i256, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        mstore v2 v0 i256;
+        mstore v3 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v3 i256;
+        (v6.i256, v7.i1) = uaddo v4 v5;
+        br v7 block5 block6;
+
+    block2:
+        call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_eb34;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        return v6;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        v13.i256 = mload v2 i256;
+        v14.i1 = lt v6 v13;
+        br v14 block2 block3;
+}
+
 func private %contract_init_abi_EchoContract() {
     block0:
         v0.objref<@layout_1> = obj.alloc @layout_1;
@@ -345,6 +422,22 @@ func private %contract_runtime_root_EchoContract() {
         unreachable;
 }
 
+func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_eb34() {
+    block0:
+        jump block1;
+
+    block1:
+        evm_revert 0.i256 0.i256;
+}
+
+func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_f5d2() {
+    block0:
+        jump block1;
+
+    block1:
+        evm_revert 0.i256 0.i256;
+}
+
 func inline(always) private %decode_field(v0.objref<@layout_3>) -> i256 {
     block0:
         jump block1;
@@ -353,7 +446,7 @@ func inline(always) private %decode_field(v0.objref<@layout_3>) -> i256 {
         br 0.i1 block2 block3;
 
     block2:
-        v3.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_1759 v0;
+        v3.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_66f1 v0;
         v4.i256 = call %base__g463e v0;
         v5.i256 = call %pos__g463e v0;
         (v6.i256, v7.i1) = uaddo v4 v3;
@@ -404,7 +497,7 @@ func inline(always) private %decode_field_from(v0.@layout_4, v1.i256, v2.i256) -
 
     block4:
         v20.i256 = mload v4 i256;
-        v21.i256 = call %decode_from__g72ab v0 v20;
+        v21.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_4818_0 v0 v20;
         return v21;
 
     block5:
@@ -413,8 +506,39 @@ func inline(always) private %decode_field_from(v0.@layout_4, v1.i256, v2.i256) -
         evm_revert 0.i256 36.i256;
 
     block6:
-        v18.i256 = call %decode_from__g72ab v0 v10;
+        v18.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_4818_0 v0 v10;
         return v18;
+}
+
+func inline(always) private %decode_field_from_prechecked_head(v0.@layout_4, v1.i256, v2.i256, v3.i256) -> i256 {
+    block0:
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        v6.*i256 = alloca i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        mstore v6 v3 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v9.i256 = mload v5 i256;
+        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_1f7f v0 v9;
+        v11.i256 = mload v4 i256;
+        v12.i256 = call %checked_tail v11 v10;
+        v13.i256 = mload v6 i256;
+        v14.i256 = call %decode_from_bounded v0 v12 v13;
+        return v14;
+
+    block3:
+        jump block4;
+
+    block4:
+        v16.i256 = mload v5 i256;
+        v17.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_4818_0 v0 v16;
+        return v17;
 }
 
 func inline(always) private %impl_trait_Echo__decode_from__gd20d(v0.@layout_4, v1.i256) -> @layout_5 {
@@ -424,14 +548,15 @@ func inline(always) private %impl_trait_Echo__decode_from__gd20d(v0.@layout_4, v
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_6a97 v0;
         v5.i256 = mload v2 i256;
-        v6.i256 = call %decode_field_from v0 v4 v5;
-        v7.objref<@layout_5> = obj.alloc @layout_5;
-        v9.objref<i256> = obj.proj v7 0.i256;
-        obj.store v9 v6;
-        v10.@layout_5 = obj.load v7;
-        return v10;
+        v6.i256 = mload v2 i256;
+        v7.i256 = call %decode_msg_field_from v0 v5 v6 v4;
+        v8.objref<@layout_5> = obj.alloc @layout_5;
+        v10.objref<i256> = obj.proj v8 0.i256;
+        obj.store v10 v7;
+        v11.@layout_5 = obj.load v8;
+        return v11;
 }
 
 func inline(always) private %impl_trait_Answer__decode_from__gd20d(v0.@layout_4, v1.i256) {
@@ -454,7 +579,7 @@ func inline(always) private %impl_trait_GetX__decode_from__gd20d(v0.@layout_4, v
         return;
 }
 
-func inline(always) private %decode_from__g72ab(v0.@layout_4, v1.i256) -> i256 {
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_4818(v0.@layout_4, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -464,6 +589,35 @@ func inline(always) private %decode_from__g72ab(v0.@layout_4, v1.i256) -> i256 {
         v4.i256 = mload v2 i256;
         v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_81b2 v0 v4;
         return v5;
+}
+
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_4818_0(v0.@layout_4, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_81b2_0 v0 v4;
+        return v5;
+}
+
+func private %decode_from_bounded(v0.@layout_4, v1.i256, v2.i256) -> i256 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v3 i256;
+        v7.i256 = mload v4 i256;
+        v8.i256 = call %checked_frame_end v5 32.i256 v7;
+        v10.i256 = mload v3 i256;
+        v11.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_4818 v0 v10;
+        return v11;
 }
 
 func inline(always) private %decode_from_prechecked_head__g2d0f(v0.@layout_4, v1.i256, v2.i256) {
@@ -511,6 +665,46 @@ func inline(always) private %decode_from_prechecked_head__g6fcf(v0.@layout_4, v1
         return v8;
 }
 
+func inline(always) private %decode_msg_field_from(v0.@layout_4, v1.i256, v2.i256, v3.i256) -> i256 {
+    block0:
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        v6.*i256 = alloca i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        mstore v6 v3 i256;
+        jump block1;
+
+    block1:
+        br 0.i1 block2 block3;
+
+    block2:
+        v9.i256 = mload v4 i256;
+        v10.i256 = mload v5 i256;
+        v11.i256 = mload v6 i256;
+        v12.i256 = call %decode_field_from_prechecked_head v0 v9 v10 v11;
+        return v12;
+
+    block3:
+        jump block4;
+
+    block4:
+        v13.i256 = mload v6 i256;
+        v15.i256 = mload v4 i256;
+        v16.i256 = mload v5 i256;
+        v17.i256 = call %decode_field_from v0 v15 v16;
+        return v17;
+}
+
+func inline(always) private %decode_payload__g407e(v0.objref<@layout_3>) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v2.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_d95a v0;
+        return v2;
+}
+
 func private %decode_payload__g4770(v0.objref<@layout_3>) -> @layout_6 {
     block0:
         jump block1;
@@ -525,15 +719,6 @@ func private %decode_payload__g4770(v0.objref<@layout_3>) -> @layout_6 {
         obj.store v8 v3;
         v9.@layout_6 = obj.load v4;
         return v9;
-}
-
-func inline(always) private %decode_payload__g407e(v0.objref<@layout_3>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_16c3 v0;
-        return v2;
 }
 
 func inline(always) private %decode_runtime_args__g9e33(v0.objref<@layout_8>) -> @layout_5 {
@@ -869,14 +1054,42 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         jump block4;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_56e9(v0.objref<@layout_1>) -> i256 {
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_6a97(v0.@layout_4) -> i256 {
     block0:
+        v1.*i256 = alloca i256;
+        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.objref<i256> = obj.proj v0 1.i256;
-        v4.i256 = obj.load v3;
-        return v4;
+        v3.i256 = evm_calldata_size;
+        mstore v1 v3 i256;
+        v6.i256 = extract_value v0 0.i256;
+        v7.i256 = mload v1 i256;
+        mstore v2 v7 i256;
+        v8.i256 = mload v2 i256;
+        v9.i1 = gt v6 v8;
+        br v9 block2 block3;
+
+    block2:
+        jump block4;
+
+    block3:
+        v11.i256 = extract_value v0 0.i256;
+        v12.i256 = mload v1 i256;
+        (v13.i256, v14.i1) = usubo v12 v11;
+        br v14 block5 block6;
+
+    block4:
+        v19.i256 = phi (0.i256 block2) (v13 block6);
+        return v19;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        jump block4;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_7c2f(v0.@layout_4) -> i256 {
@@ -917,7 +1130,17 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         jump block4;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_9d6b(v0.objref<@layout_1>) -> i256 {
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_8748(v0.objref<@layout_1>) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v3.objref<i256> = obj.proj v0 1.i256;
+        v4.i256 = obj.load v3;
+        return v4;
+}
+
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_f8db(v0.objref<@layout_1>) -> i256 {
     block0:
         jump block1;
 
@@ -1053,16 +1276,6 @@ func private %core__lib__abi__trait_AbiSize__payload_size__ge513_9950_0(v0.i256)
         return 32.i256;
 }
 
-func private %impl_trait_SolEncoder__pos(v0.objref<@layout_0>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 1.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
 func private %pos__g463e(v0.objref<@layout_3>) -> i256 {
     block0:
         jump block1;
@@ -1074,7 +1287,17 @@ func private %pos__g463e(v0.objref<@layout_3>) -> i256 {
         return v6;
 }
 
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_16c3(v0.objref<@layout_3>) -> i256 {
+func private %impl_trait_SolEncoder__pos(v0.objref<@layout_0>) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v3.objref<i256> = obj.proj v0 1.i256;
+        v4.i256 = obj.load v3;
+        return v4;
+}
+
+func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_66f1(v0.objref<@layout_3>) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
@@ -1086,7 +1309,7 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         v7.@layout_1 = obj.load v6;
         v8.objref<@layout_2> = obj.proj v0 0.i256;
         v9.objref<@layout_1> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_9d6b v9;
+        v10.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_f8db v9;
         mstore v1 v10 i256;
         v11.objref<@layout_2> = obj.proj v0 0.i256;
         v13.objref<i256> = obj.proj v11 1.i256;
@@ -1109,7 +1332,7 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         v33.i256 = obj.load v32;
         v34.objref<@layout_2> = obj.proj v0 0.i256;
         v35.objref<@layout_1> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_33be v35 v33;
+        v36.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_7f06 v35 v33;
         v38.objref<@layout_2> = obj.proj v0 0.i256;
         v39.objref<i256> = obj.proj v38 1.i256;
         obj.store v39 v16;
@@ -1135,7 +1358,7 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         br v26 block2 block5;
 }
 
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_1759(v0.objref<@layout_3>) -> i256 {
+func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_d95a(v0.objref<@layout_3>) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
@@ -1147,7 +1370,7 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         v7.@layout_1 = obj.load v6;
         v8.objref<@layout_2> = obj.proj v0 0.i256;
         v9.objref<@layout_1> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_56e9 v9;
+        v10.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_8748 v9;
         mstore v1 v10 i256;
         v11.objref<@layout_2> = obj.proj v0 0.i256;
         v13.objref<i256> = obj.proj v11 1.i256;
@@ -1170,7 +1393,7 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         v33.i256 = obj.load v32;
         v34.objref<@layout_2> = obj.proj v0 0.i256;
         v35.objref<@layout_1> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_52f5 v35 v33;
+        v36.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_38bd v35 v33;
         v38.objref<@layout_2> = obj.proj v0 0.i256;
         v39.objref<i256> = obj.proj v38 1.i256;
         obj.store v39 v16;
@@ -1238,19 +1461,6 @@ func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_f892(v0.i256, 
         evm_revert v4 v5;
 }
 
-func private %set_base__g463e(v0.objref<@layout_3>, v1.i256) {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 1.i256;
-        obj.store v6 v3;
-        return;
-}
-
 func private %impl_trait_SolEncoder__set_base(v0.objref<@layout_0>, v1.i256) {
     block0:
         v2.*i256 = alloca i256;
@@ -1260,6 +1470,19 @@ func private %impl_trait_SolEncoder__set_base(v0.objref<@layout_0>, v1.i256) {
     block1:
         v3.i256 = mload v2 i256;
         v6.objref<i256> = obj.proj v0 0.i256;
+        obj.store v6 v3;
+        return;
+}
+
+func private %set_base__g463e(v0.objref<@layout_3>, v1.i256) {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v3.i256 = mload v2 i256;
+        v6.objref<i256> = obj.proj v0 1.i256;
         obj.store v6 v3;
         return;
 }
@@ -1320,7 +1543,7 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
         return v8;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_33be(v0.objref<@layout_1>, v1.i256) -> i256 {
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_38bd(v0.objref<@layout_1>, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -1335,7 +1558,7 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_
         return v9;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_52f5(v0.objref<@layout_1>, v1.i256) -> i256 {
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_7f06(v0.objref<@layout_1>, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -1351,6 +1574,20 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_81b2(v0.@layout_4, v1.i256) -> i256 {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = extract_value v0 0.i256;
+        v6.i256 = mload v2 i256;
+        v7.i256 = add v5 v6;
+        v8.i256 = evm_calldata_load v7;
+        return v8;
+}
+
+func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_81b2_0(v0.@layout_4, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;

--- a/crates/codegen/tests/fixtures/sonatina_ir/init_args_with_child_dep.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/init_args_with_child_dep.snap
@@ -71,7 +71,17 @@ func inline(always) private %at(v0.i256) -> @layout_1 {
         return v9;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_43fa(v0.objref<@layout_4>) -> i256 {
+func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_1672(v0.objref<@layout_4>) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v3.objref<i256> = obj.proj v0 1.i256;
+        v4.i256 = obj.load v3;
+        return v4;
+}
+
+func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_2b07(v0.objref<@layout_4>) -> i256 {
     block0:
         jump block1;
 
@@ -97,16 +107,6 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_85b5(v0.objre
 
     block1:
         v3.objref<i256> = obj.proj v0 0.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_b557(v0.objref<@layout_4>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 1.i256;
         v4.i256 = obj.load v3;
         return v4;
 }
@@ -484,7 +484,7 @@ func private %create_raw(v0.i256, v1.i256, v2.i256) -> @layout_5 {
         return v13;
 }
 
-func inline(always) private %core__lib__abi__decode_field__g3854_29f4(v0.objref<@layout_4>) -> i256 {
+func inline(always) private %core__lib__abi__decode_field__g3854_271d(v0.objref<@layout_4>) -> i256 {
     block0:
         jump block1;
 
@@ -492,9 +492,9 @@ func inline(always) private %core__lib__abi__decode_field__g3854_29f4(v0.objref<
         br 0.i1 block2 block3;
 
     block2:
-        v3.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_1285 v0;
-        v4.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_43fa v0;
-        v5.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g463e_1dfb v0;
+        v3.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_6997 v0;
+        v4.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_1672 v0;
+        v5.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g463e_5a37 v0;
         (v6.i256, v7.i1) = uaddo v4 v3;
         br v7 block5 block6;
 
@@ -502,7 +502,7 @@ func inline(always) private %core__lib__abi__decode_field__g3854_29f4(v0.objref<
         jump block4;
 
     block4:
-        v23.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_payload__g407e_4e26 v0;
+        v23.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_payload__g407e_92e8 v0;
         return v23;
 
     block5:
@@ -511,16 +511,16 @@ func inline(always) private %core__lib__abi__decode_field__g3854_29f4(v0.objref<
         evm_revert 0.i256 36.i256;
 
     block6:
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_6705 v0 v6;
-        v15.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_43fa v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_4a51 v0 v15;
-        v17.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_payload__g407e_4e26 v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_6705 v0 v4;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_4a51 v0 v5;
+        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_e112 v0 v6;
+        v15.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_1672 v0;
+        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_0c70 v0 v15;
+        v17.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_payload__g407e_92e8 v0;
+        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_e112 v0 v4;
+        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_0c70 v0 v5;
         return v17;
 }
 
-func inline(always) private %core__lib__abi__decode_field__g3854_bdd0(v0.objref<@layout_4>) -> i256 {
+func inline(always) private %core__lib__abi__decode_field__g3854_e495(v0.objref<@layout_4>) -> i256 {
     block0:
         jump block1;
 
@@ -528,9 +528,9 @@ func inline(always) private %core__lib__abi__decode_field__g3854_bdd0(v0.objref<
         br 0.i1 block2 block3;
 
     block2:
-        v3.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_f2ee v0;
-        v4.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_b557 v0;
-        v5.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g463e_b693 v0;
+        v3.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_c4ab v0;
+        v4.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_2b07 v0;
+        v5.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g463e_1111 v0;
         (v6.i256, v7.i1) = uaddo v4 v3;
         br v7 block5 block6;
 
@@ -538,7 +538,7 @@ func inline(always) private %core__lib__abi__decode_field__g3854_bdd0(v0.objref<
         jump block4;
 
     block4:
-        v23.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_payload__g407e_66ca v0;
+        v23.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_payload__g407e_a9a2 v0;
         return v23;
 
     block5:
@@ -547,12 +547,12 @@ func inline(always) private %core__lib__abi__decode_field__g3854_bdd0(v0.objref<
         evm_revert 0.i256 36.i256;
 
     block6:
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_a978 v0 v6;
-        v15.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_b557 v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_25bb v0 v15;
-        v17.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_payload__g407e_66ca v0;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_a978 v0 v4;
-        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_25bb v0 v5;
+        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_bba9 v0 v6;
+        v15.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_2b07 v0;
+        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_5886 v0 v15;
+        v17.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_payload__g407e_a9a2 v0;
+        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_bba9 v0 v4;
+        call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_5886 v0 v5;
         return v17;
 }
 
@@ -561,8 +561,8 @@ func private %decode_payload__g4770(v0.objref<@layout_4>) -> @layout_0 {
         jump block1;
 
     block1:
-        v2.i256 = call %core__lib__abi__decode_field__g3854_29f4 v0;
-        v3.i256 = call %core__lib__abi__decode_field__g3854_29f4 v0;
+        v2.i256 = call %core__lib__abi__decode_field__g3854_e495 v0;
+        v3.i256 = call %core__lib__abi__decode_field__g3854_e495 v0;
         v4.objref<@layout_0> = obj.alloc @layout_0;
         v6.objref<i256> = obj.proj v4 0.i256;
         obj.store v6 v2;
@@ -577,7 +577,7 @@ func private %decode_payload__g3854(v0.objref<@layout_4>) -> @layout_6 {
         jump block1;
 
     block1:
-        v2.i256 = call %core__lib__abi__decode_field__g3854_bdd0 v0;
+        v2.i256 = call %core__lib__abi__decode_field__g3854_271d v0;
         v3.objref<@layout_6> = obj.alloc @layout_6;
         v5.objref<i256> = obj.proj v3 0.i256;
         obj.store v5 v2;
@@ -585,21 +585,21 @@ func private %decode_payload__g3854(v0.objref<@layout_4>) -> @layout_6 {
         return v6;
 }
 
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_payload__g407e_4e26(v0.objref<@layout_4>) -> i256 {
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_payload__g407e_92e8(v0.objref<@layout_4>) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v2.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_c26a v0;
+        v2.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_b4b0 v0;
         return v2;
 }
 
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_payload__g407e_66ca(v0.objref<@layout_4>) -> i256 {
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_payload__g407e_a9a2(v0.objref<@layout_4>) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v2.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_fb8f v0;
+        v2.i256 = call %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_4a6a v0;
         return v2;
 }
 
@@ -790,7 +790,7 @@ func private %encoder_new(v0.i256) -> @layout_1 {
         return v3;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_1a09(v0.objref<@layout_2>) -> i256 {
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_0d16(v0.objref<@layout_2>) -> i256 {
     block0:
         jump block1;
 
@@ -800,7 +800,7 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_1a09
         return v4;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_905b(v0.objref<@layout_2>) -> i256 {
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_2f12(v0.objref<@layout_2>) -> i256 {
     block0:
         jump block1;
 
@@ -810,7 +810,7 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_905b
         return v4;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_b301(v0.objref<@layout_2>) -> i256 {
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_4f49(v0.objref<@layout_2>) -> i256 {
     block0:
         jump block1;
 
@@ -820,7 +820,7 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_b301
         return v4;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_de70(v0.objref<@layout_2>) -> i256 {
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_d700(v0.objref<@layout_2>) -> i256 {
     block0:
         jump block1;
 
@@ -978,7 +978,7 @@ func inline(always) private %payload_size__gbd8e(v0.@layout_0) -> i256 {
         return v10;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g463e_1dfb(v0.objref<@layout_4>) -> i256 {
+func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g463e_1111(v0.objref<@layout_4>) -> i256 {
     block0:
         jump block1;
 
@@ -989,7 +989,7 @@ func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g463e_1dfb(v0
         return v6;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g463e_b693(v0.objref<@layout_4>) -> i256 {
+func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g463e_5a37(v0.objref<@layout_4>) -> i256 {
     block0:
         jump block1;
 
@@ -1000,7 +1000,7 @@ func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g463e_b693(v0
         return v6;
 }
 
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_1285(v0.objref<@layout_4>) -> i256 {
+func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_4a6a(v0.objref<@layout_4>) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
@@ -1012,7 +1012,7 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         v7.@layout_2 = obj.load v6;
         v8.objref<@layout_3> = obj.proj v0 0.i256;
         v9.objref<@layout_2> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_1a09 v9;
+        v10.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_d700 v9;
         mstore v1 v10 i256;
         v11.objref<@layout_3> = obj.proj v0 0.i256;
         v13.objref<i256> = obj.proj v11 1.i256;
@@ -1035,7 +1035,7 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         v33.i256 = obj.load v32;
         v34.objref<@layout_3> = obj.proj v0 0.i256;
         v35.objref<@layout_2> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_a9df v35 v33;
+        v36.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_7a87 v35 v33;
         v38.objref<@layout_3> = obj.proj v0 0.i256;
         v39.objref<i256> = obj.proj v38 1.i256;
         obj.store v39 v16;
@@ -1061,7 +1061,7 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         br v26 block2 block5;
 }
 
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_c26a(v0.objref<@layout_4>) -> i256 {
+func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_6997(v0.objref<@layout_4>) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
@@ -1073,7 +1073,7 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         v7.@layout_2 = obj.load v6;
         v8.objref<@layout_3> = obj.proj v0 0.i256;
         v9.objref<@layout_2> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_905b v9;
+        v10.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_0d16 v9;
         mstore v1 v10 i256;
         v11.objref<@layout_3> = obj.proj v0 0.i256;
         v13.objref<i256> = obj.proj v11 1.i256;
@@ -1096,7 +1096,7 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         v33.i256 = obj.load v32;
         v34.objref<@layout_3> = obj.proj v0 0.i256;
         v35.objref<@layout_2> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_f1c0 v35 v33;
+        v36.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_f08f v35 v33;
         v38.objref<@layout_3> = obj.proj v0 0.i256;
         v39.objref<i256> = obj.proj v38 1.i256;
         obj.store v39 v16;
@@ -1122,7 +1122,7 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         br v26 block2 block5;
 }
 
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_f2ee(v0.objref<@layout_4>) -> i256 {
+func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_b4b0(v0.objref<@layout_4>) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
@@ -1134,7 +1134,7 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         v7.@layout_2 = obj.load v6;
         v8.objref<@layout_3> = obj.proj v0 0.i256;
         v9.objref<@layout_2> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_de70 v9;
+        v10.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_4f49 v9;
         mstore v1 v10 i256;
         v11.objref<@layout_3> = obj.proj v0 0.i256;
         v13.objref<i256> = obj.proj v11 1.i256;
@@ -1157,7 +1157,7 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         v33.i256 = obj.load v32;
         v34.objref<@layout_3> = obj.proj v0 0.i256;
         v35.objref<@layout_2> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_2097 v35 v33;
+        v36.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_9236 v35 v33;
         v38.objref<@layout_3> = obj.proj v0 0.i256;
         v39.objref<i256> = obj.proj v38 1.i256;
         obj.store v39 v16;
@@ -1183,7 +1183,7 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         br v26 block2 block5;
 }
 
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_fb8f(v0.objref<@layout_4>) -> i256 {
+func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_c4ab(v0.objref<@layout_4>) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
@@ -1195,7 +1195,7 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         v7.@layout_2 = obj.load v6;
         v8.objref<@layout_3> = obj.proj v0 0.i256;
         v9.objref<@layout_2> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_b301 v9;
+        v10.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_2f12 v9;
         mstore v1 v10 i256;
         v11.objref<@layout_3> = obj.proj v0 0.i256;
         v13.objref<i256> = obj.proj v11 1.i256;
@@ -1218,7 +1218,7 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         v33.i256 = obj.load v32;
         v34.objref<@layout_3> = obj.proj v0 0.i256;
         v35.objref<@layout_2> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_f0a2 v35 v33;
+        v36.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_78ee v35 v33;
         v38.objref<@layout_3> = obj.proj v0 0.i256;
         v39.objref<i256> = obj.proj v38 1.i256;
         obj.store v39 v16;
@@ -1242,19 +1242,6 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         v25.i256 = obj.load v24;
         v26.i1 = lt v16 v25;
         br v26 block2 block5;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_6705(v0.objref<@layout_4>, v1.i256) {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 1.i256;
-        obj.store v6 v3;
-        return;
 }
 
 func private %impl_trait_SolEncoder__set_base(v0.objref<@layout_1>, v1.i256) {
@@ -1270,7 +1257,7 @@ func private %impl_trait_SolEncoder__set_base(v0.objref<@layout_1>, v1.i256) {
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_a978(v0.objref<@layout_4>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_bba9(v0.objref<@layout_4>, v1.i256) {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -1283,7 +1270,20 @@ func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_a9
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_25bb(v0.objref<@layout_4>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_e112(v0.objref<@layout_4>, v1.i256) {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v3.i256 = mload v2 i256;
+        v6.objref<i256> = obj.proj v0 1.i256;
+        obj.store v6 v3;
+        return;
+}
+
+func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_0c70(v0.objref<@layout_4>, v1.i256) {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -1297,7 +1297,7 @@ func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_25b
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_4a51(v0.objref<@layout_4>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_5886(v0.objref<@layout_4>, v1.i256) {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -1339,7 +1339,7 @@ func private %store_word(v0.i256, v1.i256) {
         return;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_2097(v0.objref<@layout_2>, v1.i256) -> i256 {
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_78ee(v0.objref<@layout_2>, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -1354,7 +1354,7 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_
         return v9;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_a9df(v0.objref<@layout_2>, v1.i256) -> i256 {
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_7a87(v0.objref<@layout_2>, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -1369,7 +1369,7 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_
         return v9;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_f0a2(v0.objref<@layout_2>, v1.i256) -> i256 {
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_9236(v0.objref<@layout_2>, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -1384,7 +1384,7 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_
         return v9;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_f1c0(v0.objref<@layout_2>, v1.i256) -> i256 {
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_f08f(v0.objref<@layout_2>, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;

--- a/crates/codegen/tests/fixtures/sonatina_ir/init_args_with_child_dep.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/init_args_with_child_dep.snap
@@ -7,9 +7,9 @@ target = "evm-ethereum-osaka"
 
 type @layout_0 = {i256, i256};
 type @layout_1 = {i256, i256};
-type @layout_2 = {@layout_1, i256};
+type @layout_2 = {i256, i256};
 type @layout_3 = {@layout_2, i256};
-type @layout_4 = {i256, i256};
+type @layout_4 = {@layout_3, i256};
 type @layout_5 = {i256};
 type @layout_6 = {i256};
 
@@ -53,7 +53,25 @@ func private %abi_payload_size(v0.@layout_0) -> i256 {
         return v2;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_43fa(v0.objref<@layout_3>) -> i256 {
+func inline(always) private %at(v0.i256) -> @layout_1 {
+    block0:
+        v1.*i256 = alloca i256;
+        mstore v1 v0 i256;
+        jump block1;
+
+    block1:
+        v2.i256 = mload v1 i256;
+        v3.i256 = mload v1 i256;
+        v4.objref<@layout_1> = obj.alloc @layout_1;
+        v6.objref<i256> = obj.proj v4 0.i256;
+        obj.store v6 v2;
+        v8.objref<i256> = obj.proj v4 1.i256;
+        obj.store v8 v3;
+        v9.@layout_1 = obj.load v4;
+        return v9;
+}
+
+func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_43fa(v0.objref<@layout_4>) -> i256 {
     block0:
         jump block1;
 
@@ -63,7 +81,7 @@ func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_43fa(v
         return v4;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_7dbb(v0.objref<@layout_4>) -> i256 {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_7dbb(v0.objref<@layout_1>) -> i256 {
     block0:
         jump block1;
 
@@ -73,7 +91,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_7dbb(v0.objre
         return v4;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_85b5(v0.objref<@layout_4>) -> i256 {
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_85b5(v0.objref<@layout_1>) -> i256 {
     block0:
         jump block1;
 
@@ -83,7 +101,7 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_85b5(v0.objre
         return v4;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_b557(v0.objref<@layout_3>) -> i256 {
+func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_b557(v0.objref<@layout_4>) -> i256 {
     block0:
         jump block1;
 
@@ -95,8 +113,8 @@ func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_b557(v
 
 func private %contract_init_abi_Child() {
     block0:
-        v0.objref<@layout_1> = obj.alloc @layout_1;
-        v1.objref<@layout_3> = obj.alloc @layout_3;
+        v0.objref<@layout_2> = obj.alloc @layout_2;
+        v1.objref<@layout_4> = obj.alloc @layout_4;
         jump block1;
 
     block1:
@@ -134,12 +152,12 @@ func private %contract_init_abi_Child() {
         obj.store v23 v20;
         v25.objref<i256> = obj.proj v0 1.i256;
         obj.store v25 v13;
-        v26.@layout_1 = obj.load v0;
-        v27.@layout_3 = call %std__lib__abi__sol__impl_trait_Sol_1f5f__decoder_new__g463e_6eaf_0 v26;
-        v28.objref<@layout_2> = obj.proj v1 0.i256;
-        v29.@layout_2 = extract_value v27 0.i256;
-        v30.objref<@layout_1> = obj.proj v28 0.i256;
-        v31.@layout_1 = extract_value v29 0.i256;
+        v26.@layout_2 = obj.load v0;
+        v27.@layout_4 = call %std__lib__abi__sol__impl_trait_Sol_1f5f__decoder_new__g463e_6eaf_0 v26;
+        v28.objref<@layout_3> = obj.proj v1 0.i256;
+        v29.@layout_3 = extract_value v27 0.i256;
+        v30.objref<@layout_2> = obj.proj v28 0.i256;
+        v31.@layout_2 = extract_value v29 0.i256;
         v32.objref<i256> = obj.proj v30 0.i256;
         v33.i256 = extract_value v31 0.i256;
         obj.store v32 v33;
@@ -161,8 +179,8 @@ func private %contract_init_abi_Child() {
 
 func private %contract_init_abi_Parent() {
     block0:
-        v0.objref<@layout_1> = obj.alloc @layout_1;
-        v1.objref<@layout_3> = obj.alloc @layout_3;
+        v0.objref<@layout_2> = obj.alloc @layout_2;
+        v1.objref<@layout_4> = obj.alloc @layout_4;
         jump block1;
 
     block1:
@@ -200,12 +218,12 @@ func private %contract_init_abi_Parent() {
         obj.store v23 v20;
         v25.objref<i256> = obj.proj v0 1.i256;
         obj.store v25 v13;
-        v26.@layout_1 = obj.load v0;
-        v27.@layout_3 = call %std__lib__abi__sol__impl_trait_Sol_1f5f__decoder_new__g463e_6eaf v26;
-        v28.objref<@layout_2> = obj.proj v1 0.i256;
-        v29.@layout_2 = extract_value v27 0.i256;
-        v30.objref<@layout_1> = obj.proj v28 0.i256;
-        v31.@layout_1 = extract_value v29 0.i256;
+        v26.@layout_2 = obj.load v0;
+        v27.@layout_4 = call %std__lib__abi__sol__impl_trait_Sol_1f5f__decoder_new__g463e_6eaf v26;
+        v28.objref<@layout_3> = obj.proj v1 0.i256;
+        v29.@layout_3 = extract_value v27 0.i256;
+        v30.objref<@layout_2> = obj.proj v28 0.i256;
+        v31.@layout_2 = extract_value v29 0.i256;
         v32.objref<i256> = obj.proj v30 0.i256;
         v33.i256 = extract_value v31 0.i256;
         obj.store v32 v33;
@@ -466,7 +484,7 @@ func private %create_raw(v0.i256, v1.i256, v2.i256) -> @layout_5 {
         return v13;
 }
 
-func inline(always) private %core__lib__abi__decode_field__g3854_29f4(v0.objref<@layout_3>) -> i256 {
+func inline(always) private %core__lib__abi__decode_field__g3854_29f4(v0.objref<@layout_4>) -> i256 {
     block0:
         jump block1;
 
@@ -502,7 +520,7 @@ func inline(always) private %core__lib__abi__decode_field__g3854_29f4(v0.objref<
         return v17;
 }
 
-func inline(always) private %core__lib__abi__decode_field__g3854_bdd0(v0.objref<@layout_3>) -> i256 {
+func inline(always) private %core__lib__abi__decode_field__g3854_bdd0(v0.objref<@layout_4>) -> i256 {
     block0:
         jump block1;
 
@@ -538,7 +556,7 @@ func inline(always) private %core__lib__abi__decode_field__g3854_bdd0(v0.objref<
         return v17;
 }
 
-func private %decode_payload__g4770(v0.objref<@layout_3>) -> @layout_0 {
+func private %decode_payload__g4770(v0.objref<@layout_4>) -> @layout_0 {
     block0:
         jump block1;
 
@@ -554,7 +572,7 @@ func private %decode_payload__g4770(v0.objref<@layout_3>) -> @layout_0 {
         return v9;
 }
 
-func private %decode_payload__g3854(v0.objref<@layout_3>) -> @layout_6 {
+func private %decode_payload__g3854(v0.objref<@layout_4>) -> @layout_6 {
     block0:
         jump block1;
 
@@ -567,7 +585,7 @@ func private %decode_payload__g3854(v0.objref<@layout_3>) -> @layout_6 {
         return v6;
 }
 
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_payload__g407e_4e26(v0.objref<@layout_3>) -> i256 {
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_payload__g407e_4e26(v0.objref<@layout_4>) -> i256 {
     block0:
         jump block1;
 
@@ -576,7 +594,7 @@ func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_payloa
         return v2;
 }
 
-func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_payload__g407e_66ca(v0.objref<@layout_3>) -> i256 {
+func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_payload__g407e_66ca(v0.objref<@layout_4>) -> i256 {
     block0:
         jump block1;
 
@@ -585,21 +603,21 @@ func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_payloa
         return v2;
 }
 
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decoder_new__g463e_6eaf(v0.@layout_1) -> @layout_3 {
+func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decoder_new__g463e_6eaf(v0.@layout_2) -> @layout_4 {
     block0:
         jump block1;
 
     block1:
-        v2.@layout_3 = call %std__lib__abi__sol__impl_SolDecoder_113c__new__g463e_7b57 v0;
+        v2.@layout_4 = call %std__lib__abi__sol__impl_SolDecoder_113c__new__g463e_7b57 v0;
         return v2;
 }
 
-func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decoder_new__g463e_6eaf_0(v0.@layout_1) -> @layout_3 {
+func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decoder_new__g463e_6eaf_0(v0.@layout_2) -> @layout_4 {
     block0:
         jump block1;
 
     block1:
-        v2.@layout_3 = call %std__lib__abi__sol__impl_SolDecoder_113c__new__g463e_7b57_0 v0;
+        v2.@layout_4 = call %std__lib__abi__sol__impl_SolDecoder_113c__new__g463e_7b57_0 v0;
         return v2;
 }
 
@@ -624,7 +642,7 @@ func private %dynamic_payload_size(v0.i256) -> i256 {
         return 0.i256;
 }
 
-func private %encode__g7769(v0.@layout_0, v1.objref<@layout_4>) {
+func inline(always) private %encode__g7769(v0.@layout_0, v1.objref<@layout_1>) {
     block0:
         v2.objref<@layout_0> = obj.alloc @layout_0;
         v3.*i256 = alloca i256;
@@ -638,33 +656,28 @@ func private %encode__g7769(v0.@layout_0, v1.objref<@layout_4>) {
 
     block1:
         v11.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_7dbb v1;
-        (v13.i256, v14.i1) = uaddo v11 64.i256;
-        br v14 block2 block3;
-
-    block2:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block3:
+        v13.i256 = add v11 64.i256;
         mstore v3 v13 i256;
-        v19.objref<i256> = obj.proj v2 0.i256;
-        v20.i256 = obj.load v19;
+        v15.i256 = add v11 32.i256;
+        v16.objref<i256> = obj.proj v2 0.i256;
+        v17.i256 = obj.load v16;
+        v18.i256 = ptr_to_int v3 i256;
+        call %encode_field_at v17 v1 v11 v11 v18;
+        v20.objref<i256> = obj.proj v2 1.i256;
+        v21.i256 = obj.load v20;
         v22.i256 = ptr_to_int v3 i256;
-        call %encode_field v20 v1 v22;
-        v24.objref<i256> = obj.proj v2 1.i256;
-        v25.i256 = obj.load v24;
-        v26.i256 = ptr_to_int v3 i256;
-        call %encode_field v25 v1 v26;
+        call %encode_field_at v21 v1 v11 v15 v22;
+        v24.i256 = add v11 64.i256;
+        call %impl_trait_SolEncoder__set_pos v1 v24;
         return;
 }
 
-func private %encode__g426c(v0.i256, v1.objref<@layout_4>) {
+func private %encode__g426c(v0.i256, v1.objref<@layout_1>) {
     block0:
         jump block1;
 
     block1:
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_98f2 v1 v0;
+        call %write_word v1 v0;
         return;
 }
 
@@ -683,8 +696,8 @@ func private %encode_alloc(v0.@layout_0) -> @layout_0 {
 
     block1:
         v2.i256 = call %abi_payload_size v0;
-        v3.@layout_4 = call %encoder_new v2;
-        v4.objref<@layout_4> = obj.alloc @layout_4;
+        v3.@layout_1 = call %encoder_new v2;
+        v4.objref<@layout_1> = obj.alloc @layout_1;
         v6.objref<i256> = obj.proj v4 0.i256;
         v7.i256 = extract_value v3 0.i256;
         obj.store v6 v7;
@@ -702,30 +715,34 @@ func private %encode_alloc(v0.@layout_0) -> @layout_0 {
         return v16;
 }
 
-func private %encode_field(v0.i256, v1.objref<@layout_4>, v2.i256) {
+func inline(always) private %encode_field_at(v0.i256, v1.objref<@layout_1>, v2.i256, v3.i256, v4.i256) {
     block0:
+        v5.*i256 = alloca i256;
+        v6.*i256 = alloca i256;
+        mstore v5 v2 i256;
+        mstore v6 v3 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v5.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_7dbb v1;
-        v8.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_b316 v0;
-        v9.i256 = mload v2 i256;
-        v10.i256 = sub v9 v5;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_9d70 v1 v10;
-        v12.i256 = call %impl_trait_SolEncoder__pos v1;
-        v13.i256 = mload v2 i256;
-        call %impl_trait_SolEncoder__set_base v1 v13;
-        v15.i256 = mload v2 i256;
-        call %impl_trait_SolEncoder__set_pos v1 v15;
+        v10.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_b316 v0;
+        v11.i256 = mload v6 i256;
+        v12.i256 = mload v5 i256;
+        v13.i256 = mload v4 i256;
+        v14.i256 = sub v13 v12;
+        call %write_word_at v1 v11 v14;
+        v17.i256 = mload v4 i256;
+        call %impl_trait_SolEncoder__set_base v1 v17;
+        v19.i256 = mload v4 i256;
+        call %impl_trait_SolEncoder__set_pos v1 v19;
         call %encode__g426c v0 v1;
-        call %impl_trait_SolEncoder__set_base v1 v5;
-        call %impl_trait_SolEncoder__set_pos v1 v12;
-        v20.i256 = mload v2 i256;
-        v21.i256 = add v20 v8;
-        mstore v2 v21 i256;
+        v22.i256 = mload v5 i256;
+        call %impl_trait_SolEncoder__set_base v1 v22;
+        v24.i256 = mload v4 i256;
+        v25.i256 = add v24 v10;
+        mstore v4 v25 i256;
         return;
 
     block3:
@@ -735,16 +752,16 @@ func private %encode_field(v0.i256, v1.objref<@layout_4>, v2.i256) {
         br 1.i1 block5 block6;
 
     block5:
-        v24.i256 = call %impl_trait_SolEncoder__pos v1;
-        call %encode_to_ptr v0 v24;
-        v28.i256 = add v24 32.i256;
-        call %impl_trait_SolEncoder__set_pos v1 v28;
+        v27.i256 = mload v6 i256;
+        call %encode_to_ptr v0 v27;
         return;
 
     block6:
         jump block7;
 
     block7:
+        v30.i256 = mload v6 i256;
+        call %impl_trait_SolEncoder__set_pos v1 v30;
         call %encode__g426c v0 v1;
         return;
 }
@@ -761,7 +778,7 @@ func private %encode_to_ptr(v0.i256, v1.i256) {
         return;
 }
 
-func private %encoder_new(v0.i256) -> @layout_4 {
+func private %encoder_new(v0.i256) -> @layout_1 {
     block0:
         v1.*i256 = alloca i256;
         mstore v1 v0 i256;
@@ -769,11 +786,11 @@ func private %encoder_new(v0.i256) -> @layout_4 {
 
     block1:
         v2.i256 = mload v1 i256;
-        v3.@layout_4 = call %impl_SolEncoder__new v2;
+        v3.@layout_1 = call %impl_SolEncoder__new v2;
         return v3;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_1a09(v0.objref<@layout_1>) -> i256 {
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_1a09(v0.objref<@layout_2>) -> i256 {
     block0:
         jump block1;
 
@@ -783,7 +800,7 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_1a09
         return v4;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_905b(v0.objref<@layout_1>) -> i256 {
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_905b(v0.objref<@layout_2>) -> i256 {
     block0:
         jump block1;
 
@@ -793,7 +810,7 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_905b
         return v4;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_b301(v0.objref<@layout_1>) -> i256 {
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_b301(v0.objref<@layout_2>) -> i256 {
     block0:
         jump block1;
 
@@ -803,7 +820,7 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_b301
         return v4;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_de70(v0.objref<@layout_1>) -> i256 {
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_de70(v0.objref<@layout_2>) -> i256 {
     block0:
         jump block1;
 
@@ -813,7 +830,7 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_de70
         return v4;
 }
 
-func private %impl_SolEncoder__new(v0.i256) -> @layout_4 {
+func private %impl_SolEncoder__new(v0.i256) -> @layout_1 {
     block0:
         v1.*i256 = alloca i256;
         mstore v1 v0 i256;
@@ -835,25 +852,20 @@ func private %impl_SolEncoder__new(v0.i256) -> @layout_4 {
 
     block4:
         v8.i256 = phi (0.i256 block2) (v7 block3);
-        v9.objref<@layout_4> = obj.alloc @layout_4;
-        v10.objref<i256> = obj.proj v9 0.i256;
-        obj.store v10 v8;
-        v12.objref<i256> = obj.proj v9 1.i256;
-        obj.store v12 v8;
-        v13.@layout_4 = obj.load v9;
-        return v13;
+        v9.@layout_1 = call %at v8;
+        return v9;
 }
 
-func inline(always) private %std__lib__abi__sol__impl_SolDecoder_113c__new__g463e_7b57(v0.@layout_1) -> @layout_3 {
+func inline(always) private %std__lib__abi__sol__impl_SolDecoder_113c__new__g463e_7b57(v0.@layout_2) -> @layout_4 {
     block0:
         jump block1;
 
     block1:
-        v2.@layout_2 = call %core__lib__abi__impl_Cursor_1a04__new__g463e_aa29 v0;
-        v4.objref<@layout_3> = obj.alloc @layout_3;
-        v5.objref<@layout_2> = obj.proj v4 0.i256;
-        v6.objref<@layout_1> = obj.proj v5 0.i256;
-        v7.@layout_1 = extract_value v2 0.i256;
+        v2.@layout_3 = call %core__lib__abi__impl_Cursor_1a04__new__g463e_aa29 v0;
+        v4.objref<@layout_4> = obj.alloc @layout_4;
+        v5.objref<@layout_3> = obj.proj v4 0.i256;
+        v6.objref<@layout_2> = obj.proj v5 0.i256;
+        v7.@layout_2 = extract_value v2 0.i256;
         v8.objref<i256> = obj.proj v6 0.i256;
         v9.i256 = extract_value v7 0.i256;
         obj.store v8 v9;
@@ -865,20 +877,20 @@ func inline(always) private %std__lib__abi__sol__impl_SolDecoder_113c__new__g463
         obj.store v13 v14;
         v15.objref<i256> = obj.proj v4 1.i256;
         obj.store v15 0.i256;
-        v16.@layout_3 = obj.load v4;
+        v16.@layout_4 = obj.load v4;
         return v16;
 }
 
-func inline(always) private %std__lib__abi__sol__impl_SolDecoder_113c__new__g463e_7b57_0(v0.@layout_1) -> @layout_3 {
+func inline(always) private %std__lib__abi__sol__impl_SolDecoder_113c__new__g463e_7b57_0(v0.@layout_2) -> @layout_4 {
     block0:
         jump block1;
 
     block1:
-        v2.@layout_2 = call %core__lib__abi__impl_Cursor_1a04__new__g463e_aa29_0 v0;
-        v4.objref<@layout_3> = obj.alloc @layout_3;
-        v5.objref<@layout_2> = obj.proj v4 0.i256;
-        v6.objref<@layout_1> = obj.proj v5 0.i256;
-        v7.@layout_1 = extract_value v2 0.i256;
+        v2.@layout_3 = call %core__lib__abi__impl_Cursor_1a04__new__g463e_aa29_0 v0;
+        v4.objref<@layout_4> = obj.alloc @layout_4;
+        v5.objref<@layout_3> = obj.proj v4 0.i256;
+        v6.objref<@layout_2> = obj.proj v5 0.i256;
+        v7.@layout_2 = extract_value v2 0.i256;
         v8.objref<i256> = obj.proj v6 0.i256;
         v9.i256 = extract_value v7 0.i256;
         obj.store v8 v9;
@@ -890,17 +902,17 @@ func inline(always) private %std__lib__abi__sol__impl_SolDecoder_113c__new__g463
         obj.store v13 v14;
         v15.objref<i256> = obj.proj v4 1.i256;
         obj.store v15 0.i256;
-        v16.@layout_3 = obj.load v4;
+        v16.@layout_4 = obj.load v4;
         return v16;
 }
 
-func inline(always) private %core__lib__abi__impl_Cursor_1a04__new__g463e_aa29(v0.@layout_1) -> @layout_2 {
+func inline(always) private %core__lib__abi__impl_Cursor_1a04__new__g463e_aa29(v0.@layout_2) -> @layout_3 {
     block0:
         jump block1;
 
     block1:
-        v2.objref<@layout_2> = obj.alloc @layout_2;
-        v4.objref<@layout_1> = obj.proj v2 0.i256;
+        v2.objref<@layout_3> = obj.alloc @layout_3;
+        v4.objref<@layout_2> = obj.proj v2 0.i256;
         v5.objref<i256> = obj.proj v4 0.i256;
         v6.i256 = extract_value v0 0.i256;
         obj.store v5 v6;
@@ -909,17 +921,17 @@ func inline(always) private %core__lib__abi__impl_Cursor_1a04__new__g463e_aa29(v
         obj.store v8 v9;
         v10.objref<i256> = obj.proj v2 1.i256;
         obj.store v10 0.i256;
-        v11.@layout_2 = obj.load v2;
+        v11.@layout_3 = obj.load v2;
         return v11;
 }
 
-func inline(always) private %core__lib__abi__impl_Cursor_1a04__new__g463e_aa29_0(v0.@layout_1) -> @layout_2 {
+func inline(always) private %core__lib__abi__impl_Cursor_1a04__new__g463e_aa29_0(v0.@layout_2) -> @layout_3 {
     block0:
         jump block1;
 
     block1:
-        v2.objref<@layout_2> = obj.alloc @layout_2;
-        v4.objref<@layout_1> = obj.proj v2 0.i256;
+        v2.objref<@layout_3> = obj.alloc @layout_3;
+        v4.objref<@layout_2> = obj.proj v2 0.i256;
         v5.objref<i256> = obj.proj v4 0.i256;
         v6.i256 = extract_value v0 0.i256;
         obj.store v5 v6;
@@ -928,7 +940,7 @@ func inline(always) private %core__lib__abi__impl_Cursor_1a04__new__g463e_aa29_0
         obj.store v8 v9;
         v10.objref<i256> = obj.proj v2 1.i256;
         obj.store v10 0.i256;
-        v11.@layout_2 = obj.load v2;
+        v11.@layout_3 = obj.load v2;
         return v11;
 }
 
@@ -952,78 +964,57 @@ func private %core__lib__abi__trait_AbiSize__payload_size__ge513_b316(v0.i256) -
         return 32.i256;
 }
 
-func private %payload_size__gbd8e(v0.@layout_0) -> i256 {
+func inline(always) private %payload_size__gbd8e(v0.@layout_0) -> i256 {
     block0:
         jump block1;
 
     block1:
         v4.i256 = extract_value v0 0.i256;
         v5.i256 = call %dynamic_payload_size v4;
-        (v6.i256, v7.i1) = uaddo 64.i256 v5;
-        br v7 block2 block3;
-
-    block2:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block3:
-        v14.i256 = extract_value v0 1.i256;
-        v15.i256 = call %dynamic_payload_size v14;
-        (v16.i256, v17.i1) = uaddo v6 v15;
-        br v17 block2 block4;
-
-    block4:
-        return v16;
+        v6.i256 = add 64.i256 v5;
+        v8.i256 = extract_value v0 1.i256;
+        v9.i256 = call %dynamic_payload_size v8;
+        v10.i256 = add v6 v9;
+        return v10;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g463e_1dfb(v0.objref<@layout_3>) -> i256 {
+func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g463e_1dfb(v0.objref<@layout_4>) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v3.objref<@layout_2> = obj.proj v0 0.i256;
+        v3.objref<@layout_3> = obj.proj v0 0.i256;
         v5.objref<i256> = obj.proj v3 1.i256;
         v6.i256 = obj.load v5;
         return v6;
 }
 
-func private %impl_trait_SolEncoder__pos(v0.objref<@layout_4>) -> i256 {
+func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g463e_b693(v0.objref<@layout_4>) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v3.objref<i256> = obj.proj v0 1.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g463e_b693(v0.objref<@layout_3>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<@layout_2> = obj.proj v0 0.i256;
+        v3.objref<@layout_3> = obj.proj v0 0.i256;
         v5.objref<i256> = obj.proj v3 1.i256;
         v6.i256 = obj.load v5;
         return v6;
 }
 
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_1285(v0.objref<@layout_3>) -> i256 {
+func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_1285(v0.objref<@layout_4>) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v5.objref<@layout_2> = obj.proj v0 0.i256;
-        v6.objref<@layout_1> = obj.proj v5 0.i256;
-        v7.@layout_1 = obj.load v6;
-        v8.objref<@layout_2> = obj.proj v0 0.i256;
-        v9.objref<@layout_1> = obj.proj v8 0.i256;
+        v5.objref<@layout_3> = obj.proj v0 0.i256;
+        v6.objref<@layout_2> = obj.proj v5 0.i256;
+        v7.@layout_2 = obj.load v6;
+        v8.objref<@layout_3> = obj.proj v0 0.i256;
+        v9.objref<@layout_2> = obj.proj v8 0.i256;
         v10.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_1a09 v9;
         mstore v1 v10 i256;
-        v11.objref<@layout_2> = obj.proj v0 0.i256;
+        v11.objref<@layout_3> = obj.proj v0 0.i256;
         v13.objref<i256> = obj.proj v11 1.i256;
         v14.i256 = obj.load v13;
         (v16.i256, v17.i1) = uaddo v14 32.i256;
@@ -1036,16 +1027,16 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         jump block4;
 
     block4:
-        v28.objref<@layout_2> = obj.proj v0 0.i256;
-        v29.objref<@layout_1> = obj.proj v28 0.i256;
-        v30.@layout_1 = obj.load v29;
-        v31.objref<@layout_2> = obj.proj v0 0.i256;
+        v28.objref<@layout_3> = obj.proj v0 0.i256;
+        v29.objref<@layout_2> = obj.proj v28 0.i256;
+        v30.@layout_2 = obj.load v29;
+        v31.objref<@layout_3> = obj.proj v0 0.i256;
         v32.objref<i256> = obj.proj v31 1.i256;
         v33.i256 = obj.load v32;
-        v34.objref<@layout_2> = obj.proj v0 0.i256;
-        v35.objref<@layout_1> = obj.proj v34 0.i256;
+        v34.objref<@layout_3> = obj.proj v0 0.i256;
+        v35.objref<@layout_2> = obj.proj v34 0.i256;
         v36.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_a9df v35 v33;
-        v38.objref<@layout_2> = obj.proj v0 0.i256;
+        v38.objref<@layout_3> = obj.proj v0 0.i256;
         v39.objref<i256> = obj.proj v38 1.i256;
         obj.store v39 v16;
         return v36;
@@ -1063,28 +1054,28 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         evm_revert 0.i256 36.i256;
 
     block7:
-        v23.objref<@layout_2> = obj.proj v0 0.i256;
+        v23.objref<@layout_3> = obj.proj v0 0.i256;
         v24.objref<i256> = obj.proj v23 1.i256;
         v25.i256 = obj.load v24;
         v26.i1 = lt v16 v25;
         br v26 block2 block5;
 }
 
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_c26a(v0.objref<@layout_3>) -> i256 {
+func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_c26a(v0.objref<@layout_4>) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v5.objref<@layout_2> = obj.proj v0 0.i256;
-        v6.objref<@layout_1> = obj.proj v5 0.i256;
-        v7.@layout_1 = obj.load v6;
-        v8.objref<@layout_2> = obj.proj v0 0.i256;
-        v9.objref<@layout_1> = obj.proj v8 0.i256;
+        v5.objref<@layout_3> = obj.proj v0 0.i256;
+        v6.objref<@layout_2> = obj.proj v5 0.i256;
+        v7.@layout_2 = obj.load v6;
+        v8.objref<@layout_3> = obj.proj v0 0.i256;
+        v9.objref<@layout_2> = obj.proj v8 0.i256;
         v10.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_905b v9;
         mstore v1 v10 i256;
-        v11.objref<@layout_2> = obj.proj v0 0.i256;
+        v11.objref<@layout_3> = obj.proj v0 0.i256;
         v13.objref<i256> = obj.proj v11 1.i256;
         v14.i256 = obj.load v13;
         (v16.i256, v17.i1) = uaddo v14 32.i256;
@@ -1097,16 +1088,16 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         jump block4;
 
     block4:
-        v28.objref<@layout_2> = obj.proj v0 0.i256;
-        v29.objref<@layout_1> = obj.proj v28 0.i256;
-        v30.@layout_1 = obj.load v29;
-        v31.objref<@layout_2> = obj.proj v0 0.i256;
+        v28.objref<@layout_3> = obj.proj v0 0.i256;
+        v29.objref<@layout_2> = obj.proj v28 0.i256;
+        v30.@layout_2 = obj.load v29;
+        v31.objref<@layout_3> = obj.proj v0 0.i256;
         v32.objref<i256> = obj.proj v31 1.i256;
         v33.i256 = obj.load v32;
-        v34.objref<@layout_2> = obj.proj v0 0.i256;
-        v35.objref<@layout_1> = obj.proj v34 0.i256;
+        v34.objref<@layout_3> = obj.proj v0 0.i256;
+        v35.objref<@layout_2> = obj.proj v34 0.i256;
         v36.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_f1c0 v35 v33;
-        v38.objref<@layout_2> = obj.proj v0 0.i256;
+        v38.objref<@layout_3> = obj.proj v0 0.i256;
         v39.objref<i256> = obj.proj v38 1.i256;
         obj.store v39 v16;
         return v36;
@@ -1124,28 +1115,28 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         evm_revert 0.i256 36.i256;
 
     block7:
-        v23.objref<@layout_2> = obj.proj v0 0.i256;
+        v23.objref<@layout_3> = obj.proj v0 0.i256;
         v24.objref<i256> = obj.proj v23 1.i256;
         v25.i256 = obj.load v24;
         v26.i1 = lt v16 v25;
         br v26 block2 block5;
 }
 
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_f2ee(v0.objref<@layout_3>) -> i256 {
+func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_f2ee(v0.objref<@layout_4>) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v5.objref<@layout_2> = obj.proj v0 0.i256;
-        v6.objref<@layout_1> = obj.proj v5 0.i256;
-        v7.@layout_1 = obj.load v6;
-        v8.objref<@layout_2> = obj.proj v0 0.i256;
-        v9.objref<@layout_1> = obj.proj v8 0.i256;
+        v5.objref<@layout_3> = obj.proj v0 0.i256;
+        v6.objref<@layout_2> = obj.proj v5 0.i256;
+        v7.@layout_2 = obj.load v6;
+        v8.objref<@layout_3> = obj.proj v0 0.i256;
+        v9.objref<@layout_2> = obj.proj v8 0.i256;
         v10.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_de70 v9;
         mstore v1 v10 i256;
-        v11.objref<@layout_2> = obj.proj v0 0.i256;
+        v11.objref<@layout_3> = obj.proj v0 0.i256;
         v13.objref<i256> = obj.proj v11 1.i256;
         v14.i256 = obj.load v13;
         (v16.i256, v17.i1) = uaddo v14 32.i256;
@@ -1158,16 +1149,16 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         jump block4;
 
     block4:
-        v28.objref<@layout_2> = obj.proj v0 0.i256;
-        v29.objref<@layout_1> = obj.proj v28 0.i256;
-        v30.@layout_1 = obj.load v29;
-        v31.objref<@layout_2> = obj.proj v0 0.i256;
+        v28.objref<@layout_3> = obj.proj v0 0.i256;
+        v29.objref<@layout_2> = obj.proj v28 0.i256;
+        v30.@layout_2 = obj.load v29;
+        v31.objref<@layout_3> = obj.proj v0 0.i256;
         v32.objref<i256> = obj.proj v31 1.i256;
         v33.i256 = obj.load v32;
-        v34.objref<@layout_2> = obj.proj v0 0.i256;
-        v35.objref<@layout_1> = obj.proj v34 0.i256;
+        v34.objref<@layout_3> = obj.proj v0 0.i256;
+        v35.objref<@layout_2> = obj.proj v34 0.i256;
         v36.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_2097 v35 v33;
-        v38.objref<@layout_2> = obj.proj v0 0.i256;
+        v38.objref<@layout_3> = obj.proj v0 0.i256;
         v39.objref<i256> = obj.proj v38 1.i256;
         obj.store v39 v16;
         return v36;
@@ -1185,28 +1176,28 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         evm_revert 0.i256 36.i256;
 
     block7:
-        v23.objref<@layout_2> = obj.proj v0 0.i256;
+        v23.objref<@layout_3> = obj.proj v0 0.i256;
         v24.objref<i256> = obj.proj v23 1.i256;
         v25.i256 = obj.load v24;
         v26.i1 = lt v16 v25;
         br v26 block2 block5;
 }
 
-func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_fb8f(v0.objref<@layout_3>) -> i256 {
+func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_fb8f(v0.objref<@layout_4>) -> i256 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v5.objref<@layout_2> = obj.proj v0 0.i256;
-        v6.objref<@layout_1> = obj.proj v5 0.i256;
-        v7.@layout_1 = obj.load v6;
-        v8.objref<@layout_2> = obj.proj v0 0.i256;
-        v9.objref<@layout_1> = obj.proj v8 0.i256;
+        v5.objref<@layout_3> = obj.proj v0 0.i256;
+        v6.objref<@layout_2> = obj.proj v5 0.i256;
+        v7.@layout_2 = obj.load v6;
+        v8.objref<@layout_3> = obj.proj v0 0.i256;
+        v9.objref<@layout_2> = obj.proj v8 0.i256;
         v10.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_b301 v9;
         mstore v1 v10 i256;
-        v11.objref<@layout_2> = obj.proj v0 0.i256;
+        v11.objref<@layout_3> = obj.proj v0 0.i256;
         v13.objref<i256> = obj.proj v11 1.i256;
         v14.i256 = obj.load v13;
         (v16.i256, v17.i1) = uaddo v14 32.i256;
@@ -1219,16 +1210,16 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         jump block4;
 
     block4:
-        v28.objref<@layout_2> = obj.proj v0 0.i256;
-        v29.objref<@layout_1> = obj.proj v28 0.i256;
-        v30.@layout_1 = obj.load v29;
-        v31.objref<@layout_2> = obj.proj v0 0.i256;
+        v28.objref<@layout_3> = obj.proj v0 0.i256;
+        v29.objref<@layout_2> = obj.proj v28 0.i256;
+        v30.@layout_2 = obj.load v29;
+        v31.objref<@layout_3> = obj.proj v0 0.i256;
         v32.objref<i256> = obj.proj v31 1.i256;
         v33.i256 = obj.load v32;
-        v34.objref<@layout_2> = obj.proj v0 0.i256;
-        v35.objref<@layout_1> = obj.proj v34 0.i256;
+        v34.objref<@layout_3> = obj.proj v0 0.i256;
+        v35.objref<@layout_2> = obj.proj v34 0.i256;
         v36.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_f0a2 v35 v33;
-        v38.objref<@layout_2> = obj.proj v0 0.i256;
+        v38.objref<@layout_3> = obj.proj v0 0.i256;
         v39.objref<i256> = obj.proj v38 1.i256;
         obj.store v39 v16;
         return v36;
@@ -1246,14 +1237,14 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         evm_revert 0.i256 36.i256;
 
     block7:
-        v23.objref<@layout_2> = obj.proj v0 0.i256;
+        v23.objref<@layout_3> = obj.proj v0 0.i256;
         v24.objref<i256> = obj.proj v23 1.i256;
         v25.i256 = obj.load v24;
         v26.i1 = lt v16 v25;
         br v26 block2 block5;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_6705(v0.objref<@layout_3>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_6705(v0.objref<@layout_4>, v1.i256) {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -1266,7 +1257,7 @@ func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_67
         return;
 }
 
-func private %impl_trait_SolEncoder__set_base(v0.objref<@layout_4>, v1.i256) {
+func private %impl_trait_SolEncoder__set_base(v0.objref<@layout_1>, v1.i256) {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -1279,7 +1270,7 @@ func private %impl_trait_SolEncoder__set_base(v0.objref<@layout_4>, v1.i256) {
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_a978(v0.objref<@layout_3>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_a978(v0.objref<@layout_4>, v1.i256) {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -1292,7 +1283,7 @@ func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_a9
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_25bb(v0.objref<@layout_3>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_25bb(v0.objref<@layout_4>, v1.i256) {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -1300,13 +1291,13 @@ func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_25b
 
     block1:
         v3.i256 = mload v2 i256;
-        v6.objref<@layout_2> = obj.proj v0 0.i256;
+        v6.objref<@layout_3> = obj.proj v0 0.i256;
         v8.objref<i256> = obj.proj v6 1.i256;
         obj.store v8 v3;
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_4a51(v0.objref<@layout_3>, v1.i256) {
+func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_4a51(v0.objref<@layout_4>, v1.i256) {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -1314,13 +1305,13 @@ func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_4a5
 
     block1:
         v3.i256 = mload v2 i256;
-        v6.objref<@layout_2> = obj.proj v0 0.i256;
+        v6.objref<@layout_3> = obj.proj v0 0.i256;
         v8.objref<i256> = obj.proj v6 1.i256;
         obj.store v8 v3;
         return;
 }
 
-func private %impl_trait_SolEncoder__set_pos(v0.objref<@layout_4>, v1.i256) {
+func private %impl_trait_SolEncoder__set_pos(v0.objref<@layout_1>, v1.i256) {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -1348,7 +1339,7 @@ func private %store_word(v0.i256, v1.i256) {
         return;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_2097(v0.objref<@layout_1>, v1.i256) -> i256 {
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_2097(v0.objref<@layout_2>, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -1363,7 +1354,7 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_
         return v9;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_a9df(v0.objref<@layout_1>, v1.i256) -> i256 {
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_a9df(v0.objref<@layout_2>, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -1378,7 +1369,7 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_
         return v9;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_f0a2(v0.objref<@layout_1>, v1.i256) -> i256 {
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_f0a2(v0.objref<@layout_2>, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -1393,7 +1384,7 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_
         return v9;
 }
 
-func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_f1c0(v0.objref<@layout_1>, v1.i256) -> i256 {
+func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_f1c0(v0.objref<@layout_2>, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -1408,7 +1399,7 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_
         return v9;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_98f2(v0.objref<@layout_4>, v1.i256) {
+func private %write_word(v0.objref<@layout_1>, v1.i256) {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
@@ -1425,20 +1416,18 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_98f2(v0
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_9d70(v0.objref<@layout_4>, v1.i256) {
+func private %write_word_at(v0.objref<@layout_1>, v1.i256, v2.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 1.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        mstore v6 v7 i256;
-        v10.i256 = add v6 32.i256;
-        v11.objref<i256> = obj.proj v0 1.i256;
-        obj.store v11 v10;
+        v5.i256 = mload v3 i256;
+        v6.i256 = mload v4 i256;
+        mstore v5 v6 i256;
         return;
 }
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/init_args_with_child_dep.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/init_args_with_child_dep.snap
@@ -690,7 +690,7 @@ func private %encode_abi_payload(v0.@layout_0) -> @layout_0 {
         return v2;
 }
 
-func private %encode_alloc(v0.@layout_0) -> @layout_0 {
+func inline(always) private %encode_alloc(v0.@layout_0) -> @layout_0 {
     block0:
         jump block1;
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/init_args_with_child_dep.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/init_args_with_child_dep.snap
@@ -73,16 +73,6 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_7dbb(v0.objre
         return v4;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_7dbb_0(v0.objref<@layout_4>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 0.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_85b5(v0.objref<@layout_4>) -> i256 {
     block0:
         jump block1;
@@ -647,7 +637,7 @@ func private %encode__g7769(v0.@layout_0, v1.objref<@layout_4>) {
         jump block1;
 
     block1:
-        v11.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_7dbb_0 v1;
+        v11.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_7dbb v1;
         (v13.i256, v14.i1) = uaddo v11 64.i256;
         br v14 block2 block3;
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/newtype_storage_byplace_effect_arg.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/newtype_storage_byplace_effect_arg.snap
@@ -7,11 +7,9 @@ target = "evm-ethereum-osaka"
 
 type @layout_0 = {i256, i256};
 type @layout_1 = {i256};
-type @layout_2 = {@layout_1, i256};
-type @layout_3 = {@layout_2, i256};
-type @layout_4 = {};
-type @layout_5 = {@layout_4};
-type @layout_6 = {i256, i256};
+type @layout_2 = {};
+type @layout_3 = {@layout_2};
+type @layout_4 = {i256, i256};
 
 global private const @layout_1 $const_region_0 = {0};
 
@@ -84,6 +82,15 @@ func private %abi_single_root_size(v0.i256) -> i256 {
         v2.i256 = mload v1 i256;
         v3.i256 = call %abi_field_size v2;
         return v3;
+}
+
+func private %abort() {
+    block0:
+        jump block1;
+
+    block1:
+        call %revert 0.i256 0.i256;
+        unreachable;
 }
 
 func private %base(v0.objref<@layout_0>) -> i256 {
@@ -159,10 +166,10 @@ func private %contract_recv_abi_NewtypeByPlaceEffectArg_1() {
         evm_revert 0.i256 0.i256;
 
     block3:
-        v5.objref<@layout_5> = obj.alloc @layout_5;
+        v5.objref<@layout_3> = obj.alloc @layout_3;
         call %decode_runtime_args v5;
         v8.i256 = call %__NewtypeByPlaceEffectArg_recv_0_0 1.i256 0.i256;
-        v9.@layout_6 = call %encode_single_root_alloc v8;
+        v9.@layout_4 = call %encode_single_root_alloc v8;
         v10.i256 = extract_value v9 0.i256;
         v11.i256 = extract_value v9 1.i256;
         evm_return v10 v11;
@@ -191,48 +198,71 @@ func private %contract_runtime_root_NewtypeByPlaceEffectArg() {
         unreachable;
 }
 
-func inline(always) private %decode_payload(v0.objref<@layout_3>) {
-    block0:
-        jump block1;
-
-    block1:
-        return;
-}
-
-func inline(always) private %decode_runtime_args(v0.objref<@layout_5>) {
-    block0:
-        jump block1;
-
-    block1:
-        v1.@layout_3 = call %runtime_decoder;
-        v2.objref<@layout_3> = obj.alloc @layout_3;
-        v4.objref<@layout_2> = obj.proj v2 0.i256;
-        v5.@layout_2 = extract_value v1 0.i256;
-        v6.objref<@layout_1> = obj.proj v4 0.i256;
-        v7.@layout_1 = extract_value v5 0.i256;
-        v8.objref<i256> = obj.proj v6 0.i256;
-        v9.i256 = extract_value v7 0.i256;
-        obj.store v8 v9;
-        v11.objref<i256> = obj.proj v4 1.i256;
-        v12.i256 = extract_value v5 1.i256;
-        obj.store v11 v12;
-        v13.objref<i256> = obj.proj v2 1.i256;
-        v14.i256 = extract_value v1 1.i256;
-        obj.store v13 v14;
-        call %decode_payload v2;
-        return;
-}
-
-func private %decoder_with_base(v0.@layout_1, v1.i256) -> @layout_3 {
+func inline(always) private %decode_from(v0.@layout_1, v1.i256) {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v5.@layout_3 = call %with_base v0 v3;
-        return v5;
+        return;
+}
+
+func inline(always) private %decode_runtime_args(v0.objref<@layout_3>) {
+    block0:
+        v1.*i256 = alloca i256;
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v5.@layout_1 = call %input;
+        v7.i256 = call %len v5;
+        mstore v1 v7 i256;
+        v8.i256 = mload v1 i256;
+        mstore v2 v8 i256;
+        v9.i256 = mload v2 i256;
+        v10.i1 = gt 4.i256 v9;
+        br v10 block2 block3;
+
+    block2:
+        call %abort;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        br 1.i1 block5 block6;
+
+    block5:
+        mstore v3 4.i256 i256;
+        br 0.i1 block8 block11;
+
+    block6:
+        jump block7;
+
+    block7:
+        call %decode_from v5 4.i256;
+        return;
+
+    block8:
+        call %abort;
+        unreachable;
+
+    block9:
+        jump block10;
+
+    block10:
+        jump block7;
+
+    block11:
+        v17.i256 = mload v1 i256;
+        mstore v4 v17 i256;
+        v19.i256 = mload v4 i256;
+        v20.i1 = gt 4.i256 v19;
+        br v20 block8 block9;
 }
 
 func private %encode(v0.i256, v1.objref<@layout_0>) {
@@ -305,7 +335,7 @@ func private %encode_single_root(v0.i256, v1.objref<@layout_0>) {
         return;
 }
 
-func private %encode_single_root_alloc(v0.i256) -> @layout_6 {
+func private %encode_single_root_alloc(v0.i256) -> @layout_4 {
     block0:
         jump block1;
 
@@ -321,12 +351,12 @@ func private %encode_single_root_alloc(v0.i256) -> @layout_6 {
         obj.store v9 v10;
         v11.i256 = call %base v4;
         call %encode_single_root v0 v4;
-        v13.objref<@layout_6> = obj.alloc @layout_6;
+        v13.objref<@layout_4> = obj.alloc @layout_4;
         v14.objref<i256> = obj.proj v13 0.i256;
         obj.store v14 v11;
         v15.objref<i256> = obj.proj v13 1.i256;
         obj.store v15 v2;
-        v16.@layout_6 = obj.load v13;
+        v16.@layout_4 = obj.load v13;
         return v16;
 }
 
@@ -354,26 +384,6 @@ func private %encoder_new(v0.i256) -> @layout_0 {
         return v3;
 }
 
-func inline(always) private %fork(v0.@layout_2, v1.i256) -> @layout_2 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v5.@layout_1 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.objref<@layout_2> = obj.alloc @layout_2;
-        v8.objref<@layout_1> = obj.proj v7 0.i256;
-        v9.objref<i256> = obj.proj v8 0.i256;
-        v10.i256 = extract_value v5 0.i256;
-        obj.store v9 v10;
-        v12.objref<i256> = obj.proj v7 1.i256;
-        obj.store v12 v6;
-        v13.@layout_2 = obj.load v7;
-        return v13;
-}
-
 func private %input() -> @layout_1 {
     block0:
         jump block1;
@@ -383,32 +393,42 @@ func private %input() -> @layout_1 {
         return v0;
 }
 
-func inline(always) private %impl_CallData__new() -> @layout_1 {
+func inline(always) private %len(v0.@layout_1) -> i256 {
     block0:
+        v1.*i256 = alloca i256;
+        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v1.constref<@layout_1> = const.ref $const_region_0;
-        v2.objref<@layout_1> = obj.alloc @layout_1;
-        obj.init.const v2 v1;
-        v3.@layout_1 = obj.load v2;
-        return v3;
-}
-
-func inline(always) private %new__gd20d(v0.@layout_1) -> @layout_2 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.objref<@layout_2> = obj.alloc @layout_2;
-        v4.objref<@layout_1> = obj.proj v2 0.i256;
-        v5.objref<i256> = obj.proj v4 0.i256;
+        v3.i256 = evm_calldata_size;
+        mstore v1 v3 i256;
         v6.i256 = extract_value v0 0.i256;
-        obj.store v5 v6;
-        v8.objref<i256> = obj.proj v2 1.i256;
-        obj.store v8 0.i256;
-        v9.@layout_2 = obj.load v2;
-        return v9;
+        v7.i256 = mload v1 i256;
+        mstore v2 v7 i256;
+        v8.i256 = mload v2 i256;
+        v9.i1 = gt v6 v8;
+        br v9 block2 block3;
+
+    block2:
+        jump block4;
+
+    block3:
+        v11.i256 = extract_value v0 0.i256;
+        v12.i256 = mload v1 i256;
+        (v13.i256, v14.i1) = usubo v12 v11;
+        br v14 block5 block6;
+
+    block4:
+        v19.i256 = phi (0.i256 block2) (v13 block6);
+        return v19;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        jump block4;
 }
 
 func private %impl_SolEncoder__new(v0.i256) -> @layout_0 {
@@ -442,6 +462,18 @@ func private %impl_SolEncoder__new(v0.i256) -> @layout_0 {
         return v13;
 }
 
+func inline(always) private %impl_CallData__new() -> @layout_1 {
+    block0:
+        jump block1;
+
+    block1:
+        v1.constref<@layout_1> = const.ref $const_region_0;
+        v2.objref<@layout_1> = obj.alloc @layout_1;
+        obj.init.const v2 v1;
+        v3.@layout_1 = obj.load v2;
+        return v3;
+}
+
 func private %core__lib__abi__trait_AbiSize__payload_size__ge513_a5ce(v0.i256) -> i256 {
     block0:
         v1.*i256 = alloca i256;
@@ -472,14 +504,18 @@ func private %pos(v0.objref<@layout_0>) -> i256 {
         return v4;
 }
 
-func inline(always) private %runtime_decoder() -> @layout_3 {
+func private %revert(v0.i256, v1.i256) {
     block0:
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        mstore v2 v0 i256;
+        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v0.@layout_1 = call %input;
-        v2.@layout_3 = call %decoder_with_base v0 4.i256;
-        return v2;
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v3 i256;
+        evm_revert v4 v5;
 }
 
 func private %set_base(v0.objref<@layout_0>, v1.i256) {
@@ -521,33 +557,6 @@ func private %store_word(v0.i256, v1.i256) {
         v5.i256 = mload v3 i256;
         mstore v4 v5 i256;
         return;
-}
-
-func inline(always) private %with_base(v0.@layout_1, v1.i256) -> @layout_3 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v4.@layout_2 = call %new__gd20d v0;
-        v5.i256 = mload v2 i256;
-        v6.@layout_2 = call %fork v4 v5;
-        v7.i256 = mload v2 i256;
-        v8.objref<@layout_3> = obj.alloc @layout_3;
-        v10.objref<@layout_2> = obj.proj v8 0.i256;
-        v11.objref<@layout_1> = obj.proj v10 0.i256;
-        v12.@layout_1 = extract_value v6 0.i256;
-        v13.objref<i256> = obj.proj v11 0.i256;
-        v14.i256 = extract_value v12 0.i256;
-        obj.store v13 v14;
-        v16.objref<i256> = obj.proj v10 1.i256;
-        v17.i256 = extract_value v6 1.i256;
-        obj.store v16 v17;
-        v18.objref<i256> = obj.proj v8 1.i256;
-        obj.store v18 v7;
-        v19.@layout_3 = obj.load v8;
-        return v19;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_8b2d(v0.objref<@layout_0>, v1.i256) {

--- a/crates/codegen/tests/fixtures/sonatina_ir/newtype_storage_byplace_effect_arg.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/newtype_storage_byplace_effect_arg.snap
@@ -226,23 +226,34 @@ func inline(always) private %decode_from(v0.@layout_1, v1.i256) {
         return;
 }
 
+func inline(always) private %decode_from_checked_head(v0.@layout_1, v1.i256, v2.i256) {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v4 i256;
+        v7.i256 = mload v3 i256;
+        call %decode_from v0 v7;
+        return;
+}
+
 func inline(always) private %decode_runtime_args(v0.objref<@layout_3>) {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
         v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v5.@layout_1 = call %input;
-        v7.i256 = call %len v5;
-        mstore v1 v7 i256;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt 4.i256 v9;
-        br v10 block2 block3;
+        v4.@layout_1 = call %input;
+        v6.i256 = call %len v4;
+        mstore v1 v6 i256;
+        mstore v2 4.i256 i256;
+        br 0.i1 block2 block5;
 
     block2:
         call %abort;
@@ -252,35 +263,16 @@ func inline(always) private %decode_runtime_args(v0.objref<@layout_3>) {
         jump block4;
 
     block4:
-        br 1.i1 block5 block6;
-
-    block5:
-        mstore v3 4.i256 i256;
-        br 0.i1 block8 block11;
-
-    block6:
-        jump block7;
-
-    block7:
-        call %decode_from v5 4.i256;
+        v11.i256 = mload v1 i256;
+        call %decode_from_checked_head v4 4.i256 v11;
         return;
 
-    block8:
-        call %abort;
-        unreachable;
-
-    block9:
-        jump block10;
-
-    block10:
-        jump block7;
-
-    block11:
-        v17.i256 = mload v1 i256;
-        mstore v4 v17 i256;
-        v19.i256 = mload v4 i256;
-        v20.i1 = gt 4.i256 v19;
-        br v20 block8 block9;
+    block5:
+        v13.i256 = mload v1 i256;
+        mstore v3 v13 i256;
+        v15.i256 = mload v3 i256;
+        v16.i1 = gt 4.i256 v15;
+        br v16 block2 block3;
 }
 
 func private %encode(v0.i256, v1.objref<@layout_0>) {

--- a/crates/codegen/tests/fixtures/sonatina_ir/newtype_storage_byplace_effect_arg.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/newtype_storage_byplace_effect_arg.snap
@@ -93,6 +93,24 @@ func private %abort() {
         unreachable;
 }
 
+func inline(always) private %at(v0.i256) -> @layout_0 {
+    block0:
+        v1.*i256 = alloca i256;
+        mstore v1 v0 i256;
+        jump block1;
+
+    block1:
+        v2.i256 = mload v1 i256;
+        v3.i256 = mload v1 i256;
+        v4.objref<@layout_0> = obj.alloc @layout_0;
+        v6.objref<i256> = obj.proj v4 0.i256;
+        obj.store v6 v2;
+        v8.objref<i256> = obj.proj v4 1.i256;
+        obj.store v8 v3;
+        v9.@layout_0 = obj.load v4;
+        return v9;
+}
+
 func private %base(v0.objref<@layout_0>) -> i256 {
     block0:
         jump block1;
@@ -453,13 +471,8 @@ func private %impl_SolEncoder__new(v0.i256) -> @layout_0 {
 
     block4:
         v8.i256 = phi (0.i256 block2) (v7 block3);
-        v9.objref<@layout_0> = obj.alloc @layout_0;
-        v10.objref<i256> = obj.proj v9 0.i256;
-        obj.store v10 v8;
-        v12.objref<i256> = obj.proj v9 1.i256;
-        obj.store v12 v8;
-        v13.@layout_0 = obj.load v9;
-        return v13;
+        v9.@layout_0 = call %at v8;
+        return v9;
 }
 
 func inline(always) private %impl_CallData__new() -> @layout_1 {

--- a/crates/codegen/tests/fixtures/sonatina_ir/newtype_storage_byplace_effect_arg.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/newtype_storage_byplace_effect_arg.snap
@@ -226,7 +226,7 @@ func inline(always) private %decode_from(v0.@layout_1, v1.i256) {
         return;
 }
 
-func inline(always) private %decode_from_checked_head(v0.@layout_1, v1.i256, v2.i256) {
+func inline(always) private %decode_from_prechecked_head(v0.@layout_1, v1.i256, v2.i256) {
     block0:
         v3.*i256 = alloca i256;
         v4.*i256 = alloca i256;
@@ -264,7 +264,7 @@ func inline(always) private %decode_runtime_args(v0.objref<@layout_3>) {
 
     block4:
         v11.i256 = mload v1 i256;
-        call %decode_from_checked_head v4 4.i256 v11;
+        call %decode_from_prechecked_head v4 4.i256 v11;
         return;
 
     block5:

--- a/crates/codegen/tests/fixtures/sonatina_ir/newtype_storage_field_mut_method_call.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/newtype_storage_field_mut_method_call.snap
@@ -7,11 +7,9 @@ target = "evm-ethereum-osaka"
 
 type @layout_0 = {i256, i256};
 type @layout_1 = {i256};
-type @layout_2 = {@layout_1, i256};
-type @layout_3 = {@layout_2, i256};
-type @layout_4 = {};
-type @layout_5 = {@layout_4};
-type @layout_6 = {i256, i256};
+type @layout_2 = {};
+type @layout_3 = {@layout_2};
+type @layout_4 = {i256, i256};
 
 global private const @layout_1 $const_region_0 = {0};
 
@@ -73,6 +71,15 @@ func private %abi_single_root_size(v0.i256) -> i256 {
         v2.i256 = mload v1 i256;
         v3.i256 = call %abi_field_size v2;
         return v3;
+}
+
+func private %abort() {
+    block0:
+        jump block1;
+
+    block1:
+        call %revert 0.i256 0.i256;
+        unreachable;
 }
 
 func private %base(v0.objref<@layout_0>) -> i256 {
@@ -148,10 +155,10 @@ func private %contract_recv_abi_NewtypeStorageFieldMutMethodCall_1() {
         evm_revert 0.i256 0.i256;
 
     block3:
-        v5.objref<@layout_5> = obj.alloc @layout_5;
+        v5.objref<@layout_3> = obj.alloc @layout_3;
         call %decode_runtime_args v5;
         v8.i256 = call %__NewtypeStorageFieldMutMethodCall_recv_0_0 1.i256;
-        v9.@layout_6 = call %encode_single_root_alloc v8;
+        v9.@layout_4 = call %encode_single_root_alloc v8;
         v10.i256 = extract_value v9 0.i256;
         v11.i256 = extract_value v9 1.i256;
         evm_return v10 v11;
@@ -180,48 +187,71 @@ func private %contract_runtime_root_NewtypeStorageFieldMutMethodCall() {
         unreachable;
 }
 
-func inline(always) private %decode_payload(v0.objref<@layout_3>) {
-    block0:
-        jump block1;
-
-    block1:
-        return;
-}
-
-func inline(always) private %decode_runtime_args(v0.objref<@layout_5>) {
-    block0:
-        jump block1;
-
-    block1:
-        v1.@layout_3 = call %runtime_decoder;
-        v2.objref<@layout_3> = obj.alloc @layout_3;
-        v4.objref<@layout_2> = obj.proj v2 0.i256;
-        v5.@layout_2 = extract_value v1 0.i256;
-        v6.objref<@layout_1> = obj.proj v4 0.i256;
-        v7.@layout_1 = extract_value v5 0.i256;
-        v8.objref<i256> = obj.proj v6 0.i256;
-        v9.i256 = extract_value v7 0.i256;
-        obj.store v8 v9;
-        v11.objref<i256> = obj.proj v4 1.i256;
-        v12.i256 = extract_value v5 1.i256;
-        obj.store v11 v12;
-        v13.objref<i256> = obj.proj v2 1.i256;
-        v14.i256 = extract_value v1 1.i256;
-        obj.store v13 v14;
-        call %decode_payload v2;
-        return;
-}
-
-func private %decoder_with_base(v0.@layout_1, v1.i256) -> @layout_3 {
+func inline(always) private %decode_from(v0.@layout_1, v1.i256) {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v5.@layout_3 = call %with_base v0 v3;
-        return v5;
+        return;
+}
+
+func inline(always) private %decode_runtime_args(v0.objref<@layout_3>) {
+    block0:
+        v1.*i256 = alloca i256;
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v5.@layout_1 = call %input;
+        v7.i256 = call %len v5;
+        mstore v1 v7 i256;
+        v8.i256 = mload v1 i256;
+        mstore v2 v8 i256;
+        v9.i256 = mload v2 i256;
+        v10.i1 = gt 4.i256 v9;
+        br v10 block2 block3;
+
+    block2:
+        call %abort;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        br 1.i1 block5 block6;
+
+    block5:
+        mstore v3 4.i256 i256;
+        br 0.i1 block8 block11;
+
+    block6:
+        jump block7;
+
+    block7:
+        call %decode_from v5 4.i256;
+        return;
+
+    block8:
+        call %abort;
+        unreachable;
+
+    block9:
+        jump block10;
+
+    block10:
+        jump block7;
+
+    block11:
+        v17.i256 = mload v1 i256;
+        mstore v4 v17 i256;
+        v19.i256 = mload v4 i256;
+        v20.i1 = gt 4.i256 v19;
+        br v20 block8 block9;
 }
 
 func private %encode(v0.i256, v1.objref<@layout_0>) {
@@ -294,7 +324,7 @@ func private %encode_single_root(v0.i256, v1.objref<@layout_0>) {
         return;
 }
 
-func private %encode_single_root_alloc(v0.i256) -> @layout_6 {
+func private %encode_single_root_alloc(v0.i256) -> @layout_4 {
     block0:
         jump block1;
 
@@ -310,12 +340,12 @@ func private %encode_single_root_alloc(v0.i256) -> @layout_6 {
         obj.store v9 v10;
         v11.i256 = call %base v4;
         call %encode_single_root v0 v4;
-        v13.objref<@layout_6> = obj.alloc @layout_6;
+        v13.objref<@layout_4> = obj.alloc @layout_4;
         v14.objref<i256> = obj.proj v13 0.i256;
         obj.store v14 v11;
         v15.objref<i256> = obj.proj v13 1.i256;
         obj.store v15 v2;
-        v16.@layout_6 = obj.load v13;
+        v16.@layout_4 = obj.load v13;
         return v16;
 }
 
@@ -343,26 +373,6 @@ func private %encoder_new(v0.i256) -> @layout_0 {
         return v3;
 }
 
-func inline(always) private %fork(v0.@layout_2, v1.i256) -> @layout_2 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v5.@layout_1 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.objref<@layout_2> = obj.alloc @layout_2;
-        v8.objref<@layout_1> = obj.proj v7 0.i256;
-        v9.objref<i256> = obj.proj v8 0.i256;
-        v10.i256 = extract_value v5 0.i256;
-        obj.store v9 v10;
-        v12.objref<i256> = obj.proj v7 1.i256;
-        obj.store v12 v6;
-        v13.@layout_2 = obj.load v7;
-        return v13;
-}
-
 func private %input() -> @layout_1 {
     block0:
         jump block1;
@@ -370,6 +380,44 @@ func private %input() -> @layout_1 {
     block1:
         v0.@layout_1 = call %impl_CallData__new;
         return v0;
+}
+
+func inline(always) private %len(v0.@layout_1) -> i256 {
+    block0:
+        v1.*i256 = alloca i256;
+        v2.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v3.i256 = evm_calldata_size;
+        mstore v1 v3 i256;
+        v6.i256 = extract_value v0 0.i256;
+        v7.i256 = mload v1 i256;
+        mstore v2 v7 i256;
+        v8.i256 = mload v2 i256;
+        v9.i1 = gt v6 v8;
+        br v9 block2 block3;
+
+    block2:
+        jump block4;
+
+    block3:
+        v11.i256 = extract_value v0 0.i256;
+        v12.i256 = mload v1 i256;
+        (v13.i256, v14.i1) = usubo v12 v11;
+        br v14 block5 block6;
+
+    block4:
+        v19.i256 = phi (0.i256 block2) (v13 block6);
+        return v19;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        jump block4;
 }
 
 func inline(always) private %impl_CallData__new() -> @layout_1 {
@@ -415,22 +463,6 @@ func private %impl_SolEncoder__new(v0.i256) -> @layout_0 {
         return v13;
 }
 
-func inline(always) private %new__gd20d(v0.@layout_1) -> @layout_2 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.objref<@layout_2> = obj.alloc @layout_2;
-        v4.objref<@layout_1> = obj.proj v2 0.i256;
-        v5.objref<i256> = obj.proj v4 0.i256;
-        v6.i256 = extract_value v0 0.i256;
-        obj.store v5 v6;
-        v8.objref<i256> = obj.proj v2 1.i256;
-        obj.store v8 0.i256;
-        v9.@layout_2 = obj.load v2;
-        return v9;
-}
-
 func private %core__lib__abi__trait_AbiSize__payload_size__ge513_4e75(v0.i256) -> i256 {
     block0:
         v1.*i256 = alloca i256;
@@ -461,14 +493,18 @@ func private %pos(v0.objref<@layout_0>) -> i256 {
         return v4;
 }
 
-func inline(always) private %runtime_decoder() -> @layout_3 {
+func private %revert(v0.i256, v1.i256) {
     block0:
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        mstore v2 v0 i256;
+        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v0.@layout_1 = call %input;
-        v2.@layout_3 = call %decoder_with_base v0 4.i256;
-        return v2;
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v3 i256;
+        evm_revert v4 v5;
 }
 
 func private %set_base(v0.objref<@layout_0>, v1.i256) {
@@ -510,33 +546,6 @@ func private %store_word(v0.i256, v1.i256) {
         v5.i256 = mload v3 i256;
         mstore v4 v5 i256;
         return;
-}
-
-func inline(always) private %with_base(v0.@layout_1, v1.i256) -> @layout_3 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v4.@layout_2 = call %new__gd20d v0;
-        v5.i256 = mload v2 i256;
-        v6.@layout_2 = call %fork v4 v5;
-        v7.i256 = mload v2 i256;
-        v8.objref<@layout_3> = obj.alloc @layout_3;
-        v10.objref<@layout_2> = obj.proj v8 0.i256;
-        v11.objref<@layout_1> = obj.proj v10 0.i256;
-        v12.@layout_1 = extract_value v6 0.i256;
-        v13.objref<i256> = obj.proj v11 0.i256;
-        v14.i256 = extract_value v12 0.i256;
-        obj.store v13 v14;
-        v16.objref<i256> = obj.proj v10 1.i256;
-        v17.i256 = extract_value v6 1.i256;
-        obj.store v16 v17;
-        v18.objref<i256> = obj.proj v8 1.i256;
-        obj.store v18 v7;
-        v19.@layout_3 = obj.load v8;
-        return v19;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_90ae(v0.objref<@layout_0>, v1.i256) {

--- a/crates/codegen/tests/fixtures/sonatina_ir/newtype_storage_field_mut_method_call.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/newtype_storage_field_mut_method_call.snap
@@ -82,6 +82,24 @@ func private %abort() {
         unreachable;
 }
 
+func inline(always) private %at(v0.i256) -> @layout_0 {
+    block0:
+        v1.*i256 = alloca i256;
+        mstore v1 v0 i256;
+        jump block1;
+
+    block1:
+        v2.i256 = mload v1 i256;
+        v3.i256 = mload v1 i256;
+        v4.objref<@layout_0> = obj.alloc @layout_0;
+        v6.objref<i256> = obj.proj v4 0.i256;
+        obj.store v6 v2;
+        v8.objref<i256> = obj.proj v4 1.i256;
+        obj.store v8 v3;
+        v9.@layout_0 = obj.load v4;
+        return v9;
+}
+
 func private %base(v0.objref<@layout_0>) -> i256 {
     block0:
         jump block1;
@@ -454,13 +472,8 @@ func private %impl_SolEncoder__new(v0.i256) -> @layout_0 {
 
     block4:
         v8.i256 = phi (0.i256 block2) (v7 block3);
-        v9.objref<@layout_0> = obj.alloc @layout_0;
-        v10.objref<i256> = obj.proj v9 0.i256;
-        obj.store v10 v8;
-        v12.objref<i256> = obj.proj v9 1.i256;
-        obj.store v12 v8;
-        v13.@layout_0 = obj.load v9;
-        return v13;
+        v9.@layout_0 = call %at v8;
+        return v9;
 }
 
 func private %core__lib__abi__trait_AbiSize__payload_size__ge513_4e75(v0.i256) -> i256 {

--- a/crates/codegen/tests/fixtures/sonatina_ir/newtype_storage_field_mut_method_call.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/newtype_storage_field_mut_method_call.snap
@@ -215,7 +215,7 @@ func inline(always) private %decode_from(v0.@layout_1, v1.i256) {
         return;
 }
 
-func inline(always) private %decode_from_checked_head(v0.@layout_1, v1.i256, v2.i256) {
+func inline(always) private %decode_from_prechecked_head(v0.@layout_1, v1.i256, v2.i256) {
     block0:
         v3.*i256 = alloca i256;
         v4.*i256 = alloca i256;
@@ -253,7 +253,7 @@ func inline(always) private %decode_runtime_args(v0.objref<@layout_3>) {
 
     block4:
         v11.i256 = mload v1 i256;
-        call %decode_from_checked_head v4 4.i256 v11;
+        call %decode_from_prechecked_head v4 4.i256 v11;
         return;
 
     block5:

--- a/crates/codegen/tests/fixtures/sonatina_ir/newtype_storage_field_mut_method_call.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/newtype_storage_field_mut_method_call.snap
@@ -215,23 +215,34 @@ func inline(always) private %decode_from(v0.@layout_1, v1.i256) {
         return;
 }
 
+func inline(always) private %decode_from_checked_head(v0.@layout_1, v1.i256, v2.i256) {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v4 i256;
+        v7.i256 = mload v3 i256;
+        call %decode_from v0 v7;
+        return;
+}
+
 func inline(always) private %decode_runtime_args(v0.objref<@layout_3>) {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
         v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v5.@layout_1 = call %input;
-        v7.i256 = call %len v5;
-        mstore v1 v7 i256;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt 4.i256 v9;
-        br v10 block2 block3;
+        v4.@layout_1 = call %input;
+        v6.i256 = call %len v4;
+        mstore v1 v6 i256;
+        mstore v2 4.i256 i256;
+        br 0.i1 block2 block5;
 
     block2:
         call %abort;
@@ -241,35 +252,16 @@ func inline(always) private %decode_runtime_args(v0.objref<@layout_3>) {
         jump block4;
 
     block4:
-        br 1.i1 block5 block6;
-
-    block5:
-        mstore v3 4.i256 i256;
-        br 0.i1 block8 block11;
-
-    block6:
-        jump block7;
-
-    block7:
-        call %decode_from v5 4.i256;
+        v11.i256 = mload v1 i256;
+        call %decode_from_checked_head v4 4.i256 v11;
         return;
 
-    block8:
-        call %abort;
-        unreachable;
-
-    block9:
-        jump block10;
-
-    block10:
-        jump block7;
-
-    block11:
-        v17.i256 = mload v1 i256;
-        mstore v4 v17 i256;
-        v19.i256 = mload v4 i256;
-        v20.i1 = gt 4.i256 v19;
-        br v20 block8 block9;
+    block5:
+        v13.i256 = mload v1 i256;
+        mstore v3 v13 i256;
+        v15.i256 = mload v3 i256;
+        v16.i1 = gt 4.i256 v15;
+        br v16 block2 block3;
 }
 
 func private %encode(v0.i256, v1.objref<@layout_0>) {

--- a/crates/codegen/tests/fixtures/sonatina_ir/tstor_ptr_contract.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/tstor_ptr_contract.snap
@@ -212,23 +212,34 @@ func inline(always) private %decode_from(v0.@layout_1, v1.i256) {
         return;
 }
 
+func inline(always) private %decode_from_checked_head(v0.@layout_1, v1.i256, v2.i256) {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v4 i256;
+        v7.i256 = mload v3 i256;
+        call %decode_from v0 v7;
+        return;
+}
+
 func inline(always) private %decode_runtime_args(v0.objref<@layout_3>) {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
         v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v5.@layout_1 = call %input;
-        v7.i256 = call %len v5;
-        mstore v1 v7 i256;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt 4.i256 v9;
-        br v10 block2 block3;
+        v4.@layout_1 = call %input;
+        v6.i256 = call %len v4;
+        mstore v1 v6 i256;
+        mstore v2 4.i256 i256;
+        br 0.i1 block2 block5;
 
     block2:
         call %abort;
@@ -238,35 +249,16 @@ func inline(always) private %decode_runtime_args(v0.objref<@layout_3>) {
         jump block4;
 
     block4:
-        br 1.i1 block5 block6;
-
-    block5:
-        mstore v3 4.i256 i256;
-        br 0.i1 block8 block11;
-
-    block6:
-        jump block7;
-
-    block7:
-        call %decode_from v5 4.i256;
+        v11.i256 = mload v1 i256;
+        call %decode_from_checked_head v4 4.i256 v11;
         return;
 
-    block8:
-        call %abort;
-        unreachable;
-
-    block9:
-        jump block10;
-
-    block10:
-        jump block7;
-
-    block11:
-        v17.i256 = mload v1 i256;
-        mstore v4 v17 i256;
-        v19.i256 = mload v4 i256;
-        v20.i1 = gt 4.i256 v19;
-        br v20 block8 block9;
+    block5:
+        v13.i256 = mload v1 i256;
+        mstore v3 v13 i256;
+        v15.i256 = mload v3 i256;
+        v16.i1 = gt 4.i256 v15;
+        br v16 block2 block3;
 }
 
 func private %encode(v0.i1, v1.objref<@layout_0>) {

--- a/crates/codegen/tests/fixtures/sonatina_ir/tstor_ptr_contract.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/tstor_ptr_contract.snap
@@ -212,7 +212,7 @@ func inline(always) private %decode_from(v0.@layout_1, v1.i256) {
         return;
 }
 
-func inline(always) private %decode_from_checked_head(v0.@layout_1, v1.i256, v2.i256) {
+func inline(always) private %decode_from_prechecked_head(v0.@layout_1, v1.i256, v2.i256) {
     block0:
         v3.*i256 = alloca i256;
         v4.*i256 = alloca i256;
@@ -250,7 +250,7 @@ func inline(always) private %decode_runtime_args(v0.objref<@layout_3>) {
 
     block4:
         v11.i256 = mload v1 i256;
-        call %decode_from_checked_head v4 4.i256 v11;
+        call %decode_from_prechecked_head v4 4.i256 v11;
         return;
 
     block5:

--- a/crates/codegen/tests/fixtures/sonatina_ir/tstor_ptr_contract.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/tstor_ptr_contract.snap
@@ -7,11 +7,9 @@ target = "evm-ethereum-osaka"
 
 type @layout_0 = {i256, i256};
 type @layout_1 = {i256};
-type @layout_2 = {@layout_1, i256};
-type @layout_3 = {@layout_2, i256};
-type @layout_4 = {};
-type @layout_5 = {@layout_4};
-type @layout_6 = {i256, i256};
+type @layout_2 = {};
+type @layout_3 = {@layout_2};
+type @layout_4 = {i256, i256};
 
 global private const @layout_1 $const_region_0 = {0};
 
@@ -91,6 +89,15 @@ func private %abi_single_root_size(v0.i1) -> i256 {
         return v3;
 }
 
+func private %abort() {
+    block0:
+        jump block1;
+
+    block1:
+        call %revert 0.i256 0.i256;
+        unreachable;
+}
+
 func private %base(v0.objref<@layout_0>) -> i256 {
     block0:
         jump block1;
@@ -145,10 +152,10 @@ func private %contract_recv_abi_GuardContract_1() {
         evm_revert 0.i256 0.i256;
 
     block3:
-        v5.objref<@layout_5> = obj.alloc @layout_5;
+        v5.objref<@layout_3> = obj.alloc @layout_3;
         call %decode_runtime_args v5;
         v7.i1 = call %__GuardContract_recv_0_0 0.i256 0.i256;
-        v8.@layout_6 = call %encode_single_root_alloc v7;
+        v8.@layout_4 = call %encode_single_root_alloc v7;
         v9.i256 = extract_value v8 0.i256;
         v11.i256 = extract_value v8 1.i256;
         evm_return v9 v11;
@@ -177,48 +184,71 @@ func private %contract_runtime_root_GuardContract() {
         unreachable;
 }
 
-func inline(always) private %decode_payload(v0.objref<@layout_3>) {
-    block0:
-        jump block1;
-
-    block1:
-        return;
-}
-
-func inline(always) private %decode_runtime_args(v0.objref<@layout_5>) {
-    block0:
-        jump block1;
-
-    block1:
-        v1.@layout_3 = call %runtime_decoder;
-        v2.objref<@layout_3> = obj.alloc @layout_3;
-        v4.objref<@layout_2> = obj.proj v2 0.i256;
-        v5.@layout_2 = extract_value v1 0.i256;
-        v6.objref<@layout_1> = obj.proj v4 0.i256;
-        v7.@layout_1 = extract_value v5 0.i256;
-        v8.objref<i256> = obj.proj v6 0.i256;
-        v9.i256 = extract_value v7 0.i256;
-        obj.store v8 v9;
-        v11.objref<i256> = obj.proj v4 1.i256;
-        v12.i256 = extract_value v5 1.i256;
-        obj.store v11 v12;
-        v13.objref<i256> = obj.proj v2 1.i256;
-        v14.i256 = extract_value v1 1.i256;
-        obj.store v13 v14;
-        call %decode_payload v2;
-        return;
-}
-
-func private %decoder_with_base(v0.@layout_1, v1.i256) -> @layout_3 {
+func inline(always) private %decode_from(v0.@layout_1, v1.i256) {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v5.@layout_3 = call %with_base v0 v3;
-        return v5;
+        return;
+}
+
+func inline(always) private %decode_runtime_args(v0.objref<@layout_3>) {
+    block0:
+        v1.*i256 = alloca i256;
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v5.@layout_1 = call %input;
+        v7.i256 = call %len v5;
+        mstore v1 v7 i256;
+        v8.i256 = mload v1 i256;
+        mstore v2 v8 i256;
+        v9.i256 = mload v2 i256;
+        v10.i1 = gt 4.i256 v9;
+        br v10 block2 block3;
+
+    block2:
+        call %abort;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        br 1.i1 block5 block6;
+
+    block5:
+        mstore v3 4.i256 i256;
+        br 0.i1 block8 block11;
+
+    block6:
+        jump block7;
+
+    block7:
+        call %decode_from v5 4.i256;
+        return;
+
+    block8:
+        call %abort;
+        unreachable;
+
+    block9:
+        jump block10;
+
+    block10:
+        jump block7;
+
+    block11:
+        v17.i256 = mload v1 i256;
+        mstore v4 v17 i256;
+        v19.i256 = mload v4 i256;
+        v20.i1 = gt 4.i256 v19;
+        br v20 block8 block9;
 }
 
 func private %encode(v0.i1, v1.objref<@layout_0>) {
@@ -301,7 +331,7 @@ func private %encode_single_root(v0.i1, v1.objref<@layout_0>) {
         return;
 }
 
-func private %encode_single_root_alloc(v0.i1) -> @layout_6 {
+func private %encode_single_root_alloc(v0.i1) -> @layout_4 {
     block0:
         jump block1;
 
@@ -317,12 +347,12 @@ func private %encode_single_root_alloc(v0.i1) -> @layout_6 {
         obj.store v9 v10;
         v11.i256 = call %base v4;
         call %encode_single_root v0 v4;
-        v13.objref<@layout_6> = obj.alloc @layout_6;
+        v13.objref<@layout_4> = obj.alloc @layout_4;
         v14.objref<i256> = obj.proj v13 0.i256;
         obj.store v14 v11;
         v15.objref<i256> = obj.proj v13 1.i256;
         obj.store v15 v2;
-        v16.@layout_6 = obj.load v13;
+        v16.@layout_4 = obj.load v13;
         return v16;
 }
 
@@ -361,26 +391,6 @@ func private %encoder_new(v0.i256) -> @layout_0 {
         return v3;
 }
 
-func inline(always) private %fork(v0.@layout_2, v1.i256) -> @layout_2 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v5.@layout_1 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.objref<@layout_2> = obj.alloc @layout_2;
-        v8.objref<@layout_1> = obj.proj v7 0.i256;
-        v9.objref<i256> = obj.proj v8 0.i256;
-        v10.i256 = extract_value v5 0.i256;
-        obj.store v9 v10;
-        v12.objref<i256> = obj.proj v7 1.i256;
-        obj.store v12 v6;
-        v13.@layout_2 = obj.load v7;
-        return v13;
-}
-
 func private %input() -> @layout_1 {
     block0:
         jump block1;
@@ -390,16 +400,42 @@ func private %input() -> @layout_1 {
         return v0;
 }
 
-func inline(always) private %impl_CallData__new() -> @layout_1 {
+func inline(always) private %len(v0.@layout_1) -> i256 {
     block0:
+        v1.*i256 = alloca i256;
+        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v1.constref<@layout_1> = const.ref $const_region_0;
-        v2.objref<@layout_1> = obj.alloc @layout_1;
-        obj.init.const v2 v1;
-        v3.@layout_1 = obj.load v2;
-        return v3;
+        v3.i256 = evm_calldata_size;
+        mstore v1 v3 i256;
+        v6.i256 = extract_value v0 0.i256;
+        v7.i256 = mload v1 i256;
+        mstore v2 v7 i256;
+        v8.i256 = mload v2 i256;
+        v9.i1 = gt v6 v8;
+        br v9 block2 block3;
+
+    block2:
+        jump block4;
+
+    block3:
+        v11.i256 = extract_value v0 0.i256;
+        v12.i256 = mload v1 i256;
+        (v13.i256, v14.i1) = usubo v12 v11;
+        br v14 block5 block6;
+
+    block4:
+        v19.i256 = phi (0.i256 block2) (v13 block6);
+        return v19;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        jump block4;
 }
 
 func private %impl_SolEncoder__new(v0.i256) -> @layout_0 {
@@ -433,20 +469,16 @@ func private %impl_SolEncoder__new(v0.i256) -> @layout_0 {
         return v13;
 }
 
-func inline(always) private %new__gd20d(v0.@layout_1) -> @layout_2 {
+func inline(always) private %impl_CallData__new() -> @layout_1 {
     block0:
         jump block1;
 
     block1:
-        v2.objref<@layout_2> = obj.alloc @layout_2;
-        v4.objref<@layout_1> = obj.proj v2 0.i256;
-        v5.objref<i256> = obj.proj v4 0.i256;
-        v6.i256 = extract_value v0 0.i256;
-        obj.store v5 v6;
-        v8.objref<i256> = obj.proj v2 1.i256;
-        obj.store v8 0.i256;
-        v9.@layout_2 = obj.load v2;
-        return v9;
+        v1.constref<@layout_1> = const.ref $const_region_0;
+        v2.objref<@layout_1> = obj.alloc @layout_1;
+        obj.init.const v2 v1;
+        v3.@layout_1 = obj.load v2;
+        return v3;
 }
 
 func private %core__lib__abi__trait_AbiSize__payload_size__gda9b_f558(v0.i1) -> i256 {
@@ -479,14 +511,18 @@ func private %pos(v0.objref<@layout_0>) -> i256 {
         return v4;
 }
 
-func inline(always) private %runtime_decoder() -> @layout_3 {
+func private %revert(v0.i256, v1.i256) {
     block0:
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        mstore v2 v0 i256;
+        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v0.@layout_1 = call %input;
-        v2.@layout_3 = call %decoder_with_base v0 4.i256;
-        return v2;
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v3 i256;
+        evm_revert v4 v5;
 }
 
 func private %set_base(v0.objref<@layout_0>, v1.i256) {
@@ -528,33 +564,6 @@ func private %store_word(v0.i256, v1.i256) {
         v5.i256 = mload v3 i256;
         mstore v4 v5 i256;
         return;
-}
-
-func inline(always) private %with_base(v0.@layout_1, v1.i256) -> @layout_3 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v4.@layout_2 = call %new__gd20d v0;
-        v5.i256 = mload v2 i256;
-        v6.@layout_2 = call %fork v4 v5;
-        v7.i256 = mload v2 i256;
-        v8.objref<@layout_3> = obj.alloc @layout_3;
-        v10.objref<@layout_2> = obj.proj v8 0.i256;
-        v11.objref<@layout_1> = obj.proj v10 0.i256;
-        v12.@layout_1 = extract_value v6 0.i256;
-        v13.objref<i256> = obj.proj v11 0.i256;
-        v14.i256 = extract_value v12 0.i256;
-        obj.store v13 v14;
-        v16.objref<i256> = obj.proj v10 1.i256;
-        v17.i256 = extract_value v6 1.i256;
-        obj.store v16 v17;
-        v18.objref<i256> = obj.proj v8 1.i256;
-        obj.store v18 v7;
-        v19.@layout_3 = obj.load v8;
-        return v19;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_74a3(v0.objref<@layout_0>, v1.i256) {

--- a/crates/codegen/tests/fixtures/sonatina_ir/tstor_ptr_contract.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/tstor_ptr_contract.snap
@@ -98,6 +98,24 @@ func private %abort() {
         unreachable;
 }
 
+func inline(always) private %at(v0.i256) -> @layout_0 {
+    block0:
+        v1.*i256 = alloca i256;
+        mstore v1 v0 i256;
+        jump block1;
+
+    block1:
+        v2.i256 = mload v1 i256;
+        v3.i256 = mload v1 i256;
+        v4.objref<@layout_0> = obj.alloc @layout_0;
+        v6.objref<i256> = obj.proj v4 0.i256;
+        obj.store v6 v2;
+        v8.objref<i256> = obj.proj v4 1.i256;
+        obj.store v8 v3;
+        v9.@layout_0 = obj.load v4;
+        return v9;
+}
+
 func private %base(v0.objref<@layout_0>) -> i256 {
     block0:
         jump block1;
@@ -460,13 +478,8 @@ func private %impl_SolEncoder__new(v0.i256) -> @layout_0 {
 
     block4:
         v8.i256 = phi (0.i256 block2) (v7 block3);
-        v9.objref<@layout_0> = obj.alloc @layout_0;
-        v10.objref<i256> = obj.proj v9 0.i256;
-        obj.store v10 v8;
-        v12.objref<i256> = obj.proj v9 1.i256;
-        obj.store v12 v8;
-        v13.@layout_0 = obj.load v9;
-        return v13;
+        v9.@layout_0 = call %at v8;
+        return v9;
 }
 
 func inline(always) private %impl_CallData__new() -> @layout_1 {

--- a/crates/codegen/tests/fixtures/sonatina_ir/tuple_return_contract.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/tuple_return_contract.snap
@@ -78,27 +78,25 @@ func private %abort() {
         unreachable;
 }
 
+func inline(always) private %at(v0.i256) -> @layout_2 {
+    block0:
+        v1.*i256 = alloca i256;
+        mstore v1 v0 i256;
+        jump block1;
+
+    block1:
+        v2.i256 = mload v1 i256;
+        v3.i256 = mload v1 i256;
+        v4.objref<@layout_2> = obj.alloc @layout_2;
+        v6.objref<i256> = obj.proj v4 0.i256;
+        obj.store v6 v2;
+        v8.objref<i256> = obj.proj v4 1.i256;
+        obj.store v8 v3;
+        v9.@layout_2 = obj.load v4;
+        return v9;
+}
+
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_8e95(v0.objref<@layout_2>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 0.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_8e95_0(v0.objref<@layout_2>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 0.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_8e95_1(v0.objref<@layout_2>) -> i256 {
     block0:
         jump block1;
 
@@ -338,7 +336,7 @@ func private %core__lib__abi__dynamic_payload_size__ge513_f973_0(v0.i256) -> i25
         return 0.i256;
 }
 
-func private %encode__g4887(v0.@layout_1, v1.objref<@layout_2>) {
+func inline(always) private %encode__g4887(v0.@layout_1, v1.objref<@layout_2>) {
     block0:
         v2.objref<@layout_1> = obj.alloc @layout_1;
         v3.*i256 = alloca i256;
@@ -353,25 +351,20 @@ func private %encode__g4887(v0.@layout_1, v1.objref<@layout_2>) {
         jump block1;
 
     block1:
-        v13.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_8e95_1 v1;
-        (v15.i256, v16.i1) = uaddo v13 64.i256;
-        br v16 block2 block3;
-
-    block2:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block3:
+        v13.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_8e95 v1;
+        v15.i256 = add v13 64.i256;
         mstore v3 v15 i256;
-        v21.objref<i256> = obj.proj v2 0.i256;
-        v22.i256 = obj.load v21;
+        v17.i256 = add v13 32.i256;
+        v18.objref<i256> = obj.proj v2 0.i256;
+        v19.i256 = obj.load v18;
+        v20.i256 = ptr_to_int v3 i256;
+        call %encode_field_at__g2e64 v19 v1 v13 v13 v20;
+        v22.objref<@layout_0> = obj.proj v2 1.i256;
+        v23.@layout_0 = obj.load v22;
         v24.i256 = ptr_to_int v3 i256;
-        call %encode_field__g2e64 v22 v1 v24;
-        v26.objref<@layout_0> = obj.proj v2 1.i256;
-        v27.@layout_0 = obj.load v26;
-        v28.i256 = ptr_to_int v3 i256;
-        call %encode_field__gf6b4 v27 v1 v28;
+        call %encode_field_at__gf6b4 v23 v1 v13 v17 v24;
+        v26.i256 = add v13 64.i256;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_0d08_1 v1 v26;
         return;
 }
 
@@ -399,7 +392,7 @@ func private %impl_trait_Address__encode__g426c(v0.@layout_0, v1.objref<@layout_
         return;
 }
 
-func private %encode_field__g189a(v0.@layout_1, v1.objref<@layout_2>, v2.i256) {
+func private %encode_field(v0.@layout_1, v1.objref<@layout_2>, v2.i256) {
     block0:
         jump block1;
 
@@ -412,7 +405,7 @@ func private %encode_field__g189a(v0.@layout_1, v1.objref<@layout_2>, v2.i256) {
         v9.i256 = mload v2 i256;
         v10.i256 = sub v9 v5;
         call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_4363 v1 v10;
-        v12.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_d646 v1;
+        v12.i256 = call %pos v1;
         v13.i256 = mload v2 i256;
         call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_80f4 v1 v13;
         v15.i256 = mload v2 i256;
@@ -432,7 +425,7 @@ func private %encode_field__g189a(v0.@layout_1, v1.objref<@layout_2>, v2.i256) {
         br 1.i1 block5 block6;
 
     block5:
-        v24.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_d646 v1;
+        v24.i256 = call %pos v1;
         call %encode_to_ptr__g753b v0 v24;
         v28.i256 = add v24 64.i256;
         call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_516e v1 v28;
@@ -446,30 +439,34 @@ func private %encode_field__g189a(v0.@layout_1, v1.objref<@layout_2>, v2.i256) {
         return;
 }
 
-func private %encode_field__gf6b4(v0.@layout_0, v1.objref<@layout_2>, v2.i256) {
+func inline(always) private %encode_field_at__gf6b4(v0.@layout_0, v1.objref<@layout_2>, v2.i256, v3.i256, v4.i256) {
     block0:
+        v5.*i256 = alloca i256;
+        v6.*i256 = alloca i256;
+        mstore v5 v2 i256;
+        mstore v6 v3 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v5.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_8e95 v1;
-        v8.i256 = call %core__lib__abi__trait_AbiSize__payload_size__g67a8_7cab v0;
-        v9.i256 = mload v2 i256;
-        v10.i256 = sub v9 v5;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_647a v1 v10;
-        v12.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_08db v1;
-        v13.i256 = mload v2 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_3ff5 v1 v13;
-        v15.i256 = mload v2 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_0d08 v1 v15;
+        v10.i256 = call %core__lib__abi__trait_AbiSize__payload_size__g67a8_7cab v0;
+        v11.i256 = mload v6 i256;
+        v12.i256 = mload v5 i256;
+        v13.i256 = mload v4 i256;
+        v14.i256 = sub v13 v12;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_at_9d2f v1 v11 v14;
+        v17.i256 = mload v4 i256;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_3ff5 v1 v17;
+        v19.i256 = mload v4 i256;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_0d08 v1 v19;
         call %impl_trait_Address__encode__g426c v0 v1;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_3ff5 v1 v5;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_0d08 v1 v12;
-        v20.i256 = mload v2 i256;
-        v21.i256 = add v20 v8;
-        mstore v2 v21 i256;
+        v22.i256 = mload v5 i256;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_3ff5 v1 v22;
+        v24.i256 = mload v4 i256;
+        v25.i256 = add v24 v10;
+        mstore v4 v25 i256;
         return;
 
     block3:
@@ -479,44 +476,48 @@ func private %encode_field__gf6b4(v0.@layout_0, v1.objref<@layout_2>, v2.i256) {
         br 1.i1 block5 block6;
 
     block5:
-        v24.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_08db v1;
-        call %std__lib__evm__effects__impl_trait_Address_ed76__encode_to_ptr__gf13e_8bc3 v0 v24;
-        v28.i256 = add v24 32.i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_0d08 v1 v28;
+        v27.i256 = mload v6 i256;
+        call %std__lib__evm__effects__impl_trait_Address_ed76__encode_to_ptr__gf13e_8bc3 v0 v27;
         return;
 
     block6:
         jump block7;
 
     block7:
+        v30.i256 = mload v6 i256;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_0d08 v1 v30;
         call %impl_trait_Address__encode__g426c v0 v1;
         return;
 }
 
-func private %encode_field__g2e64(v0.i256, v1.objref<@layout_2>, v2.i256) {
+func inline(always) private %encode_field_at__g2e64(v0.i256, v1.objref<@layout_2>, v2.i256, v3.i256, v4.i256) {
     block0:
+        v5.*i256 = alloca i256;
+        v6.*i256 = alloca i256;
+        mstore v5 v2 i256;
+        mstore v6 v3 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v5.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_8e95_0 v1;
-        v8.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_7c20 v0;
-        v9.i256 = mload v2 i256;
-        v10.i256 = sub v9 v5;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_647a_0 v1 v10;
-        v12.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_08db_0 v1;
-        v13.i256 = mload v2 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_3ff5_0 v1 v13;
-        v15.i256 = mload v2 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_0d08_0 v1 v15;
+        v10.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_7c20 v0;
+        v11.i256 = mload v6 i256;
+        v12.i256 = mload v5 i256;
+        v13.i256 = mload v4 i256;
+        v14.i256 = sub v13 v12;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_at_9d2f_0 v1 v11 v14;
+        v17.i256 = mload v4 i256;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_3ff5_0 v1 v17;
+        v19.i256 = mload v4 i256;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_0d08_0 v1 v19;
         call %impl_trait_u256__encode__g426c v0 v1;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_3ff5_0 v1 v5;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_0d08_0 v1 v12;
-        v20.i256 = mload v2 i256;
-        v21.i256 = add v20 v8;
-        mstore v2 v21 i256;
+        v22.i256 = mload v5 i256;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_3ff5_0 v1 v22;
+        v24.i256 = mload v4 i256;
+        v25.i256 = add v24 v10;
+        mstore v4 v25 i256;
         return;
 
     block3:
@@ -526,16 +527,16 @@ func private %encode_field__g2e64(v0.i256, v1.objref<@layout_2>, v2.i256) {
         br 1.i1 block5 block6;
 
     block5:
-        v24.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_08db_0 v1;
-        call %core__lib__abi__impl_trait_u256_d99e__encode_to_ptr__gf13e_3ddf v0 v24;
-        v28.i256 = add v24 32.i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_0d08_0 v1 v28;
+        v27.i256 = mload v6 i256;
+        call %core__lib__abi__impl_trait_u256_d99e__encode_to_ptr__gf13e_3ddf v0 v27;
         return;
 
     block6:
         jump block7;
 
     block7:
+        v30.i256 = mload v6 i256;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_0d08_0 v1 v30;
         call %impl_trait_u256__encode__g426c v0 v1;
         return;
 }
@@ -550,7 +551,7 @@ func private %encode_single_root(v0.@layout_1, v1.objref<@layout_2>) {
         v6.i256 = add v4 64.i256;
         mstore v2 v6 i256;
         v7.i256 = ptr_to_int v2 i256;
-        call %encode_field__g189a v0 v1 v7;
+        call %encode_field v0 v1 v7;
         return;
 }
 
@@ -760,13 +761,8 @@ func private %impl_SolEncoder__new(v0.i256) -> @layout_2 {
 
     block4:
         v8.i256 = phi (0.i256 block2) (v7 block3);
-        v9.objref<@layout_2> = obj.alloc @layout_2;
-        v10.objref<i256> = obj.proj v9 0.i256;
-        obj.store v10 v8;
-        v12.objref<i256> = obj.proj v9 1.i256;
-        obj.store v12 v8;
-        v13.@layout_2 = obj.load v9;
-        return v13;
+        v9.@layout_2 = call %at v8;
+        return v9;
 }
 
 func private %core__lib__abi__trait_AbiSize__payload_size__g67a8_75f0(v0.@layout_0) -> i256 {
@@ -823,77 +819,35 @@ func private %core__lib__abi__trait_AbiSize__payload_size__ge513_c169_0(v0.i256)
         return 32.i256;
 }
 
-func private %core__lib__abi__impl_trait____ccb6__payload_size__g6d15_e33b(v0.@layout_1) -> i256 {
+func inline(always) private %core__lib__abi__impl_trait____ccb6__payload_size__g6d15_e33b(v0.@layout_1) -> i256 {
     block0:
         jump block1;
 
     block1:
         v4.i256 = extract_value v0 0.i256;
         v5.i256 = call %core__lib__abi__dynamic_payload_size__ge513_f973 v4;
-        (v6.i256, v7.i1) = uaddo 64.i256 v5;
-        br v7 block2 block3;
-
-    block2:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block3:
-        v14.@layout_0 = extract_value v0 1.i256;
-        v15.i256 = call %core__lib__abi__dynamic_payload_size__g67a8_baae v14;
-        (v16.i256, v17.i1) = uaddo v6 v15;
-        br v17 block2 block4;
-
-    block4:
-        return v16;
+        v6.i256 = add 64.i256 v5;
+        v8.@layout_0 = extract_value v0 1.i256;
+        v9.i256 = call %core__lib__abi__dynamic_payload_size__g67a8_baae v8;
+        v10.i256 = add v6 v9;
+        return v10;
 }
 
-func private %core__lib__abi__impl_trait____ccb6__payload_size__g6d15_e33b_0(v0.@layout_1) -> i256 {
+func inline(always) private %core__lib__abi__impl_trait____ccb6__payload_size__g6d15_e33b_0(v0.@layout_1) -> i256 {
     block0:
         jump block1;
 
     block1:
         v4.i256 = extract_value v0 0.i256;
         v5.i256 = call %core__lib__abi__dynamic_payload_size__ge513_f973_0 v4;
-        (v6.i256, v7.i1) = uaddo 64.i256 v5;
-        br v7 block2 block3;
-
-    block2:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block3:
-        v14.@layout_0 = extract_value v0 1.i256;
-        v15.i256 = call %core__lib__abi__dynamic_payload_size__g67a8_baae_0 v14;
-        (v16.i256, v17.i1) = uaddo v6 v15;
-        br v17 block2 block4;
-
-    block4:
-        return v16;
+        v6.i256 = add 64.i256 v5;
+        v8.@layout_0 = extract_value v0 1.i256;
+        v9.i256 = call %core__lib__abi__dynamic_payload_size__g67a8_baae_0 v8;
+        v10.i256 = add v6 v9;
+        return v10;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_08db(v0.objref<@layout_2>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 1.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_08db_0(v0.objref<@layout_2>) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v3.objref<i256> = obj.proj v0 1.i256;
-        v4.i256 = obj.load v3;
-        return v4;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_d646(v0.objref<@layout_2>) -> i256 {
+func private %pos(v0.objref<@layout_2>) -> i256 {
     block0:
         jump block1;
 
@@ -982,6 +936,19 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_0d08_0(v0.
         return;
 }
 
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_0d08_1(v0.objref<@layout_2>, v1.i256) {
+    block0:
+        v2.*i256 = alloca i256;
+        mstore v2 v1 i256;
+        jump block1;
+
+    block1:
+        v3.i256 = mload v2 i256;
+        v6.objref<i256> = obj.proj v0 1.i256;
+        obj.store v6 v3;
+        return;
+}
+
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_516e(v0.objref<@layout_2>, v1.i256) {
     block0:
         v2.*i256 = alloca i256;
@@ -1057,40 +1024,6 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_4363(v0
         return;
 }
 
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_647a(v0.objref<@layout_2>, v1.i256) {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v5.objref<i256> = obj.proj v0 1.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        mstore v6 v7 i256;
-        v10.i256 = add v6 32.i256;
-        v11.objref<i256> = obj.proj v0 1.i256;
-        obj.store v11 v10;
-        return;
-}
-
-func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_647a_0(v0.objref<@layout_2>, v1.i256) {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v5.objref<i256> = obj.proj v0 1.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        mstore v6 v7 i256;
-        v10.i256 = add v6 32.i256;
-        v11.objref<i256> = obj.proj v0 1.i256;
-        obj.store v11 v10;
-        return;
-}
-
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_a864(v0.objref<@layout_2>, v1.i256) {
     block0:
         v2.*i256 = alloca i256;
@@ -1105,6 +1038,36 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_a864(v0
         v10.i256 = add v6 32.i256;
         v11.objref<i256> = obj.proj v0 1.i256;
         obj.store v11 v10;
+        return;
+}
+
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_at_9d2f(v0.objref<@layout_2>, v1.i256, v2.i256) {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v3 i256;
+        v6.i256 = mload v4 i256;
+        mstore v5 v6 i256;
+        return;
+}
+
+func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_at_9d2f_0(v0.objref<@layout_2>, v1.i256, v2.i256) {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v3 i256;
+        v6.i256 = mload v4 i256;
+        mstore v5 v6 i256;
         return;
 }
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/tuple_return_contract.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/tuple_return_contract.snap
@@ -201,7 +201,7 @@ func inline(always) private %decode_from(v0.@layout_3, v1.i256) {
         return;
 }
 
-func inline(always) private %decode_from_checked_head(v0.@layout_3, v1.i256, v2.i256) {
+func inline(always) private %decode_from_prechecked_head(v0.@layout_3, v1.i256, v2.i256) {
     block0:
         v3.*i256 = alloca i256;
         v4.*i256 = alloca i256;
@@ -239,7 +239,7 @@ func inline(always) private %decode_runtime_args(v0.objref<@layout_5>) {
 
     block4:
         v11.i256 = mload v1 i256;
-        call %decode_from_checked_head v4 4.i256 v11;
+        call %decode_from_prechecked_head v4 4.i256 v11;
         return;
 
     block5:

--- a/crates/codegen/tests/fixtures/sonatina_ir/tuple_return_contract.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/tuple_return_contract.snap
@@ -9,11 +9,9 @@ type @layout_0 = {i256};
 type @layout_1 = {i256, @layout_0};
 type @layout_2 = {i256, i256};
 type @layout_3 = {i256};
-type @layout_4 = {@layout_3, i256};
-type @layout_5 = {@layout_4, i256};
-type @layout_6 = {};
-type @layout_7 = {@layout_6};
-type @layout_8 = {i256, i256};
+type @layout_4 = {};
+type @layout_5 = {@layout_4};
+type @layout_6 = {i256, i256};
 
 global private const @layout_3 $const_region_0 = {0};
 global private const @layout_0 $const_region_1 = {0};
@@ -69,6 +67,15 @@ func private %abi_single_root_size(v0.@layout_1) -> i256 {
     block1:
         v2.i256 = call %abi_field_size v0;
         return v2;
+}
+
+func private %abort() {
+    block0:
+        jump block1;
+
+    block1:
+        call %revert 0.i256 0.i256;
+        unreachable;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_8e95(v0.objref<@layout_2>) -> i256 {
@@ -154,10 +161,10 @@ func private %contract_recv_abi_TupleReturnContract_1() {
         evm_revert 0.i256 0.i256;
 
     block3:
-        v5.objref<@layout_7> = obj.alloc @layout_7;
+        v5.objref<@layout_5> = obj.alloc @layout_5;
         call %decode_runtime_args v5;
         v7.@layout_1 = call %__TupleReturnContract_recv_0_0;
-        v8.@layout_8 = call %encode_single_root_alloc v7;
+        v8.@layout_6 = call %encode_single_root_alloc v7;
         v9.i256 = extract_value v8 0.i256;
         v11.i256 = extract_value v8 1.i256;
         evm_return v9 v11;
@@ -186,48 +193,71 @@ func private %contract_runtime_root_TupleReturnContract() {
         unreachable;
 }
 
-func inline(always) private %decode_payload(v0.objref<@layout_5>) {
-    block0:
-        jump block1;
-
-    block1:
-        return;
-}
-
-func inline(always) private %decode_runtime_args(v0.objref<@layout_7>) {
-    block0:
-        jump block1;
-
-    block1:
-        v1.@layout_5 = call %runtime_decoder;
-        v2.objref<@layout_5> = obj.alloc @layout_5;
-        v4.objref<@layout_4> = obj.proj v2 0.i256;
-        v5.@layout_4 = extract_value v1 0.i256;
-        v6.objref<@layout_3> = obj.proj v4 0.i256;
-        v7.@layout_3 = extract_value v5 0.i256;
-        v8.objref<i256> = obj.proj v6 0.i256;
-        v9.i256 = extract_value v7 0.i256;
-        obj.store v8 v9;
-        v11.objref<i256> = obj.proj v4 1.i256;
-        v12.i256 = extract_value v5 1.i256;
-        obj.store v11 v12;
-        v13.objref<i256> = obj.proj v2 1.i256;
-        v14.i256 = extract_value v1 1.i256;
-        obj.store v13 v14;
-        call %decode_payload v2;
-        return;
-}
-
-func private %decoder_with_base(v0.@layout_3, v1.i256) -> @layout_5 {
+func inline(always) private %decode_from(v0.@layout_3, v1.i256) {
     block0:
         v2.*i256 = alloca i256;
         mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v5.@layout_5 = call %with_base v0 v3;
-        return v5;
+        return;
+}
+
+func inline(always) private %decode_runtime_args(v0.objref<@layout_5>) {
+    block0:
+        v1.*i256 = alloca i256;
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v5.@layout_3 = call %input;
+        v7.i256 = call %len v5;
+        mstore v1 v7 i256;
+        v8.i256 = mload v1 i256;
+        mstore v2 v8 i256;
+        v9.i256 = mload v2 i256;
+        v10.i1 = gt 4.i256 v9;
+        br v10 block2 block3;
+
+    block2:
+        call %abort;
+        unreachable;
+
+    block3:
+        jump block4;
+
+    block4:
+        br 1.i1 block5 block6;
+
+    block5:
+        mstore v3 4.i256 i256;
+        br 0.i1 block8 block11;
+
+    block6:
+        jump block7;
+
+    block7:
+        call %decode_from v5 4.i256;
+        return;
+
+    block8:
+        call %abort;
+        unreachable;
+
+    block9:
+        jump block10;
+
+    block10:
+        jump block7;
+
+    block11:
+        v17.i256 = mload v1 i256;
+        mstore v4 v17 i256;
+        v19.i256 = mload v4 i256;
+        v20.i1 = gt 4.i256 v19;
+        br v20 block8 block9;
 }
 
 func private %core__lib__abi__dynamic_payload_size__g67a8_baae(v0.@layout_0) -> i256 {
@@ -524,7 +554,7 @@ func private %encode_single_root(v0.@layout_1, v1.objref<@layout_2>) {
         return;
 }
 
-func private %encode_single_root_alloc(v0.@layout_1) -> @layout_8 {
+func private %encode_single_root_alloc(v0.@layout_1) -> @layout_6 {
     block0:
         jump block1;
 
@@ -540,12 +570,12 @@ func private %encode_single_root_alloc(v0.@layout_1) -> @layout_8 {
         obj.store v9 v10;
         v11.i256 = call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_a403 v4;
         call %encode_single_root v0 v4;
-        v13.objref<@layout_8> = obj.alloc @layout_8;
+        v13.objref<@layout_6> = obj.alloc @layout_6;
         v14.objref<i256> = obj.proj v13 0.i256;
         obj.store v14 v11;
         v15.objref<i256> = obj.proj v13 1.i256;
         obj.store v15 v2;
-        v16.@layout_8 = obj.load v13;
+        v16.@layout_6 = obj.load v13;
         return v16;
 }
 
@@ -649,26 +679,6 @@ func private %encoder_new(v0.i256) -> @layout_2 {
         return v3;
 }
 
-func inline(always) private %fork(v0.@layout_4, v1.i256) -> @layout_4 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v5.@layout_3 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.objref<@layout_4> = obj.alloc @layout_4;
-        v8.objref<@layout_3> = obj.proj v7 0.i256;
-        v9.objref<i256> = obj.proj v8 0.i256;
-        v10.i256 = extract_value v5 0.i256;
-        obj.store v9 v10;
-        v12.objref<i256> = obj.proj v7 1.i256;
-        obj.store v12 v6;
-        v13.@layout_4 = obj.load v7;
-        return v13;
-}
-
 func private %input() -> @layout_3 {
     block0:
         jump block1;
@@ -676,6 +686,44 @@ func private %input() -> @layout_3 {
     block1:
         v0.@layout_3 = call %impl_CallData__new;
         return v0;
+}
+
+func inline(always) private %len(v0.@layout_3) -> i256 {
+    block0:
+        v1.*i256 = alloca i256;
+        v2.*i256 = alloca i256;
+        jump block1;
+
+    block1:
+        v3.i256 = evm_calldata_size;
+        mstore v1 v3 i256;
+        v6.i256 = extract_value v0 0.i256;
+        v7.i256 = mload v1 i256;
+        mstore v2 v7 i256;
+        v8.i256 = mload v2 i256;
+        v9.i1 = gt v6 v8;
+        br v9 block2 block3;
+
+    block2:
+        jump block4;
+
+    block3:
+        v11.i256 = extract_value v0 0.i256;
+        v12.i256 = mload v1 i256;
+        (v13.i256, v14.i1) = usubo v12 v11;
+        br v14 block5 block6;
+
+    block4:
+        v19.i256 = phi (0.i256 block2) (v13 block6);
+        return v19;
+
+    block5:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block6:
+        jump block4;
 }
 
 func inline(always) private %impl_CallData__new() -> @layout_3 {
@@ -688,22 +736,6 @@ func inline(always) private %impl_CallData__new() -> @layout_3 {
         obj.init.const v2 v1;
         v3.@layout_3 = obj.load v2;
         return v3;
-}
-
-func inline(always) private %new__gd20d(v0.@layout_3) -> @layout_4 {
-    block0:
-        jump block1;
-
-    block1:
-        v2.objref<@layout_4> = obj.alloc @layout_4;
-        v4.objref<@layout_3> = obj.proj v2 0.i256;
-        v5.objref<i256> = obj.proj v4 0.i256;
-        v6.i256 = extract_value v0 0.i256;
-        obj.store v5 v6;
-        v8.objref<i256> = obj.proj v2 1.i256;
-        obj.store v8 0.i256;
-        v9.@layout_4 = obj.load v2;
-        return v9;
 }
 
 func private %impl_SolEncoder__new(v0.i256) -> @layout_2 {
@@ -871,14 +903,18 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_d646(v0.objref
         return v4;
 }
 
-func inline(always) private %runtime_decoder() -> @layout_5 {
+func private %revert(v0.i256, v1.i256) {
     block0:
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        mstore v2 v0 i256;
+        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v0.@layout_3 = call %input;
-        v2.@layout_5 = call %decoder_with_base v0 4.i256;
-        return v2;
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v3 i256;
+        evm_revert v4 v5;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_3ff5(v0.objref<@layout_2>, v1.i256) {
@@ -1002,33 +1038,6 @@ func private %std__lib__abi__sol__impl_trait_Sol_1f5f__store_word_5688(v0.i256, 
         v5.i256 = mload v3 i256;
         mstore v4 v5 i256;
         return;
-}
-
-func inline(always) private %with_base(v0.@layout_3, v1.i256) -> @layout_5 {
-    block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
-        jump block1;
-
-    block1:
-        v4.@layout_4 = call %new__gd20d v0;
-        v5.i256 = mload v2 i256;
-        v6.@layout_4 = call %fork v4 v5;
-        v7.i256 = mload v2 i256;
-        v8.objref<@layout_5> = obj.alloc @layout_5;
-        v10.objref<@layout_4> = obj.proj v8 0.i256;
-        v11.objref<@layout_3> = obj.proj v10 0.i256;
-        v12.@layout_3 = extract_value v6 0.i256;
-        v13.objref<i256> = obj.proj v11 0.i256;
-        v14.i256 = extract_value v12 0.i256;
-        obj.store v13 v14;
-        v16.objref<i256> = obj.proj v10 1.i256;
-        v17.i256 = extract_value v6 1.i256;
-        obj.store v16 v17;
-        v18.objref<i256> = obj.proj v8 1.i256;
-        obj.store v18 v7;
-        v19.@layout_5 = obj.load v8;
-        return v19;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_4363(v0.objref<@layout_2>, v1.i256) {

--- a/crates/codegen/tests/fixtures/sonatina_ir/tuple_return_contract.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/tuple_return_contract.snap
@@ -201,23 +201,34 @@ func inline(always) private %decode_from(v0.@layout_3, v1.i256) {
         return;
 }
 
+func inline(always) private %decode_from_checked_head(v0.@layout_3, v1.i256, v2.i256) {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        mstore v3 v1 i256;
+        mstore v4 v2 i256;
+        jump block1;
+
+    block1:
+        v5.i256 = mload v4 i256;
+        v7.i256 = mload v3 i256;
+        call %decode_from v0 v7;
+        return;
+}
+
 func inline(always) private %decode_runtime_args(v0.objref<@layout_5>) {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
         v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v5.@layout_3 = call %input;
-        v7.i256 = call %len v5;
-        mstore v1 v7 i256;
-        v8.i256 = mload v1 i256;
-        mstore v2 v8 i256;
-        v9.i256 = mload v2 i256;
-        v10.i1 = gt 4.i256 v9;
-        br v10 block2 block3;
+        v4.@layout_3 = call %input;
+        v6.i256 = call %len v4;
+        mstore v1 v6 i256;
+        mstore v2 4.i256 i256;
+        br 0.i1 block2 block5;
 
     block2:
         call %abort;
@@ -227,35 +238,16 @@ func inline(always) private %decode_runtime_args(v0.objref<@layout_5>) {
         jump block4;
 
     block4:
-        br 1.i1 block5 block6;
-
-    block5:
-        mstore v3 4.i256 i256;
-        br 0.i1 block8 block11;
-
-    block6:
-        jump block7;
-
-    block7:
-        call %decode_from v5 4.i256;
+        v11.i256 = mload v1 i256;
+        call %decode_from_checked_head v4 4.i256 v11;
         return;
 
-    block8:
-        call %abort;
-        unreachable;
-
-    block9:
-        jump block10;
-
-    block10:
-        jump block7;
-
-    block11:
-        v17.i256 = mload v1 i256;
-        mstore v4 v17 i256;
-        v19.i256 = mload v4 i256;
-        v20.i1 = gt 4.i256 v19;
-        br v20 block8 block9;
+    block5:
+        v13.i256 = mload v1 i256;
+        mstore v3 v13 i256;
+        v15.i256 = mload v3 i256;
+        v16.i1 = gt 4.i256 v15;
+        br v16 block2 block3;
 }
 
 func private %core__lib__abi__dynamic_payload_size__g67a8_baae(v0.@layout_0) -> i256 {

--- a/crates/contract-harness/src/lib.rs
+++ b/crates/contract-harness/src/lib.rs
@@ -2023,6 +2023,25 @@ pub contract NestedTupleInit {
 "#
     }
 
+    fn tuple_head_guard_contract_source() -> &'static str {
+        r#"
+use std::abi::sol
+
+msg TupleHeadGuardMsg {
+    #[selector = sol("read((uint64,string))")]
+    Read { pair: (u64, Text) } -> u256,
+}
+
+pub contract TupleHeadGuard {
+    recv TupleHeadGuardMsg {
+        Read { pair } -> u256 {
+            (pair.0 as u256) + pair.1.len()
+        }
+    }
+}
+"#
+    }
+
     fn compile_nested_tuple_echo_contract() -> Option<FeContractHarness> {
         Some(
             FeContractHarness::compile_from_source(
@@ -2053,6 +2072,17 @@ pub contract NestedTupleInit {
                 CompileOptions::default(),
             )
             .expect("nested tuple init contract should compile"),
+        )
+    }
+
+    fn compile_tuple_head_guard_contract() -> Option<FeContractHarness> {
+        Some(
+            FeContractHarness::compile_from_source(
+                "TupleHeadGuard",
+                tuple_head_guard_contract_source(),
+                CompileOptions::default(),
+            )
+            .expect("tuple head guard contract should compile"),
         )
     }
 
@@ -3422,6 +3452,35 @@ pub contract FixedDynamicArrayBoundary {{
         let decoded = decode(&[nested_tuple_param_type()], &result.return_data)
             .expect("callEcho(address,(string,uint64)) should return ABI-encoded outputs");
         assert_eq!(decoded, vec![nested_tuple_token(&text, 9)]);
+    }
+
+    #[test]
+    fn truncated_dynamic_tuple_head_reverts_before_padded_offset_read() {
+        let Some(harness) = compile_tuple_head_guard_contract() else {
+            return;
+        };
+
+        let mut instance = harness
+            .deploy_with_init()
+            .expect("tuple head guard contract should deploy");
+        let mut call = encode_typed_function_call(
+            "read",
+            vec![ParamType::Tuple(vec![
+                ParamType::Uint(64),
+                ParamType::String,
+            ])],
+            &[Token::Tuple(vec![
+                Token::Uint(AbiU256::from(0u64)),
+                Token::String("missing-head".to_string()),
+            ])],
+        )
+        .expect("typed calldata should encode");
+
+        call.truncate(4 + 32 + 32);
+        let err = instance
+            .call_raw(&call, ExecutionOptions::default())
+            .expect_err("truncated tuple head should revert");
+        assert_empty_revert(err);
     }
 
     #[test]

--- a/crates/fe/tests/differential_deposit/gas_report.snap
+++ b/crates/fe/tests/differential_deposit/gas_report.snap
@@ -5,20 +5,20 @@ expression: report
 bytecode size
 path         fe-O2        sol     sol-IR    fe vs sol-IR
 ------------------------------------------------------------
-init          4993       4819       3082  +1911 (+62.0%)
-runtime       4829       4445       2844  +1985 (+69.8%)
+init          4985       4819       3082  +1903 (+61.7%)
+runtime       4821       4445       2844  +1977 (+69.5%)
 
 deployment gas
 path        fe-O2        sol     sol-IR      fe vs sol-IR
 -------------------------------------------------------------
-deploy    1792376    1738847    1379411  +412965 (+29.9%)
+deploy    1790646    1738847    1379411  +411235 (+29.8%)
 
 call gas
 path                            fe-O2        sol     sol-IR   fe vs sol-IR
 ------------------------------------------------------------------------------
-supportsInterface(erc165)       21663      21603      21600    +63 (+0.3%)
-supportsInterface(deposit)      21691      21641      21600    +91 (+0.4%)
-supportsInterface(unknown)      21678      21641      21600    +78 (+0.4%)
+supportsInterface(erc165)       21641      21603      21600    +41 (+0.2%)
+supportsInterface(deposit)      21669      21641      21600    +69 (+0.3%)
+supportsInterface(unknown)      21656      21641      21600    +56 (+0.3%)
 get_deposit_root(empty)        107925     117558     109178  -1253 (-1.1%)
 get_deposit_count(empty)        23793      24510      24099   -306 (-1.3%)
 deposit#0                       81539      84626      81089   +450 (+0.6%)
@@ -30,4 +30,4 @@ get_deposit_count(after#1)      23793      24510      24099   -306 (-1.3%)
 deposit#2                       47327      50414      46877   +450 (+1.0%)
 get_deposit_root(after#2)      107951     117582     109170  -1219 (-1.1%)
 get_deposit_count(after#2)      23793      24510      24099   -306 (-1.3%)
-TOTAL                          787804     838656     792487  -4683 (-0.6%)
+TOTAL                          787738     838656     792487  -4749 (-0.6%)

--- a/crates/fe/tests/differential_deposit/gas_report.snap
+++ b/crates/fe/tests/differential_deposit/gas_report.snap
@@ -5,29 +5,29 @@ expression: report
 bytecode size
 path         fe-O2        sol     sol-IR    fe vs sol-IR
 ------------------------------------------------------------
-init          5393       4819       3082  +2311 (+75.0%)
-runtime       5214       4445       2844  +2370 (+83.3%)
+init          5248       4819       3082  +2166 (+70.3%)
+runtime       5064       4445       2844  +2220 (+78.1%)
 
 deployment gas
 path        fe-O2        sol     sol-IR      fe vs sol-IR
 -------------------------------------------------------------
-deploy    1874777    1738847    1379411  +495366 (+35.9%)
+deploy    1843145    1738847    1379411  +463734 (+33.6%)
 
 call gas
 path                            fe-O2        sol     sol-IR   fe vs sol-IR
 ------------------------------------------------------------------------------
-supportsInterface(erc165)       21800      21603      21600   +200 (+0.9%)
-supportsInterface(deposit)      21828      21641      21600   +228 (+1.1%)
-supportsInterface(unknown)      21815      21641      21600   +215 (+1.0%)
-get_deposit_root(empty)        107882     117558     109178  -1296 (-1.2%)
-get_deposit_count(empty)        23750      24510      24099   -349 (-1.4%)
-deposit#0                       82982      84626      81089  +1893 (+2.3%)
-get_deposit_root(after#0)      107895     117570     109174  -1279 (-1.2%)
-get_deposit_count(after#0)      23750      24510      24099   -349 (-1.4%)
-deposit#1                       68424      70411      66629  +1795 (+2.7%)
-get_deposit_root(after#1)      107895     117570     109174  -1279 (-1.2%)
-get_deposit_count(after#1)      23750      24510      24099   -349 (-1.4%)
-deposit#2                       48770      50414      46877  +1893 (+4.0%)
-get_deposit_root(after#2)      107908     117582     109170  -1262 (-1.2%)
-get_deposit_count(after#2)      23750      24510      24099   -349 (-1.4%)
-TOTAL                          792199     838656     792487   -288 (-0.0%)
+supportsInterface(erc165)       21644      21603      21600    +44 (+0.2%)
+supportsInterface(deposit)      21672      21641      21600    +72 (+0.3%)
+supportsInterface(unknown)      21659      21641      21600    +59 (+0.3%)
+get_deposit_root(empty)        107906     117558     109178  -1272 (-1.2%)
+get_deposit_count(empty)        23774      24510      24099   -325 (-1.3%)
+deposit#0                       82969      84626      81089  +1880 (+2.3%)
+get_deposit_root(after#0)      107919     117570     109174  -1255 (-1.1%)
+get_deposit_count(after#0)      23774      24510      24099   -325 (-1.3%)
+deposit#1                       68411      70411      66629  +1782 (+2.7%)
+get_deposit_root(after#1)      107919     117570     109174  -1255 (-1.1%)
+get_deposit_count(after#1)      23774      24510      24099   -325 (-1.3%)
+deposit#2                       48757      50414      46877  +1880 (+4.0%)
+get_deposit_root(after#2)      107932     117582     109170  -1238 (-1.1%)
+get_deposit_count(after#2)      23774      24510      24099   -325 (-1.3%)
+TOTAL                          791884     838656     792487   -603 (-0.1%)

--- a/crates/fe/tests/differential_deposit/gas_report.snap
+++ b/crates/fe/tests/differential_deposit/gas_report.snap
@@ -5,29 +5,29 @@ expression: report
 bytecode size
 path         fe-O2        sol     sol-IR    fe vs sol-IR
 ------------------------------------------------------------
-init          5050       4819       3082  +1968 (+63.9%)
-runtime       4866       4445       2844  +2022 (+71.1%)
+init          4993       4819       3082  +1911 (+62.0%)
+runtime       4829       4445       2844  +1985 (+69.8%)
 
 deployment gas
 path        fe-O2        sol     sol-IR      fe vs sol-IR
 -------------------------------------------------------------
-deploy    1801057    1738847    1379411  +421646 (+30.6%)
+deploy    1792376    1738847    1379411  +412965 (+29.9%)
 
 call gas
 path                            fe-O2        sol     sol-IR   fe vs sol-IR
 ------------------------------------------------------------------------------
-supportsInterface(erc165)       21635      21603      21600    +35 (+0.2%)
-supportsInterface(deposit)      21663      21641      21600    +63 (+0.3%)
-supportsInterface(unknown)      21650      21641      21600    +50 (+0.2%)
-get_deposit_root(empty)        107897     117558     109178  -1281 (-1.2%)
-get_deposit_count(empty)        23764      24510      24099   -335 (-1.4%)
-deposit#0                       81559      84626      81089   +470 (+0.6%)
-get_deposit_root(after#0)      107910     117570     109174  -1264 (-1.2%)
-get_deposit_count(after#0)      23764      24510      24099   -335 (-1.4%)
-deposit#1                       67002      70411      66629   +373 (+0.6%)
-get_deposit_root(after#1)      107910     117570     109174  -1264 (-1.2%)
-get_deposit_count(after#1)      23764      24510      24099   -335 (-1.4%)
-deposit#2                       47347      50414      46877   +470 (+1.0%)
-get_deposit_root(after#2)      107923     117582     109170  -1247 (-1.1%)
-get_deposit_count(after#2)      23764      24510      24099   -335 (-1.4%)
-TOTAL                          787552     838656     792487  -4935 (-0.6%)
+supportsInterface(erc165)       21663      21603      21600    +63 (+0.3%)
+supportsInterface(deposit)      21691      21641      21600    +91 (+0.4%)
+supportsInterface(unknown)      21678      21641      21600    +78 (+0.4%)
+get_deposit_root(empty)        107925     117558     109178  -1253 (-1.1%)
+get_deposit_count(empty)        23793      24510      24099   -306 (-1.3%)
+deposit#0                       81539      84626      81089   +450 (+0.6%)
+get_deposit_root(after#0)      107938     117570     109174  -1236 (-1.1%)
+get_deposit_count(after#0)      23793      24510      24099   -306 (-1.3%)
+deposit#1                       66982      70411      66629   +353 (+0.5%)
+get_deposit_root(after#1)      107938     117570     109174  -1236 (-1.1%)
+get_deposit_count(after#1)      23793      24510      24099   -306 (-1.3%)
+deposit#2                       47327      50414      46877   +450 (+1.0%)
+get_deposit_root(after#2)      107951     117582     109170  -1219 (-1.1%)
+get_deposit_count(after#2)      23793      24510      24099   -306 (-1.3%)
+TOTAL                          787804     838656     792487  -4683 (-0.6%)

--- a/crates/fe/tests/differential_deposit/gas_report.snap
+++ b/crates/fe/tests/differential_deposit/gas_report.snap
@@ -5,13 +5,13 @@ expression: report
 bytecode size
 path         fe-O2        sol     sol-IR    fe vs sol-IR
 ------------------------------------------------------------
-init          5136       4819       3082  +2054 (+66.6%)
-runtime       4972       4445       2844  +2128 (+74.8%)
+init          5225       4819       3082  +2143 (+69.5%)
+runtime       5046       4445       2844  +2202 (+77.4%)
 
 deployment gas
 path        fe-O2        sol     sol-IR      fe vs sol-IR
 -------------------------------------------------------------
-deploy    1823761    1738847    1379411  +444350 (+32.2%)
+deploy    1840126    1738847    1379411  +460715 (+33.4%)
 
 call gas
 path                            fe-O2        sol     sol-IR   fe vs sol-IR
@@ -21,13 +21,13 @@ supportsInterface(deposit)      21672      21641      21600    +72 (+0.3%)
 supportsInterface(unknown)      21659      21641      21600    +59 (+0.3%)
 get_deposit_root(empty)        107906     117558     109178  -1272 (-1.2%)
 get_deposit_count(empty)        23774      24510      24099   -325 (-1.3%)
-deposit#0                       82086      84626      81089   +997 (+1.2%)
+deposit#0                       81603      84626      81089   +514 (+0.6%)
 get_deposit_root(after#0)      107919     117570     109174  -1255 (-1.1%)
 get_deposit_count(after#0)      23774      24510      24099   -325 (-1.3%)
-deposit#1                       67528      70411      66629   +899 (+1.3%)
+deposit#1                       67045      70411      66629   +416 (+0.6%)
 get_deposit_root(after#1)      107919     117570     109174  -1255 (-1.1%)
 get_deposit_count(after#1)      23774      24510      24099   -325 (-1.3%)
-deposit#2                       47874      50414      46877   +997 (+2.1%)
+deposit#2                       47391      50414      46877   +514 (+1.1%)
 get_deposit_root(after#2)      107932     117582     109170  -1238 (-1.1%)
 get_deposit_count(after#2)      23774      24510      24099   -325 (-1.3%)
-TOTAL                          789235     838656     792487  -3252 (-0.4%)
+TOTAL                          787786     838656     792487  -4701 (-0.6%)

--- a/crates/fe/tests/differential_deposit/gas_report.snap
+++ b/crates/fe/tests/differential_deposit/gas_report.snap
@@ -5,29 +5,29 @@ expression: report
 bytecode size
 path         fe-O2        sol     sol-IR    fe vs sol-IR
 ------------------------------------------------------------
-init          4985       4819       3082  +1903 (+61.7%)
-runtime       4821       4445       2844  +1977 (+69.5%)
+init          4633       4819       3082  +1551 (+50.3%)
+runtime       4467       4445       2844  +1623 (+57.1%)
 
 deployment gas
 path        fe-O2        sol     sol-IR      fe vs sol-IR
 -------------------------------------------------------------
-deploy    1790646    1738847    1379411  +411235 (+29.8%)
+deploy    1715464    1738847    1379411  +336053 (+24.4%)
 
 call gas
-path                            fe-O2        sol     sol-IR   fe vs sol-IR
-------------------------------------------------------------------------------
-supportsInterface(erc165)       21641      21603      21600    +41 (+0.2%)
-supportsInterface(deposit)      21669      21641      21600    +69 (+0.3%)
-supportsInterface(unknown)      21656      21641      21600    +56 (+0.3%)
-get_deposit_root(empty)        107925     117558     109178  -1253 (-1.1%)
-get_deposit_count(empty)        23793      24510      24099   -306 (-1.3%)
-deposit#0                       81539      84626      81089   +450 (+0.6%)
-get_deposit_root(after#0)      107938     117570     109174  -1236 (-1.1%)
-get_deposit_count(after#0)      23793      24510      24099   -306 (-1.3%)
-deposit#1                       66982      70411      66629   +353 (+0.5%)
-get_deposit_root(after#1)      107938     117570     109174  -1236 (-1.1%)
-get_deposit_count(after#1)      23793      24510      24099   -306 (-1.3%)
-deposit#2                       47327      50414      46877   +450 (+1.0%)
-get_deposit_root(after#2)      107951     117582     109170  -1219 (-1.1%)
-get_deposit_count(after#2)      23793      24510      24099   -306 (-1.3%)
-TOTAL                          787738     838656     792487  -4749 (-0.6%)
+path                            fe-O2        sol     sol-IR    fe vs sol-IR
+-------------------------------------------------------------------------------
+supportsInterface(erc165)       21606      21603      21600      +6 (+0.0%)
+supportsInterface(deposit)      21634      21641      21600     +34 (+0.2%)
+supportsInterface(unknown)      21621      21641      21600     +21 (+0.1%)
+get_deposit_root(empty)        105057     117558     109178   -4121 (-3.8%)
+get_deposit_count(empty)        23758      24510      24099    -341 (-1.4%)
+deposit#0                       80772      84626      81089    -317 (-0.4%)
+get_deposit_root(after#0)      105078     117570     109174   -4096 (-3.8%)
+get_deposit_count(after#0)      23758      24510      24099    -341 (-1.4%)
+deposit#1                       66214      70411      66629    -415 (-0.6%)
+get_deposit_root(after#1)      105078     117570     109174   -4096 (-3.8%)
+get_deposit_count(after#1)      23758      24510      24099    -341 (-1.4%)
+deposit#2                       46560      50414      46877    -317 (-0.7%)
+get_deposit_root(after#2)      105099     117582     109170   -4071 (-3.7%)
+get_deposit_count(after#2)      23758      24510      24099    -341 (-1.4%)
+TOTAL                          773751     838656     792487  -18736 (-2.4%)

--- a/crates/fe/tests/differential_deposit/gas_report.snap
+++ b/crates/fe/tests/differential_deposit/gas_report.snap
@@ -5,13 +5,13 @@ expression: report
 bytecode size
 path         fe-O2        sol     sol-IR    fe vs sol-IR
 ------------------------------------------------------------
-init          5202       4819       3082  +2120 (+68.8%)
-runtime       5038       4445       2844  +2194 (+77.1%)
+init          5136       4819       3082  +2054 (+66.6%)
+runtime       4972       4445       2844  +2128 (+74.8%)
 
 deployment gas
 path        fe-O2        sol     sol-IR      fe vs sol-IR
 -------------------------------------------------------------
-deploy    1838070    1738847    1379411  +458659 (+33.3%)
+deploy    1823761    1738847    1379411  +444350 (+32.2%)
 
 call gas
 path                            fe-O2        sol     sol-IR   fe vs sol-IR
@@ -21,13 +21,13 @@ supportsInterface(deposit)      21672      21641      21600    +72 (+0.3%)
 supportsInterface(unknown)      21659      21641      21600    +59 (+0.3%)
 get_deposit_root(empty)        107906     117558     109178  -1272 (-1.2%)
 get_deposit_count(empty)        23774      24510      24099   -325 (-1.3%)
-deposit#0                       82287      84626      81089  +1198 (+1.5%)
+deposit#0                       82086      84626      81089   +997 (+1.2%)
 get_deposit_root(after#0)      107919     117570     109174  -1255 (-1.1%)
 get_deposit_count(after#0)      23774      24510      24099   -325 (-1.3%)
-deposit#1                       67729      70411      66629  +1100 (+1.7%)
+deposit#1                       67528      70411      66629   +899 (+1.3%)
 get_deposit_root(after#1)      107919     117570     109174  -1255 (-1.1%)
 get_deposit_count(after#1)      23774      24510      24099   -325 (-1.3%)
-deposit#2                       48075      50414      46877  +1198 (+2.6%)
+deposit#2                       47874      50414      46877   +997 (+2.1%)
 get_deposit_root(after#2)      107932     117582     109170  -1238 (-1.1%)
 get_deposit_count(after#2)      23774      24510      24099   -325 (-1.3%)
-TOTAL                          789838     838656     792487  -2649 (-0.3%)
+TOTAL                          789235     838656     792487  -3252 (-0.4%)

--- a/crates/fe/tests/differential_deposit/gas_report.snap
+++ b/crates/fe/tests/differential_deposit/gas_report.snap
@@ -5,13 +5,13 @@ expression: report
 bytecode size
 path         fe-O2        sol     sol-IR    fe vs sol-IR
 ------------------------------------------------------------
-init          5248       4819       3082  +2166 (+70.3%)
-runtime       5064       4445       2844  +2220 (+78.1%)
+init          5202       4819       3082  +2120 (+68.8%)
+runtime       5038       4445       2844  +2194 (+77.1%)
 
 deployment gas
 path        fe-O2        sol     sol-IR      fe vs sol-IR
 -------------------------------------------------------------
-deploy    1843145    1738847    1379411  +463734 (+33.6%)
+deploy    1838070    1738847    1379411  +458659 (+33.3%)
 
 call gas
 path                            fe-O2        sol     sol-IR   fe vs sol-IR
@@ -21,13 +21,13 @@ supportsInterface(deposit)      21672      21641      21600    +72 (+0.3%)
 supportsInterface(unknown)      21659      21641      21600    +59 (+0.3%)
 get_deposit_root(empty)        107906     117558     109178  -1272 (-1.2%)
 get_deposit_count(empty)        23774      24510      24099   -325 (-1.3%)
-deposit#0                       82969      84626      81089  +1880 (+2.3%)
+deposit#0                       82287      84626      81089  +1198 (+1.5%)
 get_deposit_root(after#0)      107919     117570     109174  -1255 (-1.1%)
 get_deposit_count(after#0)      23774      24510      24099   -325 (-1.3%)
-deposit#1                       68411      70411      66629  +1782 (+2.7%)
+deposit#1                       67729      70411      66629  +1100 (+1.7%)
 get_deposit_root(after#1)      107919     117570     109174  -1255 (-1.1%)
 get_deposit_count(after#1)      23774      24510      24099   -325 (-1.3%)
-deposit#2                       48757      50414      46877  +1880 (+4.0%)
+deposit#2                       48075      50414      46877  +1198 (+2.6%)
 get_deposit_root(after#2)      107932     117582     109170  -1238 (-1.1%)
 get_deposit_count(after#2)      23774      24510      24099   -325 (-1.3%)
-TOTAL                          791884     838656     792487   -603 (-0.1%)
+TOTAL                          789838     838656     792487  -2649 (-0.3%)

--- a/crates/fe/tests/differential_deposit/gas_report.snap
+++ b/crates/fe/tests/differential_deposit/gas_report.snap
@@ -5,29 +5,29 @@ expression: report
 bytecode size
 path         fe-O2        sol     sol-IR    fe vs sol-IR
 ------------------------------------------------------------
-init          5225       4819       3082  +2143 (+69.5%)
-runtime       5046       4445       2844  +2202 (+77.4%)
+init          5050       4819       3082  +1968 (+63.9%)
+runtime       4866       4445       2844  +2022 (+71.1%)
 
 deployment gas
 path        fe-O2        sol     sol-IR      fe vs sol-IR
 -------------------------------------------------------------
-deploy    1840126    1738847    1379411  +460715 (+33.4%)
+deploy    1801057    1738847    1379411  +421646 (+30.6%)
 
 call gas
 path                            fe-O2        sol     sol-IR   fe vs sol-IR
 ------------------------------------------------------------------------------
-supportsInterface(erc165)       21644      21603      21600    +44 (+0.2%)
-supportsInterface(deposit)      21672      21641      21600    +72 (+0.3%)
-supportsInterface(unknown)      21659      21641      21600    +59 (+0.3%)
-get_deposit_root(empty)        107906     117558     109178  -1272 (-1.2%)
-get_deposit_count(empty)        23774      24510      24099   -325 (-1.3%)
-deposit#0                       81603      84626      81089   +514 (+0.6%)
-get_deposit_root(after#0)      107919     117570     109174  -1255 (-1.1%)
-get_deposit_count(after#0)      23774      24510      24099   -325 (-1.3%)
-deposit#1                       67045      70411      66629   +416 (+0.6%)
-get_deposit_root(after#1)      107919     117570     109174  -1255 (-1.1%)
-get_deposit_count(after#1)      23774      24510      24099   -325 (-1.3%)
-deposit#2                       47391      50414      46877   +514 (+1.1%)
-get_deposit_root(after#2)      107932     117582     109170  -1238 (-1.1%)
-get_deposit_count(after#2)      23774      24510      24099   -325 (-1.3%)
-TOTAL                          787786     838656     792487  -4701 (-0.6%)
+supportsInterface(erc165)       21635      21603      21600    +35 (+0.2%)
+supportsInterface(deposit)      21663      21641      21600    +63 (+0.3%)
+supportsInterface(unknown)      21650      21641      21600    +50 (+0.2%)
+get_deposit_root(empty)        107897     117558     109178  -1281 (-1.2%)
+get_deposit_count(empty)        23764      24510      24099   -335 (-1.4%)
+deposit#0                       81559      84626      81089   +470 (+0.6%)
+get_deposit_root(after#0)      107910     117570     109174  -1264 (-1.2%)
+get_deposit_count(after#0)      23764      24510      24099   -335 (-1.4%)
+deposit#1                       67002      70411      66629   +373 (+0.6%)
+get_deposit_root(after#1)      107910     117570     109174  -1264 (-1.2%)
+get_deposit_count(after#1)      23764      24510      24099   -335 (-1.4%)
+deposit#2                       47347      50414      46877   +470 (+1.0%)
+get_deposit_root(after#2)      107923     117582     109170  -1247 (-1.1%)
+get_deposit_count(after#2)      23764      24510      24099   -335 (-1.4%)
+TOTAL                          787552     838656     792487  -4935 (-0.6%)

--- a/crates/fe/tests/fixtures/fe_test/abi_nested_msg_decode_bounds.fe
+++ b/crates/fe/tests/fixtures/fe_test/abi_nested_msg_decode_bounds.fe
@@ -1,0 +1,51 @@
+use std::abi::Bytes
+use std::evm::{Call, Evm, mem}
+
+msg InnerMsg {
+    #[selector = 0x01020304]
+    Inner { marker: u256, data: Bytes },
+}
+
+msg OuterMsg {
+    #[selector = 0xaabbccdd]
+    Outer { inner: InnerMsg::Inner } -> u256,
+}
+
+pub contract NestedMsgReceiver {
+    recv OuterMsg {
+        Outer { inner } -> u256 {
+            assert!(inner.marker == 0)
+            assert!(inner.data.len() == 0)
+            1
+        }
+    }
+}
+
+#[test]
+fn test_nested_msg_decode_valid() uses (evm: mut Evm) {
+    let receiver = evm.create2<NestedMsgReceiver>(value: 0, args: (), salt: 0)
+
+    let result: u256 = evm.call(
+        addr: receiver,
+        gas: 1000000,
+        value: 0,
+        message: OuterMsg::Outer {
+            inner: InnerMsg::Inner { marker: 0, data: Bytes::empty() },
+        },
+    )
+
+    assert!(result == 1)
+}
+
+#[test]
+fn test_nested_msg_decode_truncated_inner_head_reverts() uses (evm: mut Evm) {
+    let receiver = evm.create2<NestedMsgReceiver>(value: 0, args: (), salt: 1)
+
+    let ptr = mem::alloc(96)
+    evm.mstore(addr: ptr, value: (0xaabbccdd as u256) << 224)
+    evm.mstore(addr: ptr + 4, value: 32)
+    evm.mstore(addr: ptr + 36, value: 0)
+
+    let ok = evm.raw_call(addr: receiver, gas: 1000000, value: 0, args_offset: ptr, args_len: 68)
+    assert!(!ok)
+}

--- a/crates/fe/tests/fixtures/fe_test/contract_field_mut_borrow_matrix.fe
+++ b/crates/fe/tests/fixtures/fe_test/contract_field_mut_borrow_matrix.fe
@@ -10,6 +10,8 @@ msg Msg {
     DoubleMutate -> u256,
     #[selector = 5]
     Snapshot -> u256,
+    #[selector = 6]
+    DecodeNameCollisions { input: u256, d: u256, base: u256 } -> u256,
 }
 
 struct Ledger {
@@ -110,6 +112,10 @@ pub contract C {
         Snapshot -> u256 uses (ledger) {
             ledger.a * 1000000 + ledger.b * 1000 + ledger.c
         }
+
+        DecodeNameCollisions { input, d, base } -> u256 {
+            input * 100 + d * 10 + base
+        }
     }
 }
 
@@ -147,6 +153,18 @@ fn test_contract_field_mut_borrow_matrix() uses (evm: mut Evm) {
         },
     )
     assert!(c1 == 45)
+
+    let collision = evm.call(
+        addr: c,
+        gas: 100000,
+        value: 0,
+        message: Msg::DecodeNameCollisions {
+            input: 2,
+            d: 3,
+            base: 4,
+        },
+    )
+    assert!(collision == 234)
 
     let d = evm.call(addr: c, gas: 100000, value: 0, message: Msg::DoubleMutate {})
     assert!(d == 116)

--- a/crates/fe/tests/fixtures/fe_test/deposit_contract.fe
+++ b/crates/fe/tests/fixtures/fe_test/deposit_contract.fe
@@ -172,6 +172,7 @@ pub contract DepositContract uses (ctx: Ctx, mem: mut RawMem, log: mut Log) {
 
 // Reconstruct the deposit-data SSZ root from its constituent parts. Exposed at
 // module level so tests can precompute a valid `deposit_data_root` to pass in.
+#[inline(always)]
 pub fn compute_deposit_data_root(
     pubkey: Bytes,
     withdrawal_credentials: Bytes,

--- a/crates/fe/tests/fixtures/fe_test/deposit_contract.fe
+++ b/crates/fe/tests/fixtures/fe_test/deposit_contract.fe
@@ -24,8 +24,6 @@ use std::abi::{
     Bytes,
     Bytes4,
     Bytes32,
-    BytesView,
-    MemoryInput,
     bytes_from_word,
     bytes_from_words,
     bytes_from_words_prefix,
@@ -106,10 +104,10 @@ pub contract DepositContract uses (ctx: Ctx, mem: mut RawMem, log: mut Log) {
             let amount_gwei: u64 = deposit_amount.downcast_truncate()
 
             let mut node: u256 = compute_deposit_data_root(
-                pubkey: pubkey.view(),
-                withdrawal_credentials: withdrawal_credentials.view(),
-                signature: signature.view(),
-                amount_gwei: amount_gwei,
+                pubkey,
+                withdrawal_credentials,
+                signature,
+                amount_gwei,
             )
             assert!(
                 node == deposit_data_root.val,
@@ -175,9 +173,9 @@ pub contract DepositContract uses (ctx: Ctx, mem: mut RawMem, log: mut Log) {
 // Reconstruct the deposit-data SSZ root from its constituent parts. Exposed at
 // module level so tests can precompute a valid `deposit_data_root` to pass in.
 pub fn compute_deposit_data_root(
-    pubkey: BytesView<MemoryInput>,
-    withdrawal_credentials: BytesView<MemoryInput>,
-    signature: BytesView<MemoryInput>,
+    pubkey: Bytes,
+    withdrawal_credentials: Bytes,
+    signature: Bytes,
     amount_gwei: u64,
 ) -> u256
 uses (mem: mut RawMem)
@@ -188,7 +186,8 @@ uses (mem: mut RawMem)
         withdrawal_credentials.word_at(0),
         ssz::u64_chunk(amount_gwei),
         ssz::hash_tree_root<ssz::ByteVector<96>>(signature),
-    ).merkleize()
+    )
+        .merkleize()
 }
 
 // Decode an 8-byte little-endian `Bytes` back into a `u64`. Used by tests to
@@ -304,9 +303,9 @@ fn test_deposit_rejects_non_gwei_amount() uses (evm: mut Evm, mem: mut RawMem) {
     let wc = word_bytes(w: WC)
     let sig = signature_bytes(s0: S0, s1: S1, s2: S2)
     let expected: u256 = compute_deposit_data_root(
-        pubkey: pk.view(),
-        withdrawal_credentials: wc.view(),
-        signature: sig.view(),
+        pubkey: pk,
+        withdrawal_credentials: wc,
+        signature: sig,
         amount_gwei: amount_gwei,
     )
     evm.call(
@@ -351,9 +350,9 @@ uses (evm: mut Evm, mem: mut RawMem)
     let wc = word_bytes(w: WC)
     let sig = signature_bytes(s0: S0, s1: S1, s2: S2)
     let expected_root: u256 = compute_deposit_data_root(
-        pubkey: pk.view(),
-        withdrawal_credentials: wc.view(),
-        signature: sig.view(),
+        pubkey: pk,
+        withdrawal_credentials: wc,
+        signature: sig,
         amount_gwei: amount_gwei,
     )
 
@@ -427,9 +426,9 @@ fn test_two_deposits_advance_state() uses (evm: mut Evm, mem: mut RawMem) {
     let wc = word_bytes(w: WC)
     let sig = signature_bytes(s0: S0, s1: S1, s2: S2)
     let expected: u256 = compute_deposit_data_root(
-        pubkey: pk.view(),
-        withdrawal_credentials: wc.view(),
-        signature: sig.view(),
+        pubkey: pk,
+        withdrawal_credentials: wc,
+        signature: sig,
         amount_gwei: amount_gwei,
     )
 

--- a/crates/hir/src/analysis/ty/trait_resolution/constraint.rs
+++ b/crates/hir/src/analysis/ty/trait_resolution/constraint.rs
@@ -234,8 +234,8 @@ pub(crate) fn collect_func_decl_constraints<'db>(
         }
     };
 
-    let func_constraints = collect_decl_constraints(db, hir_func.into());
     if !include_parent {
+        let func_constraints = collect_decl_constraints(db, hir_func.into());
         return func_constraints;
     }
 
@@ -246,19 +246,19 @@ pub(crate) fn collect_func_decl_constraints<'db>(
 
         Some(ItemKind::ImplTrait(impl_trait)) => {
             if lower_impl_trait(db, impl_trait).is_none() {
-                return func_constraints;
+                return collect_decl_constraints(db, hir_func.into());
             }
             collect_constraints(db, impl_trait.into())
         }
 
-        _ => return func_constraints,
+        _ => return collect_decl_constraints(db, hir_func.into()),
     };
 
-    Binder::bind(
-        func_constraints
-            .instantiate_identity()
-            .merge(db, parent_constraints.instantiate_identity()),
-    )
+    let parent_constraints = parent_constraints.instantiate_identity();
+    let func_constraints =
+        collect_decl_constraints_with_assumptions(db, hir_func.into(), parent_constraints);
+
+    Binder::bind(func_constraints)
 }
 
 #[salsa::tracked(
@@ -316,6 +316,18 @@ pub(crate) fn collect_decl_constraints<'db>(
     db: &'db dyn HirAnalysisDb,
     owner: GenericParamOwner<'db>,
 ) -> Binder<PredicateListId<'db>> {
+    Binder::bind(collect_decl_constraints_with_assumptions(
+        db,
+        owner,
+        PredicateListId::empty_list(db),
+    ))
+}
+
+fn collect_decl_constraints_with_assumptions<'db>(
+    db: &'db dyn HirAnalysisDb,
+    owner: GenericParamOwner<'db>,
+    initial_assumptions: PredicateListId<'db>,
+) -> PredicateListId<'db> {
     let mut deferred: Vec<Deferred<'db>> = Vec::new();
     let owner_scope = owner.scope();
 
@@ -372,7 +384,8 @@ pub(crate) fn collect_decl_constraints<'db>(
         }
     }
 
-    let mut all_predicates: IndexSet<TraitInstId<'db>> = IndexSet::new();
+    let mut all_predicates: IndexSet<TraitInstId<'db>> =
+        initial_assumptions.list(db).iter().copied().collect();
 
     // fixed-point iteration over deferred predicates
     while !deferred.is_empty() {
@@ -392,10 +405,7 @@ pub(crate) fn collect_decl_constraints<'db>(
         }
     }
 
-    Binder::bind(PredicateListId::new(
-        db,
-        all_predicates.into_iter().collect::<Vec<_>>(),
-    ))
+    PredicateListId::new(db, all_predicates.into_iter().collect::<Vec<_>>())
 }
 
 fn collect_constraints_cycle_initial<'db>(
@@ -509,6 +519,35 @@ mod tests {
                 _ => None,
             })
             .expect("missing trait")
+    }
+
+    #[test]
+    fn method_where_clause_resolves_with_parent_constraints() {
+        let mut db = HirAnalysisTestDb::default();
+        let file = db.new_stand_alone(
+            Utf8PathBuf::from("method_where_clause_resolves_with_parent_constraints.fe"),
+            r#"
+trait Decoder<A> {}
+
+trait Abi {
+    type Decoder: * -> *
+}
+
+fn needs_decoder<A, D>()
+where D: Decoder<A>
+{}
+
+trait Decode<A: Abi> {
+    fn decode_from<I>()
+        where A::Decoder<I>: Decoder<A>
+    {
+        needs_decoder<A, A::Decoder<I>>()
+    }
+}
+"#,
+        );
+        let (top_mod, _) = db.top_mod(file);
+        db.assert_no_diags(top_mod);
     }
 
     #[test]

--- a/crates/hir/src/core/lower/hir_builder.rs
+++ b/crates/hir/src/core/lower/hir_builder.rs
@@ -573,7 +573,7 @@ pub(super) struct DecodeInputBindings<'db> {
     pub(super) input_ident: IdentId<'db>,
     pub(super) input_ty: TypeId<'db>,
     pub(super) base_ident: IdentId<'db>,
-    pub(super) input_len_ident: Option<IdentId<'db>>,
+    pub(super) input_len_ident: IdentId<'db>,
 }
 
 impl<'ctxt, 'db, O> BodyBuilder<'ctxt, 'db, O>
@@ -856,18 +856,13 @@ where
                 }),
             ],
         );
-        let decode_func = if input.input_len_ident.is_some() {
-            "decode_field_from_prechecked_head"
-        } else {
-            "decode_field_from"
-        };
         let decode_path = PathId::from_ident(db, self.roots.core)
             .push_str(db, "abi")
-            .push_str_args(db, decode_func, decode_args);
+            .push_str_args(db, "decode_msg_field_from", decode_args);
         let decode_callee = self.path_expr(decode_path);
         let input_expr = self.ident_expr(input.input_ident);
         let base_expr = self.ident_expr(input.base_ident);
-        let mut args = vec![
+        let args = vec![
             CallArg {
                 label: None,
                 expr: input_expr,
@@ -880,13 +875,11 @@ where
                 label: Some(IdentId::new(db, "head_pos".to_string())),
                 expr: head_pos,
             },
-        ];
-        if let Some(input_len_ident) = input.input_len_ident {
-            args.push(CallArg {
+            CallArg {
                 label: Some(IdentId::new(db, "input_len".to_string())),
-                expr: self.ident_expr(input_len_ident),
-            });
-        }
+                expr: self.ident_expr(input.input_len_ident),
+            },
+        ];
         let decode_call = self.call_expr_with_args(decode_callee, args);
 
         let bind_pat = self.push_pat(Pat::Path(

--- a/crates/hir/src/core/lower/hir_builder.rs
+++ b/crates/hir/src/core/lower/hir_builder.rs
@@ -185,6 +185,14 @@ where
         TraitRefId::new(db, Partial::Present(path))
     }
 
+    pub(super) fn core_abi_trait_ref(&self, name: &str) -> TraitRefId<'db> {
+        let db = self.db();
+        let path = PathId::from_ident(db, self.roots.core)
+            .push_str(db, "abi")
+            .push_str(db, name);
+        TraitRefId::new(db, Partial::Present(path))
+    }
+
     pub(super) fn type_param_with_trait_bound(
         &self,
         name: &str,
@@ -654,6 +662,16 @@ where
         self.path_expr(qualified.push_str(self.db(), assoc_name))
     }
 
+    pub(super) fn abi_field_head_size_expr(&mut self, ty: TypeId<'db>) -> ExprId {
+        let db = self.db();
+        let args = GenericArgListId::given1_type(db, ty);
+        let path = PathId::from_ident(db, self.roots.core)
+            .push_str(db, "abi")
+            .push_str_args(db, "abi_field_head_size", args);
+        let callee = self.path_expr(path);
+        self.call_expr(callee, vec![])
+    }
+
     pub(super) fn call_expr(&mut self, callee: ExprId, args: Vec<ExprId>) -> ExprId {
         self.call_expr_with_args(
             callee,
@@ -795,6 +813,61 @@ where
         let decode_callee = self.path_expr(decode_path);
         let d_expr = self.path_expr(PathId::from_str(db, "d"));
         let decode_call = self.call_expr(decode_callee, vec![d_expr]);
+
+        let bind_pat = self.push_pat(Pat::Path(
+            Partial::Present(PathId::from_ident(db, target_ident)),
+            false,
+        ));
+        self.emit_stmt(Stmt::Let(bind_pat, Some(ty), Some(decode_call)));
+    }
+
+    pub(super) fn decode_from_into(
+        &mut self,
+        target_ident: IdentId<'db>,
+        ty: TypeId<'db>,
+        input_ident: IdentId<'db>,
+        input_ty: TypeId<'db>,
+        base_ident: IdentId<'db>,
+        head_pos: ExprId,
+    ) {
+        let db = self.db();
+        let decode_args = GenericArgListId::given(
+            db,
+            vec![
+                GenericArg::Type(TypeGenericArg {
+                    ty: Partial::Present(self.sol_ty()),
+                }),
+                GenericArg::Type(TypeGenericArg {
+                    ty: Partial::Present(ty),
+                }),
+                GenericArg::Type(TypeGenericArg {
+                    ty: Partial::Present(input_ty),
+                }),
+            ],
+        );
+        let decode_path = PathId::from_ident(db, self.roots.core)
+            .push_str(db, "abi")
+            .push_str_args(db, "decode_field_from", decode_args);
+        let decode_callee = self.path_expr(decode_path);
+        let input_expr = self.ident_expr(input_ident);
+        let base_expr = self.ident_expr(base_ident);
+        let decode_call = self.call_expr_with_args(
+            decode_callee,
+            vec![
+                CallArg {
+                    label: None,
+                    expr: input_expr,
+                },
+                CallArg {
+                    label: Some(base_ident),
+                    expr: base_expr,
+                },
+                CallArg {
+                    label: Some(IdentId::new(db, "head_pos".to_string())),
+                    expr: head_pos,
+                },
+            ],
+        );
 
         let bind_pat = self.push_pat(Pat::Path(
             Partial::Present(PathId::from_ident(db, target_ident)),

--- a/crates/hir/src/core/lower/hir_builder.rs
+++ b/crates/hir/src/core/lower/hir_builder.rs
@@ -857,7 +857,7 @@ where
             ],
         );
         let decode_func = if input.input_len_ident.is_some() {
-            "decode_field_from_with_input_len"
+            "decode_field_from_prechecked_head"
         } else {
             "decode_field_from"
         };

--- a/crates/hir/src/core/lower/hir_builder.rs
+++ b/crates/hir/src/core/lower/hir_builder.rs
@@ -568,6 +568,14 @@ where
     stmts: Vec<StmtId>,
 }
 
+#[derive(Clone, Copy)]
+pub(super) struct DecodeInputBindings<'db> {
+    pub(super) input_ident: IdentId<'db>,
+    pub(super) input_ty: TypeId<'db>,
+    pub(super) base_ident: IdentId<'db>,
+    pub(super) input_len_ident: Option<IdentId<'db>>,
+}
+
 impl<'ctxt, 'db, O> BodyBuilder<'ctxt, 'db, O>
 where
     O: Clone + Into<DesugaredOrigin>,
@@ -830,9 +838,7 @@ where
         &mut self,
         target_ident: IdentId<'db>,
         ty: TypeId<'db>,
-        input_ident: IdentId<'db>,
-        input_ty: TypeId<'db>,
-        base_ident: IdentId<'db>,
+        input: DecodeInputBindings<'db>,
         head_pos: ExprId,
     ) {
         let db = self.db();
@@ -846,39 +852,67 @@ where
                     ty: Partial::Present(ty),
                 }),
                 GenericArg::Type(TypeGenericArg {
-                    ty: Partial::Present(input_ty),
+                    ty: Partial::Present(input.input_ty),
                 }),
             ],
         );
+        let decode_func = if input.input_len_ident.is_some() {
+            "decode_field_from_with_input_len"
+        } else {
+            "decode_field_from"
+        };
         let decode_path = PathId::from_ident(db, self.roots.core)
             .push_str(db, "abi")
-            .push_str_args(db, "decode_field_from", decode_args);
+            .push_str_args(db, decode_func, decode_args);
         let decode_callee = self.path_expr(decode_path);
-        let input_expr = self.ident_expr(input_ident);
-        let base_expr = self.ident_expr(base_ident);
-        let decode_call = self.call_expr_with_args(
-            decode_callee,
-            vec![
-                CallArg {
-                    label: None,
-                    expr: input_expr,
-                },
-                CallArg {
-                    label: Some(IdentId::new(db, "base".to_string())),
-                    expr: base_expr,
-                },
-                CallArg {
-                    label: Some(IdentId::new(db, "head_pos".to_string())),
-                    expr: head_pos,
-                },
-            ],
-        );
+        let input_expr = self.ident_expr(input.input_ident);
+        let base_expr = self.ident_expr(input.base_ident);
+        let mut args = vec![
+            CallArg {
+                label: None,
+                expr: input_expr,
+            },
+            CallArg {
+                label: Some(IdentId::new(db, "base".to_string())),
+                expr: base_expr,
+            },
+            CallArg {
+                label: Some(IdentId::new(db, "head_pos".to_string())),
+                expr: head_pos,
+            },
+        ];
+        if let Some(input_len_ident) = input.input_len_ident {
+            args.push(CallArg {
+                label: Some(IdentId::new(db, "input_len".to_string())),
+                expr: self.ident_expr(input_len_ident),
+            });
+        }
+        let decode_call = self.call_expr_with_args(decode_callee, args);
 
         let bind_pat = self.push_pat(Pat::Path(
             Partial::Present(PathId::from_ident(db, target_ident)),
             false,
         ));
         self.emit_stmt(Stmt::Let(bind_pat, Some(ty), Some(decode_call)));
+    }
+
+    pub(super) fn bind_input_len(&mut self, target_ident: IdentId<'db>, input_ident: IdentId<'db>) {
+        let db = self.db();
+        let input_expr = self.ident_expr(input_ident);
+        let len_call =
+            self.method_call_expr(input_expr, IdentId::new(db, "len".to_string()), vec![]);
+        let bind_pat = self.push_pat(Pat::Path(
+            Partial::Present(PathId::from_ident(db, target_ident)),
+            false,
+        ));
+        let u256_ty = TypeId::new(
+            db,
+            TypeKind::Path(Partial::Present(PathId::from_ident(
+                db,
+                IdentId::new(db, "u256".to_string()),
+            ))),
+        );
+        self.emit_stmt(Stmt::Let(bind_pat, Some(u256_ty), Some(len_call)));
     }
 
     pub(super) fn return_record_self(&mut self, fields: &[IdentId<'db>]) {

--- a/crates/hir/src/core/lower/hir_builder.rs
+++ b/crates/hir/src/core/lower/hir_builder.rs
@@ -91,6 +91,10 @@ where
         IdentId::new(self.db(), name.to_string())
     }
 
+    pub(super) fn generated_ident(&self, name: &str) -> IdentId<'db> {
+        IdentId::new(self.db(), format!("__fe_{name}"))
+    }
+
     pub(super) fn roots(&self) -> LibRoots<'db> {
         self.roots
     }
@@ -790,6 +794,7 @@ where
         &mut self,
         target_ident: IdentId<'db>,
         ty: TypeId<'db>,
+        decoder_ident: IdentId<'db>,
         decoder_ty: TypeId<'db>,
     ) {
         let db = self.db();
@@ -811,8 +816,8 @@ where
             .push_str(db, "abi")
             .push_str_args(db, "decode_field", decode_args);
         let decode_callee = self.path_expr(decode_path);
-        let d_expr = self.path_expr(PathId::from_str(db, "d"));
-        let decode_call = self.call_expr(decode_callee, vec![d_expr]);
+        let decoder_expr = self.ident_expr(decoder_ident);
+        let decode_call = self.call_expr(decode_callee, vec![decoder_expr]);
 
         let bind_pat = self.push_pat(Pat::Path(
             Partial::Present(PathId::from_ident(db, target_ident)),
@@ -859,7 +864,7 @@ where
                     expr: input_expr,
                 },
                 CallArg {
-                    label: Some(base_ident),
+                    label: Some(IdentId::new(db, "base".to_string())),
                     expr: base_expr,
                 },
                 CallArg {

--- a/crates/hir/src/core/lower/msg.rs
+++ b/crates/hir/src/core/lower/msg.rs
@@ -2,7 +2,10 @@ use num_bigint::BigUint;
 use parser::ast::{self, AttrListOwner as _};
 use salsa::Accumulator as _;
 
-use super::{attr::named_attr_specs, hir_builder::BodyBuilder, hir_builder::HirBuilder};
+use super::{
+    attr::named_attr_specs,
+    hir_builder::{BodyBuilder, DecodeInputBindings, HirBuilder},
+};
 
 use crate::{
     HirDb, SelectorError, SelectorErrorKind,
@@ -638,6 +641,37 @@ fn build_decode_head_pos_expr<'db, O: Clone + Into<crate::span::DesugaredOrigin>
     expr
 }
 
+fn ty_uses_cached_decode_input_len<'db>(db: &'db dyn HirDb, ty: TypeId<'db>) -> bool {
+    match ty.data(db) {
+        TypeKind::Path(Partial::Present(path)) => path
+            .ident(db)
+            .to_opt()
+            .map(|ident| {
+                matches!(
+                    ident.data(db).as_str(),
+                    "Bytes" | "DynString" | "Text" | "Vec"
+                )
+            })
+            .unwrap_or_default(),
+        TypeKind::Path(Partial::Absent) => false,
+        TypeKind::Tuple(tuple) => tuple
+            .data(db)
+            .iter()
+            .copied()
+            .filter_map(Partial::to_opt)
+            .any(|elem| ty_uses_cached_decode_input_len(db, elem)),
+        TypeKind::Mode(_, inner) => inner
+            .to_opt()
+            .map(|inner| ty_uses_cached_decode_input_len(db, inner))
+            .unwrap_or_default(),
+        TypeKind::Array(elem, _) => elem
+            .to_opt()
+            .map(|elem| ty_uses_cached_decode_input_len(db, elem))
+            .unwrap_or_default(),
+        TypeKind::Ptr(_) | TypeKind::Never => false,
+    }
+}
+
 fn lower_msg_variant_decode_trait_impl<'db>(
     builder: &mut HirBuilder<'_, 'db, MsgDesugared>,
     variant: &ast::MsgVariant,
@@ -678,10 +712,24 @@ fn lower_msg_variant_decode_trait_impl<'db>(
 
         let input_ident = builder.generated_ident("msg_decode_input");
         let base_ident = builder.generated_ident("msg_decode_base");
+        let input_len_ident = if fields
+            .iter()
+            .any(|(_, ty)| ty_uses_cached_decode_input_len(db, *ty))
+        {
+            Some(builder.generated_ident("msg_decode_input_len"))
+        } else {
+            None
+        };
         let params = builder.params([
             builder.param_underscore_named(input_ident, i_ty),
             builder.param_underscore_named(base_ident, builder.ty_ident(builder.ident("u256"))),
         ]);
+        let decode_input = DecodeInputBindings {
+            input_ident,
+            input_ty: i_ty,
+            base_ident,
+            input_len_ident,
+        };
 
         builder.func_generic_inline_always(
             "decode_from",
@@ -690,9 +738,12 @@ fn lower_msg_variant_decode_trait_impl<'db>(
             Some(builder.self_ty()),
             FuncModifiers::new(Visibility::Private, false, false, false),
             |body| {
+                if let Some(input_len_ident) = input_len_ident {
+                    body.bind_input_len(input_len_ident, input_ident);
+                }
                 for (idx, (name, ty)) in fields.iter().copied().enumerate() {
                     let head_pos = build_decode_head_pos_expr(body, base_ident, &fields[..idx]);
-                    body.decode_from_into(name, ty, input_ident, i_ty, base_ident, head_pos);
+                    body.decode_from_into(name, ty, decode_input, head_pos);
                 }
                 body.return_record_self(&field_names);
             },

--- a/crates/hir/src/core/lower/msg.rs
+++ b/crates/hir/src/core/lower/msg.rs
@@ -655,7 +655,7 @@ fn lower_msg_variant_decode_trait_impl<'db>(
         let (d_generic_params, d_ty) =
             builder.type_param_with_trait_bound("D", abi_decoder_trait_ref);
 
-        let decoder_ident = builder.ident("d");
+        let decoder_ident = builder.generated_ident("msg_decode_decoder");
         let params = builder.params([builder.param_mut_underscore_named(decoder_ident, d_ty)]);
 
         builder.func_generic_inline_always(
@@ -666,7 +666,7 @@ fn lower_msg_variant_decode_trait_impl<'db>(
             FuncModifiers::new(Visibility::Private, false, false, false),
             |body| {
                 for (name, ty) in fields.iter().copied() {
-                    body.decode_into(name, ty, d_ty);
+                    body.decode_into(name, ty, decoder_ident, d_ty);
                 }
                 body.return_record_self(&field_names);
             },
@@ -676,8 +676,8 @@ fn lower_msg_variant_decode_trait_impl<'db>(
         let (i_generic_params, i_ty) =
             builder.type_param_with_trait_bound("I", byte_input_trait_ref);
 
-        let input_ident = builder.ident("input");
-        let base_ident = builder.ident("base");
+        let input_ident = builder.generated_ident("msg_decode_input");
+        let base_ident = builder.generated_ident("msg_decode_base");
         let params = builder.params([
             builder.param_underscore_named(input_ident, i_ty),
             builder.param_underscore_named(base_ident, builder.ty_ident(builder.ident("u256"))),

--- a/crates/hir/src/core/lower/msg.rs
+++ b/crates/hir/src/core/lower/msg.rs
@@ -2,12 +2,12 @@ use num_bigint::BigUint;
 use parser::ast::{self, AttrListOwner as _};
 use salsa::Accumulator as _;
 
-use super::{attr::named_attr_specs, hir_builder::HirBuilder};
+use super::{attr::named_attr_specs, hir_builder::BodyBuilder, hir_builder::HirBuilder};
 
 use crate::{
     HirDb, SelectorError, SelectorErrorKind,
     hir_def::{
-        ArithBinOp, AssocConstDef, AttrListId, BinOp, Body, BodyKind, Expr, FieldDef,
+        ArithBinOp, AssocConstDef, AttrListId, BinOp, Body, BodyKind, Expr, ExprId, FieldDef,
         FieldDefListId, FieldIndex, FuncModifiers, FuncParam, FuncParamMode, FuncParamName,
         IdentId, ImplTrait, IntegerId, LitKind, LogicalBinOp, Mod, Partial, Pat, PathId, PathKind,
         Stmt, Struct, TrackedItemVariant, TraitRefId, TupleTypeId, TypeId, TypeKind, Visibility,
@@ -621,6 +621,23 @@ pub(super) fn build_head_size_body_expr<'db, O: Clone + Into<crate::span::Desuga
     }
 }
 
+fn build_decode_head_pos_expr<'db, O: Clone + Into<crate::span::DesugaredOrigin>>(
+    body: &mut BodyBuilder<'_, 'db, O>,
+    base_ident: IdentId<'db>,
+    prior_fields: &[(IdentId<'db>, TypeId<'db>)],
+) -> ExprId {
+    let mut expr = body.ident_expr(base_ident);
+    for (_, ty) in prior_fields.iter().copied() {
+        let field_head_size = body.abi_field_head_size_expr(ty);
+        expr = body.push_expr(Expr::Bin(
+            expr,
+            field_head_size,
+            BinOp::Arith(ArithBinOp::Add),
+        ));
+    }
+    expr
+}
+
 fn lower_msg_variant_decode_trait_impl<'db>(
     builder: &mut HirBuilder<'_, 'db, MsgDesugared>,
     variant: &ast::MsgVariant,
@@ -650,6 +667,32 @@ fn lower_msg_variant_decode_trait_impl<'db>(
             |body| {
                 for (name, ty) in fields.iter().copied() {
                     body.decode_into(name, ty, d_ty);
+                }
+                body.return_record_self(&field_names);
+            },
+        );
+
+        let byte_input_trait_ref = builder.core_abi_trait_ref("ByteInput");
+        let (i_generic_params, i_ty) =
+            builder.type_param_with_trait_bound("I", byte_input_trait_ref);
+
+        let input_ident = builder.ident("input");
+        let base_ident = builder.ident("base");
+        let params = builder.params([
+            builder.param_underscore_named(input_ident, i_ty),
+            builder.param_underscore_named(base_ident, builder.ty_ident(builder.ident("u256"))),
+        ]);
+
+        builder.func_generic_inline_always(
+            "decode_from",
+            i_generic_params,
+            params,
+            Some(builder.self_ty()),
+            FuncModifiers::new(Visibility::Private, false, false, false),
+            |body| {
+                for (idx, (name, ty)) in fields.iter().copied().enumerate() {
+                    let head_pos = build_decode_head_pos_expr(body, base_ident, &fields[..idx]);
+                    body.decode_from_into(name, ty, input_ident, i_ty, base_ident, head_pos);
                 }
                 body.return_record_self(&field_names);
             },

--- a/crates/hir/src/core/lower/msg.rs
+++ b/crates/hir/src/core/lower/msg.rs
@@ -641,35 +641,17 @@ fn build_decode_head_pos_expr<'db, O: Clone + Into<crate::span::DesugaredOrigin>
     expr
 }
 
-fn ty_uses_cached_decode_input_len<'db>(db: &'db dyn HirDb, ty: TypeId<'db>) -> bool {
-    match ty.data(db) {
-        TypeKind::Path(Partial::Present(path)) => path
-            .ident(db)
-            .to_opt()
-            .map(|ident| {
-                matches!(
-                    ident.data(db).as_str(),
-                    "Bytes" | "DynString" | "Text" | "Vec"
-                )
-            })
-            .unwrap_or_default(),
-        TypeKind::Path(Partial::Absent) => false,
-        TypeKind::Tuple(tuple) => tuple
-            .data(db)
-            .iter()
-            .copied()
-            .filter_map(Partial::to_opt)
-            .any(|elem| ty_uses_cached_decode_input_len(db, elem)),
-        TypeKind::Mode(_, inner) => inner
-            .to_opt()
-            .map(|inner| ty_uses_cached_decode_input_len(db, inner))
-            .unwrap_or_default(),
-        TypeKind::Array(elem, _) => elem
-            .to_opt()
-            .map(|elem| ty_uses_cached_decode_input_len(db, elem))
-            .unwrap_or_default(),
-        TypeKind::Ptr(_) | TypeKind::Never => false,
+fn emit_msg_decode_from_fields<'db>(
+    body: &mut BodyBuilder<'_, 'db, MsgDesugared>,
+    fields: &[(IdentId<'db>, TypeId<'db>)],
+    field_names: &[IdentId<'db>],
+    decode_input: DecodeInputBindings<'db>,
+) {
+    for (idx, (name, ty)) in fields.iter().copied().enumerate() {
+        let head_pos = build_decode_head_pos_expr(body, decode_input.base_ident, &fields[..idx]);
+        body.decode_from_into(name, ty, decode_input, head_pos);
     }
+    body.return_record_self(field_names);
 }
 
 fn lower_msg_variant_decode_trait_impl<'db>(
@@ -712,17 +694,11 @@ fn lower_msg_variant_decode_trait_impl<'db>(
 
         let input_ident = builder.generated_ident("msg_decode_input");
         let base_ident = builder.generated_ident("msg_decode_base");
-        let input_len_ident = if fields
-            .iter()
-            .any(|(_, ty)| ty_uses_cached_decode_input_len(db, *ty))
-        {
-            Some(builder.generated_ident("msg_decode_input_len"))
-        } else {
-            None
-        };
+        let input_len_ident = builder.generated_ident("msg_decode_input_len");
+        let u256_ty = builder.ty_ident(builder.ident("u256"));
         let params = builder.params([
             builder.param_underscore_named(input_ident, i_ty),
-            builder.param_underscore_named(base_ident, builder.ty_ident(builder.ident("u256"))),
+            builder.param_underscore_named(base_ident, u256_ty),
         ]);
         let decode_input = DecodeInputBindings {
             input_ident,
@@ -738,14 +714,10 @@ fn lower_msg_variant_decode_trait_impl<'db>(
             Some(builder.self_ty()),
             FuncModifiers::new(Visibility::Private, false, false, false),
             |body| {
-                if let Some(input_len_ident) = input_len_ident {
+                if !fields.is_empty() {
                     body.bind_input_len(input_len_ident, input_ident);
                 }
-                for (idx, (name, ty)) in fields.iter().copied().enumerate() {
-                    let head_pos = build_decode_head_pos_expr(body, base_ident, &fields[..idx]);
-                    body.decode_from_into(name, ty, decode_input, head_pos);
-                }
-                body.return_record_self(&field_names);
+                emit_msg_decode_from_fields(body, &fields, &field_names, decode_input);
             },
         );
     })

--- a/crates/hir/src/core/semantic/mod.rs
+++ b/crates/hir/src/core/semantic/mod.rs
@@ -4150,7 +4150,7 @@ impl<'db> ImplTrait<'db> {
         // Semantic associated type implementations in this impl-trait block.
         let mut types: IndexMap<_, _> = self
             .assoc_types(db)
-            .filter_map(|v| v.name(db).and_then(|name| v.ty(db).map(|ty| (name, ty))))
+            .filter_map(|v| v.name(db).zip(v.ty(db)))
             .collect();
 
         // Merge trait associated type defaults into the implementor, but evaluated in

--- a/crates/hir/test_files/desugar/msg.snap
+++ b/crates/hir/test_files/desugar/msg.snap
@@ -38,12 +38,12 @@ mod CounterMsg {
     impl core::abi::Decode<std::abi::Sol> for Increment {
 
         #[inline(always)]
-        fn decode_payload<D: core::abi::AbiDecoder<std::abi::Sol>>(_ d: mut D) -> Self {
+        fn decode_payload<D: core::abi::AbiDecoder<std::abi::Sol>>(_ __fe_msg_decode_decoder: mut D) -> Self {
             return Self {  }
         }
 
         #[inline(always)]
-        fn decode_from<I: core::abi::ByteInput>(_ input: I, _ base: u256) -> Self {
+        fn decode_from<I: core::abi::ByteInput>(_ __fe_msg_decode_input: I, _ __fe_msg_decode_base: u256) -> Self {
             return Self {  }
         }
     }
@@ -75,12 +75,12 @@ mod CounterMsg {
     impl core::abi::Decode<std::abi::Sol> for Get {
 
         #[inline(always)]
-        fn decode_payload<D: core::abi::AbiDecoder<std::abi::Sol>>(_ d: mut D) -> Self {
+        fn decode_payload<D: core::abi::AbiDecoder<std::abi::Sol>>(_ __fe_msg_decode_decoder: mut D) -> Self {
             return Self {  }
         }
 
         #[inline(always)]
-        fn decode_from<I: core::abi::ByteInput>(_ input: I, _ base: u256) -> Self {
+        fn decode_from<I: core::abi::ByteInput>(_ __fe_msg_decode_input: I, _ __fe_msg_decode_base: u256) -> Self {
             return Self {  }
         }
     }
@@ -120,14 +120,14 @@ mod CounterMsg {
     impl core::abi::Decode<std::abi::Sol> for Set {
 
         #[inline(always)]
-        fn decode_payload<D: core::abi::AbiDecoder<std::abi::Sol>>(_ d: mut D) -> Self {
-            let val: u64 = core::abi::decode_field<std::abi::Sol, u64, D>(d)
+        fn decode_payload<D: core::abi::AbiDecoder<std::abi::Sol>>(_ __fe_msg_decode_decoder: mut D) -> Self {
+            let val: u64 = core::abi::decode_field<std::abi::Sol, u64, D>(__fe_msg_decode_decoder)
             return Self { val: val }
         }
 
         #[inline(always)]
-        fn decode_from<I: core::abi::ByteInput>(_ input: I, _ base: u256) -> Self {
-            let val: u64 = core::abi::decode_field_from<std::abi::Sol, u64, I>(input, base: base, head_pos: base)
+        fn decode_from<I: core::abi::ByteInput>(_ __fe_msg_decode_input: I, _ __fe_msg_decode_base: u256) -> Self {
+            let val: u64 = core::abi::decode_field_from<std::abi::Sol, u64, I>(__fe_msg_decode_input, base: __fe_msg_decode_base, head_pos: __fe_msg_decode_base)
             return Self { val: val }
         }
     }

--- a/crates/hir/test_files/desugar/msg.snap
+++ b/crates/hir/test_files/desugar/msg.snap
@@ -41,6 +41,11 @@ mod CounterMsg {
         fn decode_payload<D: core::abi::AbiDecoder<std::abi::Sol>>(_ d: mut D) -> Self {
             return Self {  }
         }
+
+        #[inline(always)]
+        fn decode_from<I: core::abi::ByteInput>(_ input: I, _ base: u256) -> Self {
+            return Self {  }
+        }
     }
 
     pub struct Get {}
@@ -71,6 +76,11 @@ mod CounterMsg {
 
         #[inline(always)]
         fn decode_payload<D: core::abi::AbiDecoder<std::abi::Sol>>(_ d: mut D) -> Self {
+            return Self {  }
+        }
+
+        #[inline(always)]
+        fn decode_from<I: core::abi::ByteInput>(_ input: I, _ base: u256) -> Self {
             return Self {  }
         }
     }
@@ -112,6 +122,12 @@ mod CounterMsg {
         #[inline(always)]
         fn decode_payload<D: core::abi::AbiDecoder<std::abi::Sol>>(_ d: mut D) -> Self {
             let val: u64 = core::abi::decode_field<std::abi::Sol, u64, D>(d)
+            return Self { val: val }
+        }
+
+        #[inline(always)]
+        fn decode_from<I: core::abi::ByteInput>(_ input: I, _ base: u256) -> Self {
+            let val: u64 = core::abi::decode_field_from<std::abi::Sol, u64, I>(input, base: base, head_pos: base)
             return Self { val: val }
         }
     }

--- a/crates/hir/test_files/desugar/msg.snap
+++ b/crates/hir/test_files/desugar/msg.snap
@@ -127,7 +127,8 @@ mod CounterMsg {
 
         #[inline(always)]
         fn decode_from<I: core::abi::ByteInput>(_ __fe_msg_decode_input: I, _ __fe_msg_decode_base: u256) -> Self {
-            let val: u64 = core::abi::decode_field_from<std::abi::Sol, u64, I>(__fe_msg_decode_input, base: __fe_msg_decode_base, head_pos: __fe_msg_decode_base)
+            let __fe_msg_decode_input_len: u256 = __fe_msg_decode_input.len()
+            let val: u64 = core::abi::decode_msg_field_from<std::abi::Sol, u64, I>(__fe_msg_decode_input, base: __fe_msg_decode_base, head_pos: __fe_msg_decode_base, input_len: __fe_msg_decode_input_len)
             return Self { val: val }
         }
     }

--- a/crates/hir/test_files/desugar/msg_nested_decode.fe
+++ b/crates/hir/test_files/desugar/msg_nested_decode.fe
@@ -1,0 +1,11 @@
+use std::abi::Bytes
+
+msg InnerMsg {
+    #[selector = 0x01]
+    Inner { marker: u256, data: Bytes },
+}
+
+msg OuterMsg {
+    #[selector = 0x02]
+    Outer { inner: InnerMsg::Inner },
+}

--- a/crates/hir/test_files/desugar/msg_nested_decode.snap
+++ b/crates/hir/test_files/desugar/msg_nested_decode.snap
@@ -1,0 +1,123 @@
+---
+source: crates/hir/tests/desugar.rs
+expression: output
+input_file: test_files/desugar/msg_nested_decode.fe
+---
+use core::prelude::*
+use std::prelude::*
+use std::abi::Bytes
+
+mod InnerMsg {
+    use core::prelude::*
+    use std::prelude::*
+    use super::*
+
+    pub struct Inner {
+        pub marker: u256,
+        pub data: Bytes,
+    }
+
+    impl core::message::MsgVariant<std::abi::Sol> for Inner {
+        type Return = ()
+        const SELECTOR: u32 = 1
+    }
+
+    impl core::abi::AbiSize for Inner {
+        const HEAD_SIZE: u256 = 0 + u256::HEAD_SIZE + Bytes::HEAD_SIZE
+        const IS_DYNAMIC: bool = false || u256::IS_DYNAMIC || Bytes::IS_DYNAMIC
+
+        fn payload_size(self) -> u256 {
+            return <Self as core::abi::AbiSize>::HEAD_SIZE + core::abi::dynamic_payload_size(self.marker) + core::abi::dynamic_payload_size(self.data)
+        }
+    }
+
+    impl core::abi::Encode<std::abi::Sol> for Inner {
+        const DIRECT_ENCODE: bool = true && <u256 as core::abi::Encode<std::abi::Sol> >::DIRECT_ENCODE && <Bytes as core::abi::Encode<std::abi::Sol> >::DIRECT_ENCODE
+
+        fn encode<E: core::abi::AbiEncoder<std::abi::Sol>>(own self, _ e: mut E) {
+            let mut __tail = e.base() + <Self as core::abi::AbiSize>::HEAD_SIZE
+            let __field_0 = self.marker
+            core::abi::encode_field<std::abi::Sol, u256, E>(__field_0, e, mut __tail)
+            let __field_1 = self.data
+            core::abi::encode_field<std::abi::Sol, Bytes, E>(__field_1, e, mut __tail)
+        }
+
+        fn encode_to_ptr(own self, _ ptr: u256) {
+            self.marker.encode_to_ptr(ptr)
+            let __field_ptr0 = ptr + u256::HEAD_SIZE
+            self.data.encode_to_ptr(__field_ptr0)
+        }
+    }
+
+    impl core::abi::Decode<std::abi::Sol> for Inner {
+
+        #[inline(always)]
+        fn decode_payload<D: core::abi::AbiDecoder<std::abi::Sol>>(_ __fe_msg_decode_decoder: mut D) -> Self {
+            let marker: u256 = core::abi::decode_field<std::abi::Sol, u256, D>(__fe_msg_decode_decoder)
+            let data: Bytes = core::abi::decode_field<std::abi::Sol, Bytes, D>(__fe_msg_decode_decoder)
+            return Self { marker: marker, data: data }
+        }
+
+        #[inline(always)]
+        fn decode_from<I: core::abi::ByteInput>(_ __fe_msg_decode_input: I, _ __fe_msg_decode_base: u256) -> Self {
+            let __fe_msg_decode_input_len: u256 = __fe_msg_decode_input.len()
+            let marker: u256 = core::abi::decode_msg_field_from<std::abi::Sol, u256, I>(__fe_msg_decode_input, base: __fe_msg_decode_base, head_pos: __fe_msg_decode_base, input_len: __fe_msg_decode_input_len)
+            let data: Bytes = core::abi::decode_msg_field_from<std::abi::Sol, Bytes, I>(__fe_msg_decode_input, base: __fe_msg_decode_base, head_pos: __fe_msg_decode_base + core::abi::abi_field_head_size<u256>(), input_len: __fe_msg_decode_input_len)
+            return Self { marker: marker, data: data }
+        }
+    }
+}
+
+mod OuterMsg {
+    use core::prelude::*
+    use std::prelude::*
+    use super::*
+
+    pub struct Outer {
+        pub inner: InnerMsg::Inner,
+    }
+
+    impl core::message::MsgVariant<std::abi::Sol> for Outer {
+        type Return = ()
+        const SELECTOR: u32 = 2
+    }
+
+    impl core::abi::AbiSize for Outer {
+        const HEAD_SIZE: u256 = 0 + InnerMsg::Inner::HEAD_SIZE
+        const IS_DYNAMIC: bool = false || InnerMsg::Inner::IS_DYNAMIC
+
+        fn payload_size(self) -> u256 {
+            return <Self as core::abi::AbiSize>::HEAD_SIZE + core::abi::dynamic_payload_size(self.inner)
+        }
+    }
+
+    impl core::abi::Encode<std::abi::Sol> for Outer {
+        const DIRECT_ENCODE: bool = true && <InnerMsg::Inner as core::abi::Encode<std::abi::Sol> >::DIRECT_ENCODE
+
+        fn encode<E: core::abi::AbiEncoder<std::abi::Sol>>(own self, _ e: mut E) {
+            let mut __tail = e.base() + <Self as core::abi::AbiSize>::HEAD_SIZE
+            let __field_0 = self.inner
+            core::abi::encode_field<std::abi::Sol, InnerMsg::Inner, E>(__field_0, e, mut __tail)
+        }
+
+        fn encode_to_ptr(own self, _ ptr: u256) {
+            self.inner.encode_to_ptr(ptr)
+        }
+    }
+
+    impl core::abi::Decode<std::abi::Sol> for Outer {
+
+        #[inline(always)]
+        fn decode_payload<D: core::abi::AbiDecoder<std::abi::Sol>>(_ __fe_msg_decode_decoder: mut D) -> Self {
+            let inner: InnerMsg::Inner = core::abi::decode_field<std::abi::Sol, InnerMsg::Inner, D>(__fe_msg_decode_decoder)
+            return Self { inner: inner }
+        }
+
+        #[inline(always)]
+        fn decode_from<I: core::abi::ByteInput>(_ __fe_msg_decode_input: I, _ __fe_msg_decode_base: u256) -> Self {
+            let __fe_msg_decode_input_len: u256 = __fe_msg_decode_input.len()
+            let inner: InnerMsg::Inner = core::abi::decode_msg_field_from<std::abi::Sol, InnerMsg::Inner, I>(__fe_msg_decode_input, base: __fe_msg_decode_base, head_pos: __fe_msg_decode_base, input_len: __fe_msg_decode_input_len)
+            return Self { inner: inner }
+        }
+    }
+}

--- a/crates/hir/test_files/ty_check/contract_effects.snap
+++ b/crates/hir/test_files/ty_check/contract_effects.snap
@@ -112,13 +112,13 @@ note:
    ┌─ contract_effects.fe:30:5
    │
 30 │     Deposit { amount: u256 } -> u256,
-   │     ^^^^^^^ () | Deposit | fn decode_field<Sol, u256, D> | fn dynamic_payload_size<u256> | fn encode_field<Sol, u256, E> | mut D | mut E | mut u256 | u256
+   │     ^^^^^^^ () | Deposit | I | fn decode_field<Sol, u256, D> | fn decode_field_from<Sol, u256, I> | fn dynamic_payload_size<u256> | fn encode_field<Sol, u256, E> | mut D | mut E | mut u256 | u256
 
 note:
    ┌─ contract_effects.fe:33:5
    │
 33 │     Withdraw { amount: u256 } -> bool,
-   │     ^^^^^^^^ () | Withdraw | fn decode_field<Sol, u256, D> | fn dynamic_payload_size<u256> | fn encode_field<Sol, u256, E> | mut D | mut E | mut u256 | u256
+   │     ^^^^^^^^ () | I | Withdraw | fn decode_field<Sol, u256, D> | fn decode_field_from<Sol, u256, I> | fn dynamic_payload_size<u256> | fn encode_field<Sol, u256, E> | mut D | mut E | mut u256 | u256
 
 note:
    ┌─ contract_effects.fe:36:5

--- a/crates/hir/test_files/ty_check/contract_effects.snap
+++ b/crates/hir/test_files/ty_check/contract_effects.snap
@@ -112,13 +112,13 @@ note:
    ┌─ contract_effects.fe:30:5
    │
 30 │     Deposit { amount: u256 } -> u256,
-   │     ^^^^^^^ () | Deposit | I | fn decode_field<Sol, u256, D> | fn decode_field_from<Sol, u256, I> | fn dynamic_payload_size<u256> | fn encode_field<Sol, u256, E> | mut D | mut E | mut u256 | u256
+   │     ^^^^^^^ () | Deposit | I | fn decode_field<Sol, u256, D> | fn decode_msg_field_from<Sol, u256, I> | fn dynamic_payload_size<u256> | fn encode_field<Sol, u256, E> | mut D | mut E | mut u256 | u256
 
 note:
    ┌─ contract_effects.fe:33:5
    │
 33 │     Withdraw { amount: u256 } -> bool,
-   │     ^^^^^^^^ () | I | Withdraw | fn decode_field<Sol, u256, D> | fn decode_field_from<Sol, u256, I> | fn dynamic_payload_size<u256> | fn encode_field<Sol, u256, E> | mut D | mut E | mut u256 | u256
+   │     ^^^^^^^^ () | I | Withdraw | fn decode_field<Sol, u256, D> | fn decode_msg_field_from<Sol, u256, I> | fn dynamic_payload_size<u256> | fn encode_field<Sol, u256, E> | mut D | mut E | mut u256 | u256
 
 note:
    ┌─ contract_effects.fe:36:5

--- a/crates/hir/test_files/ty_check/contract_happy.snap
+++ b/crates/hir/test_files/ty_check/contract_happy.snap
@@ -156,10 +156,10 @@ note:
    ┌─ contract_happy.fe:28:5
    │
 28 │     Withdraw { amount: u64 } -> bool,
-   │     ^^^^^^^^ () | I | Withdraw | fn decode_field<Sol, u64, D> | fn decode_field_from<Sol, u64, I> | fn dynamic_payload_size<u64> | fn encode_field<Sol, u64, E> | mut D | mut E | mut u256 | u256 | u64
+   │     ^^^^^^^^ () | I | Withdraw | fn decode_field<Sol, u64, D> | fn decode_msg_field_from<Sol, u64, I> | fn dynamic_payload_size<u64> | fn encode_field<Sol, u64, E> | mut D | mut E | mut u256 | u256 | u64
 
 note:
    ┌─ contract_happy.fe:30:5
    │
 30 │     Deposit { amount: u64 } -> u64,
-   │     ^^^^^^^ () | Deposit | I | fn decode_field<Sol, u64, D> | fn decode_field_from<Sol, u64, I> | fn dynamic_payload_size<u64> | fn encode_field<Sol, u64, E> | mut D | mut E | mut u256 | u256 | u64
+   │     ^^^^^^^ () | Deposit | I | fn decode_field<Sol, u64, D> | fn decode_msg_field_from<Sol, u64, I> | fn dynamic_payload_size<u64> | fn encode_field<Sol, u64, E> | mut D | mut E | mut u256 | u256 | u64

--- a/crates/hir/test_files/ty_check/contract_happy.snap
+++ b/crates/hir/test_files/ty_check/contract_happy.snap
@@ -156,10 +156,10 @@ note:
    ┌─ contract_happy.fe:28:5
    │
 28 │     Withdraw { amount: u64 } -> bool,
-   │     ^^^^^^^^ () | Withdraw | fn decode_field<Sol, u64, D> | fn dynamic_payload_size<u64> | fn encode_field<Sol, u64, E> | mut D | mut E | mut u256 | u256 | u64
+   │     ^^^^^^^^ () | I | Withdraw | fn decode_field<Sol, u64, D> | fn decode_field_from<Sol, u64, I> | fn dynamic_payload_size<u64> | fn encode_field<Sol, u64, E> | mut D | mut E | mut u256 | u256 | u64
 
 note:
    ┌─ contract_happy.fe:30:5
    │
 30 │     Deposit { amount: u64 } -> u64,
-   │     ^^^^^^^ () | Deposit | fn decode_field<Sol, u64, D> | fn dynamic_payload_size<u64> | fn encode_field<Sol, u64, E> | mut D | mut E | mut u256 | u256 | u64
+   │     ^^^^^^^ () | Deposit | I | fn decode_field<Sol, u64, D> | fn decode_field_from<Sol, u64, I> | fn dynamic_payload_size<u64> | fn encode_field<Sol, u64, E> | mut D | mut E | mut u256 | u256 | u64

--- a/crates/hir/test_files/ty_check/contract_recv_msg_event_name_collision.snap
+++ b/crates/hir/test_files/ty_check/contract_recv_msg_event_name_collision.snap
@@ -7,7 +7,7 @@ note:
   ┌─ contract_recv_msg_event_name_collision.fe:3:5
   │
 3 │     Transfer { to: u256, amount: u256 } -> bool,
-  │     ^^^^^^^^ () | I | Transfer | fn abi_field_head_size<u256> | fn decode_field<Sol, u256, D> | fn decode_field_from<Sol, u256, I> | fn dynamic_payload_size<u256> | fn encode_field<Sol, u256, E> | mut D | mut E | mut u256 | u256
+  │     ^^^^^^^^ () | I | Transfer | fn abi_field_head_size<u256> | fn decode_field<Sol, u256, D> | fn decode_msg_field_from<Sol, u256, I> | fn dynamic_payload_size<u256> | fn encode_field<Sol, u256, E> | mut D | mut E | mut u256 | u256
 
 note:
    ┌─ contract_recv_msg_event_name_collision.fe:6:1

--- a/crates/hir/test_files/ty_check/contract_recv_msg_event_name_collision.snap
+++ b/crates/hir/test_files/ty_check/contract_recv_msg_event_name_collision.snap
@@ -7,7 +7,7 @@ note:
   ┌─ contract_recv_msg_event_name_collision.fe:3:5
   │
 3 │     Transfer { to: u256, amount: u256 } -> bool,
-  │     ^^^^^^^^ () | Transfer | fn decode_field<Sol, u256, D> | fn dynamic_payload_size<u256> | fn encode_field<Sol, u256, E> | mut D | mut E | mut u256 | u256
+  │     ^^^^^^^^ () | I | Transfer | fn abi_field_head_size<u256> | fn decode_field<Sol, u256, D> | fn decode_field_from<Sol, u256, I> | fn dynamic_payload_size<u256> | fn encode_field<Sol, u256, E> | mut D | mut E | mut u256 | u256
 
 note:
    ┌─ contract_recv_msg_event_name_collision.fe:6:1

--- a/crates/hir/test_files/ty_check/contract_recv_variants.snap
+++ b/crates/hir/test_files/ty_check/contract_recv_variants.snap
@@ -7,13 +7,13 @@ note:
    ┌─ contract_recv_variants.fe:11:5
    │
 11 │     Deposit { amount: u64 } -> u64,
-   │     ^^^^^^^ () | Deposit | fn decode_field<Sol, u64, D> | fn dynamic_payload_size<u64> | fn encode_field<Sol, u64, E> | mut D | mut E | mut u256 | u256 | u64
+   │     ^^^^^^^ () | Deposit | I | fn decode_field<Sol, u64, D> | fn decode_field_from<Sol, u64, I> | fn dynamic_payload_size<u64> | fn encode_field<Sol, u64, E> | mut D | mut E | mut u256 | u256 | u64
 
 note:
    ┌─ contract_recv_variants.fe:13:5
    │
 13 │     Withdraw { amount: u64 } -> bool,
-   │     ^^^^^^^^ () | Withdraw | fn decode_field<Sol, u64, D> | fn dynamic_payload_size<u64> | fn encode_field<Sol, u64, E> | mut D | mut E | mut u256 | u256 | u64
+   │     ^^^^^^^^ () | I | Withdraw | fn decode_field<Sol, u64, D> | fn decode_field_from<Sol, u64, I> | fn dynamic_payload_size<u64> | fn encode_field<Sol, u64, E> | mut D | mut E | mut u256 | u256 | u64
 
 note:
    ┌─ contract_recv_variants.fe:33:82

--- a/crates/hir/test_files/ty_check/contract_recv_variants.snap
+++ b/crates/hir/test_files/ty_check/contract_recv_variants.snap
@@ -7,13 +7,13 @@ note:
    ┌─ contract_recv_variants.fe:11:5
    │
 11 │     Deposit { amount: u64 } -> u64,
-   │     ^^^^^^^ () | Deposit | I | fn decode_field<Sol, u64, D> | fn decode_field_from<Sol, u64, I> | fn dynamic_payload_size<u64> | fn encode_field<Sol, u64, E> | mut D | mut E | mut u256 | u256 | u64
+   │     ^^^^^^^ () | Deposit | I | fn decode_field<Sol, u64, D> | fn decode_msg_field_from<Sol, u64, I> | fn dynamic_payload_size<u64> | fn encode_field<Sol, u64, E> | mut D | mut E | mut u256 | u256 | u64
 
 note:
    ┌─ contract_recv_variants.fe:13:5
    │
 13 │     Withdraw { amount: u64 } -> bool,
-   │     ^^^^^^^^ () | I | Withdraw | fn decode_field<Sol, u64, D> | fn decode_field_from<Sol, u64, I> | fn dynamic_payload_size<u64> | fn encode_field<Sol, u64, E> | mut D | mut E | mut u256 | u256 | u64
+   │     ^^^^^^^^ () | I | Withdraw | fn decode_field<Sol, u64, D> | fn decode_msg_field_from<Sol, u64, I> | fn dynamic_payload_size<u64> | fn encode_field<Sol, u64, E> | mut D | mut E | mut u256 | u256 | u64
 
 note:
    ┌─ contract_recv_variants.fe:33:82

--- a/crates/hir/test_files/ty_check/recv_nested_patterns.snap
+++ b/crates/hir/test_files/ty_check/recv_nested_patterns.snap
@@ -7,25 +7,25 @@ note:
   ┌─ recv_nested_patterns.fe:6:5
   │
 6 │     SetPair { pair: (u64, bool) } -> u64,
-  │     ^^^^^^^ () | (u64, bool) | I | SetPair | fn decode_field<Sol, (u64, bool), D> | fn decode_field_from<Sol, (u64, bool), I> | fn dynamic_payload_size<(u64, bool)> | fn encode_field<Sol, (u64, bool), E> | mut D | mut E | mut u256 | u256
+  │     ^^^^^^^ () | (u64, bool) | I | SetPair | fn decode_field<Sol, (u64, bool), D> | fn decode_msg_field_from<Sol, (u64, bool), I> | fn dynamic_payload_size<(u64, bool)> | fn encode_field<Sol, (u64, bool), E> | mut D | mut E | mut u256 | u256
 
 note:
   ┌─ recv_nested_patterns.fe:8:5
   │
 8 │     SetTriple { triple: (u64, u64, u64) } -> u64,
-  │     ^^^^^^^^^ () | (u64, u64, u64) | I | SetTriple | fn decode_field<Sol, (u64, u64, u64), D> | fn decode_field_from<Sol, (u64, u64, u64), I> | fn dynamic_payload_size<(u64, u64, u64)> | fn encode_field<Sol, (u64, u64, u64), E> | mut D | mut E | mut u256 | u256
+  │     ^^^^^^^^^ () | (u64, u64, u64) | I | SetTriple | fn decode_field<Sol, (u64, u64, u64), D> | fn decode_msg_field_from<Sol, (u64, u64, u64), I> | fn dynamic_payload_size<(u64, u64, u64)> | fn encode_field<Sol, (u64, u64, u64), E> | mut D | mut E | mut u256 | u256
 
 note:
    ┌─ recv_nested_patterns.fe:10:5
    │
 10 │     SetNested { nested: ((u64, u64), bool) } -> u64,
-   │     ^^^^^^^^^ ((u64, u64), bool) | () | I | SetNested | fn decode_field<Sol, ((u64, u64), bool), D> | fn decode_field_from<Sol, ((u64, u64), bool), I> | fn dynamic_payload_size<((u64, u64), bool)> | fn encode_field<Sol, ((u64, u64), bool), E> | mut D | mut E | mut u256 | u256
+   │     ^^^^^^^^^ ((u64, u64), bool) | () | I | SetNested | fn decode_field<Sol, ((u64, u64), bool), D> | fn decode_msg_field_from<Sol, ((u64, u64), bool), I> | fn dynamic_payload_size<((u64, u64), bool)> | fn encode_field<Sol, ((u64, u64), bool), E> | mut D | mut E | mut u256 | u256
 
 note:
    ┌─ recv_nested_patterns.fe:12:5
    │
 12 │     Multi { a: (u64, u64), b: (bool, bool) } -> bool,
-   │     ^^^^^ () | (bool, bool) | (u64, u64) | I | Multi | fn abi_field_head_size<(u64, u64)> | fn decode_field<Sol, (bool, bool), D> | fn decode_field<Sol, (u64, u64), D> | fn decode_field_from<Sol, (bool, bool), I> | fn decode_field_from<Sol, (u64, u64), I> | fn dynamic_payload_size<(bool, bool)> | fn dynamic_payload_size<(u64, u64)> | fn encode_field<Sol, (bool, bool), E> | fn encode_field<Sol, (u64, u64), E> | mut D | mut E | mut u256 | u256
+   │     ^^^^^ () | (bool, bool) | (u64, u64) | I | Multi | fn abi_field_head_size<(u64, u64)> | fn decode_field<Sol, (bool, bool), D> | fn decode_field<Sol, (u64, u64), D> | fn decode_msg_field_from<Sol, (bool, bool), I> | fn decode_msg_field_from<Sol, (u64, u64), I> | fn dynamic_payload_size<(bool, bool)> | fn dynamic_payload_size<(u64, u64)> | fn encode_field<Sol, (bool, bool), E> | fn encode_field<Sol, (u64, u64), E> | mut D | mut E | mut u256 | u256
 
 note:
    ┌─ recv_nested_patterns.fe:20:9
@@ -944,7 +944,7 @@ note:
     ┌─ recv_nested_patterns.fe:109:5
     │
 109 │     TypeMismatch { pair: (u64, u64) } -> u64,
-    │     ^^^^^^^^^^^^ () | (u64, u64) | I | TypeMismatch | fn decode_field<Sol, (u64, u64), D> | fn decode_field_from<Sol, (u64, u64), I> | fn dynamic_payload_size<(u64, u64)> | fn encode_field<Sol, (u64, u64), E> | mut D | mut E | mut u256 | u256
+    │     ^^^^^^^^^^^^ () | (u64, u64) | I | TypeMismatch | fn decode_field<Sol, (u64, u64), D> | fn decode_msg_field_from<Sol, (u64, u64), I> | fn dynamic_payload_size<(u64, u64)> | fn encode_field<Sol, (u64, u64), E> | mut D | mut E | mut u256 | u256
 
 note:
     ┌─ recv_nested_patterns.fe:117:9
@@ -1001,7 +1001,7 @@ note:
     ┌─ recv_nested_patterns.fe:126:5
     │
 126 │     Deep { nested: (((u64, u64), u64), bool) } -> u64,
-    │     ^^^^ (((u64, u64), u64), bool) | () | Deep | I | fn decode_field<Sol, (((u64, u64), u64), bool), D> | fn decode_field_from<Sol, (((u64, u64), u64), bool), I> | fn dynamic_payload_size<(((u64, u64), u64), bool)> | fn encode_field<Sol, (((u64, u64), u64), bool), E> | mut D | mut E | mut u256 | u256
+    │     ^^^^ (((u64, u64), u64), bool) | () | Deep | I | fn decode_field<Sol, (((u64, u64), u64), bool), D> | fn decode_msg_field_from<Sol, (((u64, u64), u64), bool), I> | fn dynamic_payload_size<(((u64, u64), u64), bool)> | fn encode_field<Sol, (((u64, u64), u64), bool), E> | mut D | mut E | mut u256 | u256
 
 note:
     ┌─ recv_nested_patterns.fe:134:9

--- a/crates/hir/test_files/ty_check/recv_nested_patterns.snap
+++ b/crates/hir/test_files/ty_check/recv_nested_patterns.snap
@@ -7,25 +7,25 @@ note:
   ┌─ recv_nested_patterns.fe:6:5
   │
 6 │     SetPair { pair: (u64, bool) } -> u64,
-  │     ^^^^^^^ () | (u64, bool) | SetPair | fn decode_field<Sol, (u64, bool), D> | fn dynamic_payload_size<(u64, bool)> | fn encode_field<Sol, (u64, bool), E> | mut D | mut E | mut u256 | u256
+  │     ^^^^^^^ () | (u64, bool) | I | SetPair | fn decode_field<Sol, (u64, bool), D> | fn decode_field_from<Sol, (u64, bool), I> | fn dynamic_payload_size<(u64, bool)> | fn encode_field<Sol, (u64, bool), E> | mut D | mut E | mut u256 | u256
 
 note:
   ┌─ recv_nested_patterns.fe:8:5
   │
 8 │     SetTriple { triple: (u64, u64, u64) } -> u64,
-  │     ^^^^^^^^^ () | (u64, u64, u64) | SetTriple | fn decode_field<Sol, (u64, u64, u64), D> | fn dynamic_payload_size<(u64, u64, u64)> | fn encode_field<Sol, (u64, u64, u64), E> | mut D | mut E | mut u256 | u256
+  │     ^^^^^^^^^ () | (u64, u64, u64) | I | SetTriple | fn decode_field<Sol, (u64, u64, u64), D> | fn decode_field_from<Sol, (u64, u64, u64), I> | fn dynamic_payload_size<(u64, u64, u64)> | fn encode_field<Sol, (u64, u64, u64), E> | mut D | mut E | mut u256 | u256
 
 note:
    ┌─ recv_nested_patterns.fe:10:5
    │
 10 │     SetNested { nested: ((u64, u64), bool) } -> u64,
-   │     ^^^^^^^^^ ((u64, u64), bool) | () | SetNested | fn decode_field<Sol, ((u64, u64), bool), D> | fn dynamic_payload_size<((u64, u64), bool)> | fn encode_field<Sol, ((u64, u64), bool), E> | mut D | mut E | mut u256 | u256
+   │     ^^^^^^^^^ ((u64, u64), bool) | () | I | SetNested | fn decode_field<Sol, ((u64, u64), bool), D> | fn decode_field_from<Sol, ((u64, u64), bool), I> | fn dynamic_payload_size<((u64, u64), bool)> | fn encode_field<Sol, ((u64, u64), bool), E> | mut D | mut E | mut u256 | u256
 
 note:
    ┌─ recv_nested_patterns.fe:12:5
    │
 12 │     Multi { a: (u64, u64), b: (bool, bool) } -> bool,
-   │     ^^^^^ () | (bool, bool) | (u64, u64) | Multi | fn decode_field<Sol, (bool, bool), D> | fn decode_field<Sol, (u64, u64), D> | fn dynamic_payload_size<(bool, bool)> | fn dynamic_payload_size<(u64, u64)> | fn encode_field<Sol, (bool, bool), E> | fn encode_field<Sol, (u64, u64), E> | mut D | mut E | mut u256 | u256
+   │     ^^^^^ () | (bool, bool) | (u64, u64) | I | Multi | fn abi_field_head_size<(u64, u64)> | fn decode_field<Sol, (bool, bool), D> | fn decode_field<Sol, (u64, u64), D> | fn decode_field_from<Sol, (bool, bool), I> | fn decode_field_from<Sol, (u64, u64), I> | fn dynamic_payload_size<(bool, bool)> | fn dynamic_payload_size<(u64, u64)> | fn encode_field<Sol, (bool, bool), E> | fn encode_field<Sol, (u64, u64), E> | mut D | mut E | mut u256 | u256
 
 note:
    ┌─ recv_nested_patterns.fe:20:9
@@ -944,7 +944,7 @@ note:
     ┌─ recv_nested_patterns.fe:109:5
     │
 109 │     TypeMismatch { pair: (u64, u64) } -> u64,
-    │     ^^^^^^^^^^^^ () | (u64, u64) | TypeMismatch | fn decode_field<Sol, (u64, u64), D> | fn dynamic_payload_size<(u64, u64)> | fn encode_field<Sol, (u64, u64), E> | mut D | mut E | mut u256 | u256
+    │     ^^^^^^^^^^^^ () | (u64, u64) | I | TypeMismatch | fn decode_field<Sol, (u64, u64), D> | fn decode_field_from<Sol, (u64, u64), I> | fn dynamic_payload_size<(u64, u64)> | fn encode_field<Sol, (u64, u64), E> | mut D | mut E | mut u256 | u256
 
 note:
     ┌─ recv_nested_patterns.fe:117:9
@@ -1001,7 +1001,7 @@ note:
     ┌─ recv_nested_patterns.fe:126:5
     │
 126 │     Deep { nested: (((u64, u64), u64), bool) } -> u64,
-    │     ^^^^ (((u64, u64), u64), bool) | () | Deep | fn decode_field<Sol, (((u64, u64), u64), bool), D> | fn dynamic_payload_size<(((u64, u64), u64), bool)> | fn encode_field<Sol, (((u64, u64), u64), bool), E> | mut D | mut E | mut u256 | u256
+    │     ^^^^ (((u64, u64), u64), bool) | () | Deep | I | fn decode_field<Sol, (((u64, u64), u64), bool), D> | fn decode_field_from<Sol, (((u64, u64), u64), bool), I> | fn dynamic_payload_size<(((u64, u64), u64), bool)> | fn encode_field<Sol, (((u64, u64), u64), bool), E> | mut D | mut E | mut u256 | u256
 
 note:
     ┌─ recv_nested_patterns.fe:134:9

--- a/crates/language-server/test_files/completion.snap
+++ b/crates/language-server/test_files/completion.snap
@@ -47,6 +47,7 @@ completions:
   - Text (Class)
   - Vec (Class)
   - another_func_with_args (Function) -> "another_func_with_args(${1:x}, ${2:y})$0" [fn another_func_with_args(x: i32, y: i32) -> i32]
+  - assert (Function) -> "assert(${1:b})$0" [fn assert(b: bool)]
   - func_with_args (Function) -> "func_with_args(${1:x}, ${2:y})$0" [use utils::func_with_args [fn func_with_args(x: i32, y: i32) -> i32]] {+0:use utils::func_with_args}
   - help (Function) -> "help()$0" [use utils::help [fn help() -> i32]] {+0:use utils::help}
   - helper_func (Function) -> "helper_func()$0" [use utils::helper_func [fn helper_func() -> i32]] {+0:use utils::helper_func}
@@ -117,6 +118,7 @@ completions:
   - Ok (EnumMember)
   - Some (EnumMember)
   - another_func_with_args (Function) -> "another_func_with_args(${1:x}, ${2:y})$0" [fn another_func_with_args(x: i32, y: i32) -> i32]
+  - assert (Function) -> "assert(${1:b})$0" [fn assert(b: bool)]
   - func_with_args (Function) -> "func_with_args(${1:x}, ${2:y})$0" [use utils::func_with_args [fn func_with_args(x: i32, y: i32) -> i32]] {+0:use utils::func_with_args}
   - help (Function) -> "help()$0" [use utils::help [fn help() -> i32]] {+0:use utils::help}
   - helper_func (Function) -> "helper_func()$0" [use utils::helper_func [fn helper_func() -> i32]] {+0:use utils::helper_func}
@@ -182,6 +184,7 @@ completions:
   - Ok (EnumMember)
   - Some (EnumMember)
   - another_func_with_args (Function) -> "another_func_with_args(${1:x}, ${2:y})$0" [fn another_func_with_args(x: i32, y: i32) -> i32]
+  - assert (Function) -> "assert(${1:b})$0" [fn assert(b: bool)]
   - func_with_args (Function) -> "func_with_args(${1:x}, ${2:y})$0" [use utils::func_with_args [fn func_with_args(x: i32, y: i32) -> i32]] {+0:use utils::func_with_args}
   - help (Function) -> "help()$0" [use utils::help [fn help() -> i32]] {+0:use utils::help}
   - helper_func (Function) -> "helper_func()$0" [use utils::helper_func [fn helper_func() -> i32]] {+0:use utils::helper_func}

--- a/crates/semantic-indexing/src/scip_batch.rs
+++ b/crates/semantic-indexing/src/scip_batch.rs
@@ -995,6 +995,7 @@ pub fn enrich_signatures_with_base(
     // Step 2: Build per-file byte-indexed occurrence lists from SCIP documents.
     // We need file text to convert SCIP line/col → byte offsets.
     let mut file_occurrences: HashMap<String, Vec<ByteOccurrence>> = HashMap::new();
+    let mut file_texts: HashMap<String, String> = HashMap::new();
     for doc in &scip_index.documents {
         let file_url = if let Some(base) = base_url {
             // Non-file URL base (e.g. builtin-core:///): join relative path onto it
@@ -1013,6 +1014,9 @@ pub fn enrich_signatures_with_base(
             continue;
         };
         let text = file.text(db);
+        file_texts
+            .entry(doc.relative_path.clone())
+            .or_insert_with(|| text.to_string());
         let line_index = LineIndex::new(text);
 
         let occs = file_occurrences
@@ -1046,6 +1050,7 @@ pub fn enrich_signatures_with_base(
                 &item.signature,
                 project_root,
                 &file_occurrences,
+                &file_texts,
                 &symbol_to_url,
             );
             if parts.iter().any(|p| p.link.is_some()) {
@@ -1061,6 +1066,7 @@ pub fn enrich_signatures_with_base(
                     &child.signature,
                     project_root,
                     &file_occurrences,
+                    &file_texts,
                     &symbol_to_url,
                 );
                 if parts.iter().any(|p| p.link.is_some()) {
@@ -1077,6 +1083,7 @@ pub fn enrich_signatures_with_base(
                     &trait_impl.signature,
                     project_root,
                     &file_occurrences,
+                    &file_texts,
                     &symbol_to_url,
                 );
                 if parts.iter().any(|p| p.link.is_some()) {
@@ -1090,6 +1097,7 @@ pub fn enrich_signatures_with_base(
                         &method.signature,
                         project_root,
                         &file_occurrences,
+                        &file_texts,
                         &symbol_to_url,
                     );
                     if parts.iter().any(|p| p.link.is_some()) {
@@ -1171,6 +1179,7 @@ pub fn enrich_signatures_with_base(
                 &item.signature,
                 project_root,
                 &file_occurrences,
+                &file_texts,
                 &self_extras,
             );
             if !occs.is_empty() {
@@ -1201,6 +1210,7 @@ pub fn enrich_signatures_with_base(
                     sig,
                     project_root,
                     &file_occurrences,
+                    &file_texts,
                     &parent_type_params,
                 );
                 if !occs.is_empty() {
@@ -1235,6 +1245,7 @@ pub fn enrich_signatures_with_base(
                     &trait_impl.signature,
                     project_root,
                     &file_occurrences,
+                    &file_texts,
                 );
                 if !occs.is_empty() {
                     trait_impl.sig_scope = Some(scope.clone());
@@ -1260,6 +1271,7 @@ pub fn enrich_signatures_with_base(
                         &method.signature,
                         project_root,
                         &file_occurrences,
+                        &file_texts,
                         &parent_type_params,
                     );
                     if !occs.is_empty() {
@@ -1287,6 +1299,7 @@ pub fn enrich_signatures_with_base(
                     &imp.signature,
                     project_root,
                     &file_occurrences,
+                    &file_texts,
                 );
                 if !occs.is_empty() {
                     imp.sig_scope = Some(scope.clone());
@@ -1341,6 +1354,69 @@ fn scip_range_to_byte_range(line_index: &LineIndex, range: &[i32]) -> (usize, us
     }
 }
 
+struct SignatureOffsetMapper<'a> {
+    raw_text: &'a str,
+    normalized_text: &'a str,
+}
+
+impl<'a> SignatureOffsetMapper<'a> {
+    fn new(raw_text: &'a str, normalized_text: &'a str) -> Option<Self> {
+        if raw_text == normalized_text || normalize_line_endings(raw_text) == normalized_text {
+            Some(Self {
+                raw_text,
+                normalized_text,
+            })
+        } else {
+            None
+        }
+    }
+
+    fn to_normalized(&self, raw_offset: usize) -> Option<usize> {
+        if raw_offset > self.raw_text.len() || !self.raw_text.is_char_boundary(raw_offset) {
+            return None;
+        }
+        if self.raw_text == self.normalized_text {
+            return Some(raw_offset);
+        }
+
+        let mut raw_pos = 0;
+        let mut normalized_pos = 0;
+        while raw_pos < raw_offset {
+            if self.raw_text.as_bytes().get(raw_pos..raw_pos + 2) == Some(b"\r\n") {
+                raw_pos += 2;
+                normalized_pos += 1;
+            } else {
+                let ch = self.raw_text[raw_pos..].chars().next()?;
+                raw_pos += ch.len_utf8();
+                normalized_pos += ch.len_utf8();
+            }
+        }
+
+        if normalized_pos <= self.normalized_text.len()
+            && self.normalized_text.is_char_boundary(normalized_pos)
+        {
+            Some(normalized_pos)
+        } else {
+            None
+        }
+    }
+}
+
+fn normalize_line_endings(text: &str) -> String {
+    text.replace("\r\n", "\n")
+}
+
+fn signature_offset_mapper<'a>(
+    span: &fe_web::model::SignatureSpanData,
+    sig_text: &'a str,
+    rel_path: &str,
+    file_texts: &'a HashMap<String, String>,
+) -> Option<SignatureOffsetMapper<'a>> {
+    let file_text = file_texts.get(rel_path)?;
+    let raw_text = file_text.get(span.byte_start..span.byte_end)?;
+    SignatureOffsetMapper::new(raw_text, sig_text)
+}
+
 /// Build `rich_signature` parts by overlaying SCIP occurrences on a signature span.
 ///
 /// Finds non-definition occurrences within the signature's byte range, maps their
@@ -1351,6 +1427,7 @@ fn overlay_occurrences(
     sig_text: &str,
     project_root: &Utf8Path,
     file_occurrences: &HashMap<String, Vec<ByteOccurrence>>,
+    file_texts: &HashMap<String, String>,
     symbol_urls: &HashMap<String, String>,
 ) -> Vec<fe_web::model::SignaturePart> {
     use fe_web::model::SignaturePart;
@@ -1364,6 +1441,9 @@ fn overlay_occurrences(
         return vec![];
     };
     let Some(occs) = file_occurrences.get(&rel_path) else {
+        return vec![];
+    };
+    let Some(offset_mapper) = signature_offset_mapper(span, sig_text, &rel_path, file_texts) else {
         return vec![];
     };
 
@@ -1388,10 +1468,20 @@ fn overlay_occurrences(
     let mut pos = 0usize; // position within sig_text
 
     for occ in &sig_occs {
-        let occ_start = occ.byte_start.saturating_sub(span.byte_start);
-        let occ_end = occ.byte_end.saturating_sub(span.byte_start);
+        let raw_start = occ.byte_start.saturating_sub(span.byte_start);
+        let raw_end = occ.byte_end.saturating_sub(span.byte_start);
+        let Some(occ_start) = offset_mapper.to_normalized(raw_start) else {
+            continue;
+        };
+        let Some(occ_end) = offset_mapper.to_normalized(raw_end) else {
+            continue;
+        };
 
-        if occ_start > sig_text.len() || occ_end > sig_text.len() || occ_start < pos {
+        if occ_start > sig_text.len()
+            || occ_end > sig_text.len()
+            || occ_start < pos
+            || occ_end < occ_start
+        {
             continue;
         }
 
@@ -1458,8 +1548,16 @@ fn build_virtual_occurrences(
     sig_text: &str,
     project_root: &Utf8Path,
     file_occurrences: &HashMap<String, Vec<ByteOccurrence>>,
+    file_texts: &HashMap<String, String>,
 ) -> Vec<types::Occurrence> {
-    build_virtual_occurrences_with_extra(span, sig_text, project_root, file_occurrences, &[])
+    build_virtual_occurrences_with_extra(
+        span,
+        sig_text,
+        project_root,
+        file_occurrences,
+        file_texts,
+        &[],
+    )
 }
 
 fn build_virtual_occurrences_with_extra(
@@ -1467,6 +1565,7 @@ fn build_virtual_occurrences_with_extra(
     sig_text: &str,
     project_root: &Utf8Path,
     file_occurrences: &HashMap<String, Vec<ByteOccurrence>>,
+    file_texts: &HashMap<String, String>,
     extra_names: &[(String, String)],
 ) -> Vec<types::Occurrence> {
     let rel_path = match url::Url::parse(&span.file_url) {
@@ -1479,6 +1578,9 @@ fn build_virtual_occurrences_with_extra(
     let Some(occs) = file_occurrences.get(&rel_path) else {
         return vec![];
     };
+    let Some(offset_mapper) = signature_offset_mapper(span, sig_text, &rel_path, file_texts) else {
+        return vec![];
+    };
 
     // Deduplicate by position: multiple SCIP symbols can overlap at the same
     // source position (e.g. namespace-path vs item symbol).  Keep one per
@@ -1489,9 +1591,15 @@ fn build_virtual_occurrences_with_extra(
         if occ.byte_start < span.byte_start || occ.byte_end > span.byte_end {
             continue;
         }
-        let occ_start = occ.byte_start - span.byte_start;
-        let occ_end = occ.byte_end - span.byte_start;
-        if occ_end > sig_text.len() {
+        let raw_start = occ.byte_start - span.byte_start;
+        let raw_end = occ.byte_end - span.byte_start;
+        let Some(occ_start) = offset_mapper.to_normalized(raw_start) else {
+            continue;
+        };
+        let Some(occ_end) = offset_mapper.to_normalized(raw_end) else {
+            continue;
+        };
+        if occ_end > sig_text.len() || occ_end < occ_start {
             continue;
         }
 
@@ -1625,6 +1733,66 @@ mod tests {
             .touch(&mut db, url.clone(), Some(code.to_string()));
         let ingot_url = dir_url(temp.path());
         generate_scip(&db, &ingot_url).expect("generate scip index")
+    }
+
+    #[test]
+    fn signature_overlay_maps_raw_crlf_offsets_to_normalized_text() {
+        let temp = tempfile::tempdir().expect("create temp dir");
+        let project_root =
+            Utf8PathBuf::from_path_buf(temp.path().to_path_buf()).expect("utf8 temp path");
+        let file_path = project_root.join("test.fe");
+        let file_url = url::Url::from_file_path(file_path.as_std_path()).expect("file url");
+
+        let raw_sig = "a\r\nFoo—";
+        let sig_text = raw_sig.replace("\r\n", "\n");
+        let span = fe_web::model::SignatureSpanData {
+            file_url: file_url.to_string(),
+            byte_start: 0,
+            byte_end: raw_sig.len(),
+        };
+        let foo_start = raw_sig.find("Foo").expect("Foo in raw signature");
+        let mut file_occurrences = HashMap::new();
+        file_occurrences.insert(
+            "test.fe".to_string(),
+            vec![ByteOccurrence {
+                byte_start: foo_start,
+                byte_end: foo_start + "Foo".len(),
+                symbol: "test Foo".to_string(),
+                is_definition: false,
+            }],
+        );
+        let mut file_texts = HashMap::new();
+        file_texts.insert("test.fe".to_string(), raw_sig.to_string());
+        let mut symbol_urls = HashMap::new();
+        symbol_urls.insert("test Foo".to_string(), "test/Foo".to_string());
+
+        let parts = overlay_occurrences(
+            &span,
+            &sig_text,
+            &project_root,
+            &file_occurrences,
+            &file_texts,
+            &symbol_urls,
+        );
+        assert_eq!(
+            parts,
+            vec![
+                fe_web::model::SignaturePart::text("a\n"),
+                fe_web::model::SignaturePart::link("Foo", "test/Foo"),
+                fe_web::model::SignaturePart::text("—"),
+            ]
+        );
+
+        let virtual_occurrences = build_virtual_occurrences(
+            &span,
+            &sig_text,
+            &project_root,
+            &file_occurrences,
+            &file_texts,
+        );
+        assert_eq!(virtual_occurrences.len(), 1);
+        assert_eq!(virtual_occurrences[0].range, vec![1, 0, 3]);
+        assert_eq!(virtual_occurrences[0].symbol, "test Foo");
     }
 
     #[test]

--- a/crates/uitest/fixtures/ty_check/error_unsupported_field_type.snap
+++ b/crates/uitest/fixtures/ty_check/error_unsupported_field_type.snap
@@ -21,9 +21,9 @@ error[6-0003]: trait bound is not satisfied
   6 │ │ }
     │ ╰─^ `StorageMap<Address, u256, 0>` doesn't implement `AbiSize`
     │
-    ┌─ src/abi.fe:219:32
+    ┌─ src/abi.fe:226:32
     │
-219 │ pub fn dynamic_payload_size<T: AbiSize>(_ value: T) -> u256 {
+226 │ pub fn dynamic_payload_size<T: AbiSize>(_ value: T) -> u256 {
     │                                ------- required by this bound on `dynamic_payload_size`
 
 error[6-0003]: trait bound is not satisfied
@@ -35,9 +35,9 @@ error[6-0003]: trait bound is not satisfied
   6 │ │ }
     │ ╰─^ `StorageMap<Address, u256, 0>` doesn't implement `Encode<Sol>`
     │
-    ┌─ src/abi.fe:292:14
+    ┌─ src/abi.fe:313:14
     │
-292 │     where T: Encode<A> + AbiSize, E: AbiEncoder<A>
+313 │     where T: Encode<A> + AbiSize, E: AbiEncoder<A>
     │              --------- required by this bound on `encode_field`
 
 error[6-0003]: trait bound is not satisfied
@@ -49,7 +49,7 @@ error[6-0003]: trait bound is not satisfied
   6 │ │ }
     │ ╰─^ `StorageMap<Address, u256, 0>` doesn't implement `AbiSize`
     │
-    ┌─ src/abi.fe:292:26
+    ┌─ src/abi.fe:313:26
     │
-292 │     where T: Encode<A> + AbiSize, E: AbiEncoder<A>
+313 │     where T: Encode<A> + AbiSize, E: AbiEncoder<A>
     │                          ------- required by this bound on `encode_field`

--- a/crates/uitest/fixtures/ty_check/error_unsupported_field_type.snap
+++ b/crates/uitest/fixtures/ty_check/error_unsupported_field_type.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/uitest/tests/ty_check.rs
+assertion_line: 27
 expression: diags
 input_file: fixtures/ty_check/error_unsupported_field_type.fe
 ---
@@ -21,9 +22,9 @@ error[6-0003]: trait bound is not satisfied
   6 │ │ }
     │ ╰─^ `StorageMap<Address, u256, 0>` doesn't implement `AbiSize`
     │
-    ┌─ src/abi.fe:288:32
+    ┌─ src/abi.fe:298:32
     │
-288 │ pub fn dynamic_payload_size<T: AbiSize>(_ value: T) -> u256 {
+298 │ pub fn dynamic_payload_size<T: AbiSize>(_ value: T) -> u256 {
     │                                ------- required by this bound on `dynamic_payload_size`
 
 error[6-0003]: trait bound is not satisfied
@@ -35,9 +36,9 @@ error[6-0003]: trait bound is not satisfied
   6 │ │ }
     │ ╰─^ `StorageMap<Address, u256, 0>` doesn't implement `Encode<Sol>`
     │
-    ┌─ src/abi.fe:399:14
+    ┌─ src/abi.fe:404:14
     │
-399 │     where T: Encode<A> + AbiSize, E: AbiEncoder<A>
+404 │     where T: Encode<A> + AbiSize, E: AbiEncoder<A>
     │              --------- required by this bound on `encode_field`
 
 error[6-0003]: trait bound is not satisfied
@@ -49,7 +50,7 @@ error[6-0003]: trait bound is not satisfied
   6 │ │ }
     │ ╰─^ `StorageMap<Address, u256, 0>` doesn't implement `AbiSize`
     │
-    ┌─ src/abi.fe:399:26
+    ┌─ src/abi.fe:404:26
     │
-399 │     where T: Encode<A> + AbiSize, E: AbiEncoder<A>
+404 │     where T: Encode<A> + AbiSize, E: AbiEncoder<A>
     │                          ------- required by this bound on `encode_field`

--- a/crates/uitest/fixtures/ty_check/error_unsupported_field_type.snap
+++ b/crates/uitest/fixtures/ty_check/error_unsupported_field_type.snap
@@ -22,9 +22,9 @@ error[6-0003]: trait bound is not satisfied
   6 │ │ }
     │ ╰─^ `StorageMap<Address, u256, 0>` doesn't implement `AbiSize`
     │
-    ┌─ src/abi.fe:235:32
+    ┌─ src/abi.fe:247:32
     │
-235 │ pub fn dynamic_payload_size<T: AbiSize>(_ value: T) -> u256 {
+247 │ pub fn dynamic_payload_size<T: AbiSize>(_ value: T) -> u256 {
     │                                ------- required by this bound on `dynamic_payload_size`
 
 error[6-0003]: trait bound is not satisfied
@@ -36,9 +36,9 @@ error[6-0003]: trait bound is not satisfied
   6 │ │ }
     │ ╰─^ `StorageMap<Address, u256, 0>` doesn't implement `Encode<Sol>`
     │
-    ┌─ src/abi.fe:322:14
+    ┌─ src/abi.fe:348:14
     │
-322 │     where T: Encode<A> + AbiSize, E: AbiEncoder<A>
+348 │     where T: Encode<A> + AbiSize, E: AbiEncoder<A>
     │              --------- required by this bound on `encode_field`
 
 error[6-0003]: trait bound is not satisfied
@@ -50,7 +50,7 @@ error[6-0003]: trait bound is not satisfied
   6 │ │ }
     │ ╰─^ `StorageMap<Address, u256, 0>` doesn't implement `AbiSize`
     │
-    ┌─ src/abi.fe:322:26
+    ┌─ src/abi.fe:348:26
     │
-322 │     where T: Encode<A> + AbiSize, E: AbiEncoder<A>
+348 │     where T: Encode<A> + AbiSize, E: AbiEncoder<A>
     │                          ------- required by this bound on `encode_field`

--- a/crates/uitest/fixtures/ty_check/error_unsupported_field_type.snap
+++ b/crates/uitest/fixtures/ty_check/error_unsupported_field_type.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/uitest/tests/ty_check.rs
-assertion_line: 27
 expression: diags
 input_file: fixtures/ty_check/error_unsupported_field_type.fe
 ---
@@ -22,9 +21,9 @@ error[6-0003]: trait bound is not satisfied
   6 │ │ }
     │ ╰─^ `StorageMap<Address, u256, 0>` doesn't implement `AbiSize`
     │
-    ┌─ src/abi.fe:298:32
+    ┌─ src/abi.fe:299:32
     │
-298 │ pub fn dynamic_payload_size<T: AbiSize>(_ value: T) -> u256 {
+299 │ pub fn dynamic_payload_size<T: AbiSize>(_ value: T) -> u256 {
     │                                ------- required by this bound on `dynamic_payload_size`
 
 error[6-0003]: trait bound is not satisfied
@@ -36,9 +35,9 @@ error[6-0003]: trait bound is not satisfied
   6 │ │ }
     │ ╰─^ `StorageMap<Address, u256, 0>` doesn't implement `Encode<Sol>`
     │
-    ┌─ src/abi.fe:404:14
+    ┌─ src/abi.fe:419:14
     │
-404 │     where T: Encode<A> + AbiSize, E: AbiEncoder<A>
+419 │     where T: Encode<A> + AbiSize, E: AbiEncoder<A>
     │              --------- required by this bound on `encode_field`
 
 error[6-0003]: trait bound is not satisfied
@@ -50,7 +49,7 @@ error[6-0003]: trait bound is not satisfied
   6 │ │ }
     │ ╰─^ `StorageMap<Address, u256, 0>` doesn't implement `AbiSize`
     │
-    ┌─ src/abi.fe:404:26
+    ┌─ src/abi.fe:419:26
     │
-404 │     where T: Encode<A> + AbiSize, E: AbiEncoder<A>
+419 │     where T: Encode<A> + AbiSize, E: AbiEncoder<A>
     │                          ------- required by this bound on `encode_field`

--- a/crates/uitest/fixtures/ty_check/error_unsupported_field_type.snap
+++ b/crates/uitest/fixtures/ty_check/error_unsupported_field_type.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/uitest/tests/ty_check.rs
-assertion_line: 27
 expression: diags
 input_file: fixtures/ty_check/error_unsupported_field_type.fe
 ---
@@ -22,9 +21,9 @@ error[6-0003]: trait bound is not satisfied
   6 │ │ }
     │ ╰─^ `StorageMap<Address, u256, 0>` doesn't implement `AbiSize`
     │
-    ┌─ src/abi.fe:247:32
+    ┌─ src/abi.fe:288:32
     │
-247 │ pub fn dynamic_payload_size<T: AbiSize>(_ value: T) -> u256 {
+288 │ pub fn dynamic_payload_size<T: AbiSize>(_ value: T) -> u256 {
     │                                ------- required by this bound on `dynamic_payload_size`
 
 error[6-0003]: trait bound is not satisfied
@@ -36,9 +35,9 @@ error[6-0003]: trait bound is not satisfied
   6 │ │ }
     │ ╰─^ `StorageMap<Address, u256, 0>` doesn't implement `Encode<Sol>`
     │
-    ┌─ src/abi.fe:348:14
+    ┌─ src/abi.fe:399:14
     │
-348 │     where T: Encode<A> + AbiSize, E: AbiEncoder<A>
+399 │     where T: Encode<A> + AbiSize, E: AbiEncoder<A>
     │              --------- required by this bound on `encode_field`
 
 error[6-0003]: trait bound is not satisfied
@@ -50,7 +49,7 @@ error[6-0003]: trait bound is not satisfied
   6 │ │ }
     │ ╰─^ `StorageMap<Address, u256, 0>` doesn't implement `AbiSize`
     │
-    ┌─ src/abi.fe:348:26
+    ┌─ src/abi.fe:399:26
     │
-348 │     where T: Encode<A> + AbiSize, E: AbiEncoder<A>
+399 │     where T: Encode<A> + AbiSize, E: AbiEncoder<A>
     │                          ------- required by this bound on `encode_field`

--- a/crates/uitest/fixtures/ty_check/error_unsupported_field_type.snap
+++ b/crates/uitest/fixtures/ty_check/error_unsupported_field_type.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/uitest/tests/ty_check.rs
+assertion_line: 27
 expression: diags
 input_file: fixtures/ty_check/error_unsupported_field_type.fe
 ---
@@ -21,9 +22,9 @@ error[6-0003]: trait bound is not satisfied
   6 │ │ }
     │ ╰─^ `StorageMap<Address, u256, 0>` doesn't implement `AbiSize`
     │
-    ┌─ src/abi.fe:226:32
+    ┌─ src/abi.fe:235:32
     │
-226 │ pub fn dynamic_payload_size<T: AbiSize>(_ value: T) -> u256 {
+235 │ pub fn dynamic_payload_size<T: AbiSize>(_ value: T) -> u256 {
     │                                ------- required by this bound on `dynamic_payload_size`
 
 error[6-0003]: trait bound is not satisfied
@@ -35,9 +36,9 @@ error[6-0003]: trait bound is not satisfied
   6 │ │ }
     │ ╰─^ `StorageMap<Address, u256, 0>` doesn't implement `Encode<Sol>`
     │
-    ┌─ src/abi.fe:313:14
+    ┌─ src/abi.fe:322:14
     │
-313 │     where T: Encode<A> + AbiSize, E: AbiEncoder<A>
+322 │     where T: Encode<A> + AbiSize, E: AbiEncoder<A>
     │              --------- required by this bound on `encode_field`
 
 error[6-0003]: trait bound is not satisfied
@@ -49,7 +50,7 @@ error[6-0003]: trait bound is not satisfied
   6 │ │ }
     │ ╰─^ `StorageMap<Address, u256, 0>` doesn't implement `AbiSize`
     │
-    ┌─ src/abi.fe:313:26
+    ┌─ src/abi.fe:322:26
     │
-313 │     where T: Encode<A> + AbiSize, E: AbiEncoder<A>
+322 │     where T: Encode<A> + AbiSize, E: AbiEncoder<A>
     │                          ------- required by this bound on `encode_field`

--- a/crates/uitest/fixtures/ty_check/event_unsupported_field_type.snap
+++ b/crates/uitest/fixtures/ty_check/event_unsupported_field_type.snap
@@ -12,9 +12,9 @@ error[6-0003]: trait bound is not satisfied
   6 │ │ }
     │ ╰─^ `StorageMap<Address, u256, 0>` doesn't implement `Encode<Sol>`
     │
-    ┌─ src/evm/effects.fe:351:14
+    ┌─ src/evm/effects.fe:361:14
     │
-351 │     where T: Encode<Sol> + AbiSize
+361 │     where T: Encode<Sol> + AbiSize
     │              ----------- required by this bound on `encode_abi_payload`
 
 error[6-0003]: trait bound is not satisfied
@@ -26,7 +26,7 @@ error[6-0003]: trait bound is not satisfied
   6 │ │ }
     │ ╰─^ `StorageMap<Address, u256, 0>` doesn't implement `AbiSize`
     │
-    ┌─ src/evm/effects.fe:351:28
+    ┌─ src/evm/effects.fe:361:28
     │
-351 │     where T: Encode<Sol> + AbiSize
+361 │     where T: Encode<Sol> + AbiSize
     │                            ------- required by this bound on `encode_abi_payload`

--- a/ingots/core/src/abi.fe
+++ b/ingots/core/src/abi.fe
@@ -170,6 +170,13 @@ pub trait AbiSpan<A: Abi>: AbiSize {
 
 pub trait Decode<A: Abi> {
     fn decode_payload<D: AbiDecoder<A>>(_: mut D) -> Self
+
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self
+        where A::Decoder<I>: AbiDecoder<A>
+    {
+        let mut d = A::decoder_with_base(input, pos)
+        Self::decode_payload(mut d)
+    }
 }
 
 pub trait Encode<A: Abi>: AbiSize {
@@ -255,6 +262,20 @@ pub fn decode_field<A: Abi, T, D>(_ d: mut D) -> T
     }
 
     T::decode_payload(d)
+}
+
+#[inline(always)]
+pub fn decode_field_from<A: Abi, T, I>(_ input: I, base: u256, head_pos: u256) -> T
+    where T: Decode<A> + AbiSize,
+          I: ByteInput,
+          A::Decoder<I>: AbiDecoder<A>
+{
+    if T::IS_DYNAMIC {
+        let tail_rel = input.word_at(head_pos)
+        return T::decode_from(input, base + tail_rel)
+    }
+
+    T::decode_from(input, head_pos)
 }
 
 fn decode_field_at<A: Abi, T, D>(d: mut D, pos: u256) -> T
@@ -1174,6 +1195,11 @@ impl<A: Abi> Decode<A> for u256 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         d.read_word()
     }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        input.word_at(pos)
+    }
 }
 
 impl<A: Abi> Encode<A> for u256 {
@@ -1242,6 +1268,14 @@ impl<A: Abi> Decode<A> for DynString {
             size: payload_size,
         }
     }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self
+        where A::Decoder<I>: AbiDecoder<A>
+    {
+        let mut d = A::decoder_with_base(input, pos)
+        Self::decode_payload(mut d)
+    }
 }
 
 impl<A: Abi> Encode<A> for DynString {
@@ -1264,6 +1298,11 @@ impl<A: Abi> Decode<A> for bool {
     #[inline(always)]
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         A::decode_bool_word(d.read_word())
+    }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        A::decode_bool_word(input.word_at(pos))
     }
 }
 
@@ -1291,6 +1330,11 @@ impl<A: Abi> Decode<A> for u8 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         A::decode_u8_word(d.read_word())
     }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        A::decode_u8_word(input.word_at(pos))
+    }
 }
 
 impl<A: Abi> Encode<A> for u8 {
@@ -1308,6 +1352,11 @@ impl<A: Abi> Encode<A> for u8 {
 impl<A: Abi> Decode<A> for u16 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         A::decode_u16_word(d.read_word())
+    }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        A::decode_u16_word(input.word_at(pos))
     }
 }
 
@@ -1327,6 +1376,11 @@ impl<A: Abi> Decode<A> for u32 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         A::decode_u32_word(d.read_word())
     }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        A::decode_u32_word(input.word_at(pos))
+    }
 }
 
 impl<A: Abi> Encode<A> for u32 {
@@ -1344,6 +1398,11 @@ impl<A: Abi> Encode<A> for u32 {
 impl<A: Abi> Decode<A> for u64 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         A::decode_u64_word(d.read_word())
+    }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        A::decode_u64_word(input.word_at(pos))
     }
 }
 
@@ -1363,6 +1422,11 @@ impl<A: Abi> Decode<A> for u128 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         A::decode_u128_word(d.read_word())
     }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        A::decode_u128_word(input.word_at(pos))
+    }
 }
 
 impl<A: Abi> Encode<A> for u128 {
@@ -1380,6 +1444,11 @@ impl<A: Abi> Encode<A> for u128 {
 impl<A: Abi> Decode<A> for i8 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         A::decode_i8_word(d.read_word())
+    }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        A::decode_i8_word(input.word_at(pos))
     }
 }
 
@@ -1399,6 +1468,11 @@ impl<A: Abi> Decode<A> for i16 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         A::decode_i16_word(d.read_word())
     }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        A::decode_i16_word(input.word_at(pos))
+    }
 }
 
 impl<A: Abi> Encode<A> for i16 {
@@ -1416,6 +1490,11 @@ impl<A: Abi> Encode<A> for i16 {
 impl<A: Abi> Decode<A> for i32 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         A::decode_i32_word(d.read_word())
+    }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        A::decode_i32_word(input.word_at(pos))
     }
 }
 
@@ -1435,6 +1514,11 @@ impl<A: Abi> Decode<A> for i64 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         A::decode_i64_word(d.read_word())
     }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        A::decode_i64_word(input.word_at(pos))
+    }
 }
 
 impl<A: Abi> Encode<A> for i64 {
@@ -1452,6 +1536,11 @@ impl<A: Abi> Encode<A> for i64 {
 impl<A: Abi> Decode<A> for i128 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         A::decode_i128_word(d.read_word())
+    }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        A::decode_i128_word(input.word_at(pos))
     }
 }
 
@@ -1471,6 +1560,11 @@ impl<A: Abi> Decode<A> for i256 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         d.read_word().downcast_unchecked()
     }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        input.word_at(pos).downcast_unchecked()
+    }
 }
 
 impl<A: Abi> Encode<A> for i256 {
@@ -1488,6 +1582,11 @@ impl<A: Abi> Encode<A> for i256 {
 impl<A: Abi> Decode<A> for usize {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         d.read_word() as usize
+    }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        input.word_at(pos) as usize
     }
 }
 
@@ -1507,6 +1606,11 @@ impl<A: Abi> Decode<A> for isize {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         d.read_word().downcast_unchecked()
     }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        input.word_at(pos).downcast_unchecked()
+    }
 }
 
 impl<A: Abi> Encode<A> for isize {
@@ -1523,6 +1627,11 @@ impl<A: Abi> Encode<A> for isize {
 
 impl<A: Abi> Decode<A> for () {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
+        ()
+    }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_: I, _: u256) -> Self {
         ()
     }
 }
@@ -1551,6 +1660,14 @@ impl<A: Abi> Decode<A> for Bytes {
             len: data_len,
             size: payload_size,
         }
+    }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self
+        where A::Decoder<I>: AbiDecoder<A>
+    {
+        let mut d = A::decoder_with_base(input, pos)
+        Self::decode_payload(mut d)
     }
 }
 
@@ -1639,6 +1756,14 @@ impl<A: Abi, T> Decode<A> for DynArray<T>
             len: elem_count,
             size: payload_size,
         }
+    }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self
+        where A::Decoder<I>: AbiDecoder<A>
+    {
+        let mut d = A::decoder_with_base(input, pos)
+        Self::decode_payload(mut d)
     }
 }
 
@@ -2439,6 +2564,22 @@ impl<A: Abi, T, const N: usize> Decode<A> for [T; N]
         let mut i: usize = 1
         while i < N {
             out[i] = decode_field<A, T, D>(mut d)
+            i += 1
+        }
+        out
+    }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self
+        where A::Decoder<I>: AbiDecoder<A>
+    {
+        let first = decode_field_from<A, T, I>(input, base: pos, head_pos: pos)
+        let mut out: [T; N] = [first; N]
+        let mut i: usize = 1
+        let mut head_pos = pos + abi_field_head_size<T>()
+        while i < N {
+            out[i] = decode_field_from<A, T, I>(input, base: pos, head_pos: head_pos)
+            head_pos += abi_field_head_size<T>()
             i += 1
         }
         out

--- a/ingots/core/src/abi.fe
+++ b/ingots/core/src/abi.fe
@@ -131,6 +131,12 @@ pub trait Abi {
 
     fn alloc(_ size: u256) -> u256
     fn encoder_new(_ size: u256) -> Self::Encoder
+    fn encoder_at(_ base: u256) -> Self::Encoder {
+        let mut e = Self::encoder_new(0)
+        e.set_base(base)
+        e.set_pos(base)
+        e
+    }
     fn store_word(ptr: u256, value: u256)
 }
 
@@ -809,6 +815,8 @@ impl<T0> AbiSize for (T0,)
     const HEAD_SIZE: u256 = abi_field_head_size<T0>()
     const IS_DYNAMIC: bool = T0::IS_DYNAMIC
 
+    #[arithmetic(unchecked)]
+    #[inline(always)]
     fn payload_size(self) -> u256 {
         Self::HEAD_SIZE + dynamic_payload_size(self.0)
     }
@@ -820,6 +828,8 @@ impl<T0, T1> AbiSize for (T0, T1)
     const HEAD_SIZE: u256 = abi_field_head_size<T0>() + abi_field_head_size<T1>()
     const IS_DYNAMIC: bool = T0::IS_DYNAMIC || T1::IS_DYNAMIC
 
+    #[arithmetic(unchecked)]
+    #[inline(always)]
     fn payload_size(self) -> u256 {
         Self::HEAD_SIZE + dynamic_payload_size(self.0) + dynamic_payload_size(self.1)
     }
@@ -831,6 +841,8 @@ impl<T0, T1, T2> AbiSize for (T0, T1, T2)
     const HEAD_SIZE: u256 = abi_field_head_size<T0>() + abi_field_head_size<T1>() + abi_field_head_size<T2>()
     const IS_DYNAMIC: bool = T0::IS_DYNAMIC || T1::IS_DYNAMIC || T2::IS_DYNAMIC
 
+    #[arithmetic(unchecked)]
+    #[inline(always)]
     fn payload_size(self) -> u256 {
         Self::HEAD_SIZE
             + dynamic_payload_size(self.0)
@@ -846,6 +858,8 @@ impl<T0, T1, T2, T3> AbiSize for (T0, T1, T2, T3)
         abi_field_head_size<T0>() + abi_field_head_size<T1>() + abi_field_head_size<T2>() + abi_field_head_size<T3>()
     const IS_DYNAMIC: bool = T0::IS_DYNAMIC || T1::IS_DYNAMIC || T2::IS_DYNAMIC || T3::IS_DYNAMIC
 
+    #[arithmetic(unchecked)]
+    #[inline(always)]
     fn payload_size(self) -> u256 {
         Self::HEAD_SIZE
             + dynamic_payload_size(self.0)
@@ -867,6 +881,8 @@ impl<T0, T1, T2, T3, T4> AbiSize for (T0, T1, T2, T3, T4)
     const IS_DYNAMIC: bool =
         T0::IS_DYNAMIC || T1::IS_DYNAMIC || T2::IS_DYNAMIC || T3::IS_DYNAMIC || T4::IS_DYNAMIC
 
+    #[arithmetic(unchecked)]
+    #[inline(always)]
     fn payload_size(self) -> u256 {
         Self::HEAD_SIZE
             + dynamic_payload_size(self.0)
@@ -890,6 +906,8 @@ impl<T0, T1, T2, T3, T4, T5> AbiSize for (T0, T1, T2, T3, T4, T5)
     const IS_DYNAMIC: bool =
         T0::IS_DYNAMIC || T1::IS_DYNAMIC || T2::IS_DYNAMIC || T3::IS_DYNAMIC || T4::IS_DYNAMIC || T5::IS_DYNAMIC
 
+    #[arithmetic(unchecked)]
+    #[inline(always)]
     fn payload_size(self) -> u256 {
         Self::HEAD_SIZE
             + dynamic_payload_size(self.0)
@@ -915,6 +933,8 @@ impl<T0, T1, T2, T3, T4, T5, T6> AbiSize for (T0, T1, T2, T3, T4, T5, T6)
     const IS_DYNAMIC: bool =
         T0::IS_DYNAMIC || T1::IS_DYNAMIC || T2::IS_DYNAMIC || T3::IS_DYNAMIC || T4::IS_DYNAMIC || T5::IS_DYNAMIC || T6::IS_DYNAMIC
 
+    #[arithmetic(unchecked)]
+    #[inline(always)]
     fn payload_size(self) -> u256 {
         Self::HEAD_SIZE
             + dynamic_payload_size(self.0)
@@ -942,6 +962,8 @@ impl<T0, T1, T2, T3, T4, T5, T6, T7> AbiSize for (T0, T1, T2, T3, T4, T5, T6, T7
     const IS_DYNAMIC: bool =
         T0::IS_DYNAMIC || T1::IS_DYNAMIC || T2::IS_DYNAMIC || T3::IS_DYNAMIC || T4::IS_DYNAMIC || T5::IS_DYNAMIC || T6::IS_DYNAMIC || T7::IS_DYNAMIC
 
+    #[arithmetic(unchecked)]
+    #[inline(always)]
     fn payload_size(self) -> u256 {
         Self::HEAD_SIZE
             + dynamic_payload_size(self.0)
@@ -971,6 +993,8 @@ impl<T0, T1, T2, T3, T4, T5, T6, T7, T8> AbiSize for (T0, T1, T2, T3, T4, T5, T6
     const IS_DYNAMIC: bool =
         T0::IS_DYNAMIC || T1::IS_DYNAMIC || T2::IS_DYNAMIC || T3::IS_DYNAMIC || T4::IS_DYNAMIC || T5::IS_DYNAMIC || T6::IS_DYNAMIC || T7::IS_DYNAMIC || T8::IS_DYNAMIC
 
+    #[arithmetic(unchecked)]
+    #[inline(always)]
     fn payload_size(self) -> u256 {
         Self::HEAD_SIZE
             + dynamic_payload_size(self.0)
@@ -1002,6 +1026,8 @@ impl<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> AbiSize for (T0, T1, T2, T3, T4, T5
     const IS_DYNAMIC: bool =
         T0::IS_DYNAMIC || T1::IS_DYNAMIC || T2::IS_DYNAMIC || T3::IS_DYNAMIC || T4::IS_DYNAMIC || T5::IS_DYNAMIC || T6::IS_DYNAMIC || T7::IS_DYNAMIC || T8::IS_DYNAMIC || T9::IS_DYNAMIC
 
+    #[arithmetic(unchecked)]
+    #[inline(always)]
     fn payload_size(self) -> u256 {
         Self::HEAD_SIZE
             + dynamic_payload_size(self.0)
@@ -1035,6 +1061,8 @@ impl<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> AbiSize for (T0, T1, T2, T3, T
     const IS_DYNAMIC: bool =
         T0::IS_DYNAMIC || T1::IS_DYNAMIC || T2::IS_DYNAMIC || T3::IS_DYNAMIC || T4::IS_DYNAMIC || T5::IS_DYNAMIC || T6::IS_DYNAMIC || T7::IS_DYNAMIC || T8::IS_DYNAMIC || T9::IS_DYNAMIC || T10::IS_DYNAMIC
 
+    #[arithmetic(unchecked)]
+    #[inline(always)]
     fn payload_size(self) -> u256 {
         Self::HEAD_SIZE
             + dynamic_payload_size(self.0)
@@ -1070,6 +1098,8 @@ impl<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> AbiSize for (T0, T1, T2, 
     const IS_DYNAMIC: bool =
         T0::IS_DYNAMIC || T1::IS_DYNAMIC || T2::IS_DYNAMIC || T3::IS_DYNAMIC || T4::IS_DYNAMIC || T5::IS_DYNAMIC || T6::IS_DYNAMIC || T7::IS_DYNAMIC || T8::IS_DYNAMIC || T9::IS_DYNAMIC || T10::IS_DYNAMIC || T11::IS_DYNAMIC
 
+    #[arithmetic(unchecked)]
+    #[inline(always)]
     fn payload_size(self) -> u256 {
         Self::HEAD_SIZE
             + dynamic_payload_size(self.0)
@@ -1903,6 +1933,8 @@ impl<A: Abi, T0> Encode<A> for (T0,)
 {
     const DIRECT_ENCODE: bool = T0::DIRECT_ENCODE
 
+    #[arithmetic(unchecked)]
+    #[inline(always)]
     fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) {
         let mut tail = e.base() + Self::HEAD_SIZE
         encode_field<A, T0, E>(self.0, mut e, mut tail)
@@ -1947,6 +1979,8 @@ impl<A: Abi, T0, T1> Encode<A> for (T0, T1)
 {
     const DIRECT_ENCODE: bool = T0::DIRECT_ENCODE && T1::DIRECT_ENCODE
 
+    #[arithmetic(unchecked)]
+    #[inline(always)]
     fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) {
         let mut tail = e.base() + Self::HEAD_SIZE
         encode_field<A, T0, E>(self.0, mut e, mut tail)
@@ -2001,6 +2035,8 @@ impl<A: Abi, T0, T1, T2> Encode<A> for (T0, T1, T2)
 {
     const DIRECT_ENCODE: bool = T0::DIRECT_ENCODE && T1::DIRECT_ENCODE && T2::DIRECT_ENCODE
 
+    #[arithmetic(unchecked)]
+    #[inline(always)]
     fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) {
         let mut tail = e.base() + Self::HEAD_SIZE
         encode_field<A, T0, E>(self.0, mut e, mut tail)
@@ -2069,6 +2105,8 @@ impl<A: Abi, T0, T1, T2, T3> Encode<A> for (T0, T1, T2, T3)
     const DIRECT_ENCODE: bool =
         T0::DIRECT_ENCODE && T1::DIRECT_ENCODE && T2::DIRECT_ENCODE && T3::DIRECT_ENCODE
 
+    #[arithmetic(unchecked)]
+    #[inline(always)]
     fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) {
         let mut tail = e.base() + Self::HEAD_SIZE
         encode_field<A, T0, E>(self.0, mut e, mut tail)
@@ -2153,6 +2191,8 @@ impl<A: Abi, T0, T1, T2, T3, T4> Encode<A> for (T0, T1, T2, T3, T4)
     const DIRECT_ENCODE: bool =
         T0::DIRECT_ENCODE && T1::DIRECT_ENCODE && T2::DIRECT_ENCODE && T3::DIRECT_ENCODE && T4::DIRECT_ENCODE
 
+    #[arithmetic(unchecked)]
+    #[inline(always)]
     fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) {
         let mut tail = e.base() + Self::HEAD_SIZE
         encode_field<A, T0, E>(self.0, mut e, mut tail)
@@ -2226,6 +2266,8 @@ impl<A: Abi, T0, T1, T2, T3, T4, T5> Encode<A> for (T0, T1, T2, T3, T4, T5)
     const DIRECT_ENCODE: bool =
         T0::DIRECT_ENCODE && T1::DIRECT_ENCODE && T2::DIRECT_ENCODE && T3::DIRECT_ENCODE && T4::DIRECT_ENCODE && T5::DIRECT_ENCODE
 
+    #[arithmetic(unchecked)]
+    #[inline(always)]
     fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) {
         let mut tail = e.base() + Self::HEAD_SIZE
         encode_field<A, T0, E>(self.0, mut e, mut tail)
@@ -2307,6 +2349,8 @@ impl<A: Abi, T0, T1, T2, T3, T4, T5, T6> Encode<A> for (T0, T1, T2, T3, T4, T5, 
     const DIRECT_ENCODE: bool =
         T0::DIRECT_ENCODE && T1::DIRECT_ENCODE && T2::DIRECT_ENCODE && T3::DIRECT_ENCODE && T4::DIRECT_ENCODE && T5::DIRECT_ENCODE && T6::DIRECT_ENCODE
 
+    #[arithmetic(unchecked)]
+    #[inline(always)]
     fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) {
         let mut tail = e.base() + Self::HEAD_SIZE
         encode_field<A, T0, E>(self.0, mut e, mut tail)
@@ -2396,6 +2440,8 @@ impl<A: Abi, T0, T1, T2, T3, T4, T5, T6, T7> Encode<A> for (T0, T1, T2, T3, T4, 
     const DIRECT_ENCODE: bool =
         T0::DIRECT_ENCODE && T1::DIRECT_ENCODE && T2::DIRECT_ENCODE && T3::DIRECT_ENCODE && T4::DIRECT_ENCODE && T5::DIRECT_ENCODE && T6::DIRECT_ENCODE && T7::DIRECT_ENCODE
 
+    #[arithmetic(unchecked)]
+    #[inline(always)]
     fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) {
         let mut tail = e.base() + Self::HEAD_SIZE
         encode_field<A, T0, E>(self.0, mut e, mut tail)
@@ -2493,6 +2539,8 @@ impl<A: Abi, T0, T1, T2, T3, T4, T5, T6, T7, T8> Encode<A> for (T0, T1, T2, T3, 
     const DIRECT_ENCODE: bool =
         T0::DIRECT_ENCODE && T1::DIRECT_ENCODE && T2::DIRECT_ENCODE && T3::DIRECT_ENCODE && T4::DIRECT_ENCODE && T5::DIRECT_ENCODE && T6::DIRECT_ENCODE && T7::DIRECT_ENCODE && T8::DIRECT_ENCODE
 
+    #[arithmetic(unchecked)]
+    #[inline(always)]
     fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) {
         let mut tail = e.base() + Self::HEAD_SIZE
         encode_field<A, T0, E>(self.0, mut e, mut tail)
@@ -2600,6 +2648,8 @@ impl<A: Abi, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> Encode<A>
     const DIRECT_ENCODE: bool =
         T0::DIRECT_ENCODE && T1::DIRECT_ENCODE && T2::DIRECT_ENCODE && T3::DIRECT_ENCODE && T4::DIRECT_ENCODE && T5::DIRECT_ENCODE && T6::DIRECT_ENCODE && T7::DIRECT_ENCODE && T8::DIRECT_ENCODE && T9::DIRECT_ENCODE
 
+    #[arithmetic(unchecked)]
+    #[inline(always)]
     fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) {
         let mut tail = e.base() + Self::HEAD_SIZE
         encode_field<A, T0, E>(self.0, mut e, mut tail)
@@ -2715,6 +2765,8 @@ impl<A: Abi, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Encode<A>
     const DIRECT_ENCODE: bool =
         T0::DIRECT_ENCODE && T1::DIRECT_ENCODE && T2::DIRECT_ENCODE && T3::DIRECT_ENCODE && T4::DIRECT_ENCODE && T5::DIRECT_ENCODE && T6::DIRECT_ENCODE && T7::DIRECT_ENCODE && T8::DIRECT_ENCODE && T9::DIRECT_ENCODE && T10::DIRECT_ENCODE
 
+    #[arithmetic(unchecked)]
+    #[inline(always)]
     fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) {
         let mut tail = e.base() + Self::HEAD_SIZE
         encode_field<A, T0, E>(self.0, mut e, mut tail)
@@ -2838,6 +2890,8 @@ impl<A: Abi, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Encode<A>
     const DIRECT_ENCODE: bool =
         T0::DIRECT_ENCODE && T1::DIRECT_ENCODE && T2::DIRECT_ENCODE && T3::DIRECT_ENCODE && T4::DIRECT_ENCODE && T5::DIRECT_ENCODE && T6::DIRECT_ENCODE && T7::DIRECT_ENCODE && T8::DIRECT_ENCODE && T9::DIRECT_ENCODE && T10::DIRECT_ENCODE && T11::DIRECT_ENCODE
 
+    #[arithmetic(unchecked)]
+    #[inline(always)]
     fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) {
         let mut tail = e.base() + Self::HEAD_SIZE
         encode_field<A, T0, E>(self.0, mut e, mut tail)

--- a/ingots/core/src/abi.fe
+++ b/ingots/core/src/abi.fe
@@ -473,6 +473,7 @@ fn encode_field_at<A: Abi, T, E>(_ value: own T, _ e: mut E, base: u256, head_po
     value.encode(mut e)
 }
 
+#[inline(always)]
 pub fn encode_alloc<A: Abi, T>(_ value: own T) -> (u256, u256)
     where T: Encode<A> + AbiSize
 {
@@ -635,6 +636,7 @@ impl<I> BytesView<I>
     }
 
     #[arithmetic(unchecked)]
+    #[inline(always)]
     pub fn word_at(self, _ offset: u256) -> u256 {
         self.input.word_at(self.start + offset)
     }
@@ -746,10 +748,12 @@ impl Bytes {
     }
 
     #[arithmetic(unchecked)]
+    #[inline(always)]
     pub fn payload_ptr(self) -> u256 {
         self.data + 32
     }
 
+    #[inline(always)]
     pub fn view(self) -> BytesView<MemoryInput> {
         let input = MemoryInput {
             base: self.payload_ptr(),
@@ -763,6 +767,7 @@ impl Bytes {
     }
 
     #[arithmetic(unchecked)]
+    #[inline(always)]
     pub fn word_at(self, _ offset: u256) -> u256 {
         mem_word_at(base: self.payload_ptr(), offset: offset)
     }
@@ -798,6 +803,7 @@ fn mem_word_store(value: u256) uses (slot: mut u256) {
     slot = value
 }
 
+#[inline(always)]
 fn mem_word_at(base: u256, offset: u256) -> u256 {
     let ptr: MemPtr<u256> = MemPtr::from_raw(base + offset)
     with (ptr) {
@@ -811,6 +817,7 @@ impl ByteInput for MemoryInput {
     }
 
     #[arithmetic(unchecked)]
+    #[inline(always)]
     fn word_at(self, _ byte_offset: u256) -> u256 {
         mem_word_at(base: self.base, offset: byte_offset)
     }

--- a/ingots/core/src/abi.fe
+++ b/ingots/core/src/abi.fe
@@ -181,6 +181,11 @@ pub trait AbiSize {
 
 pub trait AbiSpan<A: Abi>: AbiSize {
     fn payload_end<I: ByteInput>(_: I, base: u256, pos: u256) -> u256
+
+    fn payload_end_with_input_len<I: ByteInput>(_ input: I, base: u256, pos: u256, input_len: u256) -> u256 {
+        let _ = input_len
+        Self::payload_end(input, base: base, pos: pos)
+    }
 }
 
 pub trait Decode<A: Abi> {
@@ -191,6 +196,14 @@ pub trait Decode<A: Abi> {
     {
         let mut d = A::decoder_with_base(input, pos)
         Self::decode_payload(mut d)
+    }
+
+    #[inline(always)]
+    fn decode_from_checked_head<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+        where A::Decoder<I>: AbiDecoder<A>
+    {
+        let _ = input_len
+        Self::decode_from(input, pos)
     }
 
     fn decode_from_with_input_len<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
@@ -226,6 +239,34 @@ pub const fn abi_payload_head_size<T: AbiSize>() -> u256 {
 
 pub const fn abi_single_root_head_size<T: AbiSize>() -> u256 {
     abi_field_head_size<T>()
+}
+
+#[inline(always)]
+pub fn checked_frame_end<A: Abi>(_ pos: u256, _ head_size: u256, _ input_len: u256) -> u256 {
+    let end = pos + head_size
+    if end < pos || end > input_len {
+        A::decode_error()
+    }
+    end
+}
+
+#[inline(always)]
+pub fn checked_tail<A: Abi>(_ base: u256, _ tail_rel: u256) -> u256 {
+    let tail_at = base + tail_rel
+    if tail_at < base {
+        A::decode_error()
+    }
+    tail_at
+}
+
+#[inline(always)]
+pub fn decode_frame_from<A: Abi, T, I>(_ input: I, _ pos: u256, _ input_len: u256) -> T
+    where T: Decode<A> + AbiSize,
+          I: ByteInput,
+          A::Decoder<I>: AbiDecoder<A>
+{
+    checked_frame_end<A>(pos, T::HEAD_SIZE, input_len)
+    T::decode_from_checked_head(input, pos, input_len)
 }
 
 pub fn abi_payload_size<T: AbiSize>(_ value: T) -> u256 {
@@ -300,17 +341,27 @@ pub fn decode_field_from<A: Abi, T, I>(_ input: I, base: u256, head_pos: u256) -
 }
 
 #[inline(always)]
-pub fn decode_field_from_with_input_len<A: Abi, T, I>(_ input: I, base: u256, head_pos: u256, input_len: u256) -> T
+pub fn decode_field_from_checked_head<A: Abi, T, I>(_ input: I, base: u256, head_pos: u256, input_len: u256) -> T
     where T: Decode<A> + AbiSize,
           I: ByteInput,
           A::Decoder<I>: AbiDecoder<A>
 {
     if T::IS_DYNAMIC {
         let tail_rel = input.word_at(head_pos)
-        return T::decode_from_with_input_len(input, base + tail_rel, input_len)
+        let tail_at = checked_tail<A>(base, tail_rel)
+        return T::decode_from_with_input_len(input, tail_at, input_len)
     }
 
     T::decode_from(input, head_pos)
+}
+
+#[inline(always)]
+pub fn decode_field_from_with_input_len<A: Abi, T, I>(_ input: I, base: u256, head_pos: u256, input_len: u256) -> T
+    where T: Decode<A> + AbiSize,
+          I: ByteInput,
+          A::Decoder<I>: AbiDecoder<A>
+{
+    decode_field_from_checked_head<A, T, I>(input, base: base, head_pos: head_pos, input_len: input_len)
 }
 
 fn decode_field_at<A: Abi, T, D>(d: mut D, pos: u256) -> T
@@ -443,11 +494,37 @@ pub fn abi_field_end<A: Abi, T, I>(_ input: I, base: u256, pos: u256) -> u256
     T::payload_end(input, base: base, pos: pos)
 }
 
+pub fn abi_field_end_with_input_len<A: Abi, T, I>(_ input: I, base: u256, pos: u256, input_len: u256) -> u256
+    where T: AbiSpan<A> + AbiSize,
+          I: ByteInput
+{
+    if T::IS_DYNAMIC {
+        let tail_rel = input.word_at(pos)
+        let tail_at = checked_tail<A>(base, tail_rel)
+        checked_frame_end<A>(tail_at, T::HEAD_SIZE, input_len)
+        return T::payload_end_with_input_len(input, base: tail_at, pos: tail_at, input_len: input_len)
+    }
+
+    T::payload_end_with_input_len(input, base: base, pos: pos, input_len: input_len)
+}
+
 fn round_up_words(_ len: u256) -> u256 {
     if len == 0 {
         return 0
     }
     (((len - 1) / 32) + 1) * 32
+}
+
+#[inline(always)]
+fn checked_dynamic_payload_after_head<A: Abi, I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> (u256, u256) {
+    let data_len = input.word_at(pos)
+    let payload_size = 32 + round_up_words(data_len)
+    let payload_end = pos + payload_size
+    if payload_end < pos || payload_end > input_len {
+        A::decode_error()
+    }
+
+    (data_len, payload_size)
 }
 
 #[inline(always)]
@@ -463,14 +540,7 @@ fn checked_dynamic_payload_with_input_len<A: Abi, I: ByteInput>(_ input: I, _ po
         A::decode_error()
     }
 
-    let data_len = input.word_at(pos)
-    let payload_size = 32 + round_up_words(data_len)
-    let payload_end = pos + payload_size
-    if payload_end < pos || payload_end > input_len {
-        A::decode_error()
-    }
-
-    (data_len, payload_size)
+    checked_dynamic_payload_after_head<A, I>(input, pos, input_len)
 }
 
 #[inline(always)]
@@ -500,6 +570,22 @@ fn packed_string_len(_ word: u256) -> u256 {
         value = value >> 8
     }
     len
+}
+
+fn decode_string_payload_after_head<A: Abi, I: ByteInput, const N: usize>(_ input: I, _ pos: u256, _ data_len: u256) -> String<N> {
+    let data_start = pos + 32
+    if data_len > 32 || data_len > (N as u256) {
+        A::decode_error()
+    }
+
+    let packed = if data_len == 0 {
+        0
+    } else {
+        let shift = if data_len >= 32 { 0 } else { (32 - data_len) * 8 }
+        input.word_at(data_start) >> shift
+    }
+
+    packed as String<N>
 }
 
 pub struct BytesView<I> {
@@ -1219,22 +1305,40 @@ impl<A: Abi> AbiSpan<A> for u256 {
 
 impl<A: Abi, const N: usize> AbiSpan<A> for String<N> {
     fn payload_end<I: ByteInput>(_ input: I, base: u256, pos: u256) -> u256 {
-        let data_len = input.word_at(pos)
-        pos + 32 + round_up_words(data_len)
+        let input_len = input.len()
+        Self::payload_end_with_input_len(input, base: base, pos: pos, input_len: input_len)
+    }
+
+    fn payload_end_with_input_len<I: ByteInput>(_ input: I, base: u256, pos: u256, input_len: u256) -> u256 {
+        let _ = base
+        let payload = checked_dynamic_payload_with_input_len<A, I>(input, pos, input_len)
+        pos + payload.1
     }
 }
 
 impl<A: Abi> AbiSpan<A> for Bytes {
     fn payload_end<I: ByteInput>(_ input: I, base: u256, pos: u256) -> u256 {
-        let data_len = input.word_at(pos)
-        pos + 32 + round_up_words(data_len)
+        let input_len = input.len()
+        Self::payload_end_with_input_len(input, base: base, pos: pos, input_len: input_len)
+    }
+
+    fn payload_end_with_input_len<I: ByteInput>(_ input: I, base: u256, pos: u256, input_len: u256) -> u256 {
+        let _ = base
+        let payload = checked_dynamic_payload_with_input_len<A, I>(input, pos, input_len)
+        pos + payload.1
     }
 }
 
 impl<A: Abi> AbiSpan<A> for DynString {
     fn payload_end<I: ByteInput>(_ input: I, base: u256, pos: u256) -> u256 {
-        let data_len = input.word_at(pos)
-        pos + 32 + round_up_words(data_len)
+        let input_len = input.len()
+        Self::payload_end_with_input_len(input, base: base, pos: pos, input_len: input_len)
+    }
+
+    fn payload_end_with_input_len<I: ByteInput>(_ input: I, base: u256, pos: u256, input_len: u256) -> u256 {
+        let _ = base
+        let payload = checked_dynamic_payload_with_input_len<A, I>(input, pos, input_len)
+        pos + payload.1
     }
 }
 
@@ -1355,21 +1459,33 @@ impl<A: Abi> Encode<A> for u256 {
 impl<A: Abi, const N: usize> Decode<A> for String<N> {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         let payload_at = d.pos()
-        let data_len = d.read_word()
-        let data_start = payload_at + 32
+        let input = d.input()
+        let payload = checked_dynamic_payload_with_input_len<A, D::Input>(input, payload_at, input.len())
+        decode_string_payload_after_head<A, D::Input, N>(input, payload_at, payload.0)
+    }
 
-        if data_len > 32 || data_len > (N as u256) {
-            A::decode_error()
-        }
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self
+        where A::Decoder<I>: AbiDecoder<A>
+    {
+        let input_len = input.len()
+        Self::decode_from_with_input_len(input, pos, input_len)
+    }
 
-        let packed = if data_len == 0 {
-            0
-        } else {
-            let shift = if data_len >= 32 { 0 } else { (32 - data_len) * 8 }
-            d.peek_word(data_start) >> shift
-        }
+    #[inline(always)]
+    fn decode_from_checked_head<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+        where A::Decoder<I>: AbiDecoder<A>
+    {
+        let payload = checked_dynamic_payload_after_head<A, I>(input, pos, input_len)
+        decode_string_payload_after_head<A, I, N>(input, pos, payload.0)
+    }
 
-        packed as String<N>
+    #[inline(always)]
+    fn decode_from_with_input_len<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+        where A::Decoder<I>: AbiDecoder<A>
+    {
+        let payload = checked_dynamic_payload_with_input_len<A, I>(input, pos, input_len)
+        decode_string_payload_after_head<A, I, N>(input, pos, payload.0)
     }
 }
 
@@ -1394,21 +1510,16 @@ impl<A: Abi, const N: usize> Encode<A> for String<N> {
 impl<A: Abi> Decode<A> for DynString {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         let payload_at = d.pos()
-        let data_len = d.read_word()
-        let payload_size = 32 + round_up_words(data_len)
-        let payload_end = payload_at + payload_size
         let input = d.input()
-        if payload_end < payload_at || payload_end > input.len() {
-            A::decode_error()
-        }
-        let data_ptr = d.alloc(payload_size)
+        let payload: (u256, u256) = checked_dynamic_payload_with_input_len<A, D::Input>(input, payload_at, input.len())
+        let data_ptr = d.alloc(payload.1)
 
-        input.copy_to_memory_unchecked_aligned(dest: data_ptr, src_offset: payload_at, len: payload_size)
+        input.copy_to_memory_unchecked_aligned(dest: data_ptr, src_offset: payload_at, len: payload.1)
 
         DynString {
             data: data_ptr,
-            len: data_len,
-            size: payload_size,
+            len: payload.0,
+            size: payload.1,
         }
     }
 
@@ -1417,6 +1528,35 @@ impl<A: Abi> Decode<A> for DynString {
         where A::Decoder<I>: AbiDecoder<A>
     {
         let payload: (u256, u256, u256) = copy_dynamic_payload_from<A, I>(input, pos)
+
+        DynString {
+            data: payload.0,
+            len: payload.1,
+            size: payload.2,
+        }
+    }
+
+    #[inline(always)]
+    fn decode_from_checked_head<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+        where A::Decoder<I>: AbiDecoder<A>
+    {
+        let payload: (u256, u256) = checked_dynamic_payload_after_head<A, I>(input, pos, input_len)
+        let data_ptr = A::alloc(payload.1)
+
+        input.copy_to_memory_unchecked_aligned(dest: data_ptr, src_offset: pos, len: payload.1)
+
+        DynString {
+            data: data_ptr,
+            len: payload.0,
+            size: payload.1,
+        }
+    }
+
+    #[inline(always)]
+    fn decode_from_with_input_len<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+        where A::Decoder<I>: AbiDecoder<A>
+    {
+        let payload: (u256, u256, u256) = copy_dynamic_payload_from_with_input_len<A, I>(input, pos, input_len)
 
         DynString {
             data: payload.0,
@@ -1797,18 +1937,13 @@ impl<A: Abi> Encode<A> for () {
 impl<A: Abi> Decode<A> for Bytes {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         let payload_at = d.pos()
-        let data_len = d.read_word()
-        let payload_size = 32 + round_up_words(data_len)
-        let payload_end = payload_at + payload_size
         let input = d.input()
-        if payload_end < payload_at || payload_end > input.len() {
-            A::decode_error()
-        }
-        let data_ptr = d.alloc(payload_size)
+        let payload: (u256, u256) = checked_dynamic_payload_with_input_len<A, D::Input>(input, payload_at, input.len())
+        let data_ptr = d.alloc(payload.1)
 
-        input.copy_to_memory_unchecked_aligned(dest: data_ptr, src_offset: payload_at, len: payload_size)
+        input.copy_to_memory_unchecked_aligned(dest: data_ptr, src_offset: payload_at, len: payload.1)
 
-        Bytes::from_abi_tail(data: data_ptr, len: data_len, size: payload_size)
+        Bytes::from_abi_tail(data: data_ptr, len: payload.0, size: payload.1)
     }
 
     #[inline(always)]
@@ -1818,6 +1953,18 @@ impl<A: Abi> Decode<A> for Bytes {
         let payload: (u256, u256, u256) = copy_dynamic_payload_from<A, I>(input, pos)
 
         Bytes::from_abi_tail(data: payload.0, len: payload.1, size: payload.2)
+    }
+
+    #[inline(always)]
+    fn decode_from_checked_head<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+        where A::Decoder<I>: AbiDecoder<A>
+    {
+        let payload: (u256, u256) = checked_dynamic_payload_after_head<A, I>(input, pos, input_len)
+        let data_ptr = A::alloc(payload.1)
+
+        input.copy_to_memory_unchecked_aligned(dest: data_ptr, src_offset: pos, len: payload.1)
+
+        Bytes::from_abi_tail(data: data_ptr, len: payload.0, size: payload.1)
     }
 
     #[inline(always)]
@@ -1846,7 +1993,7 @@ impl<A: Abi> Encode<A> for Bytes {
     }
 }
 
-fn dyn_array_payload_end_scan<A: Abi, T, I>(_ input: I, elems_base: u256, head_end: u256, elem_count: u256) -> u256
+fn dyn_array_payload_end_scan_with_input_len<A: Abi, T, I>(_ input: I, elems_base: u256, head_end: u256, elem_count: u256, input_len: u256) -> u256
     where T: AbiSpan<A> + AbiSize,
           I: ByteInput
 {
@@ -1854,27 +2001,32 @@ fn dyn_array_payload_end_scan<A: Abi, T, I>(_ input: I, elems_base: u256, head_e
     let mut end = head_end
     let mut i: u256 = 0
     while i < elem_count {
-        end = max_u256(a: end, b: abi_field_end<A, T, I>(input, base: elems_base, pos: head_pos))
+        end = max_u256(a: end, b: abi_field_end_with_input_len<A, T, I>(input, base: elems_base, pos: head_pos, input_len: input_len))
         head_pos += abi_field_head_size<T>()
         i += 1
     }
     end
 }
 
-fn dyn_array_payload_end<A: Abi, T, I>(_ input: I, tail_at: u256, elem_count: u256) -> u256
+fn dyn_array_payload_end_with_input_len<A: Abi, T, I>(_ input: I, tail_at: u256, elem_count: u256, input_len: u256) -> u256
     where T: AbiSpan<A> + AbiSize,
           I: ByteInput
 {
     let elems_base = tail_at + 32
     let head_size = elem_count * abi_field_head_size<T>()
+    if elems_base < tail_at || (abi_field_head_size<T>() != 0 && head_size / abi_field_head_size<T>() != elem_count) {
+        A::decode_error()
+    }
+
     let head_end = elems_base + head_size
+    if head_end < elems_base || head_end > input_len {
+        A::decode_error()
+    }
 
     if elem_count == 0 || !T::IS_DYNAMIC {
         return head_end
     }
 
-    // Fast path: prove that each tail starts after the head and after the
-    // previous element ends. Non-canonical layouts fall back to a max scan.
     let mut prev_offset = head_size
     let mut prev_end = head_end
     let mut i: u256 = 0
@@ -1882,16 +2034,16 @@ fn dyn_array_payload_end<A: Abi, T, I>(_ input: I, tail_at: u256, elem_count: u2
         let head_pos = elems_base + (i * abi_field_head_size<T>())
         let offset = input.word_at(head_pos)
         if offset < prev_offset || offset % 32 != 0 {
-            return dyn_array_payload_end_scan<A, T, I>(input, elems_base: elems_base, head_end: head_end, elem_count: elem_count)
+            return dyn_array_payload_end_scan_with_input_len<A, T, I>(input, elems_base: elems_base, head_end: head_end, elem_count: elem_count, input_len: input_len)
         }
 
         let tail_at = elems_base + offset
         if tail_at < elems_base || prev_end > tail_at {
-            return dyn_array_payload_end_scan<A, T, I>(input, elems_base: elems_base, head_end: head_end, elem_count: elem_count)
+            return dyn_array_payload_end_scan_with_input_len<A, T, I>(input, elems_base: elems_base, head_end: head_end, elem_count: elem_count, input_len: input_len)
         }
 
         prev_offset = offset
-        prev_end = abi_field_end<A, T, I>(input, base: elems_base, pos: head_pos)
+        prev_end = abi_field_end_with_input_len<A, T, I>(input, base: elems_base, pos: head_pos, input_len: input_len)
         i += 1
     }
 
@@ -1903,12 +2055,11 @@ impl<A: Abi, T> Decode<A> for DynArray<T>
 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         let payload_at = d.pos()
-        let elem_count = d.read_word()
         let input = d.input()
-        let payload_end = dyn_array_payload_end<A, T, D::Input>(input, tail_at: payload_at, elem_count: elem_count)
-        if payload_end < payload_at || payload_end > input.len() {
-            A::decode_error()
-        }
+        let input_len = input.len()
+        checked_frame_end<A>(payload_at, Self::HEAD_SIZE, input_len)
+        let elem_count = input.word_at(payload_at)
+        let payload_end = dyn_array_payload_end_with_input_len<A, T, D::Input>(input, tail_at: payload_at, elem_count: elem_count, input_len: input_len)
         let payload_size = payload_end - payload_at
         let data_ptr = d.alloc(payload_size)
 
@@ -1926,16 +2077,15 @@ impl<A: Abi, T> Decode<A> for DynArray<T>
         where A::Decoder<I>: AbiDecoder<A>
     {
         let input_len = input.len()
-        let len_end = pos + 32
-        if len_end < pos || len_end > input_len {
-            A::decode_error()
-        }
+        decode_frame_from<A, Self, I>(input, pos, input_len)
+    }
 
+    #[inline(always)]
+    fn decode_from_checked_head<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+        where A::Decoder<I>: AbiDecoder<A>
+    {
         let elem_count = input.word_at(pos)
-        let payload_end = dyn_array_payload_end<A, T, I>(input, tail_at: pos, elem_count: elem_count)
-        if payload_end < pos || payload_end > input_len {
-            A::decode_error()
-        }
+        let payload_end = dyn_array_payload_end_with_input_len<A, T, I>(input, tail_at: pos, elem_count: elem_count, input_len: input_len)
 
         let payload_size = payload_end - pos
         let data_ptr = A::alloc(payload_size)
@@ -1947,6 +2097,13 @@ impl<A: Abi, T> Decode<A> for DynArray<T>
             len: elem_count,
             size: payload_size,
         }
+    }
+
+    #[inline(always)]
+    fn decode_from_with_input_len<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+        where A::Decoder<I>: AbiDecoder<A>
+    {
+        decode_frame_from<A, Self, I>(input, pos, input_len)
     }
 }
 
@@ -1972,8 +2129,15 @@ impl<A: Abi, T> AbiSpan<A> for DynArray<T>
     where T: AbiSpan<A> + AbiSize
 {
     fn payload_end<I: ByteInput>(_ input: I, base: u256, pos: u256) -> u256 {
+        let input_len = input.len()
+        Self::payload_end_with_input_len(input, base: base, pos: pos, input_len: input_len)
+    }
+
+    fn payload_end_with_input_len<I: ByteInput>(_ input: I, base: u256, pos: u256, input_len: u256) -> u256 {
+        let _ = base
+        checked_frame_end<A>(pos, Self::HEAD_SIZE, input_len)
         let elem_count = input.word_at(pos)
-        dyn_array_payload_end<A, T, I>(input, tail_at: pos, elem_count: elem_count)
+        dyn_array_payload_end_with_input_len<A, T, I>(input, tail_at: pos, elem_count: elem_count, input_len: input_len)
     }
 }
 
@@ -1991,6 +2155,22 @@ impl<A: Abi, T0> Decode<A> for (T0,)
     {
         let v0: T0 = decode_field_from<A, T0, I>(input, base: pos, head_pos: pos)
         (v0,)
+    }
+
+    #[inline(always)]
+    fn decode_from_checked_head<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+        where A::Decoder<I>: AbiDecoder<A>
+    {
+        let v0: T0 = decode_field_from_checked_head<A, T0, I>(input, base: pos, head_pos: pos, input_len: input_len)
+        (v0,)
+    }
+
+    #[inline(always)]
+    fn decode_from_with_input_len<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+        where A::Decoder<I>: AbiDecoder<A>
+    {
+        checked_frame_end<A>(pos, Self::HEAD_SIZE, input_len)
+        Self::decode_from_checked_head(input, pos, input_len)
     }
 }
 
@@ -2019,6 +2199,12 @@ impl<A: Abi, T0> AbiSpan<A> for (T0,)
     fn payload_end<I: ByteInput>(_ input: I, base: u256, pos: u256) -> u256 {
         abi_field_end<A, T0, I>(input, base: pos, pos: pos)
     }
+
+    fn payload_end_with_input_len<I: ByteInput>(_ input: I, base: u256, pos: u256, input_len: u256) -> u256 {
+        let _ = base
+        checked_frame_end<A>(pos, Self::HEAD_SIZE, input_len)
+        abi_field_end_with_input_len<A, T0, I>(input, base: pos, pos: pos, input_len: input_len)
+    }
 }
 
 impl<A: Abi, T0, T1> Decode<A> for (T0, T1)
@@ -2039,6 +2225,25 @@ impl<A: Abi, T0, T1> Decode<A> for (T0, T1)
         head_pos += abi_field_head_size<T0>()
         let v1: T1 = decode_field_from<A, T1, I>(input, base: pos, head_pos: head_pos)
         (v0, v1)
+    }
+
+    #[inline(always)]
+    fn decode_from_checked_head<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+        where A::Decoder<I>: AbiDecoder<A>
+    {
+        let mut head_pos = pos
+        let v0: T0 = decode_field_from_checked_head<A, T0, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T0>()
+        let v1: T1 = decode_field_from_checked_head<A, T1, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        (v0, v1)
+    }
+
+    #[inline(always)]
+    fn decode_from_with_input_len<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+        where A::Decoder<I>: AbiDecoder<A>
+    {
+        checked_frame_end<A>(pos, Self::HEAD_SIZE, input_len)
+        Self::decode_from_checked_head(input, pos, input_len)
     }
 }
 
@@ -2075,6 +2280,15 @@ impl<A: Abi, T0, T1> AbiSpan<A> for (T0, T1)
         end = max_u256(a: end, b: abi_field_end<A, T1, I>(input, base: pos, pos: pos + abi_field_head_size<T0>()))
         end
     }
+
+    fn payload_end_with_input_len<I: ByteInput>(_ input: I, base: u256, pos: u256, input_len: u256) -> u256 {
+        let _ = base
+        checked_frame_end<A>(pos, Self::HEAD_SIZE, input_len)
+        let mut end = pos + abi_field_head_size<T0>() + abi_field_head_size<T1>()
+        end = max_u256(a: end, b: abi_field_end_with_input_len<A, T0, I>(input, base: pos, pos: pos, input_len: input_len))
+        end = max_u256(a: end, b: abi_field_end_with_input_len<A, T1, I>(input, base: pos, pos: pos + abi_field_head_size<T0>(), input_len: input_len))
+        end
+    }
 }
 
 impl<A: Abi, T0, T1, T2> Decode<A> for (T0, T1, T2)
@@ -2098,6 +2312,27 @@ impl<A: Abi, T0, T1, T2> Decode<A> for (T0, T1, T2)
         head_pos += abi_field_head_size<T1>()
         let v2: T2 = decode_field_from<A, T2, I>(input, base: pos, head_pos: head_pos)
         (v0, v1, v2)
+    }
+
+    #[inline(always)]
+    fn decode_from_checked_head<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+        where A::Decoder<I>: AbiDecoder<A>
+    {
+        let mut head_pos = pos
+        let v0: T0 = decode_field_from_checked_head<A, T0, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T0>()
+        let v1: T1 = decode_field_from_checked_head<A, T1, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T1>()
+        let v2: T2 = decode_field_from_checked_head<A, T2, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        (v0, v1, v2)
+    }
+
+    #[inline(always)]
+    fn decode_from_with_input_len<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+        where A::Decoder<I>: AbiDecoder<A>
+    {
+        checked_frame_end<A>(pos, Self::HEAD_SIZE, input_len)
+        Self::decode_from_checked_head(input, pos, input_len)
     }
 }
 
@@ -2142,6 +2377,18 @@ impl<A: Abi, T0, T1, T2> AbiSpan<A> for (T0, T1, T2)
         end = max_u256(a: end, b: abi_field_end<A, T2, I>(input, base: pos, pos: field2))
         end
     }
+
+    fn payload_end_with_input_len<I: ByteInput>(_ input: I, base: u256, pos: u256, input_len: u256) -> u256 {
+        let _ = base
+        checked_frame_end<A>(pos, Self::HEAD_SIZE, input_len)
+        let field1 = pos + abi_field_head_size<T0>()
+        let field2 = field1 + abi_field_head_size<T1>()
+        let mut end = field2 + abi_field_head_size<T2>()
+        end = max_u256(a: end, b: abi_field_end_with_input_len<A, T0, I>(input, base: pos, pos: pos, input_len: input_len))
+        end = max_u256(a: end, b: abi_field_end_with_input_len<A, T1, I>(input, base: pos, pos: field1, input_len: input_len))
+        end = max_u256(a: end, b: abi_field_end_with_input_len<A, T2, I>(input, base: pos, pos: field2, input_len: input_len))
+        end
+    }
 }
 
 impl<A: Abi, T0, T1, T2, T3> Decode<A> for (T0, T1, T2, T3)
@@ -2168,6 +2415,29 @@ impl<A: Abi, T0, T1, T2, T3> Decode<A> for (T0, T1, T2, T3)
         head_pos += abi_field_head_size<T2>()
         let v3: T3 = decode_field_from<A, T3, I>(input, base: pos, head_pos: head_pos)
         (v0, v1, v2, v3)
+    }
+
+    #[inline(always)]
+    fn decode_from_checked_head<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+        where A::Decoder<I>: AbiDecoder<A>
+    {
+        let mut head_pos = pos
+        let v0: T0 = decode_field_from_checked_head<A, T0, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T0>()
+        let v1: T1 = decode_field_from_checked_head<A, T1, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T1>()
+        let v2: T2 = decode_field_from_checked_head<A, T2, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T2>()
+        let v3: T3 = decode_field_from_checked_head<A, T3, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        (v0, v1, v2, v3)
+    }
+
+    #[inline(always)]
+    fn decode_from_with_input_len<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+        where A::Decoder<I>: AbiDecoder<A>
+    {
+        checked_frame_end<A>(pos, Self::HEAD_SIZE, input_len)
+        Self::decode_from_checked_head(input, pos, input_len)
     }
 }
 
@@ -2223,6 +2493,20 @@ impl<A: Abi, T0, T1, T2, T3> AbiSpan<A> for (T0, T1, T2, T3)
         end = max_u256(a: end, b: abi_field_end<A, T3, I>(input, base: pos, pos: field3))
         end
     }
+
+    fn payload_end_with_input_len<I: ByteInput>(_ input: I, base: u256, pos: u256, input_len: u256) -> u256 {
+        let _ = base
+        checked_frame_end<A>(pos, Self::HEAD_SIZE, input_len)
+        let field1 = pos + abi_field_head_size<T0>()
+        let field2 = field1 + abi_field_head_size<T1>()
+        let field3 = field2 + abi_field_head_size<T2>()
+        let mut end = field3 + abi_field_head_size<T3>()
+        end = max_u256(a: end, b: abi_field_end_with_input_len<A, T0, I>(input, base: pos, pos: pos, input_len: input_len))
+        end = max_u256(a: end, b: abi_field_end_with_input_len<A, T1, I>(input, base: pos, pos: field1, input_len: input_len))
+        end = max_u256(a: end, b: abi_field_end_with_input_len<A, T2, I>(input, base: pos, pos: field2, input_len: input_len))
+        end = max_u256(a: end, b: abi_field_end_with_input_len<A, T3, I>(input, base: pos, pos: field3, input_len: input_len))
+        end
+    }
 }
 
 impl<A: Abi, T0, T1, T2, T3, T4> Decode<A> for (T0, T1, T2, T3, T4)
@@ -2258,6 +2542,31 @@ impl<A: Abi, T0, T1, T2, T3, T4> Decode<A> for (T0, T1, T2, T3, T4)
         head_pos += abi_field_head_size<T3>()
         let v4: T4 = decode_field_from<A, T4, I>(input, base: pos, head_pos: head_pos)
         (v0, v1, v2, v3, v4)
+    }
+
+    #[inline(always)]
+    fn decode_from_checked_head<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+        where A::Decoder<I>: AbiDecoder<A>
+    {
+        let mut head_pos = pos
+        let v0: T0 = decode_field_from_checked_head<A, T0, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T0>()
+        let v1: T1 = decode_field_from_checked_head<A, T1, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T1>()
+        let v2: T2 = decode_field_from_checked_head<A, T2, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T2>()
+        let v3: T3 = decode_field_from_checked_head<A, T3, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T3>()
+        let v4: T4 = decode_field_from_checked_head<A, T4, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        (v0, v1, v2, v3, v4)
+    }
+
+    #[inline(always)]
+    fn decode_from_with_input_len<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+        where A::Decoder<I>: AbiDecoder<A>
+    {
+        checked_frame_end<A>(pos, Self::HEAD_SIZE, input_len)
+        Self::decode_from_checked_head(input, pos, input_len)
     }
 }
 
@@ -2338,6 +2647,33 @@ impl<A: Abi, T0, T1, T2, T3, T4, T5> Decode<A> for (T0, T1, T2, T3, T4, T5)
         head_pos += abi_field_head_size<T4>()
         let v5: T5 = decode_field_from<A, T5, I>(input, base: pos, head_pos: head_pos)
         (v0, v1, v2, v3, v4, v5)
+    }
+
+    #[inline(always)]
+    fn decode_from_checked_head<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+        where A::Decoder<I>: AbiDecoder<A>
+    {
+        let mut head_pos = pos
+        let v0: T0 = decode_field_from_checked_head<A, T0, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T0>()
+        let v1: T1 = decode_field_from_checked_head<A, T1, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T1>()
+        let v2: T2 = decode_field_from_checked_head<A, T2, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T2>()
+        let v3: T3 = decode_field_from_checked_head<A, T3, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T3>()
+        let v4: T4 = decode_field_from_checked_head<A, T4, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T4>()
+        let v5: T5 = decode_field_from_checked_head<A, T5, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        (v0, v1, v2, v3, v4, v5)
+    }
+
+    #[inline(always)]
+    fn decode_from_with_input_len<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+        where A::Decoder<I>: AbiDecoder<A>
+    {
+        checked_frame_end<A>(pos, Self::HEAD_SIZE, input_len)
+        Self::decode_from_checked_head(input, pos, input_len)
     }
 }
 
@@ -2427,6 +2763,35 @@ impl<A: Abi, T0, T1, T2, T3, T4, T5, T6> Decode<A> for (T0, T1, T2, T3, T4, T5, 
         head_pos += abi_field_head_size<T5>()
         let v6: T6 = decode_field_from<A, T6, I>(input, base: pos, head_pos: head_pos)
         (v0, v1, v2, v3, v4, v5, v6)
+    }
+
+    #[inline(always)]
+    fn decode_from_checked_head<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+        where A::Decoder<I>: AbiDecoder<A>
+    {
+        let mut head_pos = pos
+        let v0: T0 = decode_field_from_checked_head<A, T0, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T0>()
+        let v1: T1 = decode_field_from_checked_head<A, T1, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T1>()
+        let v2: T2 = decode_field_from_checked_head<A, T2, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T2>()
+        let v3: T3 = decode_field_from_checked_head<A, T3, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T3>()
+        let v4: T4 = decode_field_from_checked_head<A, T4, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T4>()
+        let v5: T5 = decode_field_from_checked_head<A, T5, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T5>()
+        let v6: T6 = decode_field_from_checked_head<A, T6, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        (v0, v1, v2, v3, v4, v5, v6)
+    }
+
+    #[inline(always)]
+    fn decode_from_with_input_len<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+        where A::Decoder<I>: AbiDecoder<A>
+    {
+        checked_frame_end<A>(pos, Self::HEAD_SIZE, input_len)
+        Self::decode_from_checked_head(input, pos, input_len)
     }
 }
 
@@ -2525,6 +2890,37 @@ impl<A: Abi, T0, T1, T2, T3, T4, T5, T6, T7> Decode<A> for (T0, T1, T2, T3, T4, 
         head_pos += abi_field_head_size<T6>()
         let v7: T7 = decode_field_from<A, T7, I>(input, base: pos, head_pos: head_pos)
         (v0, v1, v2, v3, v4, v5, v6, v7)
+    }
+
+    #[inline(always)]
+    fn decode_from_checked_head<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+        where A::Decoder<I>: AbiDecoder<A>
+    {
+        let mut head_pos = pos
+        let v0: T0 = decode_field_from_checked_head<A, T0, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T0>()
+        let v1: T1 = decode_field_from_checked_head<A, T1, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T1>()
+        let v2: T2 = decode_field_from_checked_head<A, T2, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T2>()
+        let v3: T3 = decode_field_from_checked_head<A, T3, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T3>()
+        let v4: T4 = decode_field_from_checked_head<A, T4, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T4>()
+        let v5: T5 = decode_field_from_checked_head<A, T5, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T5>()
+        let v6: T6 = decode_field_from_checked_head<A, T6, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T6>()
+        let v7: T7 = decode_field_from_checked_head<A, T7, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        (v0, v1, v2, v3, v4, v5, v6, v7)
+    }
+
+    #[inline(always)]
+    fn decode_from_with_input_len<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+        where A::Decoder<I>: AbiDecoder<A>
+    {
+        checked_frame_end<A>(pos, Self::HEAD_SIZE, input_len)
+        Self::decode_from_checked_head(input, pos, input_len)
     }
 }
 
@@ -2632,6 +3028,39 @@ impl<A: Abi, T0, T1, T2, T3, T4, T5, T6, T7, T8> Decode<A> for (T0, T1, T2, T3, 
         head_pos += abi_field_head_size<T7>()
         let v8: T8 = decode_field_from<A, T8, I>(input, base: pos, head_pos: head_pos)
         (v0, v1, v2, v3, v4, v5, v6, v7, v8)
+    }
+
+    #[inline(always)]
+    fn decode_from_checked_head<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+        where A::Decoder<I>: AbiDecoder<A>
+    {
+        let mut head_pos = pos
+        let v0: T0 = decode_field_from_checked_head<A, T0, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T0>()
+        let v1: T1 = decode_field_from_checked_head<A, T1, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T1>()
+        let v2: T2 = decode_field_from_checked_head<A, T2, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T2>()
+        let v3: T3 = decode_field_from_checked_head<A, T3, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T3>()
+        let v4: T4 = decode_field_from_checked_head<A, T4, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T4>()
+        let v5: T5 = decode_field_from_checked_head<A, T5, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T5>()
+        let v6: T6 = decode_field_from_checked_head<A, T6, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T6>()
+        let v7: T7 = decode_field_from_checked_head<A, T7, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T7>()
+        let v8: T8 = decode_field_from_checked_head<A, T8, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        (v0, v1, v2, v3, v4, v5, v6, v7, v8)
+    }
+
+    #[inline(always)]
+    fn decode_from_with_input_len<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+        where A::Decoder<I>: AbiDecoder<A>
+    {
+        checked_frame_end<A>(pos, Self::HEAD_SIZE, input_len)
+        Self::decode_from_checked_head(input, pos, input_len)
     }
 }
 
@@ -2749,6 +3178,41 @@ impl<A: Abi, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> Decode<A>
         head_pos += abi_field_head_size<T8>()
         let v9: T9 = decode_field_from<A, T9, I>(input, base: pos, head_pos: head_pos)
         (v0, v1, v2, v3, v4, v5, v6, v7, v8, v9)
+    }
+
+    #[inline(always)]
+    fn decode_from_checked_head<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+        where A::Decoder<I>: AbiDecoder<A>
+    {
+        let mut head_pos = pos
+        let v0: T0 = decode_field_from_checked_head<A, T0, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T0>()
+        let v1: T1 = decode_field_from_checked_head<A, T1, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T1>()
+        let v2: T2 = decode_field_from_checked_head<A, T2, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T2>()
+        let v3: T3 = decode_field_from_checked_head<A, T3, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T3>()
+        let v4: T4 = decode_field_from_checked_head<A, T4, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T4>()
+        let v5: T5 = decode_field_from_checked_head<A, T5, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T5>()
+        let v6: T6 = decode_field_from_checked_head<A, T6, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T6>()
+        let v7: T7 = decode_field_from_checked_head<A, T7, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T7>()
+        let v8: T8 = decode_field_from_checked_head<A, T8, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T8>()
+        let v9: T9 = decode_field_from_checked_head<A, T9, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        (v0, v1, v2, v3, v4, v5, v6, v7, v8, v9)
+    }
+
+    #[inline(always)]
+    fn decode_from_with_input_len<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+        where A::Decoder<I>: AbiDecoder<A>
+    {
+        checked_frame_end<A>(pos, Self::HEAD_SIZE, input_len)
+        Self::decode_from_checked_head(input, pos, input_len)
     }
 }
 
@@ -2876,6 +3340,43 @@ impl<A: Abi, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Decode<A>
         head_pos += abi_field_head_size<T9>()
         let v10: T10 = decode_field_from<A, T10, I>(input, base: pos, head_pos: head_pos)
         (v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10)
+    }
+
+    #[inline(always)]
+    fn decode_from_checked_head<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+        where A::Decoder<I>: AbiDecoder<A>
+    {
+        let mut head_pos = pos
+        let v0: T0 = decode_field_from_checked_head<A, T0, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T0>()
+        let v1: T1 = decode_field_from_checked_head<A, T1, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T1>()
+        let v2: T2 = decode_field_from_checked_head<A, T2, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T2>()
+        let v3: T3 = decode_field_from_checked_head<A, T3, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T3>()
+        let v4: T4 = decode_field_from_checked_head<A, T4, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T4>()
+        let v5: T5 = decode_field_from_checked_head<A, T5, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T5>()
+        let v6: T6 = decode_field_from_checked_head<A, T6, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T6>()
+        let v7: T7 = decode_field_from_checked_head<A, T7, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T7>()
+        let v8: T8 = decode_field_from_checked_head<A, T8, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T8>()
+        let v9: T9 = decode_field_from_checked_head<A, T9, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T9>()
+        let v10: T10 = decode_field_from_checked_head<A, T10, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        (v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10)
+    }
+
+    #[inline(always)]
+    fn decode_from_with_input_len<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+        where A::Decoder<I>: AbiDecoder<A>
+    {
+        checked_frame_end<A>(pos, Self::HEAD_SIZE, input_len)
+        Self::decode_from_checked_head(input, pos, input_len)
     }
 }
 
@@ -3013,6 +3514,45 @@ impl<A: Abi, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Decode<A>
         let v11: T11 = decode_field_from<A, T11, I>(input, base: pos, head_pos: head_pos)
         (v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11)
     }
+
+    #[inline(always)]
+    fn decode_from_checked_head<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+        where A::Decoder<I>: AbiDecoder<A>
+    {
+        let mut head_pos = pos
+        let v0: T0 = decode_field_from_checked_head<A, T0, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T0>()
+        let v1: T1 = decode_field_from_checked_head<A, T1, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T1>()
+        let v2: T2 = decode_field_from_checked_head<A, T2, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T2>()
+        let v3: T3 = decode_field_from_checked_head<A, T3, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T3>()
+        let v4: T4 = decode_field_from_checked_head<A, T4, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T4>()
+        let v5: T5 = decode_field_from_checked_head<A, T5, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T5>()
+        let v6: T6 = decode_field_from_checked_head<A, T6, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T6>()
+        let v7: T7 = decode_field_from_checked_head<A, T7, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T7>()
+        let v8: T8 = decode_field_from_checked_head<A, T8, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T8>()
+        let v9: T9 = decode_field_from_checked_head<A, T9, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T9>()
+        let v10: T10 = decode_field_from_checked_head<A, T10, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        head_pos += abi_field_head_size<T10>()
+        let v11: T11 = decode_field_from_checked_head<A, T11, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        (v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11)
+    }
+
+    #[inline(always)]
+    fn decode_from_with_input_len<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+        where A::Decoder<I>: AbiDecoder<A>
+    {
+        checked_frame_end<A>(pos, Self::HEAD_SIZE, input_len)
+        Self::decode_from_checked_head(input, pos, input_len)
+    }
 }
 
 impl<A: Abi, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Encode<A>
@@ -3120,6 +3660,30 @@ impl<A: Abi, T, const N: usize> Decode<A> for [T; N]
         }
         out
     }
+
+    #[inline(always)]
+    fn decode_from_checked_head<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+        where A::Decoder<I>: AbiDecoder<A>
+    {
+        let first = decode_field_from_checked_head<A, T, I>(input, base: pos, head_pos: pos, input_len: input_len)
+        let mut out: [T; N] = [first; N]
+        let mut i: usize = 1
+        let mut head_pos = pos + abi_field_head_size<T>()
+        while i < N {
+            out[i] = decode_field_from_checked_head<A, T, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+            head_pos += abi_field_head_size<T>()
+            i += 1
+        }
+        out
+    }
+
+    #[inline(always)]
+    fn decode_from_with_input_len<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+        where A::Decoder<I>: AbiDecoder<A>
+    {
+        checked_frame_end<A>(pos, Self::HEAD_SIZE, input_len)
+        Self::decode_from_checked_head(input, pos, input_len)
+    }
 }
 
 impl<A: Abi, T, const N: usize> AbiSpan<A> for [T; N]
@@ -3132,6 +3696,20 @@ impl<A: Abi, T, const N: usize> AbiSpan<A> for [T; N]
         let mut i: usize = 0
         while i < N {
             end = max_u256(a: end, b: abi_field_end<A, T, I>(input, base: pos, pos: head_pos))
+            head_pos += abi_field_head_size<T>()
+            i += 1
+        }
+        max_u256(a: end, b: head_pos)
+    }
+
+    fn payload_end_with_input_len<I: ByteInput>(_ input: I, base: u256, pos: u256, input_len: u256) -> u256 {
+        let _ = base
+        checked_frame_end<A>(pos, Self::HEAD_SIZE, input_len)
+        let mut head_pos = pos
+        let mut end = pos
+        let mut i: usize = 0
+        while i < N {
+            end = max_u256(a: end, b: abi_field_end_with_input_len<A, T, I>(input, base: pos, pos: head_pos, input_len: input_len))
             head_pos += abi_field_head_size<T>()
             i += 1
         }

--- a/ingots/core/src/abi.fe
+++ b/ingots/core/src/abi.fe
@@ -188,7 +188,7 @@ pub trait AbiSpan<A: Abi>: AbiSize {
     }
 }
 
-pub trait Decode<A: Abi> {
+pub trait Decode<A: Abi>: AbiSize {
     fn decode_payload<D: AbiDecoder<A>>(_: mut D) -> Self
 
     /// Decode from a raw ABI payload position. Callers that use this path are
@@ -219,6 +219,7 @@ pub trait Decode<A: Abi> {
     fn decode_from_bounded<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
         where A::Decoder<I>: AbiDecoder<A>
     {
+        checked_frame_end<A>(pos, Self::HEAD_SIZE, input_len)
         Self::decode_from(input, pos)
     }
 }
@@ -348,6 +349,20 @@ pub fn decode_field_from<A: Abi, T, I>(_ input: I, base: u256, head_pos: u256) -
     }
 
     T::decode_from(input, head_pos)
+}
+
+#[inline(always)]
+pub fn decode_msg_field_from<A: Abi, T, I>(_ input: I, base: u256, head_pos: u256, input_len: u256) -> T
+    where T: Decode<A> + AbiSize,
+          I: ByteInput,
+          A::Decoder<I>: AbiDecoder<A>
+{
+    if T::IS_DYNAMIC {
+        return decode_field_from_prechecked_head<A, T, I>(input, base: base, head_pos: head_pos, input_len: input_len)
+    }
+
+    let _ = input_len
+    decode_field_from<A, T, I>(input, base: base, head_pos: head_pos)
 }
 
 /// Decode a field whose head word lies inside an already-checked parent frame.

--- a/ingots/core/src/abi.fe
+++ b/ingots/core/src/abi.fe
@@ -192,6 +192,12 @@ pub trait Decode<A: Abi> {
         let mut d = A::decoder_with_base(input, pos)
         Self::decode_payload(mut d)
     }
+
+    fn decode_from_with_input_len<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+        where A::Decoder<I>: AbiDecoder<A>
+    {
+        Self::decode_from(input, pos)
+    }
 }
 
 pub trait Encode<A: Abi>: AbiSize {
@@ -288,6 +294,20 @@ pub fn decode_field_from<A: Abi, T, I>(_ input: I, base: u256, head_pos: u256) -
     if T::IS_DYNAMIC {
         let tail_rel = input.word_at(head_pos)
         return T::decode_from(input, base + tail_rel)
+    }
+
+    T::decode_from(input, head_pos)
+}
+
+#[inline(always)]
+pub fn decode_field_from_with_input_len<A: Abi, T, I>(_ input: I, base: u256, head_pos: u256, input_len: u256) -> T
+    where T: Decode<A> + AbiSize,
+          I: ByteInput,
+          A::Decoder<I>: AbiDecoder<A>
+{
+    if T::IS_DYNAMIC {
+        let tail_rel = input.word_at(head_pos)
+        return T::decode_from_with_input_len(input, base + tail_rel, input_len)
     }
 
     T::decode_from(input, head_pos)
@@ -433,6 +453,11 @@ fn round_up_words(_ len: u256) -> u256 {
 #[inline(always)]
 fn checked_dynamic_payload<A: Abi, I: ByteInput>(_ input: I, _ pos: u256) -> (u256, u256) {
     let input_len = input.len()
+    checked_dynamic_payload_with_input_len<A, I>(input, pos, input_len)
+}
+
+#[inline(always)]
+fn checked_dynamic_payload_with_input_len<A: Abi, I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> (u256, u256) {
     let len_end = pos + 32
     if len_end < pos || len_end > input_len {
         A::decode_error()
@@ -450,7 +475,12 @@ fn checked_dynamic_payload<A: Abi, I: ByteInput>(_ input: I, _ pos: u256) -> (u2
 
 #[inline(always)]
 fn copy_dynamic_payload_from<A: Abi, I: ByteInput>(_ input: I, _ pos: u256) -> (u256, u256, u256) {
-    let payload: (u256, u256) = checked_dynamic_payload<A, I>(input, pos)
+    let input_len = input.len()
+    copy_dynamic_payload_from_with_input_len<A, I>(input, pos, input_len)
+}
+
+fn copy_dynamic_payload_from_with_input_len<A: Abi, I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> (u256, u256, u256) {
+    let payload: (u256, u256) = checked_dynamic_payload_with_input_len<A, I>(input, pos, input_len)
     let data_len = payload.0
     let payload_size = payload.1
     let data_ptr = A::alloc(payload_size)
@@ -560,11 +590,7 @@ impl DynString {
     }
 
     pub fn as_bytes(self) -> Bytes {
-        Bytes {
-            data: self.data,
-            len: self.len,
-            size: self.size,
-        }
+        Bytes::from_abi_tail(data: self.data, len: self.len, size: self.size)
     }
 
     pub fn view(self) -> StringView<MemoryInput> {
@@ -598,11 +624,11 @@ pub struct Bytes {
 
 impl Bytes {
     pub fn empty() -> Self {
-        Bytes {
-            data: 0,
-            len: 0,
-            size: 32,
-        }
+        Bytes::from_abi_tail(data: 0, len: 0, size: 32)
+    }
+
+    pub fn from_abi_tail(data: u256, len: u256, size: u256) -> Self {
+        Bytes { data, len, size }
     }
 
     pub fn len(self) -> u256 {
@@ -1771,11 +1797,7 @@ impl<A: Abi> Decode<A> for Bytes {
 
         input.copy_to_memory_unchecked_aligned(dest: data_ptr, src_offset: payload_at, len: payload_size)
 
-        Bytes {
-            data: data_ptr,
-            len: data_len,
-            size: payload_size,
-        }
+        Bytes::from_abi_tail(data: data_ptr, len: data_len, size: payload_size)
     }
 
     #[inline(always)]
@@ -1784,11 +1806,16 @@ impl<A: Abi> Decode<A> for Bytes {
     {
         let payload: (u256, u256, u256) = copy_dynamic_payload_from<A, I>(input, pos)
 
-        Bytes {
-            data: payload.0,
-            len: payload.1,
-            size: payload.2,
-        }
+        Bytes::from_abi_tail(data: payload.0, len: payload.1, size: payload.2)
+    }
+
+    #[inline(always)]
+    fn decode_from_with_input_len<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+        where A::Decoder<I>: AbiDecoder<A>
+    {
+        let payload: (u256, u256, u256) = copy_dynamic_payload_from_with_input_len<A, I>(input, pos, input_len)
+
+        Bytes::from_abi_tail(data: payload.0, len: payload.1, size: payload.2)
     }
 }
 

--- a/ingots/core/src/abi.fe
+++ b/ingots/core/src/abi.fe
@@ -33,6 +33,14 @@ pub trait ByteInput: Copy {
     ///
     /// Callers currently rely on `len` being a whole number of words.
     fn copy_to_memory(self, dest: u256, src_offset: u256, len: u256)
+
+    /// Copy an already validated, word-aligned range into linear memory.
+    ///
+    /// Callers must validate bounds and `len % 32 == 0` before using this fast
+    /// path. Implementations may skip all checks.
+    fn copy_to_memory_unchecked_aligned(self, dest: u256, src_offset: u256, len: u256) {
+        self.copy_to_memory(dest: dest, src_offset: src_offset, len: len)
+    }
 }
 
 /// First-word prefix used for fast dispatch.
@@ -121,6 +129,7 @@ pub trait Abi {
     fn decoder_new<I: ByteInput>(_: own I) -> Self::Decoder<I>
     fn decoder_with_base<I: ByteInput>(_: own I, _ base: u256) -> Self::Decoder<I>
 
+    fn alloc(_ size: u256) -> u256
     fn encoder_new(_ size: u256) -> Self::Encoder
     fn store_word(ptr: u256, value: u256)
 }
@@ -387,6 +396,36 @@ fn round_up_words(_ len: u256) -> u256 {
     (((len - 1) / 32) + 1) * 32
 }
 
+#[inline(always)]
+fn checked_dynamic_payload<A: Abi, I: ByteInput>(_ input: I, _ pos: u256) -> (u256, u256) {
+    let input_len = input.len()
+    let len_end = pos + 32
+    if len_end < pos || len_end > input_len {
+        A::decode_error()
+    }
+
+    let data_len = input.word_at(pos)
+    let payload_size = 32 + round_up_words(data_len)
+    let payload_end = pos + payload_size
+    if payload_end < pos || payload_end > input_len {
+        A::decode_error()
+    }
+
+    (data_len, payload_size)
+}
+
+#[inline(always)]
+fn copy_dynamic_payload_from<A: Abi, I: ByteInput>(_ input: I, _ pos: u256) -> (u256, u256, u256) {
+    let payload: (u256, u256) = checked_dynamic_payload<A, I>(input, pos)
+    let data_len = payload.0
+    let payload_size = payload.1
+    let data_ptr = A::alloc(payload_size)
+
+    input.copy_to_memory_unchecked_aligned(dest: data_ptr, src_offset: pos, len: payload_size)
+
+    (data_ptr, data_len, payload_size)
+}
+
 // Fe strings are currently represented as a single packed word. This limits the
 // ABI path here to strings whose runtime payload fits in 32 bytes.
 fn packed_string_len(_ word: u256) -> u256 {
@@ -618,6 +657,10 @@ impl ByteInput for MemoryInput {
             super::panic()
         }
 
+        mcopy(dest: dest, addr: self.base + src_offset, len: len)
+    }
+
+    fn copy_to_memory_unchecked_aligned(self, dest: u256, src_offset: u256, len: u256) {
         mcopy(dest: dest, addr: self.base + src_offset, len: len)
     }
 }
@@ -1258,9 +1301,14 @@ impl<A: Abi> Decode<A> for DynString {
         let payload_at = d.pos()
         let data_len = d.read_word()
         let payload_size = 32 + round_up_words(data_len)
+        let payload_end = payload_at + payload_size
+        let input = d.input()
+        if payload_end < payload_at || payload_end > input.len() {
+            A::decode_error()
+        }
         let data_ptr = d.alloc(payload_size)
 
-        d.input().copy_to_memory(dest: data_ptr, src_offset: payload_at, len: payload_size)
+        input.copy_to_memory_unchecked_aligned(dest: data_ptr, src_offset: payload_at, len: payload_size)
 
         DynString {
             data: data_ptr,
@@ -1273,8 +1321,13 @@ impl<A: Abi> Decode<A> for DynString {
     fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self
         where A::Decoder<I>: AbiDecoder<A>
     {
-        let mut d = A::decoder_with_base(input, pos)
-        Self::decode_payload(mut d)
+        let payload: (u256, u256, u256) = copy_dynamic_payload_from<A, I>(input, pos)
+
+        DynString {
+            data: payload.0,
+            len: payload.1,
+            size: payload.2,
+        }
     }
 }
 
@@ -1651,9 +1704,14 @@ impl<A: Abi> Decode<A> for Bytes {
         let payload_at = d.pos()
         let data_len = d.read_word()
         let payload_size = 32 + round_up_words(data_len)
+        let payload_end = payload_at + payload_size
+        let input = d.input()
+        if payload_end < payload_at || payload_end > input.len() {
+            A::decode_error()
+        }
         let data_ptr = d.alloc(payload_size)
 
-        d.input().copy_to_memory(dest: data_ptr, src_offset: payload_at, len: payload_size)
+        input.copy_to_memory_unchecked_aligned(dest: data_ptr, src_offset: payload_at, len: payload_size)
 
         Bytes {
             data: data_ptr,
@@ -1666,8 +1724,13 @@ impl<A: Abi> Decode<A> for Bytes {
     fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self
         where A::Decoder<I>: AbiDecoder<A>
     {
-        let mut d = A::decoder_with_base(input, pos)
-        Self::decode_payload(mut d)
+        let payload: (u256, u256, u256) = copy_dynamic_payload_from<A, I>(input, pos)
+
+        Bytes {
+            data: payload.0,
+            len: payload.1,
+            size: payload.2,
+        }
     }
 }
 
@@ -1745,11 +1808,15 @@ impl<A: Abi, T> Decode<A> for DynArray<T>
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         let payload_at = d.pos()
         let elem_count = d.read_word()
-        let payload_end = dyn_array_payload_end<A, T, D::Input>(d.input(), tail_at: payload_at, elem_count: elem_count)
+        let input = d.input()
+        let payload_end = dyn_array_payload_end<A, T, D::Input>(input, tail_at: payload_at, elem_count: elem_count)
+        if payload_end < payload_at || payload_end > input.len() {
+            A::decode_error()
+        }
         let payload_size = payload_end - payload_at
         let data_ptr = d.alloc(payload_size)
 
-        d.input().copy_to_memory(dest: data_ptr, src_offset: payload_at, len: payload_size)
+        input.copy_to_memory_unchecked_aligned(dest: data_ptr, src_offset: payload_at, len: payload_size)
 
         DynArray {
             data: data_ptr,
@@ -1762,8 +1829,28 @@ impl<A: Abi, T> Decode<A> for DynArray<T>
     fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self
         where A::Decoder<I>: AbiDecoder<A>
     {
-        let mut d = A::decoder_with_base(input, pos)
-        Self::decode_payload(mut d)
+        let input_len = input.len()
+        let len_end = pos + 32
+        if len_end < pos || len_end > input_len {
+            A::decode_error()
+        }
+
+        let elem_count = input.word_at(pos)
+        let payload_end = dyn_array_payload_end<A, T, I>(input, tail_at: pos, elem_count: elem_count)
+        if payload_end < pos || payload_end > input_len {
+            A::decode_error()
+        }
+
+        let payload_size = payload_end - pos
+        let data_ptr = A::alloc(payload_size)
+
+        input.copy_to_memory_unchecked_aligned(dest: data_ptr, src_offset: pos, len: payload_size)
+
+        DynArray {
+            data: data_ptr,
+            len: elem_count,
+            size: payload_size,
+        }
     }
 }
 
@@ -1801,6 +1888,14 @@ impl<A: Abi, T0> Decode<A> for (T0,)
         let v0: T0 = decode_field<A, T0, D>(mut d)
         (v0,)
     }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self
+        where A::Decoder<I>: AbiDecoder<A>
+    {
+        let v0: T0 = decode_field_from<A, T0, I>(input, base: pos, head_pos: pos)
+        (v0,)
+    }
 }
 
 impl<A: Abi, T0> Encode<A> for (T0,)
@@ -1832,6 +1927,17 @@ impl<A: Abi, T0, T1> Decode<A> for (T0, T1)
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         let v0: T0 = decode_field<A, T0, D>(mut d)
         let v1: T1 = decode_field<A, T1, D>(mut d)
+        (v0, v1)
+    }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self
+        where A::Decoder<I>: AbiDecoder<A>
+    {
+        let mut head_pos = pos
+        let v0: T0 = decode_field_from<A, T0, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T0>()
+        let v1: T1 = decode_field_from<A, T1, I>(input, base: pos, head_pos: head_pos)
         (v0, v1)
     }
 }
@@ -1873,6 +1979,19 @@ impl<A: Abi, T0, T1, T2> Decode<A> for (T0, T1, T2)
         let v0: T0 = decode_field<A, T0, D>(mut d)
         let v1: T1 = decode_field<A, T1, D>(mut d)
         let v2: T2 = decode_field<A, T2, D>(mut d)
+        (v0, v1, v2)
+    }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self
+        where A::Decoder<I>: AbiDecoder<A>
+    {
+        let mut head_pos = pos
+        let v0: T0 = decode_field_from<A, T0, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T0>()
+        let v1: T1 = decode_field_from<A, T1, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T1>()
+        let v2: T2 = decode_field_from<A, T2, I>(input, base: pos, head_pos: head_pos)
         (v0, v1, v2)
     }
 }
@@ -1922,6 +2041,21 @@ impl<A: Abi, T0, T1, T2, T3> Decode<A> for (T0, T1, T2, T3)
         let v1: T1 = decode_field<A, T1, D>(mut d)
         let v2: T2 = decode_field<A, T2, D>(mut d)
         let v3: T3 = decode_field<A, T3, D>(mut d)
+        (v0, v1, v2, v3)
+    }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self
+        where A::Decoder<I>: AbiDecoder<A>
+    {
+        let mut head_pos = pos
+        let v0: T0 = decode_field_from<A, T0, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T0>()
+        let v1: T1 = decode_field_from<A, T1, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T1>()
+        let v2: T2 = decode_field_from<A, T2, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T2>()
+        let v3: T3 = decode_field_from<A, T3, I>(input, base: pos, head_pos: head_pos)
         (v0, v1, v2, v3)
     }
 }
@@ -1990,6 +2124,23 @@ impl<A: Abi, T0, T1, T2, T3, T4> Decode<A> for (T0, T1, T2, T3, T4)
             v4,
         )
     }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self
+        where A::Decoder<I>: AbiDecoder<A>
+    {
+        let mut head_pos = pos
+        let v0: T0 = decode_field_from<A, T0, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T0>()
+        let v1: T1 = decode_field_from<A, T1, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T1>()
+        let v2: T2 = decode_field_from<A, T2, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T2>()
+        let v3: T3 = decode_field_from<A, T3, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T3>()
+        let v4: T4 = decode_field_from<A, T4, I>(input, base: pos, head_pos: head_pos)
+        (v0, v1, v2, v3, v4)
+    }
 }
 
 impl<A: Abi, T0, T1, T2, T3, T4> Encode<A> for (T0, T1, T2, T3, T4)
@@ -2042,6 +2193,25 @@ impl<A: Abi, T0, T1, T2, T3, T4, T5> Decode<A> for (T0, T1, T2, T3, T4, T5)
             v4,
             v5,
         )
+    }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self
+        where A::Decoder<I>: AbiDecoder<A>
+    {
+        let mut head_pos = pos
+        let v0: T0 = decode_field_from<A, T0, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T0>()
+        let v1: T1 = decode_field_from<A, T1, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T1>()
+        let v2: T2 = decode_field_from<A, T2, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T2>()
+        let v3: T3 = decode_field_from<A, T3, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T3>()
+        let v4: T4 = decode_field_from<A, T4, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T4>()
+        let v5: T5 = decode_field_from<A, T5, I>(input, base: pos, head_pos: head_pos)
+        (v0, v1, v2, v3, v4, v5)
     }
 }
 
@@ -2101,6 +2271,27 @@ impl<A: Abi, T0, T1, T2, T3, T4, T5, T6> Decode<A> for (T0, T1, T2, T3, T4, T5, 
             v5,
             v6,
         )
+    }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self
+        where A::Decoder<I>: AbiDecoder<A>
+    {
+        let mut head_pos = pos
+        let v0: T0 = decode_field_from<A, T0, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T0>()
+        let v1: T1 = decode_field_from<A, T1, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T1>()
+        let v2: T2 = decode_field_from<A, T2, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T2>()
+        let v3: T3 = decode_field_from<A, T3, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T3>()
+        let v4: T4 = decode_field_from<A, T4, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T4>()
+        let v5: T5 = decode_field_from<A, T5, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T5>()
+        let v6: T6 = decode_field_from<A, T6, I>(input, base: pos, head_pos: head_pos)
+        (v0, v1, v2, v3, v4, v5, v6)
     }
 }
 
@@ -2166,6 +2357,29 @@ impl<A: Abi, T0, T1, T2, T3, T4, T5, T6, T7> Decode<A> for (T0, T1, T2, T3, T4, 
             v6,
             v7,
         )
+    }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self
+        where A::Decoder<I>: AbiDecoder<A>
+    {
+        let mut head_pos = pos
+        let v0: T0 = decode_field_from<A, T0, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T0>()
+        let v1: T1 = decode_field_from<A, T1, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T1>()
+        let v2: T2 = decode_field_from<A, T2, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T2>()
+        let v3: T3 = decode_field_from<A, T3, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T3>()
+        let v4: T4 = decode_field_from<A, T4, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T4>()
+        let v5: T5 = decode_field_from<A, T5, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T5>()
+        let v6: T6 = decode_field_from<A, T6, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T6>()
+        let v7: T7 = decode_field_from<A, T7, I>(input, base: pos, head_pos: head_pos)
+        (v0, v1, v2, v3, v4, v5, v6, v7)
     }
 }
 
@@ -2237,6 +2451,31 @@ impl<A: Abi, T0, T1, T2, T3, T4, T5, T6, T7, T8> Decode<A> for (T0, T1, T2, T3, 
             v7,
             v8,
         )
+    }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self
+        where A::Decoder<I>: AbiDecoder<A>
+    {
+        let mut head_pos = pos
+        let v0: T0 = decode_field_from<A, T0, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T0>()
+        let v1: T1 = decode_field_from<A, T1, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T1>()
+        let v2: T2 = decode_field_from<A, T2, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T2>()
+        let v3: T3 = decode_field_from<A, T3, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T3>()
+        let v4: T4 = decode_field_from<A, T4, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T4>()
+        let v5: T5 = decode_field_from<A, T5, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T5>()
+        let v6: T6 = decode_field_from<A, T6, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T6>()
+        let v7: T7 = decode_field_from<A, T7, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T7>()
+        let v8: T8 = decode_field_from<A, T8, I>(input, base: pos, head_pos: head_pos)
+        (v0, v1, v2, v3, v4, v5, v6, v7, v8)
     }
 }
 
@@ -2315,6 +2554,33 @@ impl<A: Abi, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> Decode<A>
             v8,
             v9,
         )
+    }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self
+        where A::Decoder<I>: AbiDecoder<A>
+    {
+        let mut head_pos = pos
+        let v0: T0 = decode_field_from<A, T0, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T0>()
+        let v1: T1 = decode_field_from<A, T1, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T1>()
+        let v2: T2 = decode_field_from<A, T2, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T2>()
+        let v3: T3 = decode_field_from<A, T3, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T3>()
+        let v4: T4 = decode_field_from<A, T4, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T4>()
+        let v5: T5 = decode_field_from<A, T5, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T5>()
+        let v6: T6 = decode_field_from<A, T6, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T6>()
+        let v7: T7 = decode_field_from<A, T7, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T7>()
+        let v8: T8 = decode_field_from<A, T8, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T8>()
+        let v9: T9 = decode_field_from<A, T9, I>(input, base: pos, head_pos: head_pos)
+        (v0, v1, v2, v3, v4, v5, v6, v7, v8, v9)
     }
 }
 
@@ -2400,6 +2666,35 @@ impl<A: Abi, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Decode<A>
             v9,
             v10,
         )
+    }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self
+        where A::Decoder<I>: AbiDecoder<A>
+    {
+        let mut head_pos = pos
+        let v0: T0 = decode_field_from<A, T0, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T0>()
+        let v1: T1 = decode_field_from<A, T1, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T1>()
+        let v2: T2 = decode_field_from<A, T2, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T2>()
+        let v3: T3 = decode_field_from<A, T3, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T3>()
+        let v4: T4 = decode_field_from<A, T4, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T4>()
+        let v5: T5 = decode_field_from<A, T5, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T5>()
+        let v6: T6 = decode_field_from<A, T6, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T6>()
+        let v7: T7 = decode_field_from<A, T7, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T7>()
+        let v8: T8 = decode_field_from<A, T8, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T8>()
+        let v9: T9 = decode_field_from<A, T9, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T9>()
+        let v10: T10 = decode_field_from<A, T10, I>(input, base: pos, head_pos: head_pos)
+        (v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10)
     }
 }
 
@@ -2491,6 +2786,37 @@ impl<A: Abi, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Decode<A>
             v10,
             v11,
         )
+    }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self
+        where A::Decoder<I>: AbiDecoder<A>
+    {
+        let mut head_pos = pos
+        let v0: T0 = decode_field_from<A, T0, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T0>()
+        let v1: T1 = decode_field_from<A, T1, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T1>()
+        let v2: T2 = decode_field_from<A, T2, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T2>()
+        let v3: T3 = decode_field_from<A, T3, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T3>()
+        let v4: T4 = decode_field_from<A, T4, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T4>()
+        let v5: T5 = decode_field_from<A, T5, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T5>()
+        let v6: T6 = decode_field_from<A, T6, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T6>()
+        let v7: T7 = decode_field_from<A, T7, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T7>()
+        let v8: T8 = decode_field_from<A, T8, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T8>()
+        let v9: T9 = decode_field_from<A, T9, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T9>()
+        let v10: T10 = decode_field_from<A, T10, I>(input, base: pos, head_pos: head_pos)
+        head_pos += abi_field_head_size<T10>()
+        let v11: T11 = decode_field_from<A, T11, I>(input, base: pos, head_pos: head_pos)
+        (v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11)
     }
 }
 

--- a/ingots/core/src/abi.fe
+++ b/ingots/core/src/abi.fe
@@ -191,6 +191,8 @@ pub trait AbiSpan<A: Abi>: AbiSize {
 pub trait Decode<A: Abi> {
     fn decode_payload<D: AbiDecoder<A>>(_: mut D) -> Self
 
+    /// Decode from a raw ABI payload position. Callers that use this path are
+    /// responsible for any bounds checks needed by the input source.
     fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self
         where A::Decoder<I>: AbiDecoder<A>
     {
@@ -198,15 +200,23 @@ pub trait Decode<A: Abi> {
         Self::decode_payload(mut d)
     }
 
+    /// Decode after the caller has already checked this value's head frame.
+    ///
+    /// Dynamic leaves can read their length word without repeating the
+    /// `pos + HEAD_SIZE <= input_len` check.
     #[inline(always)]
-    fn decode_from_checked_head<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+    fn decode_from_prechecked_head<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
         where A::Decoder<I>: AbiDecoder<A>
     {
         let _ = input_len
         Self::decode_from(input, pos)
     }
 
-    fn decode_from_with_input_len<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+    /// Decode from a position with only `input_len` known.
+    ///
+    /// Composite implementations must validate their own head frame before
+    /// entering the prechecked-head fast path.
+    fn decode_from_bounded<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
         where A::Decoder<I>: AbiDecoder<A>
     {
         Self::decode_from(input, pos)
@@ -266,7 +276,7 @@ pub fn decode_frame_from<A: Abi, T, I>(_ input: I, _ pos: u256, _ input_len: u25
           A::Decoder<I>: AbiDecoder<A>
 {
     checked_frame_end<A>(pos, T::HEAD_SIZE, input_len)
-    T::decode_from_checked_head(input, pos, input_len)
+    T::decode_from_prechecked_head(input, pos, input_len)
 }
 
 pub fn abi_payload_size<T: AbiSize>(_ value: T) -> u256 {
@@ -340,8 +350,12 @@ pub fn decode_field_from<A: Abi, T, I>(_ input: I, base: u256, head_pos: u256) -
     T::decode_from(input, head_pos)
 }
 
+/// Decode a field whose head word lies inside an already-checked parent frame.
+///
+/// Static fields can decode directly from the head position. Dynamic fields use
+/// `input_len` to validate their tail before entering that tail's decode path.
 #[inline(always)]
-pub fn decode_field_from_checked_head<A: Abi, T, I>(_ input: I, base: u256, head_pos: u256, input_len: u256) -> T
+pub fn decode_field_from_prechecked_head<A: Abi, T, I>(_ input: I, base: u256, head_pos: u256, input_len: u256) -> T
     where T: Decode<A> + AbiSize,
           I: ByteInput,
           A::Decoder<I>: AbiDecoder<A>
@@ -349,19 +363,10 @@ pub fn decode_field_from_checked_head<A: Abi, T, I>(_ input: I, base: u256, head
     if T::IS_DYNAMIC {
         let tail_rel = input.word_at(head_pos)
         let tail_at = checked_tail<A>(base, tail_rel)
-        return T::decode_from_with_input_len(input, tail_at, input_len)
+        return T::decode_from_bounded(input, tail_at, input_len)
     }
 
     T::decode_from(input, head_pos)
-}
-
-#[inline(always)]
-pub fn decode_field_from_with_input_len<A: Abi, T, I>(_ input: I, base: u256, head_pos: u256, input_len: u256) -> T
-    where T: Decode<A> + AbiSize,
-          I: ByteInput,
-          A::Decoder<I>: AbiDecoder<A>
-{
-    decode_field_from_checked_head<A, T, I>(input, base: base, head_pos: head_pos, input_len: input_len)
 }
 
 fn decode_field_at<A: Abi, T, D>(d: mut D, pos: u256) -> T
@@ -1469,11 +1474,11 @@ impl<A: Abi, const N: usize> Decode<A> for String<N> {
         where A::Decoder<I>: AbiDecoder<A>
     {
         let input_len = input.len()
-        Self::decode_from_with_input_len(input, pos, input_len)
+        Self::decode_from_bounded(input, pos, input_len)
     }
 
     #[inline(always)]
-    fn decode_from_checked_head<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+    fn decode_from_prechecked_head<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
         where A::Decoder<I>: AbiDecoder<A>
     {
         let payload = checked_dynamic_payload_after_head<A, I>(input, pos, input_len)
@@ -1481,7 +1486,7 @@ impl<A: Abi, const N: usize> Decode<A> for String<N> {
     }
 
     #[inline(always)]
-    fn decode_from_with_input_len<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+    fn decode_from_bounded<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
         where A::Decoder<I>: AbiDecoder<A>
     {
         let payload = checked_dynamic_payload_with_input_len<A, I>(input, pos, input_len)
@@ -1537,7 +1542,7 @@ impl<A: Abi> Decode<A> for DynString {
     }
 
     #[inline(always)]
-    fn decode_from_checked_head<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+    fn decode_from_prechecked_head<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
         where A::Decoder<I>: AbiDecoder<A>
     {
         let payload: (u256, u256) = checked_dynamic_payload_after_head<A, I>(input, pos, input_len)
@@ -1553,7 +1558,7 @@ impl<A: Abi> Decode<A> for DynString {
     }
 
     #[inline(always)]
-    fn decode_from_with_input_len<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+    fn decode_from_bounded<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
         where A::Decoder<I>: AbiDecoder<A>
     {
         let payload: (u256, u256, u256) = copy_dynamic_payload_from_with_input_len<A, I>(input, pos, input_len)
@@ -1956,7 +1961,7 @@ impl<A: Abi> Decode<A> for Bytes {
     }
 
     #[inline(always)]
-    fn decode_from_checked_head<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+    fn decode_from_prechecked_head<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
         where A::Decoder<I>: AbiDecoder<A>
     {
         let payload: (u256, u256) = checked_dynamic_payload_after_head<A, I>(input, pos, input_len)
@@ -1968,7 +1973,7 @@ impl<A: Abi> Decode<A> for Bytes {
     }
 
     #[inline(always)]
-    fn decode_from_with_input_len<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+    fn decode_from_bounded<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
         where A::Decoder<I>: AbiDecoder<A>
     {
         let payload: (u256, u256, u256) = copy_dynamic_payload_from_with_input_len<A, I>(input, pos, input_len)
@@ -2081,7 +2086,7 @@ impl<A: Abi, T> Decode<A> for DynArray<T>
     }
 
     #[inline(always)]
-    fn decode_from_checked_head<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+    fn decode_from_prechecked_head<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
         where A::Decoder<I>: AbiDecoder<A>
     {
         let elem_count = input.word_at(pos)
@@ -2100,7 +2105,7 @@ impl<A: Abi, T> Decode<A> for DynArray<T>
     }
 
     #[inline(always)]
-    fn decode_from_with_input_len<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+    fn decode_from_bounded<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
         where A::Decoder<I>: AbiDecoder<A>
     {
         decode_frame_from<A, Self, I>(input, pos, input_len)
@@ -2158,19 +2163,19 @@ impl<A: Abi, T0> Decode<A> for (T0,)
     }
 
     #[inline(always)]
-    fn decode_from_checked_head<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+    fn decode_from_prechecked_head<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
         where A::Decoder<I>: AbiDecoder<A>
     {
-        let v0: T0 = decode_field_from_checked_head<A, T0, I>(input, base: pos, head_pos: pos, input_len: input_len)
+        let v0: T0 = decode_field_from_prechecked_head<A, T0, I>(input, base: pos, head_pos: pos, input_len: input_len)
         (v0,)
     }
 
     #[inline(always)]
-    fn decode_from_with_input_len<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+    fn decode_from_bounded<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
         where A::Decoder<I>: AbiDecoder<A>
     {
         checked_frame_end<A>(pos, Self::HEAD_SIZE, input_len)
-        Self::decode_from_checked_head(input, pos, input_len)
+        Self::decode_from_prechecked_head(input, pos, input_len)
     }
 }
 
@@ -2228,22 +2233,22 @@ impl<A: Abi, T0, T1> Decode<A> for (T0, T1)
     }
 
     #[inline(always)]
-    fn decode_from_checked_head<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+    fn decode_from_prechecked_head<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
         where A::Decoder<I>: AbiDecoder<A>
     {
         let mut head_pos = pos
-        let v0: T0 = decode_field_from_checked_head<A, T0, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v0: T0 = decode_field_from_prechecked_head<A, T0, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T0>()
-        let v1: T1 = decode_field_from_checked_head<A, T1, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v1: T1 = decode_field_from_prechecked_head<A, T1, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         (v0, v1)
     }
 
     #[inline(always)]
-    fn decode_from_with_input_len<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+    fn decode_from_bounded<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
         where A::Decoder<I>: AbiDecoder<A>
     {
         checked_frame_end<A>(pos, Self::HEAD_SIZE, input_len)
-        Self::decode_from_checked_head(input, pos, input_len)
+        Self::decode_from_prechecked_head(input, pos, input_len)
     }
 }
 
@@ -2315,24 +2320,24 @@ impl<A: Abi, T0, T1, T2> Decode<A> for (T0, T1, T2)
     }
 
     #[inline(always)]
-    fn decode_from_checked_head<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+    fn decode_from_prechecked_head<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
         where A::Decoder<I>: AbiDecoder<A>
     {
         let mut head_pos = pos
-        let v0: T0 = decode_field_from_checked_head<A, T0, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v0: T0 = decode_field_from_prechecked_head<A, T0, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T0>()
-        let v1: T1 = decode_field_from_checked_head<A, T1, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v1: T1 = decode_field_from_prechecked_head<A, T1, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T1>()
-        let v2: T2 = decode_field_from_checked_head<A, T2, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v2: T2 = decode_field_from_prechecked_head<A, T2, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         (v0, v1, v2)
     }
 
     #[inline(always)]
-    fn decode_from_with_input_len<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+    fn decode_from_bounded<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
         where A::Decoder<I>: AbiDecoder<A>
     {
         checked_frame_end<A>(pos, Self::HEAD_SIZE, input_len)
-        Self::decode_from_checked_head(input, pos, input_len)
+        Self::decode_from_prechecked_head(input, pos, input_len)
     }
 }
 
@@ -2418,26 +2423,26 @@ impl<A: Abi, T0, T1, T2, T3> Decode<A> for (T0, T1, T2, T3)
     }
 
     #[inline(always)]
-    fn decode_from_checked_head<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+    fn decode_from_prechecked_head<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
         where A::Decoder<I>: AbiDecoder<A>
     {
         let mut head_pos = pos
-        let v0: T0 = decode_field_from_checked_head<A, T0, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v0: T0 = decode_field_from_prechecked_head<A, T0, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T0>()
-        let v1: T1 = decode_field_from_checked_head<A, T1, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v1: T1 = decode_field_from_prechecked_head<A, T1, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T1>()
-        let v2: T2 = decode_field_from_checked_head<A, T2, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v2: T2 = decode_field_from_prechecked_head<A, T2, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T2>()
-        let v3: T3 = decode_field_from_checked_head<A, T3, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v3: T3 = decode_field_from_prechecked_head<A, T3, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         (v0, v1, v2, v3)
     }
 
     #[inline(always)]
-    fn decode_from_with_input_len<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+    fn decode_from_bounded<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
         where A::Decoder<I>: AbiDecoder<A>
     {
         checked_frame_end<A>(pos, Self::HEAD_SIZE, input_len)
-        Self::decode_from_checked_head(input, pos, input_len)
+        Self::decode_from_prechecked_head(input, pos, input_len)
     }
 }
 
@@ -2545,28 +2550,28 @@ impl<A: Abi, T0, T1, T2, T3, T4> Decode<A> for (T0, T1, T2, T3, T4)
     }
 
     #[inline(always)]
-    fn decode_from_checked_head<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+    fn decode_from_prechecked_head<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
         where A::Decoder<I>: AbiDecoder<A>
     {
         let mut head_pos = pos
-        let v0: T0 = decode_field_from_checked_head<A, T0, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v0: T0 = decode_field_from_prechecked_head<A, T0, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T0>()
-        let v1: T1 = decode_field_from_checked_head<A, T1, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v1: T1 = decode_field_from_prechecked_head<A, T1, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T1>()
-        let v2: T2 = decode_field_from_checked_head<A, T2, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v2: T2 = decode_field_from_prechecked_head<A, T2, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T2>()
-        let v3: T3 = decode_field_from_checked_head<A, T3, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v3: T3 = decode_field_from_prechecked_head<A, T3, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T3>()
-        let v4: T4 = decode_field_from_checked_head<A, T4, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v4: T4 = decode_field_from_prechecked_head<A, T4, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         (v0, v1, v2, v3, v4)
     }
 
     #[inline(always)]
-    fn decode_from_with_input_len<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+    fn decode_from_bounded<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
         where A::Decoder<I>: AbiDecoder<A>
     {
         checked_frame_end<A>(pos, Self::HEAD_SIZE, input_len)
-        Self::decode_from_checked_head(input, pos, input_len)
+        Self::decode_from_prechecked_head(input, pos, input_len)
     }
 }
 
@@ -2650,30 +2655,30 @@ impl<A: Abi, T0, T1, T2, T3, T4, T5> Decode<A> for (T0, T1, T2, T3, T4, T5)
     }
 
     #[inline(always)]
-    fn decode_from_checked_head<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+    fn decode_from_prechecked_head<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
         where A::Decoder<I>: AbiDecoder<A>
     {
         let mut head_pos = pos
-        let v0: T0 = decode_field_from_checked_head<A, T0, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v0: T0 = decode_field_from_prechecked_head<A, T0, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T0>()
-        let v1: T1 = decode_field_from_checked_head<A, T1, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v1: T1 = decode_field_from_prechecked_head<A, T1, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T1>()
-        let v2: T2 = decode_field_from_checked_head<A, T2, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v2: T2 = decode_field_from_prechecked_head<A, T2, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T2>()
-        let v3: T3 = decode_field_from_checked_head<A, T3, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v3: T3 = decode_field_from_prechecked_head<A, T3, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T3>()
-        let v4: T4 = decode_field_from_checked_head<A, T4, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v4: T4 = decode_field_from_prechecked_head<A, T4, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T4>()
-        let v5: T5 = decode_field_from_checked_head<A, T5, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v5: T5 = decode_field_from_prechecked_head<A, T5, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         (v0, v1, v2, v3, v4, v5)
     }
 
     #[inline(always)]
-    fn decode_from_with_input_len<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+    fn decode_from_bounded<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
         where A::Decoder<I>: AbiDecoder<A>
     {
         checked_frame_end<A>(pos, Self::HEAD_SIZE, input_len)
-        Self::decode_from_checked_head(input, pos, input_len)
+        Self::decode_from_prechecked_head(input, pos, input_len)
     }
 }
 
@@ -2766,32 +2771,32 @@ impl<A: Abi, T0, T1, T2, T3, T4, T5, T6> Decode<A> for (T0, T1, T2, T3, T4, T5, 
     }
 
     #[inline(always)]
-    fn decode_from_checked_head<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+    fn decode_from_prechecked_head<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
         where A::Decoder<I>: AbiDecoder<A>
     {
         let mut head_pos = pos
-        let v0: T0 = decode_field_from_checked_head<A, T0, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v0: T0 = decode_field_from_prechecked_head<A, T0, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T0>()
-        let v1: T1 = decode_field_from_checked_head<A, T1, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v1: T1 = decode_field_from_prechecked_head<A, T1, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T1>()
-        let v2: T2 = decode_field_from_checked_head<A, T2, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v2: T2 = decode_field_from_prechecked_head<A, T2, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T2>()
-        let v3: T3 = decode_field_from_checked_head<A, T3, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v3: T3 = decode_field_from_prechecked_head<A, T3, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T3>()
-        let v4: T4 = decode_field_from_checked_head<A, T4, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v4: T4 = decode_field_from_prechecked_head<A, T4, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T4>()
-        let v5: T5 = decode_field_from_checked_head<A, T5, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v5: T5 = decode_field_from_prechecked_head<A, T5, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T5>()
-        let v6: T6 = decode_field_from_checked_head<A, T6, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v6: T6 = decode_field_from_prechecked_head<A, T6, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         (v0, v1, v2, v3, v4, v5, v6)
     }
 
     #[inline(always)]
-    fn decode_from_with_input_len<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+    fn decode_from_bounded<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
         where A::Decoder<I>: AbiDecoder<A>
     {
         checked_frame_end<A>(pos, Self::HEAD_SIZE, input_len)
-        Self::decode_from_checked_head(input, pos, input_len)
+        Self::decode_from_prechecked_head(input, pos, input_len)
     }
 }
 
@@ -2893,34 +2898,34 @@ impl<A: Abi, T0, T1, T2, T3, T4, T5, T6, T7> Decode<A> for (T0, T1, T2, T3, T4, 
     }
 
     #[inline(always)]
-    fn decode_from_checked_head<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+    fn decode_from_prechecked_head<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
         where A::Decoder<I>: AbiDecoder<A>
     {
         let mut head_pos = pos
-        let v0: T0 = decode_field_from_checked_head<A, T0, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v0: T0 = decode_field_from_prechecked_head<A, T0, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T0>()
-        let v1: T1 = decode_field_from_checked_head<A, T1, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v1: T1 = decode_field_from_prechecked_head<A, T1, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T1>()
-        let v2: T2 = decode_field_from_checked_head<A, T2, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v2: T2 = decode_field_from_prechecked_head<A, T2, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T2>()
-        let v3: T3 = decode_field_from_checked_head<A, T3, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v3: T3 = decode_field_from_prechecked_head<A, T3, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T3>()
-        let v4: T4 = decode_field_from_checked_head<A, T4, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v4: T4 = decode_field_from_prechecked_head<A, T4, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T4>()
-        let v5: T5 = decode_field_from_checked_head<A, T5, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v5: T5 = decode_field_from_prechecked_head<A, T5, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T5>()
-        let v6: T6 = decode_field_from_checked_head<A, T6, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v6: T6 = decode_field_from_prechecked_head<A, T6, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T6>()
-        let v7: T7 = decode_field_from_checked_head<A, T7, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v7: T7 = decode_field_from_prechecked_head<A, T7, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         (v0, v1, v2, v3, v4, v5, v6, v7)
     }
 
     #[inline(always)]
-    fn decode_from_with_input_len<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+    fn decode_from_bounded<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
         where A::Decoder<I>: AbiDecoder<A>
     {
         checked_frame_end<A>(pos, Self::HEAD_SIZE, input_len)
-        Self::decode_from_checked_head(input, pos, input_len)
+        Self::decode_from_prechecked_head(input, pos, input_len)
     }
 }
 
@@ -3031,36 +3036,36 @@ impl<A: Abi, T0, T1, T2, T3, T4, T5, T6, T7, T8> Decode<A> for (T0, T1, T2, T3, 
     }
 
     #[inline(always)]
-    fn decode_from_checked_head<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+    fn decode_from_prechecked_head<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
         where A::Decoder<I>: AbiDecoder<A>
     {
         let mut head_pos = pos
-        let v0: T0 = decode_field_from_checked_head<A, T0, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v0: T0 = decode_field_from_prechecked_head<A, T0, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T0>()
-        let v1: T1 = decode_field_from_checked_head<A, T1, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v1: T1 = decode_field_from_prechecked_head<A, T1, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T1>()
-        let v2: T2 = decode_field_from_checked_head<A, T2, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v2: T2 = decode_field_from_prechecked_head<A, T2, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T2>()
-        let v3: T3 = decode_field_from_checked_head<A, T3, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v3: T3 = decode_field_from_prechecked_head<A, T3, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T3>()
-        let v4: T4 = decode_field_from_checked_head<A, T4, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v4: T4 = decode_field_from_prechecked_head<A, T4, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T4>()
-        let v5: T5 = decode_field_from_checked_head<A, T5, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v5: T5 = decode_field_from_prechecked_head<A, T5, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T5>()
-        let v6: T6 = decode_field_from_checked_head<A, T6, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v6: T6 = decode_field_from_prechecked_head<A, T6, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T6>()
-        let v7: T7 = decode_field_from_checked_head<A, T7, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v7: T7 = decode_field_from_prechecked_head<A, T7, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T7>()
-        let v8: T8 = decode_field_from_checked_head<A, T8, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v8: T8 = decode_field_from_prechecked_head<A, T8, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         (v0, v1, v2, v3, v4, v5, v6, v7, v8)
     }
 
     #[inline(always)]
-    fn decode_from_with_input_len<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+    fn decode_from_bounded<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
         where A::Decoder<I>: AbiDecoder<A>
     {
         checked_frame_end<A>(pos, Self::HEAD_SIZE, input_len)
-        Self::decode_from_checked_head(input, pos, input_len)
+        Self::decode_from_prechecked_head(input, pos, input_len)
     }
 }
 
@@ -3181,38 +3186,38 @@ impl<A: Abi, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> Decode<A>
     }
 
     #[inline(always)]
-    fn decode_from_checked_head<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+    fn decode_from_prechecked_head<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
         where A::Decoder<I>: AbiDecoder<A>
     {
         let mut head_pos = pos
-        let v0: T0 = decode_field_from_checked_head<A, T0, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v0: T0 = decode_field_from_prechecked_head<A, T0, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T0>()
-        let v1: T1 = decode_field_from_checked_head<A, T1, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v1: T1 = decode_field_from_prechecked_head<A, T1, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T1>()
-        let v2: T2 = decode_field_from_checked_head<A, T2, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v2: T2 = decode_field_from_prechecked_head<A, T2, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T2>()
-        let v3: T3 = decode_field_from_checked_head<A, T3, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v3: T3 = decode_field_from_prechecked_head<A, T3, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T3>()
-        let v4: T4 = decode_field_from_checked_head<A, T4, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v4: T4 = decode_field_from_prechecked_head<A, T4, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T4>()
-        let v5: T5 = decode_field_from_checked_head<A, T5, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v5: T5 = decode_field_from_prechecked_head<A, T5, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T5>()
-        let v6: T6 = decode_field_from_checked_head<A, T6, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v6: T6 = decode_field_from_prechecked_head<A, T6, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T6>()
-        let v7: T7 = decode_field_from_checked_head<A, T7, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v7: T7 = decode_field_from_prechecked_head<A, T7, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T7>()
-        let v8: T8 = decode_field_from_checked_head<A, T8, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v8: T8 = decode_field_from_prechecked_head<A, T8, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T8>()
-        let v9: T9 = decode_field_from_checked_head<A, T9, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v9: T9 = decode_field_from_prechecked_head<A, T9, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         (v0, v1, v2, v3, v4, v5, v6, v7, v8, v9)
     }
 
     #[inline(always)]
-    fn decode_from_with_input_len<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+    fn decode_from_bounded<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
         where A::Decoder<I>: AbiDecoder<A>
     {
         checked_frame_end<A>(pos, Self::HEAD_SIZE, input_len)
-        Self::decode_from_checked_head(input, pos, input_len)
+        Self::decode_from_prechecked_head(input, pos, input_len)
     }
 }
 
@@ -3343,40 +3348,40 @@ impl<A: Abi, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Decode<A>
     }
 
     #[inline(always)]
-    fn decode_from_checked_head<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+    fn decode_from_prechecked_head<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
         where A::Decoder<I>: AbiDecoder<A>
     {
         let mut head_pos = pos
-        let v0: T0 = decode_field_from_checked_head<A, T0, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v0: T0 = decode_field_from_prechecked_head<A, T0, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T0>()
-        let v1: T1 = decode_field_from_checked_head<A, T1, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v1: T1 = decode_field_from_prechecked_head<A, T1, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T1>()
-        let v2: T2 = decode_field_from_checked_head<A, T2, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v2: T2 = decode_field_from_prechecked_head<A, T2, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T2>()
-        let v3: T3 = decode_field_from_checked_head<A, T3, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v3: T3 = decode_field_from_prechecked_head<A, T3, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T3>()
-        let v4: T4 = decode_field_from_checked_head<A, T4, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v4: T4 = decode_field_from_prechecked_head<A, T4, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T4>()
-        let v5: T5 = decode_field_from_checked_head<A, T5, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v5: T5 = decode_field_from_prechecked_head<A, T5, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T5>()
-        let v6: T6 = decode_field_from_checked_head<A, T6, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v6: T6 = decode_field_from_prechecked_head<A, T6, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T6>()
-        let v7: T7 = decode_field_from_checked_head<A, T7, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v7: T7 = decode_field_from_prechecked_head<A, T7, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T7>()
-        let v8: T8 = decode_field_from_checked_head<A, T8, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v8: T8 = decode_field_from_prechecked_head<A, T8, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T8>()
-        let v9: T9 = decode_field_from_checked_head<A, T9, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v9: T9 = decode_field_from_prechecked_head<A, T9, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T9>()
-        let v10: T10 = decode_field_from_checked_head<A, T10, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v10: T10 = decode_field_from_prechecked_head<A, T10, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         (v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10)
     }
 
     #[inline(always)]
-    fn decode_from_with_input_len<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+    fn decode_from_bounded<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
         where A::Decoder<I>: AbiDecoder<A>
     {
         checked_frame_end<A>(pos, Self::HEAD_SIZE, input_len)
-        Self::decode_from_checked_head(input, pos, input_len)
+        Self::decode_from_prechecked_head(input, pos, input_len)
     }
 }
 
@@ -3516,42 +3521,42 @@ impl<A: Abi, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Decode<A>
     }
 
     #[inline(always)]
-    fn decode_from_checked_head<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+    fn decode_from_prechecked_head<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
         where A::Decoder<I>: AbiDecoder<A>
     {
         let mut head_pos = pos
-        let v0: T0 = decode_field_from_checked_head<A, T0, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v0: T0 = decode_field_from_prechecked_head<A, T0, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T0>()
-        let v1: T1 = decode_field_from_checked_head<A, T1, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v1: T1 = decode_field_from_prechecked_head<A, T1, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T1>()
-        let v2: T2 = decode_field_from_checked_head<A, T2, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v2: T2 = decode_field_from_prechecked_head<A, T2, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T2>()
-        let v3: T3 = decode_field_from_checked_head<A, T3, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v3: T3 = decode_field_from_prechecked_head<A, T3, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T3>()
-        let v4: T4 = decode_field_from_checked_head<A, T4, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v4: T4 = decode_field_from_prechecked_head<A, T4, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T4>()
-        let v5: T5 = decode_field_from_checked_head<A, T5, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v5: T5 = decode_field_from_prechecked_head<A, T5, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T5>()
-        let v6: T6 = decode_field_from_checked_head<A, T6, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v6: T6 = decode_field_from_prechecked_head<A, T6, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T6>()
-        let v7: T7 = decode_field_from_checked_head<A, T7, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v7: T7 = decode_field_from_prechecked_head<A, T7, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T7>()
-        let v8: T8 = decode_field_from_checked_head<A, T8, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v8: T8 = decode_field_from_prechecked_head<A, T8, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T8>()
-        let v9: T9 = decode_field_from_checked_head<A, T9, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v9: T9 = decode_field_from_prechecked_head<A, T9, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T9>()
-        let v10: T10 = decode_field_from_checked_head<A, T10, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v10: T10 = decode_field_from_prechecked_head<A, T10, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         head_pos += abi_field_head_size<T10>()
-        let v11: T11 = decode_field_from_checked_head<A, T11, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+        let v11: T11 = decode_field_from_prechecked_head<A, T11, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
         (v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11)
     }
 
     #[inline(always)]
-    fn decode_from_with_input_len<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+    fn decode_from_bounded<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
         where A::Decoder<I>: AbiDecoder<A>
     {
         checked_frame_end<A>(pos, Self::HEAD_SIZE, input_len)
-        Self::decode_from_checked_head(input, pos, input_len)
+        Self::decode_from_prechecked_head(input, pos, input_len)
     }
 }
 
@@ -3662,15 +3667,15 @@ impl<A: Abi, T, const N: usize> Decode<A> for [T; N]
     }
 
     #[inline(always)]
-    fn decode_from_checked_head<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+    fn decode_from_prechecked_head<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
         where A::Decoder<I>: AbiDecoder<A>
     {
-        let first = decode_field_from_checked_head<A, T, I>(input, base: pos, head_pos: pos, input_len: input_len)
+        let first = decode_field_from_prechecked_head<A, T, I>(input, base: pos, head_pos: pos, input_len: input_len)
         let mut out: [T; N] = [first; N]
         let mut i: usize = 1
         let mut head_pos = pos + abi_field_head_size<T>()
         while i < N {
-            out[i] = decode_field_from_checked_head<A, T, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
+            out[i] = decode_field_from_prechecked_head<A, T, I>(input, base: pos, head_pos: head_pos, input_len: input_len)
             head_pos += abi_field_head_size<T>()
             i += 1
         }
@@ -3678,11 +3683,11 @@ impl<A: Abi, T, const N: usize> Decode<A> for [T; N]
     }
 
     #[inline(always)]
-    fn decode_from_with_input_len<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
+    fn decode_from_bounded<I: ByteInput>(_ input: I, _ pos: u256, _ input_len: u256) -> Self
         where A::Decoder<I>: AbiDecoder<A>
     {
         checked_frame_end<A>(pos, Self::HEAD_SIZE, input_len)
-        Self::decode_from_checked_head(input, pos, input_len)
+        Self::decode_from_prechecked_head(input, pos, input_len)
     }
 }
 

--- a/ingots/core/src/abi.fe
+++ b/ingots/core/src/abi.fe
@@ -639,9 +639,14 @@ impl Bytes {
         self.len == 0
     }
 
+    #[arithmetic(unchecked)]
+    pub fn payload_ptr(self) -> u256 {
+        self.data + 32
+    }
+
     pub fn view(self) -> BytesView<MemoryInput> {
         let input = MemoryInput {
-            base: self.data + 32,
+            base: self.payload_ptr(),
             len: self.len,
         }
         BytesView {
@@ -651,16 +656,22 @@ impl Bytes {
         }
     }
 
+    #[arithmetic(unchecked)]
+    pub fn word_at(self, _ offset: u256) -> u256 {
+        mem_word_at(base: self.payload_ptr(), offset: offset)
+    }
+
+    #[arithmetic(unchecked)]
     pub fn byte_at(self, _ index: u256) -> u8 {
         if index >= self.len {
             super::panic()
         }
 
-        let input = MemoryInput {
-            base: self.data + 32,
-            len: self.len,
-        }
-        input.byte_at(index)
+        let word_offset = index - (index % 32)
+        let word = self.word_at(word_offset)
+        let idx = index - word_offset
+        let shift = (31 - idx) * 8
+        (word >> shift).downcast_truncate()
     }
 }
 

--- a/ingots/core/src/abi.fe
+++ b/ingots/core/src/abi.fe
@@ -354,6 +354,34 @@ pub fn encode_field<A: Abi, T, E>(_ value: own T, _ e: mut E, _ tail: mut u256)
     value.encode(mut e)
 }
 
+#[arithmetic(unchecked)]
+#[inline(always)]
+fn encode_field_at<A: Abi, T, E>(_ value: own T, _ e: mut E, base: u256, head_pos: u256, _ tail: mut u256)
+    where T: Encode<A> + AbiSize, E: AbiEncoder<A>
+{
+    if T::IS_DYNAMIC {
+        let child_base = tail
+        let child_size = value.payload_size()
+        e.write_word_at(at: head_pos, value: child_base - base)
+
+        e.set_base(child_base)
+        e.set_pos(child_base)
+        value.encode(mut e)
+        e.set_base(base)
+        tail = child_base + child_size
+        return
+    }
+
+    if T::DIRECT_ENCODE {
+        value.encode_to_ptr(head_pos)
+        return
+    }
+
+    let _ = tail
+    e.set_pos(head_pos)
+    value.encode(mut e)
+}
+
 pub fn encode_alloc<A: Abi, T>(_ value: own T) -> (u256, u256)
     where T: Encode<A> + AbiSize
 {
@@ -1936,8 +1964,10 @@ impl<A: Abi, T0> Encode<A> for (T0,)
     #[arithmetic(unchecked)]
     #[inline(always)]
     fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) {
-        let mut tail = e.base() + Self::HEAD_SIZE
-        encode_field<A, T0, E>(self.0, mut e, mut tail)
+        let base = e.base()
+        let mut tail = base + Self::HEAD_SIZE
+        encode_field_at<A, T0, E>(self.0, mut e, base, head_pos: base, mut tail)
+        e.set_pos(base + Self::HEAD_SIZE)
     }
 
     fn encode_to_ptr(own self, _ ptr: u256) {
@@ -1982,9 +2012,12 @@ impl<A: Abi, T0, T1> Encode<A> for (T0, T1)
     #[arithmetic(unchecked)]
     #[inline(always)]
     fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) {
-        let mut tail = e.base() + Self::HEAD_SIZE
-        encode_field<A, T0, E>(self.0, mut e, mut tail)
-        encode_field<A, T1, E>(self.1, mut e, mut tail)
+        let base = e.base()
+        let mut tail = base + Self::HEAD_SIZE
+        let head1 = base + abi_field_head_size<T0>()
+        encode_field_at<A, T0, E>(self.0, mut e, base, head_pos: base, mut tail)
+        encode_field_at<A, T1, E>(self.1, mut e, base, head_pos: head1, mut tail)
+        e.set_pos(base + Self::HEAD_SIZE)
     }
 
     #[arithmetic(unchecked)]
@@ -2038,10 +2071,14 @@ impl<A: Abi, T0, T1, T2> Encode<A> for (T0, T1, T2)
     #[arithmetic(unchecked)]
     #[inline(always)]
     fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) {
-        let mut tail = e.base() + Self::HEAD_SIZE
-        encode_field<A, T0, E>(self.0, mut e, mut tail)
-        encode_field<A, T1, E>(self.1, mut e, mut tail)
-        encode_field<A, T2, E>(self.2, mut e, mut tail)
+        let base = e.base()
+        let mut tail = base + Self::HEAD_SIZE
+        let head1 = base + abi_field_head_size<T0>()
+        let head2 = head1 + abi_field_head_size<T1>()
+        encode_field_at<A, T0, E>(self.0, mut e, base, head_pos: base, mut tail)
+        encode_field_at<A, T1, E>(self.1, mut e, base, head_pos: head1, mut tail)
+        encode_field_at<A, T2, E>(self.2, mut e, base, head_pos: head2, mut tail)
+        e.set_pos(base + Self::HEAD_SIZE)
     }
 
     #[arithmetic(unchecked)]
@@ -2108,11 +2145,16 @@ impl<A: Abi, T0, T1, T2, T3> Encode<A> for (T0, T1, T2, T3)
     #[arithmetic(unchecked)]
     #[inline(always)]
     fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) {
-        let mut tail = e.base() + Self::HEAD_SIZE
-        encode_field<A, T0, E>(self.0, mut e, mut tail)
-        encode_field<A, T1, E>(self.1, mut e, mut tail)
-        encode_field<A, T2, E>(self.2, mut e, mut tail)
-        encode_field<A, T3, E>(self.3, mut e, mut tail)
+        let base = e.base()
+        let mut tail = base + Self::HEAD_SIZE
+        let head1 = base + abi_field_head_size<T0>()
+        let head2 = head1 + abi_field_head_size<T1>()
+        let head3 = head2 + abi_field_head_size<T2>()
+        encode_field_at<A, T0, E>(self.0, mut e, base, head_pos: base, mut tail)
+        encode_field_at<A, T1, E>(self.1, mut e, base, head_pos: head1, mut tail)
+        encode_field_at<A, T2, E>(self.2, mut e, base, head_pos: head2, mut tail)
+        encode_field_at<A, T3, E>(self.3, mut e, base, head_pos: head3, mut tail)
+        e.set_pos(base + Self::HEAD_SIZE)
     }
 
     #[arithmetic(unchecked)]
@@ -2194,12 +2236,18 @@ impl<A: Abi, T0, T1, T2, T3, T4> Encode<A> for (T0, T1, T2, T3, T4)
     #[arithmetic(unchecked)]
     #[inline(always)]
     fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) {
-        let mut tail = e.base() + Self::HEAD_SIZE
-        encode_field<A, T0, E>(self.0, mut e, mut tail)
-        encode_field<A, T1, E>(self.1, mut e, mut tail)
-        encode_field<A, T2, E>(self.2, mut e, mut tail)
-        encode_field<A, T3, E>(self.3, mut e, mut tail)
-        encode_field<A, T4, E>(self.4, mut e, mut tail)
+        let base = e.base()
+        let mut tail = base + Self::HEAD_SIZE
+        let head1 = base + abi_field_head_size<T0>()
+        let head2 = head1 + abi_field_head_size<T1>()
+        let head3 = head2 + abi_field_head_size<T2>()
+        let head4 = head3 + abi_field_head_size<T3>()
+        encode_field_at<A, T0, E>(self.0, mut e, base, head_pos: base, mut tail)
+        encode_field_at<A, T1, E>(self.1, mut e, base, head_pos: head1, mut tail)
+        encode_field_at<A, T2, E>(self.2, mut e, base, head_pos: head2, mut tail)
+        encode_field_at<A, T3, E>(self.3, mut e, base, head_pos: head3, mut tail)
+        encode_field_at<A, T4, E>(self.4, mut e, base, head_pos: head4, mut tail)
+        e.set_pos(base + Self::HEAD_SIZE)
     }
 
     #[arithmetic(unchecked)]
@@ -2269,13 +2317,20 @@ impl<A: Abi, T0, T1, T2, T3, T4, T5> Encode<A> for (T0, T1, T2, T3, T4, T5)
     #[arithmetic(unchecked)]
     #[inline(always)]
     fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) {
-        let mut tail = e.base() + Self::HEAD_SIZE
-        encode_field<A, T0, E>(self.0, mut e, mut tail)
-        encode_field<A, T1, E>(self.1, mut e, mut tail)
-        encode_field<A, T2, E>(self.2, mut e, mut tail)
-        encode_field<A, T3, E>(self.3, mut e, mut tail)
-        encode_field<A, T4, E>(self.4, mut e, mut tail)
-        encode_field<A, T5, E>(self.5, mut e, mut tail)
+        let base = e.base()
+        let mut tail = base + Self::HEAD_SIZE
+        let head1 = base + abi_field_head_size<T0>()
+        let head2 = head1 + abi_field_head_size<T1>()
+        let head3 = head2 + abi_field_head_size<T2>()
+        let head4 = head3 + abi_field_head_size<T3>()
+        let head5 = head4 + abi_field_head_size<T4>()
+        encode_field_at<A, T0, E>(self.0, mut e, base, head_pos: base, mut tail)
+        encode_field_at<A, T1, E>(self.1, mut e, base, head_pos: head1, mut tail)
+        encode_field_at<A, T2, E>(self.2, mut e, base, head_pos: head2, mut tail)
+        encode_field_at<A, T3, E>(self.3, mut e, base, head_pos: head3, mut tail)
+        encode_field_at<A, T4, E>(self.4, mut e, base, head_pos: head4, mut tail)
+        encode_field_at<A, T5, E>(self.5, mut e, base, head_pos: head5, mut tail)
+        e.set_pos(base + Self::HEAD_SIZE)
     }
 
     #[arithmetic(unchecked)]
@@ -2352,14 +2407,22 @@ impl<A: Abi, T0, T1, T2, T3, T4, T5, T6> Encode<A> for (T0, T1, T2, T3, T4, T5, 
     #[arithmetic(unchecked)]
     #[inline(always)]
     fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) {
-        let mut tail = e.base() + Self::HEAD_SIZE
-        encode_field<A, T0, E>(self.0, mut e, mut tail)
-        encode_field<A, T1, E>(self.1, mut e, mut tail)
-        encode_field<A, T2, E>(self.2, mut e, mut tail)
-        encode_field<A, T3, E>(self.3, mut e, mut tail)
-        encode_field<A, T4, E>(self.4, mut e, mut tail)
-        encode_field<A, T5, E>(self.5, mut e, mut tail)
-        encode_field<A, T6, E>(self.6, mut e, mut tail)
+        let base = e.base()
+        let mut tail = base + Self::HEAD_SIZE
+        let head1 = base + abi_field_head_size<T0>()
+        let head2 = head1 + abi_field_head_size<T1>()
+        let head3 = head2 + abi_field_head_size<T2>()
+        let head4 = head3 + abi_field_head_size<T3>()
+        let head5 = head4 + abi_field_head_size<T4>()
+        let head6 = head5 + abi_field_head_size<T5>()
+        encode_field_at<A, T0, E>(self.0, mut e, base, head_pos: base, mut tail)
+        encode_field_at<A, T1, E>(self.1, mut e, base, head_pos: head1, mut tail)
+        encode_field_at<A, T2, E>(self.2, mut e, base, head_pos: head2, mut tail)
+        encode_field_at<A, T3, E>(self.3, mut e, base, head_pos: head3, mut tail)
+        encode_field_at<A, T4, E>(self.4, mut e, base, head_pos: head4, mut tail)
+        encode_field_at<A, T5, E>(self.5, mut e, base, head_pos: head5, mut tail)
+        encode_field_at<A, T6, E>(self.6, mut e, base, head_pos: head6, mut tail)
+        e.set_pos(base + Self::HEAD_SIZE)
     }
 
     #[arithmetic(unchecked)]
@@ -2443,15 +2506,24 @@ impl<A: Abi, T0, T1, T2, T3, T4, T5, T6, T7> Encode<A> for (T0, T1, T2, T3, T4, 
     #[arithmetic(unchecked)]
     #[inline(always)]
     fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) {
-        let mut tail = e.base() + Self::HEAD_SIZE
-        encode_field<A, T0, E>(self.0, mut e, mut tail)
-        encode_field<A, T1, E>(self.1, mut e, mut tail)
-        encode_field<A, T2, E>(self.2, mut e, mut tail)
-        encode_field<A, T3, E>(self.3, mut e, mut tail)
-        encode_field<A, T4, E>(self.4, mut e, mut tail)
-        encode_field<A, T5, E>(self.5, mut e, mut tail)
-        encode_field<A, T6, E>(self.6, mut e, mut tail)
-        encode_field<A, T7, E>(self.7, mut e, mut tail)
+        let base = e.base()
+        let mut tail = base + Self::HEAD_SIZE
+        let head1 = base + abi_field_head_size<T0>()
+        let head2 = head1 + abi_field_head_size<T1>()
+        let head3 = head2 + abi_field_head_size<T2>()
+        let head4 = head3 + abi_field_head_size<T3>()
+        let head5 = head4 + abi_field_head_size<T4>()
+        let head6 = head5 + abi_field_head_size<T5>()
+        let head7 = head6 + abi_field_head_size<T6>()
+        encode_field_at<A, T0, E>(self.0, mut e, base, head_pos: base, mut tail)
+        encode_field_at<A, T1, E>(self.1, mut e, base, head_pos: head1, mut tail)
+        encode_field_at<A, T2, E>(self.2, mut e, base, head_pos: head2, mut tail)
+        encode_field_at<A, T3, E>(self.3, mut e, base, head_pos: head3, mut tail)
+        encode_field_at<A, T4, E>(self.4, mut e, base, head_pos: head4, mut tail)
+        encode_field_at<A, T5, E>(self.5, mut e, base, head_pos: head5, mut tail)
+        encode_field_at<A, T6, E>(self.6, mut e, base, head_pos: head6, mut tail)
+        encode_field_at<A, T7, E>(self.7, mut e, base, head_pos: head7, mut tail)
+        e.set_pos(base + Self::HEAD_SIZE)
     }
 
     #[arithmetic(unchecked)]
@@ -2542,16 +2614,26 @@ impl<A: Abi, T0, T1, T2, T3, T4, T5, T6, T7, T8> Encode<A> for (T0, T1, T2, T3, 
     #[arithmetic(unchecked)]
     #[inline(always)]
     fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) {
-        let mut tail = e.base() + Self::HEAD_SIZE
-        encode_field<A, T0, E>(self.0, mut e, mut tail)
-        encode_field<A, T1, E>(self.1, mut e, mut tail)
-        encode_field<A, T2, E>(self.2, mut e, mut tail)
-        encode_field<A, T3, E>(self.3, mut e, mut tail)
-        encode_field<A, T4, E>(self.4, mut e, mut tail)
-        encode_field<A, T5, E>(self.5, mut e, mut tail)
-        encode_field<A, T6, E>(self.6, mut e, mut tail)
-        encode_field<A, T7, E>(self.7, mut e, mut tail)
-        encode_field<A, T8, E>(self.8, mut e, mut tail)
+        let base = e.base()
+        let mut tail = base + Self::HEAD_SIZE
+        let head1 = base + abi_field_head_size<T0>()
+        let head2 = head1 + abi_field_head_size<T1>()
+        let head3 = head2 + abi_field_head_size<T2>()
+        let head4 = head3 + abi_field_head_size<T3>()
+        let head5 = head4 + abi_field_head_size<T4>()
+        let head6 = head5 + abi_field_head_size<T5>()
+        let head7 = head6 + abi_field_head_size<T6>()
+        let head8 = head7 + abi_field_head_size<T7>()
+        encode_field_at<A, T0, E>(self.0, mut e, base, head_pos: base, mut tail)
+        encode_field_at<A, T1, E>(self.1, mut e, base, head_pos: head1, mut tail)
+        encode_field_at<A, T2, E>(self.2, mut e, base, head_pos: head2, mut tail)
+        encode_field_at<A, T3, E>(self.3, mut e, base, head_pos: head3, mut tail)
+        encode_field_at<A, T4, E>(self.4, mut e, base, head_pos: head4, mut tail)
+        encode_field_at<A, T5, E>(self.5, mut e, base, head_pos: head5, mut tail)
+        encode_field_at<A, T6, E>(self.6, mut e, base, head_pos: head6, mut tail)
+        encode_field_at<A, T7, E>(self.7, mut e, base, head_pos: head7, mut tail)
+        encode_field_at<A, T8, E>(self.8, mut e, base, head_pos: head8, mut tail)
+        e.set_pos(base + Self::HEAD_SIZE)
     }
 
     #[arithmetic(unchecked)]
@@ -2651,17 +2733,28 @@ impl<A: Abi, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> Encode<A>
     #[arithmetic(unchecked)]
     #[inline(always)]
     fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) {
-        let mut tail = e.base() + Self::HEAD_SIZE
-        encode_field<A, T0, E>(self.0, mut e, mut tail)
-        encode_field<A, T1, E>(self.1, mut e, mut tail)
-        encode_field<A, T2, E>(self.2, mut e, mut tail)
-        encode_field<A, T3, E>(self.3, mut e, mut tail)
-        encode_field<A, T4, E>(self.4, mut e, mut tail)
-        encode_field<A, T5, E>(self.5, mut e, mut tail)
-        encode_field<A, T6, E>(self.6, mut e, mut tail)
-        encode_field<A, T7, E>(self.7, mut e, mut tail)
-        encode_field<A, T8, E>(self.8, mut e, mut tail)
-        encode_field<A, T9, E>(self.9, mut e, mut tail)
+        let base = e.base()
+        let mut tail = base + Self::HEAD_SIZE
+        let head1 = base + abi_field_head_size<T0>()
+        let head2 = head1 + abi_field_head_size<T1>()
+        let head3 = head2 + abi_field_head_size<T2>()
+        let head4 = head3 + abi_field_head_size<T3>()
+        let head5 = head4 + abi_field_head_size<T4>()
+        let head6 = head5 + abi_field_head_size<T5>()
+        let head7 = head6 + abi_field_head_size<T6>()
+        let head8 = head7 + abi_field_head_size<T7>()
+        let head9 = head8 + abi_field_head_size<T8>()
+        encode_field_at<A, T0, E>(self.0, mut e, base, head_pos: base, mut tail)
+        encode_field_at<A, T1, E>(self.1, mut e, base, head_pos: head1, mut tail)
+        encode_field_at<A, T2, E>(self.2, mut e, base, head_pos: head2, mut tail)
+        encode_field_at<A, T3, E>(self.3, mut e, base, head_pos: head3, mut tail)
+        encode_field_at<A, T4, E>(self.4, mut e, base, head_pos: head4, mut tail)
+        encode_field_at<A, T5, E>(self.5, mut e, base, head_pos: head5, mut tail)
+        encode_field_at<A, T6, E>(self.6, mut e, base, head_pos: head6, mut tail)
+        encode_field_at<A, T7, E>(self.7, mut e, base, head_pos: head7, mut tail)
+        encode_field_at<A, T8, E>(self.8, mut e, base, head_pos: head8, mut tail)
+        encode_field_at<A, T9, E>(self.9, mut e, base, head_pos: head9, mut tail)
+        e.set_pos(base + Self::HEAD_SIZE)
     }
 
     #[arithmetic(unchecked)]
@@ -2768,18 +2861,30 @@ impl<A: Abi, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Encode<A>
     #[arithmetic(unchecked)]
     #[inline(always)]
     fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) {
-        let mut tail = e.base() + Self::HEAD_SIZE
-        encode_field<A, T0, E>(self.0, mut e, mut tail)
-        encode_field<A, T1, E>(self.1, mut e, mut tail)
-        encode_field<A, T2, E>(self.2, mut e, mut tail)
-        encode_field<A, T3, E>(self.3, mut e, mut tail)
-        encode_field<A, T4, E>(self.4, mut e, mut tail)
-        encode_field<A, T5, E>(self.5, mut e, mut tail)
-        encode_field<A, T6, E>(self.6, mut e, mut tail)
-        encode_field<A, T7, E>(self.7, mut e, mut tail)
-        encode_field<A, T8, E>(self.8, mut e, mut tail)
-        encode_field<A, T9, E>(self.9, mut e, mut tail)
-        encode_field<A, T10, E>(self.10, mut e, mut tail)
+        let base = e.base()
+        let mut tail = base + Self::HEAD_SIZE
+        let head1 = base + abi_field_head_size<T0>()
+        let head2 = head1 + abi_field_head_size<T1>()
+        let head3 = head2 + abi_field_head_size<T2>()
+        let head4 = head3 + abi_field_head_size<T3>()
+        let head5 = head4 + abi_field_head_size<T4>()
+        let head6 = head5 + abi_field_head_size<T5>()
+        let head7 = head6 + abi_field_head_size<T6>()
+        let head8 = head7 + abi_field_head_size<T7>()
+        let head9 = head8 + abi_field_head_size<T8>()
+        let head10 = head9 + abi_field_head_size<T9>()
+        encode_field_at<A, T0, E>(self.0, mut e, base, head_pos: base, mut tail)
+        encode_field_at<A, T1, E>(self.1, mut e, base, head_pos: head1, mut tail)
+        encode_field_at<A, T2, E>(self.2, mut e, base, head_pos: head2, mut tail)
+        encode_field_at<A, T3, E>(self.3, mut e, base, head_pos: head3, mut tail)
+        encode_field_at<A, T4, E>(self.4, mut e, base, head_pos: head4, mut tail)
+        encode_field_at<A, T5, E>(self.5, mut e, base, head_pos: head5, mut tail)
+        encode_field_at<A, T6, E>(self.6, mut e, base, head_pos: head6, mut tail)
+        encode_field_at<A, T7, E>(self.7, mut e, base, head_pos: head7, mut tail)
+        encode_field_at<A, T8, E>(self.8, mut e, base, head_pos: head8, mut tail)
+        encode_field_at<A, T9, E>(self.9, mut e, base, head_pos: head9, mut tail)
+        encode_field_at<A, T10, E>(self.10, mut e, base, head_pos: head10, mut tail)
+        e.set_pos(base + Self::HEAD_SIZE)
     }
 
     #[arithmetic(unchecked)]
@@ -2893,19 +2998,32 @@ impl<A: Abi, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Encode<A>
     #[arithmetic(unchecked)]
     #[inline(always)]
     fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) {
-        let mut tail = e.base() + Self::HEAD_SIZE
-        encode_field<A, T0, E>(self.0, mut e, mut tail)
-        encode_field<A, T1, E>(self.1, mut e, mut tail)
-        encode_field<A, T2, E>(self.2, mut e, mut tail)
-        encode_field<A, T3, E>(self.3, mut e, mut tail)
-        encode_field<A, T4, E>(self.4, mut e, mut tail)
-        encode_field<A, T5, E>(self.5, mut e, mut tail)
-        encode_field<A, T6, E>(self.6, mut e, mut tail)
-        encode_field<A, T7, E>(self.7, mut e, mut tail)
-        encode_field<A, T8, E>(self.8, mut e, mut tail)
-        encode_field<A, T9, E>(self.9, mut e, mut tail)
-        encode_field<A, T10, E>(self.10, mut e, mut tail)
-        encode_field<A, T11, E>(self.11, mut e, mut tail)
+        let base = e.base()
+        let mut tail = base + Self::HEAD_SIZE
+        let head1 = base + abi_field_head_size<T0>()
+        let head2 = head1 + abi_field_head_size<T1>()
+        let head3 = head2 + abi_field_head_size<T2>()
+        let head4 = head3 + abi_field_head_size<T3>()
+        let head5 = head4 + abi_field_head_size<T4>()
+        let head6 = head5 + abi_field_head_size<T5>()
+        let head7 = head6 + abi_field_head_size<T6>()
+        let head8 = head7 + abi_field_head_size<T7>()
+        let head9 = head8 + abi_field_head_size<T8>()
+        let head10 = head9 + abi_field_head_size<T9>()
+        let head11 = head10 + abi_field_head_size<T10>()
+        encode_field_at<A, T0, E>(self.0, mut e, base, head_pos: base, mut tail)
+        encode_field_at<A, T1, E>(self.1, mut e, base, head_pos: head1, mut tail)
+        encode_field_at<A, T2, E>(self.2, mut e, base, head_pos: head2, mut tail)
+        encode_field_at<A, T3, E>(self.3, mut e, base, head_pos: head3, mut tail)
+        encode_field_at<A, T4, E>(self.4, mut e, base, head_pos: head4, mut tail)
+        encode_field_at<A, T5, E>(self.5, mut e, base, head_pos: head5, mut tail)
+        encode_field_at<A, T6, E>(self.6, mut e, base, head_pos: head6, mut tail)
+        encode_field_at<A, T7, E>(self.7, mut e, base, head_pos: head7, mut tail)
+        encode_field_at<A, T8, E>(self.8, mut e, base, head_pos: head8, mut tail)
+        encode_field_at<A, T9, E>(self.9, mut e, base, head_pos: head9, mut tail)
+        encode_field_at<A, T10, E>(self.10, mut e, base, head_pos: head10, mut tail)
+        encode_field_at<A, T11, E>(self.11, mut e, base, head_pos: head11, mut tail)
+        e.set_pos(base + Self::HEAD_SIZE)
     }
 
     #[arithmetic(unchecked)]

--- a/ingots/core/src/contracts.fe
+++ b/ingots/core/src/contracts.fe
@@ -58,18 +58,12 @@ pub fn decode_runtime_args<H, A, T>(_ host: mut H) -> T
     let input = host.input()
     let base = A::SELECTOR_SIZE
     let len = input.len()
-    if base > len {
+    let end = base + T::HEAD_SIZE
+    if end < base || end > len {
         host.abort()
     }
 
-    if !T::IS_DYNAMIC {
-        let end = base + T::HEAD_SIZE
-        if end < base || end > len {
-            host.abort()
-        }
-    }
-
-    T::decode_from(input, base)
+    T::decode_from_checked_head(input, base, len)
 }
 
 /// Target configuration used by compiler-generated contract entrypoints.

--- a/ingots/core/src/contracts.fe
+++ b/ingots/core/src/contracts.fe
@@ -63,7 +63,7 @@ pub fn decode_runtime_args<H, A, T>(_ host: mut H) -> T
         host.abort()
     }
 
-    T::decode_from_checked_head(input, base, len)
+    T::decode_from_prechecked_head(input, base, len)
 }
 
 /// Target configuration used by compiler-generated contract entrypoints.

--- a/ingots/core/src/contracts.fe
+++ b/ingots/core/src/contracts.fe
@@ -52,11 +52,24 @@ pub trait ContractHost {
 pub fn decode_runtime_args<H, A, T>(_ host: mut H) -> T
     where H: ContractHost,
           A: Abi,
-          T: Decode<A>,
+          T: Decode<A> + AbiSize,
           A::Decoder<H::Input>: AbiDecoder<A>
 {
-    let mut d = host.runtime_decoder<A>()
-    T::decode_payload(mut d)
+    let input = host.input()
+    let base = A::SELECTOR_SIZE
+    let len = input.len()
+    if base > len {
+        host.abort()
+    }
+
+    if !T::IS_DYNAMIC {
+        let end = base + T::HEAD_SIZE
+        if end < base || end > len {
+            host.abort()
+        }
+    }
+
+    T::decode_from(input, base)
 }
 
 /// Target configuration used by compiler-generated contract entrypoints.

--- a/ingots/std/src/abi.fe
+++ b/ingots/std/src/abi.fe
@@ -16,6 +16,7 @@ use super::evm::{mem, ops}
 /// The returned value owns a memory tail with layout `(len = 32, word)`.
 /// Use this when an ABI `bytes` parameter or event field should contain one
 /// full 32-byte chunk, for example a `bytes`-typed wrapper around a `bytes32`.
+#[inline(always)]
 pub fn bytes_from_word(_ w: u256) -> Bytes uses (mem: mut RawMem) {
     let data = mem::alloc(64)
     mem.mstore(addr: data, value: 32)

--- a/ingots/std/src/abi.fe
+++ b/ingots/std/src/abi.fe
@@ -20,7 +20,7 @@ pub fn bytes_from_word(_ w: u256) -> Bytes uses (mem: mut RawMem) {
     let data = mem::alloc(64)
     mem.mstore(addr: data, value: 32)
     mem.mstore(addr: data + 32, value: w)
-    Bytes { data: data, len: 32, size: 64 }
+    Bytes::from_abi_tail(data: data, len: 32, size: 64)
 }
 
 /// Allocate a Solidity ABI `bytes` value from `N` full 32-byte words.
@@ -40,7 +40,7 @@ uses (mem: mut RawMem)
         mem.mstore(addr: data + 32 + (i as u256) * 32, value: words[i])
         i += 1
     }
-    Bytes { data: data, len: len, size: size }
+    Bytes::from_abi_tail(data: data, len: len, size: size)
 }
 
 /// Allocate a `Bytes` of byte length `LEN` from `N` u256 words.
@@ -71,5 +71,5 @@ uses (mem: mut RawMem)
         mem.mstore(addr: data + 32 + (i as u256) * 32, value: words[i])
         i += 1
     }
-    Bytes { data: data, len: len, size: size }
+    Bytes::from_abi_tail(data: data, len: len, size: size)
 }

--- a/ingots/std/src/abi/sol.fe
+++ b/ingots/std/src/abi/sol.fe
@@ -13,8 +13,9 @@ use core::abi::{
     Encode,
     StringView,
     abi_single_root_head_size,
-    decode_payload_root,
-    decode_single_root,
+    checked_frame_end,
+    decode_field_from_checked_head,
+    decode_frame_from,
 }
 use core::{AsBytes, keccak}
 use core::num::IntDowncast
@@ -196,7 +197,7 @@ impl<I> SolDecoder<I>
 
 /// Decode a Solidity ABI payload from an arbitrary byte input starting at byte 0.
 pub fn decode_input<T, I>(_ input: own I) -> T
-    where T: Decode<Sol>, I: ByteInput
+    where T: Decode<Sol> + AbiSize, I: ByteInput
 {
     decode_input_at(input, 0)
 }
@@ -206,14 +207,10 @@ pub fn decode_input<T, I>(_ input: own I) -> T
 /// The input stays raw; `base` chooses where the ABI payload begins. Dynamic
 /// offsets remain relative to `base`, matching Solidity ABI rules.
 pub fn decode_input_at<T, I>(_ input: own I, _ base: u256) -> T
-    where T: Decode<Sol>, I: ByteInput
+    where T: Decode<Sol> + AbiSize, I: ByteInput
 {
-    if base > input.len() {
-        revert(offset: 0, len: 0)
-    }
-
-    let mut d = SolDecoder<I>::with_base(input, base)
-    decode_payload_root<Sol, T, SolDecoder<I>>(mut d)
+    let input_len = input.len()
+    decode_frame_from<Sol, T, I>(input, base, input_len)
 }
 
 /// Decode a Solidity ABI return/output payload from an arbitrary byte input at byte 0.
@@ -230,12 +227,9 @@ pub fn decode_output<T, I>(_ input: own I) -> T
 pub fn decode_output_at<T, I>(_ input: own I, _ base: u256) -> T
     where T: Decode<Sol> + AbiSize, I: ByteInput
 {
-    if base > input.len() {
-        revert(offset: 0, len: 0)
-    }
-
-    let mut d = SolDecoder<I>::with_base(input, base)
-    decode_single_root<Sol, T, SolDecoder<I>>(mut d)
+    let input_len = input.len()
+    checked_frame_end<Sol>(base, abi_single_root_head_size<T>(), input_len)
+    decode_field_from_checked_head<Sol, T, I>(input, base: base, head_pos: base, input_len: input_len)
 }
 
 /// Decode a Solidity ABI `bytes` payload view from `input` at byte 0.

--- a/ingots/std/src/abi/sol.fe
+++ b/ingots/std/src/abi/sol.fe
@@ -161,6 +161,9 @@ impl Abi for Sol {
 
     fn encoder_new(_ size: u256) -> Self::Encoder { SolEncoder::new(size) }
 
+    #[inline(always)]
+    fn encoder_at(_ base: u256) -> Self::Encoder { SolEncoder::at(base) }
+
     fn store_word(ptr: u256, value: u256) {
         mstore(addr: ptr, value: value)
     }
@@ -380,6 +383,11 @@ pub struct SolEncoder {
 impl SolEncoder {
     pub fn new(_ size: u256) -> Self {
         let base = if size == 0 { 0 } else { mem::alloc(size) }
+        SolEncoder::at(base)
+    }
+
+    #[inline(always)]
+    pub fn at(_ base: u256) -> Self {
         SolEncoder {
             base,
             pos: base,

--- a/ingots/std/src/abi/sol.fe
+++ b/ingots/std/src/abi/sol.fe
@@ -157,6 +157,8 @@ impl Abi for Sol {
         SolDecoder::with_base(input, base)
     }
 
+    fn alloc(_ size: u256) -> u256 { mem::alloc(size) }
+
     fn encoder_new(_ size: u256) -> Self::Encoder { SolEncoder::new(size) }
 
     fn store_word(ptr: u256, value: u256) {

--- a/ingots/std/src/abi/sol.fe
+++ b/ingots/std/src/abi/sol.fe
@@ -14,7 +14,7 @@ use core::abi::{
     StringView,
     abi_single_root_head_size,
     checked_frame_end,
-    decode_field_from_checked_head,
+    decode_field_from_prechecked_head,
     decode_frame_from,
 }
 use core::{AsBytes, keccak}
@@ -229,7 +229,7 @@ pub fn decode_output_at<T, I>(_ input: own I, _ base: u256) -> T
 {
     let input_len = input.len()
     checked_frame_end<Sol>(base, abi_single_root_head_size<T>(), input_len)
-    decode_field_from_checked_head<Sol, T, I>(input, base: base, head_pos: base, input_len: input_len)
+    decode_field_from_prechecked_head<Sol, T, I>(input, base: base, head_pos: base, input_len: input_len)
 }
 
 /// Decode a Solidity ABI `bytes` payload view from `input` at byte 0.

--- a/ingots/std/src/abi/sol/ints.fe
+++ b/ingots/std/src/abi/sol/ints.fe
@@ -1,4 +1,4 @@
-use core::abi::{Abi, AbiDecoder, AbiEncoder, AbiSize, AbiSpan, Decode, Encode}
+use core::abi::{Abi, AbiDecoder, AbiEncoder, AbiSize, AbiSpan, ByteInput, Decode, Encode}
 use core::num::IntDowncast
 use ingot::evm::{TopicValue, ops::revert}
 
@@ -6,6 +6,7 @@ use super::types::SolCompat
 
 const FULL_WORD_MASK: u256 = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 
+#[inline(always)]
 fn canonical_unsigned_word(word: u256, bits: u256) -> u256 {
     // Canonical Solidity ABI encoding for an unsigned integer of width `bits`
     // requires that all higher bits are zero.
@@ -18,6 +19,7 @@ fn canonical_unsigned_word(word: u256, bits: u256) -> u256 {
     revert(offset: 0, len: 0)
 }
 
+#[inline(always)]
 fn canonical_custom_signed_word(word: u256, bits: u256) -> u256 {
     // Canonical Solidity ABI encoding for a signed integer of width `bits`
     // requires that all higher bits are a sign-extension of the sign bit.
@@ -42,37 +44,45 @@ fn canonical_custom_signed_word(word: u256, bits: u256) -> u256 {
     revert(offset: 0, len: 0)
 }
 
+#[inline(always)]
 fn decode_uint_u32(word: u256, bits: u256) -> u32 {
     canonical_unsigned_word(word: word, bits: bits).downcast_unchecked()
 }
 
+#[inline(always)]
 fn decode_uint_u64(word: u256, bits: u256) -> u64 {
     canonical_unsigned_word(word: word, bits: bits).downcast_unchecked()
 }
 
+#[inline(always)]
 fn decode_uint_u128(word: u256, bits: u256) -> u128 {
     canonical_unsigned_word(word: word, bits: bits).downcast_unchecked()
 }
 
+#[inline(always)]
 fn decode_uint_u256(word: u256, bits: u256) -> u256 {
     canonical_unsigned_word(word: word, bits: bits)
 }
 
+#[inline(always)]
 fn decode_int_i32(word: u256, bits: u256) -> i32 {
     let signed_word: i256 = canonical_custom_signed_word(word: word, bits: bits).downcast_unchecked()
     signed_word.downcast_unchecked()
 }
 
+#[inline(always)]
 fn decode_int_i64(word: u256, bits: u256) -> i64 {
     let signed_word: i256 = canonical_custom_signed_word(word: word, bits: bits).downcast_unchecked()
     signed_word.downcast_unchecked()
 }
 
+#[inline(always)]
 fn decode_int_i128(word: u256, bits: u256) -> i128 {
     let signed_word: i256 = canonical_custom_signed_word(word: word, bits: bits).downcast_unchecked()
     signed_word.downcast_unchecked()
 }
 
+#[inline(always)]
 fn decode_int_i256(word: u256, bits: u256) -> i256 {
     canonical_custom_signed_word(word: word, bits: bits).downcast_unchecked()
 }
@@ -996,11 +1006,21 @@ impl<A: Abi> Decode<A> for Uint24 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         Uint24 { val: decode_uint_u32(word: d.read_word(), bits: 24) }
     }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        Uint24 { val: decode_uint_u32(word: input.word_at(pos), bits: 24) }
+    }
 }
 
 impl<A: Abi> Decode<A> for Uint40 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         Uint40 { val: decode_uint_u64(word: d.read_word(), bits: 40) }
+    }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        Uint40 { val: decode_uint_u64(word: input.word_at(pos), bits: 40) }
     }
 }
 
@@ -1008,11 +1028,21 @@ impl<A: Abi> Decode<A> for Uint48 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         Uint48 { val: decode_uint_u64(word: d.read_word(), bits: 48) }
     }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        Uint48 { val: decode_uint_u64(word: input.word_at(pos), bits: 48) }
+    }
 }
 
 impl<A: Abi> Decode<A> for Uint56 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         Uint56 { val: decode_uint_u64(word: d.read_word(), bits: 56) }
+    }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        Uint56 { val: decode_uint_u64(word: input.word_at(pos), bits: 56) }
     }
 }
 
@@ -1020,11 +1050,21 @@ impl<A: Abi> Decode<A> for Uint72 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         Uint72 { val: decode_uint_u128(word: d.read_word(), bits: 72) }
     }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        Uint72 { val: decode_uint_u128(word: input.word_at(pos), bits: 72) }
+    }
 }
 
 impl<A: Abi> Decode<A> for Uint80 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         Uint80 { val: decode_uint_u128(word: d.read_word(), bits: 80) }
+    }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        Uint80 { val: decode_uint_u128(word: input.word_at(pos), bits: 80) }
     }
 }
 
@@ -1032,11 +1072,21 @@ impl<A: Abi> Decode<A> for Uint88 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         Uint88 { val: decode_uint_u128(word: d.read_word(), bits: 88) }
     }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        Uint88 { val: decode_uint_u128(word: input.word_at(pos), bits: 88) }
+    }
 }
 
 impl<A: Abi> Decode<A> for Uint96 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         Uint96 { val: decode_uint_u128(word: d.read_word(), bits: 96) }
+    }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        Uint96 { val: decode_uint_u128(word: input.word_at(pos), bits: 96) }
     }
 }
 
@@ -1044,11 +1094,21 @@ impl<A: Abi> Decode<A> for Uint104 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         Uint104 { val: decode_uint_u128(word: d.read_word(), bits: 104) }
     }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        Uint104 { val: decode_uint_u128(word: input.word_at(pos), bits: 104) }
+    }
 }
 
 impl<A: Abi> Decode<A> for Uint112 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         Uint112 { val: decode_uint_u128(word: d.read_word(), bits: 112) }
+    }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        Uint112 { val: decode_uint_u128(word: input.word_at(pos), bits: 112) }
     }
 }
 
@@ -1056,11 +1116,21 @@ impl<A: Abi> Decode<A> for Uint120 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         Uint120 { val: decode_uint_u128(word: d.read_word(), bits: 120) }
     }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        Uint120 { val: decode_uint_u128(word: input.word_at(pos), bits: 120) }
+    }
 }
 
 impl<A: Abi> Decode<A> for Uint136 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         Uint136 { val: decode_uint_u256(word: d.read_word(), bits: 136) }
+    }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        Uint136 { val: decode_uint_u256(word: input.word_at(pos), bits: 136) }
     }
 }
 
@@ -1068,11 +1138,21 @@ impl<A: Abi> Decode<A> for Uint144 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         Uint144 { val: decode_uint_u256(word: d.read_word(), bits: 144) }
     }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        Uint144 { val: decode_uint_u256(word: input.word_at(pos), bits: 144) }
+    }
 }
 
 impl<A: Abi> Decode<A> for Uint152 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         Uint152 { val: decode_uint_u256(word: d.read_word(), bits: 152) }
+    }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        Uint152 { val: decode_uint_u256(word: input.word_at(pos), bits: 152) }
     }
 }
 
@@ -1080,11 +1160,21 @@ impl<A: Abi> Decode<A> for Uint160 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         Uint160 { val: decode_uint_u256(word: d.read_word(), bits: 160) }
     }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        Uint160 { val: decode_uint_u256(word: input.word_at(pos), bits: 160) }
+    }
 }
 
 impl<A: Abi> Decode<A> for Uint168 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         Uint168 { val: decode_uint_u256(word: d.read_word(), bits: 168) }
+    }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        Uint168 { val: decode_uint_u256(word: input.word_at(pos), bits: 168) }
     }
 }
 
@@ -1092,11 +1182,21 @@ impl<A: Abi> Decode<A> for Uint176 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         Uint176 { val: decode_uint_u256(word: d.read_word(), bits: 176) }
     }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        Uint176 { val: decode_uint_u256(word: input.word_at(pos), bits: 176) }
+    }
 }
 
 impl<A: Abi> Decode<A> for Uint184 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         Uint184 { val: decode_uint_u256(word: d.read_word(), bits: 184) }
+    }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        Uint184 { val: decode_uint_u256(word: input.word_at(pos), bits: 184) }
     }
 }
 
@@ -1104,11 +1204,21 @@ impl<A: Abi> Decode<A> for Uint192 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         Uint192 { val: decode_uint_u256(word: d.read_word(), bits: 192) }
     }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        Uint192 { val: decode_uint_u256(word: input.word_at(pos), bits: 192) }
+    }
 }
 
 impl<A: Abi> Decode<A> for Uint200 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         Uint200 { val: decode_uint_u256(word: d.read_word(), bits: 200) }
+    }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        Uint200 { val: decode_uint_u256(word: input.word_at(pos), bits: 200) }
     }
 }
 
@@ -1116,11 +1226,21 @@ impl<A: Abi> Decode<A> for Uint208 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         Uint208 { val: decode_uint_u256(word: d.read_word(), bits: 208) }
     }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        Uint208 { val: decode_uint_u256(word: input.word_at(pos), bits: 208) }
+    }
 }
 
 impl<A: Abi> Decode<A> for Uint216 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         Uint216 { val: decode_uint_u256(word: d.read_word(), bits: 216) }
+    }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        Uint216 { val: decode_uint_u256(word: input.word_at(pos), bits: 216) }
     }
 }
 
@@ -1128,11 +1248,21 @@ impl<A: Abi> Decode<A> for Uint224 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         Uint224 { val: decode_uint_u256(word: d.read_word(), bits: 224) }
     }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        Uint224 { val: decode_uint_u256(word: input.word_at(pos), bits: 224) }
+    }
 }
 
 impl<A: Abi> Decode<A> for Uint232 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         Uint232 { val: decode_uint_u256(word: d.read_word(), bits: 232) }
+    }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        Uint232 { val: decode_uint_u256(word: input.word_at(pos), bits: 232) }
     }
 }
 
@@ -1140,11 +1270,21 @@ impl<A: Abi> Decode<A> for Uint240 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         Uint240 { val: decode_uint_u256(word: d.read_word(), bits: 240) }
     }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        Uint240 { val: decode_uint_u256(word: input.word_at(pos), bits: 240) }
+    }
 }
 
 impl<A: Abi> Decode<A> for Uint248 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         Uint248 { val: decode_uint_u256(word: d.read_word(), bits: 248) }
+    }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        Uint248 { val: decode_uint_u256(word: input.word_at(pos), bits: 248) }
     }
 }
 
@@ -1152,11 +1292,21 @@ impl<A: Abi> Decode<A> for Int24 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         Int24 { val: decode_int_i32(word: d.read_word(), bits: 24) }
     }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        Int24 { val: decode_int_i32(word: input.word_at(pos), bits: 24) }
+    }
 }
 
 impl<A: Abi> Decode<A> for Int40 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         Int40 { val: decode_int_i64(word: d.read_word(), bits: 40) }
+    }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        Int40 { val: decode_int_i64(word: input.word_at(pos), bits: 40) }
     }
 }
 
@@ -1164,11 +1314,21 @@ impl<A: Abi> Decode<A> for Int48 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         Int48 { val: decode_int_i64(word: d.read_word(), bits: 48) }
     }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        Int48 { val: decode_int_i64(word: input.word_at(pos), bits: 48) }
+    }
 }
 
 impl<A: Abi> Decode<A> for Int56 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         Int56 { val: decode_int_i64(word: d.read_word(), bits: 56) }
+    }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        Int56 { val: decode_int_i64(word: input.word_at(pos), bits: 56) }
     }
 }
 
@@ -1176,11 +1336,21 @@ impl<A: Abi> Decode<A> for Int72 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         Int72 { val: decode_int_i128(word: d.read_word(), bits: 72) }
     }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        Int72 { val: decode_int_i128(word: input.word_at(pos), bits: 72) }
+    }
 }
 
 impl<A: Abi> Decode<A> for Int80 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         Int80 { val: decode_int_i128(word: d.read_word(), bits: 80) }
+    }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        Int80 { val: decode_int_i128(word: input.word_at(pos), bits: 80) }
     }
 }
 
@@ -1188,11 +1358,21 @@ impl<A: Abi> Decode<A> for Int88 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         Int88 { val: decode_int_i128(word: d.read_word(), bits: 88) }
     }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        Int88 { val: decode_int_i128(word: input.word_at(pos), bits: 88) }
+    }
 }
 
 impl<A: Abi> Decode<A> for Int96 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         Int96 { val: decode_int_i128(word: d.read_word(), bits: 96) }
+    }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        Int96 { val: decode_int_i128(word: input.word_at(pos), bits: 96) }
     }
 }
 
@@ -1200,11 +1380,21 @@ impl<A: Abi> Decode<A> for Int104 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         Int104 { val: decode_int_i128(word: d.read_word(), bits: 104) }
     }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        Int104 { val: decode_int_i128(word: input.word_at(pos), bits: 104) }
+    }
 }
 
 impl<A: Abi> Decode<A> for Int112 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         Int112 { val: decode_int_i128(word: d.read_word(), bits: 112) }
+    }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        Int112 { val: decode_int_i128(word: input.word_at(pos), bits: 112) }
     }
 }
 
@@ -1212,11 +1402,21 @@ impl<A: Abi> Decode<A> for Int120 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         Int120 { val: decode_int_i128(word: d.read_word(), bits: 120) }
     }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        Int120 { val: decode_int_i128(word: input.word_at(pos), bits: 120) }
+    }
 }
 
 impl<A: Abi> Decode<A> for Int136 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         Int136 { val: decode_int_i256(word: d.read_word(), bits: 136) }
+    }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        Int136 { val: decode_int_i256(word: input.word_at(pos), bits: 136) }
     }
 }
 
@@ -1224,11 +1424,21 @@ impl<A: Abi> Decode<A> for Int144 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         Int144 { val: decode_int_i256(word: d.read_word(), bits: 144) }
     }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        Int144 { val: decode_int_i256(word: input.word_at(pos), bits: 144) }
+    }
 }
 
 impl<A: Abi> Decode<A> for Int152 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         Int152 { val: decode_int_i256(word: d.read_word(), bits: 152) }
+    }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        Int152 { val: decode_int_i256(word: input.word_at(pos), bits: 152) }
     }
 }
 
@@ -1236,11 +1446,21 @@ impl<A: Abi> Decode<A> for Int160 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         Int160 { val: decode_int_i256(word: d.read_word(), bits: 160) }
     }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        Int160 { val: decode_int_i256(word: input.word_at(pos), bits: 160) }
+    }
 }
 
 impl<A: Abi> Decode<A> for Int168 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         Int168 { val: decode_int_i256(word: d.read_word(), bits: 168) }
+    }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        Int168 { val: decode_int_i256(word: input.word_at(pos), bits: 168) }
     }
 }
 
@@ -1248,11 +1468,21 @@ impl<A: Abi> Decode<A> for Int176 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         Int176 { val: decode_int_i256(word: d.read_word(), bits: 176) }
     }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        Int176 { val: decode_int_i256(word: input.word_at(pos), bits: 176) }
+    }
 }
 
 impl<A: Abi> Decode<A> for Int184 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         Int184 { val: decode_int_i256(word: d.read_word(), bits: 184) }
+    }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        Int184 { val: decode_int_i256(word: input.word_at(pos), bits: 184) }
     }
 }
 
@@ -1260,11 +1490,21 @@ impl<A: Abi> Decode<A> for Int192 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         Int192 { val: decode_int_i256(word: d.read_word(), bits: 192) }
     }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        Int192 { val: decode_int_i256(word: input.word_at(pos), bits: 192) }
+    }
 }
 
 impl<A: Abi> Decode<A> for Int200 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         Int200 { val: decode_int_i256(word: d.read_word(), bits: 200) }
+    }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        Int200 { val: decode_int_i256(word: input.word_at(pos), bits: 200) }
     }
 }
 
@@ -1272,11 +1512,21 @@ impl<A: Abi> Decode<A> for Int208 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         Int208 { val: decode_int_i256(word: d.read_word(), bits: 208) }
     }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        Int208 { val: decode_int_i256(word: input.word_at(pos), bits: 208) }
+    }
 }
 
 impl<A: Abi> Decode<A> for Int216 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         Int216 { val: decode_int_i256(word: d.read_word(), bits: 216) }
+    }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        Int216 { val: decode_int_i256(word: input.word_at(pos), bits: 216) }
     }
 }
 
@@ -1284,11 +1534,21 @@ impl<A: Abi> Decode<A> for Int224 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         Int224 { val: decode_int_i256(word: d.read_word(), bits: 224) }
     }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        Int224 { val: decode_int_i256(word: input.word_at(pos), bits: 224) }
+    }
 }
 
 impl<A: Abi> Decode<A> for Int232 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         Int232 { val: decode_int_i256(word: d.read_word(), bits: 232) }
+    }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        Int232 { val: decode_int_i256(word: input.word_at(pos), bits: 232) }
     }
 }
 
@@ -1296,11 +1556,21 @@ impl<A: Abi> Decode<A> for Int240 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         Int240 { val: decode_int_i256(word: d.read_word(), bits: 240) }
     }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        Int240 { val: decode_int_i256(word: input.word_at(pos), bits: 240) }
+    }
 }
 
 impl<A: Abi> Decode<A> for Int248 {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         Int248 { val: decode_int_i256(word: d.read_word(), bits: 248) }
+    }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        Int248 { val: decode_int_i256(word: input.word_at(pos), bits: 248) }
     }
 }
 

--- a/ingots/std/src/abi/sol/types.fe
+++ b/ingots/std/src/abi/sol/types.fe
@@ -111,6 +111,7 @@ impl SolCompat for Bytes {
 }
 
 #[arithmetic(unchecked)]
+#[inline(always)]
 fn encode_fixed_bytes_word(value: u256, len: u256) -> u256 {
     if len == 0 || len > 32 {
         revert(offset: 0, len: 0)
@@ -128,6 +129,7 @@ fn encode_fixed_bytes_word(value: u256, len: u256) -> u256 {
 }
 
 #[arithmetic(unchecked)]
+#[inline(always)]
 fn decode_fixed_bytes_word(word: u256, len: u256) -> u256 {
     if len == 0 || len > 32 {
         revert(offset: 0, len: 0)
@@ -182,6 +184,11 @@ impl<A: Abi, const N: usize> AbiSpan<A> for FixedBytes<N> {
 impl<A: Abi, const N: usize> Decode<A> for FixedBytes<N> {
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         FixedBytes { val: decode_fixed_bytes_word(word: d.read_word(), len: N as u256) }
+    }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        FixedBytes { val: decode_fixed_bytes_word(word: input.word_at(pos), len: N as u256) }
     }
 }
 

--- a/ingots/std/src/evm/calldata.fe
+++ b/ingots/std/src/evm/calldata.fe
@@ -1,4 +1,4 @@
-use core::abi::{ByteInput, Decode}
+use core::abi::{AbiSize, ByteInput, Decode}
 use core::Copy
 use core::num::IntDowncast
 use ingot::abi::Sol
@@ -27,7 +27,7 @@ impl CallData {
     }
 
     /// Decode Solidity ABI data from this calldata view.
-    pub fn decode<T>(self) -> T where T: Decode<Sol> {
+    pub fn decode<T>(self) -> T where T: Decode<Sol> + AbiSize {
         decode_input(self)
     }
 }

--- a/ingots/std/src/evm/calldata.fe
+++ b/ingots/std/src/evm/calldata.fe
@@ -72,4 +72,10 @@ impl ByteInput for CallData {
 
         calldatacopy(dest: dest, offset: self.base + src_offset, len: len)
     }
+
+    #[arithmetic(unchecked)]
+    #[inline(always)]
+    fn copy_to_memory_unchecked_aligned(self, dest: u256, src_offset: u256, len: u256) {
+        calldatacopy(dest: dest, offset: self.base + src_offset, len: len)
+    }
 }

--- a/ingots/std/src/evm/effects.fe
+++ b/ingots/std/src/evm/effects.fe
@@ -452,6 +452,8 @@ impl Ctx for Evm {
     fn balance(self, _ addr: Address) -> u256 {
         ops::balance(addr.inner)
     }
+
+    #[inline(always)]
     fn value(self) -> u256 {
         ops::callvalue()
     }

--- a/ingots/std/src/evm/effects.fe
+++ b/ingots/std/src/evm/effects.fe
@@ -6,6 +6,7 @@ use core::abi::{
     AbiEncoder,
     AbiSize,
     AbiSpan,
+    ByteInput,
     Decode,
     Encode,
     encode_alloc,
@@ -67,6 +68,15 @@ impl<A: Abi> Decode<A> for Address {
     #[inline(always)]
     fn decode_payload<D: AbiDecoder<A>>(_ d: mut D) -> Self {
         let word = d.read_word()
+        if word >> 160 != 0 {
+            ops::revert(offset: 0, len: 0)
+        }
+        Address { inner: word }
+    }
+
+    #[inline(always)]
+    fn decode_from<I: ByteInput>(_ input: I, _ pos: u256) -> Self {
+        let word = input.word_at(pos)
         if word >> 160 != 0 {
             ops::revert(offset: 0, len: 0)
         }

--- a/ingots/std/src/evm/effects.fe
+++ b/ingots/std/src/evm/effects.fe
@@ -617,16 +617,23 @@ impl Create for Evm {
     }
 }
 
+#[arithmetic(unchecked)]
+#[inline(always)]
 fn encode_calldata<M>(_ selector: u32, _ message: own M) -> (u256, u256)
 where M: Encode<Sol>
 {
     let selector_size = size_of<Sol::Selector>()
+    let payload_len = message.payload_size()
+    let total_len = selector_size + payload_len
+    let ptr = mem::alloc(total_len)
     let selector_word = (selector as u256) << 224
-    let encoded = encode_abi_payload(message)
-    let ptr = mem::alloc(selector_size + encoded.1)
     ops::mstore(addr: ptr, value: selector_word)
-    copy_words(dest: ptr + selector_size, src: encoded.0, len: encoded.1)
-    (ptr, selector_size + encoded.1)
+
+    let payload_ptr = ptr + selector_size
+    let mut encoder = Sol::encoder_at(payload_ptr)
+    message.encode(mut encoder)
+
+    (ptr, total_len)
 }
 
 fn copy_returndata() -> MemoryBytes {

--- a/ingots/std/src/evm/effects.fe
+++ b/ingots/std/src/evm/effects.fe
@@ -430,7 +430,7 @@ impl Evm {
 
     /// Decode the current Solidity call arguments, skipping the 4-byte selector.
     pub fn decode_args<T>(self) -> T
-        where T: Decode<Sol>
+        where T: Decode<Sol> + AbiSize
     {
         decode_input_at(self.input(), size_of<Sol::Selector>())
     }

--- a/ingots/std/src/evm/memory_input.fe
+++ b/ingots/std/src/evm/memory_input.fe
@@ -61,4 +61,13 @@ impl ByteInput for MemoryBytes {
             offset += 32
         }
     }
+
+    #[arithmetic(unchecked)]
+    fn copy_to_memory_unchecked_aligned(self, dest: u256, src_offset: u256, len: u256) {
+        let mut offset: u256 = 0
+        while offset < len {
+            mstore(addr: dest + offset, value: mload(self.base + src_offset + offset))
+            offset += 32
+        }
+    }
 }

--- a/ingots/std/src/evm/memory_input.fe
+++ b/ingots/std/src/evm/memory_input.fe
@@ -1,4 +1,4 @@
-use core::abi::{ByteInput, Decode}
+use core::abi::{AbiSize, ByteInput, Decode}
 use core::Copy
 use core::num::IntDowncast
 use ingot::abi::Sol
@@ -20,7 +20,7 @@ impl MemoryBytes {
 
     /// Decode Solidity ABI data from this memory view.
     pub fn decode<T>(self) -> T
-        where T: Decode<Sol>
+        where T: Decode<Sol> + AbiSize
     {
         decode_input(self)
     }

--- a/ingots/std/src/evm/ssz.fe
+++ b/ingots/std/src/evm/ssz.fe
@@ -58,6 +58,7 @@ use super::ops
 /// use the higher-level `Merkleize` trait; reach for `hash_pair`
 /// directly when building an incremental tree (the deposit contract's
 /// `branch[]` accumulator is the canonical example).
+#[inline(always)]
 pub fn hash_pair(left: u256, right: u256) -> u256 uses (mem: mut RawMem) {
     let ptr = mem::alloc(64)
     mem.mstore(addr: ptr, value: left)
@@ -84,6 +85,7 @@ pub fn hash_pair(left: u256, right: u256) -> u256 uses (mem: mut RawMem) {
 /// required because the byte-swap relies on wrapping multiplication-
 /// free shifts that the bounds checker can't otherwise prove safe.
 #[arithmetic(unchecked)]
+#[inline(always)]
 pub fn u64_chunk(_ value: u64) -> u256 {
     let mut v = value as u256
     // Swap adjacent byte pairs:  AB CD EF GH  →  BA DC FE HG
@@ -105,6 +107,7 @@ pub fn u64_chunk(_ value: u64) -> u256 {
 ///
 /// Note: the on-wire layout matches `u64_chunk` (LE in the top 8
 /// bytes of a word), wrapped with `len = 8` and `size = 64`.
+#[inline(always)]
 pub fn serialize_u64(_ value: u64) -> Bytes uses (mem: mut RawMem) {
     let out: u256 = mem::alloc(64)
     mem.mstore(addr: out, value: 8)
@@ -135,6 +138,7 @@ pub trait HashTreeRoot {
 ///
 /// Use as `ssz::hash_tree_root<ssz::ByteVector<48>>(bytes)`. The
 /// turbofish chooses the implementation; the argument supplies the bytes.
+#[inline(always)]
 pub fn hash_tree_root<T>(_ bytes: Bytes) -> u256
 uses (mem: mut RawMem) where T: HashTreeRoot
 {
@@ -150,6 +154,7 @@ uses (mem: mut RawMem) where T: HashTreeRoot
 ///
 /// Used for BLS public keys.
 impl HashTreeRoot for ByteVector<48> {
+    #[inline(always)]
     fn hash_tree_root(_ bytes: Bytes) -> u256
     uses (mem: mut RawMem)
     {
@@ -185,6 +190,7 @@ impl HashTreeRoot for ByteVector<48> {
 ///
 /// Used for BLS signatures.
 impl HashTreeRoot for ByteVector<96> {
+    #[inline(always)]
     fn hash_tree_root(_ bytes: Bytes) -> u256
     uses (mem: mut RawMem)
     {
@@ -249,6 +255,7 @@ impl Merkleize for (u256, u256, u256) {
 }
 
 impl Merkleize for (u256, u256, u256, u256) {
+    #[inline(always)]
     fn merkleize(self) -> u256 uses (mem: mut RawMem) {
         merkleize4(self.0, self.1, self.2, self.3)
     }
@@ -371,6 +378,7 @@ impl Merkleize for (
 /// Call this on the merkleized capacity-padded root with the actual
 /// element count to get the canonical `List` root. The deposit
 /// contract uses it on `deposit_count` to finalize `get_deposit_root`.
+#[inline(always)]
 pub fn mix_in_length(root: u256, len: u64) -> u256 uses (mem: mut RawMem) {
     hash_pair(left: root, right: u64_chunk(len))
 }
@@ -384,6 +392,7 @@ pub fn mix_in_length(root: u256, len: u64) -> u256 uses (mem: mut RawMem) {
 // behavior centralized so the public `Merkleize` impls just route a tuple to
 // the right one.
 
+#[inline(always)]
 fn merkleize4(_ a: u256, _ b: u256, _ c: u256, _ d: u256) -> u256
 uses (mem: mut RawMem)
 {
@@ -438,6 +447,7 @@ uses (mem: mut RawMem)
 // then returns it loaded into a u256. Reverts on precompile failure
 // or short return (defensive — sha256 always returns 32 bytes on
 // real EVM, but we don't want to trust silent truncation).
+#[inline(always)]
 fn sha256_64_to(_ offset: u256, _ out: u256) -> u256 {
     let ok: u256 = ops::staticcall(
         gas: ops::gas(),

--- a/ingots/std/src/evm/ssz.fe
+++ b/ingots/std/src/evm/ssz.fe
@@ -46,7 +46,7 @@
 /// in current consensus types. For wider containers, extend the trait
 /// or pre-merkleize sub-trees yourself. Variable-length lists are
 /// supported via `mix_in_length` on top of a fixed-arity merkleization.
-use core::abi::{Bytes, BytesView, MemoryInput}
+use core::abi::Bytes
 use super::effects::RawMem
 use super::mem
 use super::ops
@@ -122,25 +122,23 @@ pub fn serialize_u64(_ value: u64) -> Bytes uses (mem: mut RawMem) {
 /// add an `impl HashTreeRoot for ByteVector<X>` to support new sizes.
 pub struct ByteVector<const N: usize> {}
 
-/// Compute the SSZ hash-tree-root of a value given its in-memory view.
+/// Compute the SSZ hash-tree-root of a byte payload.
 ///
 /// Implementors decide how many chunks the value occupies and how to
-/// merkleize them. The view-based input avoids copying — callers
-/// pass an existing `BytesView` (typically from a calldata- or
-/// memory-backed `Bytes`).
+/// merkleize them.
 pub trait HashTreeRoot {
-    /// Compute the SSZ root for `view`.
-    fn hash_tree_root(_: BytesView<MemoryInput>) -> u256 uses (mem: mut RawMem)
+    /// Compute the SSZ root for `bytes`.
+    fn hash_tree_root(_: Bytes) -> u256 uses (mem: mut RawMem)
 }
 
 /// User-facing entry point for `HashTreeRoot`.
 ///
-/// Use as `ssz::hash_tree_root<ssz::ByteVector<48>>(view)`. The
-/// turbofish chooses the implementation; the view supplies the bytes.
-pub fn hash_tree_root<T>(_ view: BytesView<MemoryInput>) -> u256
+/// Use as `ssz::hash_tree_root<ssz::ByteVector<48>>(bytes)`. The
+/// turbofish chooses the implementation; the argument supplies the bytes.
+pub fn hash_tree_root<T>(_ bytes: Bytes) -> u256
 uses (mem: mut RawMem) where T: HashTreeRoot
 {
-    T::hash_tree_root(view)
+    T::hash_tree_root(bytes)
 }
 
 /// `ByteVector[48]` — packs into two chunks.
@@ -152,16 +150,16 @@ uses (mem: mut RawMem) where T: HashTreeRoot
 ///
 /// Used for BLS public keys.
 impl HashTreeRoot for ByteVector<48> {
-    fn hash_tree_root(_ view: BytesView<MemoryInput>) -> u256
+    fn hash_tree_root(_ bytes: Bytes) -> u256
     uses (mem: mut RawMem)
     {
-        assert!(view.len == 48)
+        assert!(bytes.len == 48)
         let ptr = mem::alloc(64)
-        mem.mstore(addr: ptr, value: view.word_at(0))
+        mem.mstore(addr: ptr, value: bytes.word_at(0))
         // Word at offset 32 holds bytes 32..48 in its top 16 bytes
         // followed by 16 bytes of slack. Mask the slack to zero by
         // shifting the high 128 bits down and back up.
-        let tail = view.word_at(32)
+        let tail = bytes.word_at(32)
         mem.mstore(addr: ptr + 32, value: (tail >> 128) << 128)
         sha256_64_to(ptr, ptr)
     }
@@ -187,15 +185,15 @@ impl HashTreeRoot for ByteVector<48> {
 ///
 /// Used for BLS signatures.
 impl HashTreeRoot for ByteVector<96> {
-    fn hash_tree_root(_ view: BytesView<MemoryInput>) -> u256
+    fn hash_tree_root(_ bytes: Bytes) -> u256
     uses (mem: mut RawMem)
     {
-        assert!(view.len == 96)
-        let base = view.input.base + view.start
+        assert!(bytes.len == 96)
+        let base = bytes.payload_ptr()
         let ptr = mem::alloc(64)
         let left = sha256_64_to(base, ptr)
 
-        mem.mstore(addr: ptr, value: view.word_at(64))
+        mem.mstore(addr: ptr, value: bytes.word_at(64))
         mem.mstore(addr: ptr + 32, value: 0)
         let right = sha256_64_to(ptr, ptr)
 


### PR DESCRIPTION
Per-commit effect, deltas vs parent:

| commit | change | init/runtime | deploy | deposit#0/#1/#2 | total calls |
| --- | --- | ---: | ---: | ---: | ---: |
| `16a607277` | Add decode_from ABI lowering | -145/-150 | -31,632 | -13/-13/-13 | -315 |
| `200338570` | Optimize ABI decode_from paths | -46/-26 | -5,075 | -682/-682/-682 | -2,046 |
| `a35cdaee1` | Avoid msg decode generated name collisions | 0/0 | 0 | 0/0/0 | 0 |
| `75fc01946` | Optimize ABI encode paths | -66/-66 | -14,309 | -201/-201/-201 | -603 |
| `2d9e6fb53` | Optimize tuple ABI field encoding | +89/+74 | +16,365 | -483/-483/-483 | -1,449 |
| `9a32671a4` | Outline dynamic Bytes decode helper | -175/-180 | -39,069 | -44/-43/-44 | -234 |
| `88f0482d1` | Remove BytesView from ssz/deposit_contract | -57/-37 | -8,681 | -20/-20/-20 | +252 |
| `f262a469b` | sonatina f4b5b31 | 0/0 | 0 | 0/0/0 | 0 |
| `1b540e02e` | Validate ABI dynamic decode heads | -8/-8 | -1,730 | 0/0/0 | -66 |

Regarding 88f0482d1 (Remove BytesView from ssz/deposit_contract), this is greatly improved by some fe/sonatina aggregate parameter improvements that I'll push up soon.