### PR TITLE
Add StoragePackedArray for dense bit-packed integer storage

### DIFF
--- a/crates/codegen/tests/fixtures/sonatina_ir/storage_packed_array.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/storage_packed_array.snap
@@ -1,0 +1,253 @@
+---
+source: crates/codegen/tests/sonatina_ir.rs
+expression: output
+input_file: crates/codegen/tests/fixtures/storage_packed_array.fe
+---
+target = "evm-ethereum-osaka"
+
+type @layout_0 = enum {
+    #Some(i256),
+    #None,
+};
+
+func inline(always) private %get(v0.i256) -> i256 {
+    block0:
+        v1.*i256 = alloca i256;
+        mstore v1 v0 i256;
+        jump block1;
+
+    block1:
+        v9.i256 = mload v1 i256;
+        v10.i256 = evm_udiv v9 32.i256;
+        v11.i256 = add 18569430475105882587588266137607568536673111973893317399460219858819262702947.i256 v10;
+        v12.i256 = mload v1 i256;
+        v13.i256 = evm_umod v12 32.i256;
+        v14.i256 = mul v13 8.i256;
+        v15.i256 = evm_sload v11;
+        v16.i256 = shr v14 v15;
+        v17.i256 = and v16 255.i256;
+        return v17;
+}
+
+func private %get_status(v0.i256) -> i256 {
+    block0:
+        v1.*i256 = alloca i256;
+        mstore v1 v0 i256;
+        jump block1;
+
+    block1:
+        v2.i256 = mload v1 i256;
+        v3.i256 = call %get v2;
+        return v3;
+}
+
+func private %main() -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        call %new;
+        call %set_status 1.i256 2.i256;
+        call %set_status 33.i256 5.i256;
+        v9.i256 = call %search_status 5.i256 0.i256 64.i256;
+        v10.i256 = call %get_status 1.i256;
+        return v10;
+}
+
+func private %main_root() {
+    block0:
+        jump block1;
+
+    block1:
+        v0.i256 = call %main;
+        evm_stop;
+}
+
+func private %new() {
+    block0:
+        jump block1;
+
+    block1:
+        return;
+}
+
+func private %search(v0.i256, v1.i256, v2.i256) -> @layout_0 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        v6.*i256 = alloca i256;
+        v7.*i256 = alloca i256;
+        v8.*i256 = alloca i256;
+        mstore v3 v0 i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        jump block1;
+
+    block1:
+        v16.i256 = mload v4 i256;
+        mstore v6 v16 i256;
+        jump block2;
+
+    block2:
+        v17.i256 = mload v6 i256;
+        v18.i256 = mload v5 i256;
+        v19.i1 = lt v17 v18;
+        br v19 block3 block4;
+
+    block3:
+        v20.i256 = mload v6 i256;
+        v22.i256 = evm_udiv v20 32.i256;
+        v24.i256 = add 18569430475105882587588266137607568536673111973893317399460219858819262702947.i256 v22;
+        v25.i256 = evm_sload v24;
+        v26.i256 = mload v6 i256;
+        v27.i256 = evm_umod v26 32.i256;
+        mstore v7 v27 i256;
+        jump block5;
+
+    block4:
+        v28.@layout_0 = enum.make @layout_0 #None;
+        return v28;
+
+    block5:
+        mstore v8 32.i256 i256;
+        v29.i256 = mload v7 i256;
+        v30.i256 = mload v8 i256;
+        v31.i1 = lt v29 v30;
+        br v31 block8 block7;
+
+    block6:
+        v32.i256 = mload v7 i256;
+        v33.i256 = mul v32 8.i256;
+        v35.i256 = shr v33 v25;
+        v37.i256 = and v35 255.i256;
+        v38.i256 = mload v3 i256;
+        v39.i1 = eq v37 v38;
+        br v39 block9 block10;
+
+    block7:
+        jump block2;
+
+    block8:
+        v40.i256 = mload v6 i256;
+        v41.i256 = mload v5 i256;
+        v42.i1 = lt v40 v41;
+        br v42 block6 block7;
+
+    block9:
+        v43.i256 = mload v6 i256;
+        v44.@layout_0 = enum.make @layout_0 #Some v43;
+        return v44;
+
+    block10:
+        jump block11;
+
+    block11:
+        v45.i256 = ptr_to_int v7 i256;
+        v46.i256 = mload v45 i256;
+        v47.i256 = add v46 1.i256;
+        mstore v45 v47 i256;
+        v48.i256 = ptr_to_int v6 i256;
+        v49.i256 = mload v48 i256;
+        v50.i256 = add v49 1.i256;
+        mstore v48 v50 i256;
+        jump block5;
+}
+
+func private %search_status(v0.i256, v1.i256, v2.i256) -> i256 {
+    block0:
+        v3.*i256 = alloca i256;
+        v4.*i256 = alloca i256;
+        v5.*i256 = alloca i256;
+        v6.objref<@layout_0> = obj.alloc @layout_0;
+        mstore v3 v0 i256;
+        mstore v4 v1 i256;
+        mstore v5 v2 i256;
+        jump block1;
+
+    block1:
+        v7.i256 = mload v3 i256;
+        v8.i256 = mload v4 i256;
+        v9.i256 = mload v5 i256;
+        v10.@layout_0 = call %search v7 v8 v9;
+        v11.enumtag(@layout_0) = enum.tag v10;
+        br_table v11 block5 (0.enumtag(@layout_0) block6) (1.enumtag(@layout_0) block7);
+
+    block2:
+        v19.@layout_0 = obj.load v6;
+        enum.assert_variant v19 #Some;
+        v20.i256 = enum.extract v19 #Some 0.i256;
+        return v20;
+
+    block3:
+        return -1.i256;
+
+    block4:
+        v17.@layout_0 = obj.load v6;
+        v18.enumtag(@layout_0) = enum.tag v17;
+        br_table v18 (0.enumtag(@layout_0) block2) (1.enumtag(@layout_0) block3);
+
+    block5:
+        unreachable;
+
+    block6:
+        enum.set_tag v6 #Some;
+        enum.assert_variant v10 #Some;
+        v15.objref<i256> = enum.proj v6 #Some 0.i256;
+        v16.i256 = enum.extract v10 #Some 0.i256;
+        obj.store v15 v16;
+        jump block4;
+
+    block7:
+        enum.set_tag v6 #None;
+        jump block4;
+}
+
+func inline(always) private %set(v0.i256, v1.i256) {
+    block0:
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        mstore v2 v0 i256;
+        mstore v3 v1 i256;
+        jump block1;
+
+    block1:
+        v11.i256 = mload v2 i256;
+        v12.i256 = evm_udiv v11 32.i256;
+        v13.i256 = add 18569430475105882587588266137607568536673111973893317399460219858819262702947.i256 v12;
+        v14.i256 = mload v2 i256;
+        v15.i256 = evm_umod v14 32.i256;
+        v16.i256 = mul v15 8.i256;
+        v17.i256 = shl v16 255.i256;
+        v18.i256 = evm_sload v13;
+        v20.i256 = xor -1.i256 v17;
+        v21.i256 = and v18 v20;
+        v22.i256 = mload v3 i256;
+        v23.i256 = and v22 255.i256;
+        v24.i256 = shl v16 v23;
+        v25.i256 = or v21 v24;
+        evm_sstore v13 v25;
+        return;
+}
+
+func private %set_status(v0.i256, v1.i256) {
+    block0:
+        v2.*i256 = alloca i256;
+        v3.*i256 = alloca i256;
+        mstore v2 v0 i256;
+        mstore v3 v1 i256;
+        jump block1;
+
+    block1:
+        v4.i256 = mload v2 i256;
+        v5.i256 = mload v3 i256;
+        call %set v4 v5;
+        return;
+}
+
+
+object @main {
+    section main {
+        entry %main_root;
+    }
+}

--- a/crates/codegen/tests/fixtures/storage_packed_array.fe
+++ b/crates/codegen/tests/fixtures/storage_packed_array.fe
@@ -1,0 +1,40 @@
+use std::evm::StoragePackedArray
+
+fn get_status(_ id: u256) -> u256
+    uses (status: StoragePackedArray<8, 0>)
+{
+    status.get(id)
+}
+
+fn set_status(id: u256, value: u256)
+    uses (status: mut StoragePackedArray<8, 0>)
+{
+    status.set(i: id, value)
+}
+
+fn search_status(needle: u256, start: u256, end: u256) -> u256
+    uses (status: StoragePackedArray<8, 0>)
+{
+    match status.search(needle: needle, start: start, end: end) {
+        Option::Some(i) => return i
+        Option::None => return 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+    }
+}
+
+pub fn main() -> u256 {
+    let mut status = StoragePackedArray<8, 0>::new()
+    with (status) {
+        set_status(id: 1, value: 2)
+        set_status(id: 33, value: 5)
+        search_status(needle: 5, start: 0, end: 64)
+        get_status(1)
+    }
+}
+
+#[test]
+fn foo() {
+    let mut st = StoragePackedArray<8, 0>::new()
+    with (st) {
+        main()
+    }
+}

--- a/crates/fe/tests/fixtures/fe_test/storage_packed_array.fe
+++ b/crates/fe/tests/fixtures/fe_test/storage_packed_array.fe
@@ -1,0 +1,341 @@
+use std::evm::StoragePackedArray
+
+const U256_MAX: u256 = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+
+msg PackedMsg {
+    #[selector = 0x00000001]
+    Get8 { i: u256 } -> u256,
+
+    #[selector = 0x00000002]
+    Set8 { i: u256, v: u256 } -> u256,
+
+    #[selector = 0x00000003]
+    Get32 { i: u256 } -> u256,
+
+    #[selector = 0x00000004]
+    Set32 { i: u256, v: u256 } -> u256,
+
+    #[selector = 0x00000005]
+    Get1 { i: u256 } -> u256,
+
+    #[selector = 0x00000006]
+    Set1 { i: u256, v: u256 } -> u256,
+
+    // Returns the index if found, U256_MAX if not.
+    #[selector = 0x00000007]
+    Search8 { needle: u256, start: u256, end: u256 } -> u256,
+}
+
+struct PackedStore {
+    s8: StoragePackedArray<8>,
+    s32: StoragePackedArray<32>,
+    s1: StoragePackedArray<1>,
+}
+
+pub contract Packed {
+    mut store: PackedStore
+
+    init() uses (mut store) {}
+
+    recv PackedMsg {
+        Get8 { i } -> u256 uses (store) {
+            return store.s8.get(i)
+        }
+
+        Set8 { i, v } -> u256 uses (mut store) {
+            store.s8.set(i: i, value: v)
+            return 0
+        }
+
+        Get32 { i } -> u256 uses (store) {
+            return store.s32.get(i)
+        }
+
+        Set32 { i, v } -> u256 uses (mut store) {
+            store.s32.set(i: i, value: v)
+            return 0
+        }
+
+        Get1 { i } -> u256 uses (store) {
+            return store.s1.get(i)
+        }
+
+        Set1 { i, v } -> u256 uses (mut store) {
+            store.s1.set(i: i, value: v)
+            return 0
+        }
+
+        Search8 { needle, start, end } -> u256 uses (store) {
+            match store.s8.search(needle: needle, start: start, end: end) {
+                Option::Some(idx) => return idx
+                Option::None => return U256_MAX
+            }
+        }
+    }
+}
+
+// -- Tests -------------------------------------------------------------------
+
+#[test]
+fn test_initial_zero_and_roundtrip_8bit() uses (evm: mut Evm) {
+    let addr = evm.create2<Packed>(value: 0, args: (), salt: 0)
+
+    // Initially empty: every lane reads as 0.
+    let v: u256 = evm.call(
+        addr: addr, gas: 100000, value: 0,
+        message: PackedMsg::Get8 { i: 5 }
+    )
+    assert(v == 0)
+
+    // Write 0x2A at index 5 and read it back.
+    evm.call(
+        addr: addr, gas: 100000, value: 0,
+        message: PackedMsg::Set8 { i: 5, v: 0x2A }
+    )
+    let v: u256 = evm.call(
+        addr: addr, gas: 100000, value: 0,
+        message: PackedMsg::Get8 { i: 5 }
+    )
+    assert(v == 0x2A)
+}
+
+#[test]
+fn test_lane_isolation_within_slot() uses (evm: mut Evm) {
+    let addr = evm.create2<Packed>(value: 0, args: (), salt: 0)
+
+    // Indices 0..32 share slot 0 with 8-bit packing. Write three lanes
+    // in that slot and ensure all three round-trip without overwriting
+    // each other.
+    evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Set8 { i: 0, v: 0xAA })
+    evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Set8 { i: 1, v: 0xBB })
+    evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Set8 { i: 31, v: 0xCC })
+
+    let v0: u256 = evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Get8 { i: 0 })
+    let v1: u256 = evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Get8 { i: 1 })
+    let v31: u256 = evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Get8 { i: 31 })
+    assert(v0 == 0xAA)
+    assert(v1 == 0xBB)
+    assert(v31 == 0xCC)
+
+    // Overwrite the middle lane. The two siblings must remain unchanged —
+    // this catches mask bugs in the read-modify-write path.
+    evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Set8 { i: 1, v: 0x99 })
+    let v0: u256 = evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Get8 { i: 0 })
+    let v1: u256 = evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Get8 { i: 1 })
+    let v31: u256 = evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Get8 { i: 31 })
+    assert(v0 == 0xAA)
+    assert(v1 == 0x99)
+    assert(v31 == 0xCC)
+}
+
+#[test]
+fn test_slot_boundary() uses (evm: mut Evm) {
+    let addr = evm.create2<Packed>(value: 0, args: (), salt: 0)
+
+    // Index 31 is the last lane of slot 0; index 32 is the first lane of
+    // slot 1. They live in distinct storage slots — writes must not bleed.
+    evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Set8 { i: 31, v: 0xAA })
+    evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Set8 { i: 32, v: 0xBB })
+
+    let v31: u256 = evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Get8 { i: 31 })
+    let v32: u256 = evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Get8 { i: 32 })
+    let v33: u256 = evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Get8 { i: 33 })
+    assert(v31 == 0xAA)
+    assert(v32 == 0xBB)
+    assert(v33 == 0)
+}
+
+#[test]
+fn test_truncation_8bit() uses (evm: mut Evm) {
+    let addr = evm.create2<Packed>(value: 0, args: (), salt: 0)
+
+    // Values with bits set above BITS=8 must be silently truncated.
+    evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Set8 { i: 7, v: 0x1FF })
+    let v: u256 = evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Get8 { i: 7 })
+    assert(v == 0xFF)
+
+    // Test the top of the byte range too.
+    evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Set8 { i: 8, v: 0xABCD })
+    let v: u256 = evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Get8 { i: 8 })
+    assert(v == 0xCD)
+}
+
+#[test]
+fn test_32bit_lanes() uses (evm: mut Evm) {
+    let addr = evm.create2<Packed>(value: 0, args: (), salt: 0)
+
+    // With BITS=32, 8 lanes fit per slot. Test isolation across all 8.
+    evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Set32 { i: 0, v: 0xDEADBEEF })
+    evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Set32 { i: 7, v: 0xCAFEBABE })
+    evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Set32 { i: 8, v: 0x12345678 })
+
+    let v0: u256 = evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Get32 { i: 0 })
+    let v7: u256 = evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Get32 { i: 7 })
+    let v8: u256 = evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Get32 { i: 8 })
+    assert(v0 == 0xDEADBEEF)
+    assert(v7 == 0xCAFEBABE)
+    assert(v8 == 0x12345678)
+}
+
+#[test]
+fn test_1bit_bitmap() uses (evm: mut Evm) {
+    let addr = evm.create2<Packed>(value: 0, args: (), salt: 0)
+
+    // BITS=1: 256 lanes per slot. Set bits at scattered positions across
+    // the first slot and the second slot.
+    evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Set1 { i: 0, v: 1 })
+    evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Set1 { i: 7, v: 1 })
+    evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Set1 { i: 255, v: 1 })
+    evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Set1 { i: 256, v: 1 })
+
+    let b0: u256 = evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Get1 { i: 0 })
+    let b1: u256 = evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Get1 { i: 1 })
+    let b7: u256 = evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Get1 { i: 7 })
+    let b255: u256 = evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Get1 { i: 255 })
+    let b256: u256 = evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Get1 { i: 256 })
+    let b257: u256 = evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Get1 { i: 257 })
+    assert(b0 == 1)
+    assert(b1 == 0)
+    assert(b7 == 1)
+    assert(b255 == 1)
+    assert(b256 == 1)
+    assert(b257 == 0)
+
+    // Clear bit 7 — its neighbours and the cross-slot bit must remain.
+    evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Set1 { i: 7, v: 0 })
+    let b0: u256 = evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Get1 { i: 0 })
+    let b7: u256 = evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Get1 { i: 7 })
+    let b255: u256 = evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Get1 { i: 255 })
+    let b256: u256 = evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Get1 { i: 256 })
+    assert(b0 == 1)
+    assert(b7 == 0)
+    assert(b255 == 1)
+    assert(b256 == 1)
+}
+
+#[test]
+fn test_arrays_with_different_salts_are_independent() uses (evm: mut Evm) {
+    let addr = evm.create2<Packed>(value: 0, args: (), salt: 0)
+
+    // Write at the same index in three arrays with different SALTs.
+    // They must live in disjoint storage regions.
+    evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Set8 { i: 0, v: 0x11 })
+    evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Set32 { i: 0, v: 0x22222222 })
+    evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Set1 { i: 0, v: 1 })
+
+    let s8: u256 = evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Get8 { i: 0 })
+    let s32: u256 = evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Get32 { i: 0 })
+    let s1: u256 = evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Get1 { i: 0 })
+    assert(s8 == 0x11)
+    assert(s32 == 0x22222222)
+    assert(s1 == 1)
+}
+
+#[test]
+fn test_inferred_salts_do_not_collide_across_slots() uses (evm: mut Evm) {
+    let addr = evm.create2<Packed>(value: 0, args: (), salt: 0)
+
+    // PackedStore declares `s8` and `s32` as adjacent fields. With raw
+    // arithmetic addressing (slot = SALT + i / lanes_per_slot), writing
+    // to s8 at index 32 would spill into the next storage slot — which
+    // is exactly where the next field starts under inferred salts. The
+    // hashed base (keccak(SALT)) puts each array's data ≈2^256 slots away
+    // from any other, so adjacent fields remain disjoint regardless of
+    // how far the array grows.
+    //
+    // Pre-populate s32 so we can detect any clobber. Then write into s8
+    // at indices that cross multiple slot boundaries (32, 64, 96).
+    evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Set32 { i: 0, v: 0xCAFEBABE })
+    evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Set32 { i: 1, v: 0xDEADBEEF })
+    evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Set8 { i: 32, v: 0xAA })
+    evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Set8 { i: 64, v: 0xBB })
+    evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Set8 { i: 96, v: 0xCC })
+
+    // s32 must be untouched by the cross-slot writes into s8.
+    let v0: u256 = evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Get32 { i: 0 })
+    let v1: u256 = evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Get32 { i: 1 })
+    assert(v0 == 0xCAFEBABE)
+    assert(v1 == 0xDEADBEEF)
+
+    // And s8 must read back the values we just wrote.
+    let s8_32: u256 = evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Get8 { i: 32 })
+    let s8_64: u256 = evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Get8 { i: 64 })
+    let s8_96: u256 = evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Get8 { i: 96 })
+    assert(s8_32 == 0xAA)
+    assert(s8_64 == 0xBB)
+    assert(s8_96 == 0xCC)
+}
+
+#[test]
+fn test_search_hit_within_slot() uses (evm: mut Evm) {
+    let addr = evm.create2<Packed>(value: 0, args: (), salt: 0)
+
+    // Populate three lanes in slot 0. Search for the middle one.
+    evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Set8 { i: 3, v: 0x42 })
+    evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Set8 { i: 7, v: 0x99 })
+    evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Set8 { i: 12, v: 0xFF })
+
+    let idx: u256 = evm.call(
+        addr: addr, gas: 200000, value: 0,
+        message: PackedMsg::Search8 { needle: 0x99, start: 0, end: 32 }
+    )
+    assert(idx == 7)
+}
+
+#[test]
+fn test_search_miss_returns_sentinel() uses (evm: mut Evm) {
+    let addr = evm.create2<Packed>(value: 0, args: (), salt: 0)
+
+    evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Set8 { i: 3, v: 0x42 })
+
+    let idx: u256 = evm.call(
+        addr: addr, gas: 200000, value: 0,
+        message: PackedMsg::Search8 { needle: 0xAB, start: 0, end: 32 }
+    )
+    assert(idx == U256_MAX)
+}
+
+#[test]
+fn test_search_across_slots() uses (evm: mut Evm) {
+    let addr = evm.create2<Packed>(value: 0, args: (), salt: 0)
+
+    // Needle lives in slot 2 (index >= 64). Starting from 0 forces the
+    // search to walk past two full slots before hitting it — exercises
+    // the word-at-a-time loop's outer slot transition.
+    evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Set8 { i: 70, v: 0x55 })
+
+    let idx: u256 = evm.call(
+        addr: addr, gas: 500000, value: 0,
+        message: PackedMsg::Search8 { needle: 0x55, start: 0, end: 96 }
+    )
+    assert(idx == 70)
+}
+
+#[test]
+fn test_search_respects_start_and_end() uses (evm: mut Evm) {
+    let addr = evm.create2<Packed>(value: 0, args: (), salt: 0)
+
+    evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Set8 { i: 5, v: 0x77 })
+    evm.call(addr: addr, gas: 100000, value: 0, message: PackedMsg::Set8 { i: 25, v: 0x77 })
+
+    // start excludes the first match → finds the second
+    let idx: u256 = evm.call(
+        addr: addr, gas: 200000, value: 0,
+        message: PackedMsg::Search8 { needle: 0x77, start: 10, end: 32 }
+    )
+    assert(idx == 25)
+
+    // end excludes the second match → finds the first
+    let idx: u256 = evm.call(
+        addr: addr, gas: 200000, value: 0,
+        message: PackedMsg::Search8 { needle: 0x77, start: 0, end: 20 }
+    )
+    assert(idx == 5)
+
+    // Range that excludes both → miss
+    let idx: u256 = evm.call(
+        addr: addr, gas: 200000, value: 0,
+        message: PackedMsg::Search8 { needle: 0x77, start: 10, end: 20 }
+    )
+    assert(idx == U256_MAX)
+}

--- a/crates/uitest/fixtures/ty_check/storage_packed_array_invalid_bits.fe
+++ b/crates/uitest/fixtures/ty_check/storage_packed_array_invalid_bits.fe
@@ -1,0 +1,36 @@
+use std::evm::{PackedBits, StoragePackedArray, ValidPackedBits}
+
+// `BITS` must divide 256 evenly (power of two ≤ 128). Other widths
+// produce a "trait bound is not satisfied" error from the `ValidPackedBits`
+// constraint on the impl block.
+
+pub fn ok_8bit() -> u256 {
+    let a = StoragePackedArray<8, 0>::new()
+    a.get(0)
+}
+
+pub fn bad_7bit() -> u256 {
+    let a = StoragePackedArray<7, 0>::new()
+    a.get(0)
+}
+
+pub fn bad_24bit() -> u256 {
+    let a = StoragePackedArray<24, 0>::new()
+    a.get(0)
+}
+
+pub fn bad_zero() -> u256 {
+    let a = StoragePackedArray<0, 0>::new()
+    a.get(0)
+}
+
+pub fn bad_256() -> u256 {
+    let a = StoragePackedArray<256, 0>::new()
+    a.get(0)
+}
+
+pub fn ok_generic<const BITS: u256, const SALT: u256>(_ a: StoragePackedArray<BITS, SALT>) -> u256
+    where PackedBits<BITS>: ValidPackedBits
+{
+    a.get(0)
+}

--- a/crates/uitest/fixtures/ty_check/storage_packed_array_invalid_bits.snap
+++ b/crates/uitest/fixtures/ty_check/storage_packed_array_invalid_bits.snap
@@ -1,0 +1,164 @@
+---
+source: crates/uitest/tests/ty_check.rs
+expression: diags
+input_file: fixtures/ty_check/storage_packed_array_invalid_bits.fe
+---
+error[6-0003]: trait bound is not satisfied
+   ┌─ storage_packed_array_invalid_bits.fe:13:13
+   │
+13 │     let a = StoragePackedArray<7, 0>::new()
+   │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `PackedBits<7>` doesn't implement `ValidPackedBits`
+   │
+   ┌─ src/evm/storage_packed_array.fe:71:29
+   │
+71 │     where PackedBits<BITS>: ValidPackedBits
+   │                             --------------- required by this bound on `new`
+
+error[6-0003]: trait bound is not satisfied
+   ┌─ storage_packed_array_invalid_bits.fe:13:32
+   │
+13 │     let a = StoragePackedArray<7, 0>::new()
+   │                                ^ `PackedBits<7>` doesn't implement `ValidPackedBits`
+
+error[6-0003]: trait bound is not satisfied
+   ┌─ storage_packed_array_invalid_bits.fe:13:35
+   │
+13 │     let a = StoragePackedArray<7, 0>::new()
+   │                                   ^ `PackedBits<7>` doesn't implement `ValidPackedBits`
+
+error[6-0003]: trait bound is not satisfied
+   ┌─ storage_packed_array_invalid_bits.fe:14:7
+   │
+14 │     a.get(0)
+   │       ^^^ `PackedBits<7>` doesn't implement `ValidPackedBits`
+   │
+   ┌─ src/evm/storage_packed_array.fe:71:29
+   │
+71 │     where PackedBits<BITS>: ValidPackedBits
+   │                             --------------- required by this bound on `get`
+
+error[6-0003]: trait bound is not satisfied
+   ┌─ storage_packed_array_invalid_bits.fe:14:7
+   │
+14 │     a.get(0)
+   │       ^^^ `PackedBits<7>` doesn't implement `ValidPackedBits`
+
+error[6-0003]: trait bound is not satisfied
+   ┌─ storage_packed_array_invalid_bits.fe:18:13
+   │
+18 │     let a = StoragePackedArray<24, 0>::new()
+   │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `PackedBits<24>` doesn't implement `ValidPackedBits`
+   │
+   ┌─ src/evm/storage_packed_array.fe:71:29
+   │
+71 │     where PackedBits<BITS>: ValidPackedBits
+   │                             --------------- required by this bound on `new`
+
+error[6-0003]: trait bound is not satisfied
+   ┌─ storage_packed_array_invalid_bits.fe:18:32
+   │
+18 │     let a = StoragePackedArray<24, 0>::new()
+   │                                ^^ `PackedBits<24>` doesn't implement `ValidPackedBits`
+
+error[6-0003]: trait bound is not satisfied
+   ┌─ storage_packed_array_invalid_bits.fe:18:36
+   │
+18 │     let a = StoragePackedArray<24, 0>::new()
+   │                                    ^ `PackedBits<24>` doesn't implement `ValidPackedBits`
+
+error[6-0003]: trait bound is not satisfied
+   ┌─ storage_packed_array_invalid_bits.fe:19:7
+   │
+19 │     a.get(0)
+   │       ^^^ `PackedBits<24>` doesn't implement `ValidPackedBits`
+   │
+   ┌─ src/evm/storage_packed_array.fe:71:29
+   │
+71 │     where PackedBits<BITS>: ValidPackedBits
+   │                             --------------- required by this bound on `get`
+
+error[6-0003]: trait bound is not satisfied
+   ┌─ storage_packed_array_invalid_bits.fe:19:7
+   │
+19 │     a.get(0)
+   │       ^^^ `PackedBits<24>` doesn't implement `ValidPackedBits`
+
+error[6-0003]: trait bound is not satisfied
+   ┌─ storage_packed_array_invalid_bits.fe:23:13
+   │
+23 │     let a = StoragePackedArray<0, 0>::new()
+   │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `PackedBits<0>` doesn't implement `ValidPackedBits`
+   │
+   ┌─ src/evm/storage_packed_array.fe:71:29
+   │
+71 │     where PackedBits<BITS>: ValidPackedBits
+   │                             --------------- required by this bound on `new`
+
+error[6-0003]: trait bound is not satisfied
+   ┌─ storage_packed_array_invalid_bits.fe:23:32
+   │
+23 │     let a = StoragePackedArray<0, 0>::new()
+   │                                ^ `PackedBits<0>` doesn't implement `ValidPackedBits`
+
+error[6-0003]: trait bound is not satisfied
+   ┌─ storage_packed_array_invalid_bits.fe:23:35
+   │
+23 │     let a = StoragePackedArray<0, 0>::new()
+   │                                   ^ `PackedBits<0>` doesn't implement `ValidPackedBits`
+
+error[6-0003]: trait bound is not satisfied
+   ┌─ storage_packed_array_invalid_bits.fe:24:7
+   │
+24 │     a.get(0)
+   │       ^^^ `PackedBits<0>` doesn't implement `ValidPackedBits`
+   │
+   ┌─ src/evm/storage_packed_array.fe:71:29
+   │
+71 │     where PackedBits<BITS>: ValidPackedBits
+   │                             --------------- required by this bound on `get`
+
+error[6-0003]: trait bound is not satisfied
+   ┌─ storage_packed_array_invalid_bits.fe:24:7
+   │
+24 │     a.get(0)
+   │       ^^^ `PackedBits<0>` doesn't implement `ValidPackedBits`
+
+error[6-0003]: trait bound is not satisfied
+   ┌─ storage_packed_array_invalid_bits.fe:28:13
+   │
+28 │     let a = StoragePackedArray<256, 0>::new()
+   │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `PackedBits<256>` doesn't implement `ValidPackedBits`
+   │
+   ┌─ src/evm/storage_packed_array.fe:71:29
+   │
+71 │     where PackedBits<BITS>: ValidPackedBits
+   │                             --------------- required by this bound on `new`
+
+error[6-0003]: trait bound is not satisfied
+   ┌─ storage_packed_array_invalid_bits.fe:28:32
+   │
+28 │     let a = StoragePackedArray<256, 0>::new()
+   │                                ^^^ `PackedBits<256>` doesn't implement `ValidPackedBits`
+
+error[6-0003]: trait bound is not satisfied
+   ┌─ storage_packed_array_invalid_bits.fe:28:37
+   │
+28 │     let a = StoragePackedArray<256, 0>::new()
+   │                                     ^ `PackedBits<256>` doesn't implement `ValidPackedBits`
+
+error[6-0003]: trait bound is not satisfied
+   ┌─ storage_packed_array_invalid_bits.fe:29:7
+   │
+29 │     a.get(0)
+   │       ^^^ `PackedBits<256>` doesn't implement `ValidPackedBits`
+   │
+   ┌─ src/evm/storage_packed_array.fe:71:29
+   │
+71 │     where PackedBits<BITS>: ValidPackedBits
+   │                             --------------- required by this bound on `get`
+
+error[6-0003]: trait bound is not satisfied
+   ┌─ storage_packed_array_invalid_bits.fe:29:7
+   │
+29 │     a.get(0)
+   │       ^^^ `PackedBits<256>` doesn't implement `ValidPackedBits`

--- a/ingots/std/src/evm.fe
+++ b/ingots/std/src/evm.fe
@@ -16,5 +16,6 @@ pub use mutex::{self, *}
 pub use ssz::{self, *}
 pub use storage_bytes::{self, *}
 pub use storage_map::{StorageKey, StorageMap}
+pub use storage_packed_array::{PackedBits, StoragePackedArray, ValidPackedBits}
 pub use units::{self, *}
 pub use word::{self, *}

--- a/ingots/std/src/evm/storage_packed_array.fe
+++ b/ingots/std/src/evm/storage_packed_array.fe
@@ -1,0 +1,127 @@
+use core::keccak
+use core::option::Option
+
+use super::ops::{sload, sstore}
+
+const U256_MASK: u256 = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+
+/// A storage-backed packed array of fixed-bit-width integer lanes.
+///
+/// Multiple lanes are packed into each 256-bit storage slot, and consecutive
+/// indices live in consecutive slots — so this is only meaningful for dense
+/// integer indices (token IDs, user IDs, order IDs, sequence positions).
+/// Passing addresses or hashes as `i` would spread one value per slot and
+/// is strictly worse than `StorageMap`.
+///
+/// `BITS` must be a power of two that divides 256 — one of
+/// 1, 2, 4, 8, 16, 32, 64, 128. The constraint is enforced at compile time
+/// via `PackedBits<BITS>: ValidPackedBits`; invalid widths fail type-checking
+/// with a "trait bound is not satisfied" error.
+///
+/// `SALT` is the layout seed. Lanes are stored starting at
+/// `keccak256(SALT)` (computed at compile time per monomorphization),
+/// so each array occupies a region of the 256-bit slot space that is
+/// effectively collision-free with any other field — adjacent inferred
+/// salts produce hashed bases ≈2²⁵⁶ apart. When the array is declared
+/// as a contract storage field, `SALT` is inferred automatically.
+/// Supply it explicitly only when you need a stable layout — for example
+/// with `core::keccak("myapp.storage.foo")` for upgradeable contracts.
+///
+/// # Example
+///
+/// ```fe
+/// // As a contract field — salts are inferred per-field:
+/// struct Store {
+///     order_status: StoragePackedArray<8>,
+///     order_tier:   StoragePackedArray<4>,
+/// }
+///
+/// // With an explicit namespaced salt:
+/// const ORDERS_NS: u256 = keccak("myapp.storage.order_status")
+/// let order_status: StoragePackedArray<8, ORDERS_NS> = StoragePackedArray::new()
+/// order_status.set(42, 1)
+/// ```
+pub struct StoragePackedArray<const BITS: u256, const SALT: u256 = _> {}
+
+/// Marker trait for `BITS` values that produce a well-formed packed layout
+/// — power of two ≤ 128, so 256 divides evenly into `256 / BITS` lanes.
+///
+/// Implemented only via `PackedBits<N>` for valid `N`; not user-extensible.
+pub trait ValidPackedBits {}
+
+/// Type-level witness used to constrain `BITS` of `StoragePackedArray`.
+///
+/// Most users do not name this directly. Generic helpers over `BITS` may need
+/// a `where PackedBits<BITS>: ValidPackedBits` bound to call the accessor methods
+/// for an otherwise unknown lane width.
+pub struct PackedBits<const N: u256> {}
+
+impl ValidPackedBits for PackedBits<1> {}
+impl ValidPackedBits for PackedBits<2> {}
+impl ValidPackedBits for PackedBits<4> {}
+impl ValidPackedBits for PackedBits<8> {}
+impl ValidPackedBits for PackedBits<16> {}
+impl ValidPackedBits for PackedBits<32> {}
+impl ValidPackedBits for PackedBits<64> {}
+impl ValidPackedBits for PackedBits<128> {}
+
+impl<const BITS: u256, const SALT: u256> Copy for StoragePackedArray<BITS, SALT> {}
+
+impl<const BITS: u256, const SALT: u256> StoragePackedArray<BITS, SALT>
+    where PackedBits<BITS>: ValidPackedBits
+{
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    /// Read the lane at index `i`. Returns the lane value zero-extended to `u256`.
+    #[arithmetic(unchecked)]
+    #[inline(always)]
+    pub fn get(self, _ i: u256) -> u256 {
+        let lanes_per_slot: u256 = 256 / BITS
+        let lane_mask: u256 = (1 << BITS) - 1
+        let slot: u256 = keccak(SALT) + (i / lanes_per_slot)
+        let bit_pos: u256 = (i % lanes_per_slot) * BITS
+        (sload(slot) >> bit_pos) & lane_mask
+    }
+
+    /// Overwrite the lane at index `i` with `value`. Bits above `BITS` in
+    /// `value` are silently dropped.
+    #[arithmetic(unchecked)]
+    #[inline(always)]
+    pub fn set(self, i: u256, value: u256) {
+        let lanes_per_slot: u256 = 256 / BITS
+        let lane_mask: u256 = (1 << BITS) - 1
+        let slot: u256 = keccak(SALT) + (i / lanes_per_slot)
+        let bit_pos: u256 = (i % lanes_per_slot) * BITS
+        let lane_mask_shifted: u256 = lane_mask << bit_pos
+        let cleared: u256 = sload(slot) & (U256_MASK ^ lane_mask_shifted)
+        let inserted: u256 = (value & lane_mask) << bit_pos
+        sstore(slot: slot, value: cleared | inserted)
+    }
+
+    /// Linear search in `[start, end)` for the first lane equal to `needle`.
+    ///
+    /// Reads one SLOAD per slot and then scans up to `lanes_per_slot` lanes
+    /// from the in-register word, amortizing storage access across
+    /// consecutive indices.
+    #[arithmetic(unchecked)]
+    pub fn search(self, needle: u256, start: u256, end: u256) -> Option<u256> {
+        let lanes_per_slot: u256 = 256 / BITS
+        let lane_mask: u256 = (1 << BITS) - 1
+        let base: u256 = keccak(SALT)
+        let mut i: u256 = start
+        while i < end {
+            let word: u256 = sload(base + (i / lanes_per_slot))
+            let mut lane: u256 = i % lanes_per_slot
+            while lane < lanes_per_slot && i < end {
+                if ((word >> (lane * BITS)) & lane_mask) == needle {
+                    return Option::Some(i)
+                }
+                lane += 1
+                i += 1
+            }
+        }
+        Option::None
+    }
+}


### PR DESCRIPTION
## Summary

  Adds `StoragePackedArray<BITS, SALT>` to the EVM stdlib — a Fe port of [Solady's `LibMap`](https://github.com/Vectorized/solady/blob/main/src/utils/LibMap.sol) (`Uint8Map`, `Uint40Map`, `Uint128Map`, …) that
  packs `256 / BITS` integer lanes into each storage slot. Targets dense integer indices (token IDs, order IDs, sequence positions) where a full `StorageMap` slot per entry would waste 96–99% of storage.

  Where Solady needs a separate hand-written type per width plus inline assembly for the read-modify-write + XOR-mask pattern, Fe expresses the whole family as a single generic with a safe high-level `get` /
  `set` / `search` API that compiles to the same bytecode.

  ## Design

  - **Generic over `BITS` and `SALT`.** `BITS` selects the lane width; `SALT` is the layout seed. When used as a contract field, `SALT` is inferred per-field; supply it explicitly (e.g.
  `keccak("myapp.storage.foo")`) only when a stable layout is required.
  - **Hashed base slot via CTFE.** Lanes live starting at `keccak256(SALT)` — folded at compile time by Fe's const-fn machinery (`core::keccak`, evaluated via the CTFE `__keccak256` intrinsic). Each
  monomorphization gets its hash as a `PUSH32` constant, so runtime cost is identical to using the raw salt while adjacent inferred salts produce bases ≈2²⁵⁶ apart, eliminating cross-field collisions when an
  array grows past its first slot. Verified by the IR snapshot — zero KECCAK256 opcodes remain at runtime.
  - **Compile-time width validation.** `BITS` is constrained to `{1, 2, 4, 8, 16, 32, 64, 128}` via a `where PackedBits<BITS>: ValidPackedBits` bound. Invalid widths like `7`, `24`, or `256` are rejected at
  type-check with a clear "trait bound not satisfied" error — pinned by a uitest snapshot. Solady gets this safety only by virtue of having one type per width; we keep the single-type ergonomics without losing
  it.

  ## Testing

  - **12 REVM-backed behavioural tests** covering: round-trip, lane isolation within a slot, slot boundary, value truncation at `BITS`, multiple bit widths (1, 8, 32), independence between arrays with different
  salts, **inferred-salt collision safety across slot boundaries**, and `search` (hit, miss, cross-slot, bounded).
  - **Codegen snapshot** pins the Sonatina IR shape — confirms the hashed base is a folded `PUSH32` and catches silent lowering regressions.
  - **UI test snapshot** for the invalid-`BITS` diagnostic.

  ## Known workaround

  Derived constants (`lanes_per_slot`, `lane_mask`) are inlined as `let` bindings in each method instead of associated `const` items, because associated consts in inherent impls currently panic in HIR lowering.
  Bytecode is unaffected — the expressions still const-fold per type parameter. Worth filing a follow-up issue to clean up once that's fixed.

