### PR TITLE
Reject tuple alias event fields

### DIFF
--- a/crates/hir/src/analysis/analysis_pass.rs
+++ b/crates/hir/src/analysis/analysis_pass.rs
@@ -1,9 +1,17 @@
-use crate::analysis::{HirAnalysisDb, diagnostics::DiagnosticVoucher};
-use crate::{
-    AttrMisuseError, ErrorDiagnostic, EventError, ParserError, SelectorError,
-    hir_def::{ModuleTree, TopLevelMod},
-    lower::{parse_file_impl, scope_graph_impl},
+use crate::analysis::{
+    HirAnalysisDb,
+    diagnostics::DiagnosticVoucher,
+    ty::{adt_def::AdtRef, ty_lower::lower_hir_ty},
 };
+use crate::{
+    AbiFieldContext, AbiFieldDiagnostic, AttrMisuseError, ErrorDiagnostic, EventError, ParserError,
+    SelectorError,
+    hir_def::{ModuleTree, TopLevelMod},
+    lower::{parse_file_impl, scope_graph_impl, top_mod_ast},
+    semantic::constraints_for,
+    span::{DesugaredOrigin, HirOrigin},
+};
+use parser::ast::{self, prelude::*};
 
 /// All analysis passes that run analysis on the HIR top level module
 /// granularity should implement this trait.
@@ -107,10 +115,125 @@ impl ModuleAnalysisPass for EventLowerPass {
         db: &'db dyn HirAnalysisDb,
         top_mod: TopLevelMod<'db>,
     ) -> Vec<Box<dyn DiagnosticVoucher>> {
-        scope_graph_impl::accumulated::<EventError>(db, top_mod)
+        let mut diags = scope_graph_impl::accumulated::<EventError>(db, top_mod)
             .into_iter()
             .map(|d| Box::new(d.clone()) as _)
-            .collect::<Vec<_>>()
+            .collect::<Vec<_>>();
+        diags.extend(
+            accumulated_abi_field_diagnostics(db, top_mod, AbiFieldContext::Event)
+                .map(|d| Box::new(d) as _),
+        );
+        diags.extend(
+            semantic_tuple_field_type_errors(db, top_mod, AbiFieldContext::Event)
+                .map(|d| Box::new(d) as _),
+        );
+        diags
+    }
+}
+
+// Syntactic non-path field types are rejected during event/error lowering so we
+// can skip generated selector/TOPIC0 constants. This catches unsupported shapes
+// that only become visible after type aliases are resolved.
+fn accumulated_abi_field_diagnostics<'db>(
+    db: &'db dyn HirAnalysisDb,
+    top_mod: TopLevelMod<'db>,
+    context: AbiFieldContext,
+) -> impl Iterator<Item = AbiFieldDiagnostic> {
+    scope_graph_impl::accumulated::<AbiFieldDiagnostic>(db, top_mod)
+        .into_iter()
+        .filter(move |diag| diag.context == context)
+        .cloned()
+}
+
+fn semantic_tuple_field_type_errors<'db>(
+    db: &'db dyn HirAnalysisDb,
+    top_mod: TopLevelMod<'db>,
+    context: AbiFieldContext,
+) -> impl Iterator<Item = AbiFieldDiagnostic> {
+    let mut diags = Vec::new();
+    let mut seen_structs = Vec::new();
+
+    for &impl_trait in top_mod.all_impl_traits(db) {
+        let HirOrigin::Desugared(origin) = impl_trait.origin(db) else {
+            continue;
+        };
+        let Some(struct_ptr) = abi_field_struct(origin, context) else {
+            continue;
+        };
+
+        let Some(self_ty) = impl_trait.type_ref(db).to_opt() else {
+            continue;
+        };
+        let self_ty = lower_hir_ty(
+            db,
+            self_ty,
+            impl_trait.scope(),
+            constraints_for(db, impl_trait.into()),
+        );
+        let Some(AdtRef::Struct(abi_struct)) = self_ty.adt_ref(db) else {
+            continue;
+        };
+        if seen_structs.contains(&abi_struct) {
+            continue;
+        }
+        seen_structs.push(abi_struct);
+
+        let root = top_mod_ast(db, top_mod).syntax().clone();
+        let ast_struct = struct_ptr
+            .syntax_node_ptr()
+            .try_to_node(&root)
+            .and_then(ast::Struct::cast);
+
+        let assumptions = constraints_for(db, abi_struct.into());
+        let fields = abi_struct.hir_fields(db);
+        for (field_idx, field) in fields.data(db).iter().enumerate() {
+            let Some(field_ty) = field.type_ref().to_opt() else {
+                continue;
+            };
+
+            let resolved_ty = lower_hir_ty(db, field_ty, abi_struct.scope(), assumptions);
+            if !resolved_ty.is_tuple(db) {
+                continue;
+            }
+
+            let primary_range = ast_struct
+                .as_ref()
+                .and_then(|ast_struct| ast_struct.fields())
+                .and_then(|fields| fields.into_iter().nth(field_idx))
+                .and_then(|field| field.ty())
+                .map_or_else(
+                    || parser::TextRange::empty(0.into()),
+                    |ty| ty.syntax().text_range(),
+                );
+            diags.push(AbiFieldDiagnostic {
+                context,
+                ty: resolved_ty.pretty_print(db).to_string(),
+                file: top_mod.file(db),
+                primary_range,
+                struct_name: abi_struct
+                    .name(db)
+                    .to_opt()
+                    .map(|name| name.data(db).to_string()),
+                field_name: field.name.to_opt().map(|name| name.data(db).to_string()),
+            });
+        }
+    }
+
+    diags.into_iter()
+}
+
+fn abi_field_struct(
+    origin: &DesugaredOrigin,
+    context: AbiFieldContext,
+) -> Option<parser::ast::AstPtr<ast::Struct>> {
+    match (origin, context) {
+        (DesugaredOrigin::Event(event_origin), AbiFieldContext::Event) => {
+            Some(event_origin.event_struct.clone())
+        }
+        (DesugaredOrigin::Error(error_origin), AbiFieldContext::Error) => {
+            Some(error_origin.error_struct.clone())
+        }
+        _ => None,
     }
 }
 
@@ -123,10 +246,19 @@ impl ModuleAnalysisPass for ErrorLowerPass {
         db: &'db dyn HirAnalysisDb,
         top_mod: TopLevelMod<'db>,
     ) -> Vec<Box<dyn DiagnosticVoucher>> {
-        scope_graph_impl::accumulated::<ErrorDiagnostic>(db, top_mod)
+        let mut diags = scope_graph_impl::accumulated::<ErrorDiagnostic>(db, top_mod)
             .into_iter()
             .map(|d| Box::new(d.clone()) as _)
-            .collect::<Vec<_>>()
+            .collect::<Vec<_>>();
+        diags.extend(
+            accumulated_abi_field_diagnostics(db, top_mod, AbiFieldContext::Error)
+                .map(|d| Box::new(d) as _),
+        );
+        diags.extend(
+            semantic_tuple_field_type_errors(db, top_mod, AbiFieldContext::Error)
+                .map(|d| Box::new(d) as _),
+        );
+        diags
     }
 }
 

--- a/crates/hir/src/analysis/diagnostics.rs
+++ b/crates/hir/src/analysis/diagnostics.rs
@@ -563,12 +563,6 @@ impl DiagnosticVoucher for crate::EventError {
                 format!("EVM supports at most 3 indexed fields (found {indexed_count})"),
                 vec!["remove `#[indexed]` from fields until there are at most 3".to_string()],
             ),
-            EventErrorKind::UnsupportedFieldType { ty } => (
-                7,
-                "unsupported event field type".to_string(),
-                format!("`{ty}` is not supported as an event field"),
-                vec!["event field types must be named types (e.g. `u256`, `Address`)".to_string()],
-            ),
         };
 
         let error_code = GlobalErrorCode::new(DiagnosticPass::EventLower, code);
@@ -587,6 +581,33 @@ impl DiagnosticVoucher for crate::EventError {
     }
 }
 
+impl DiagnosticVoucher for crate::AbiFieldDiagnostic {
+    fn to_complete(&self, _db: &dyn SpannedHirAnalysisDb) -> CompleteDiagnostic {
+        use crate::AbiFieldContext;
+
+        let primary_span = Span::new(self.file, self.primary_range, SpanKind::Original);
+        let (diagnostic_pass, code, field_context) = match self.context {
+            AbiFieldContext::Event => (DiagnosticPass::EventLower, 7, "an event"),
+            AbiFieldContext::Error => (DiagnosticPass::ErrorLower, 4, "a custom error"),
+        };
+
+        CompleteDiagnostic::new(
+            Severity::Error,
+            "unsupported ABI field type".to_string(),
+            vec![SubDiagnostic::new(
+                LabelStyle::Primary,
+                format!("`{}` is not supported as {field_context} field", self.ty),
+                Some(primary_span),
+            )],
+            vec![
+                "tuples are not supported in event or custom error fields; use a struct type for grouped data"
+                    .to_string(),
+            ],
+            GlobalErrorCode::new(diagnostic_pass, code),
+        )
+    }
+}
+
 impl DiagnosticVoucher for crate::ErrorDiagnostic {
     fn to_complete(&self, _db: &dyn SpannedHirAnalysisDb) -> CompleteDiagnostic {
         use crate::ErrorDiagnosticKind;
@@ -599,12 +620,6 @@ impl DiagnosticVoucher for crate::ErrorDiagnostic {
                 "`#[error]` structs must be non-generic".to_string(),
                 "generics are not supported on `#[error]` structs".to_string(),
                 vec!["remove generic parameters from the error struct".to_string()],
-            ),
-            ErrorDiagnosticKind::UnsupportedFieldType { ty } => (
-                4,
-                "unsupported error field type".to_string(),
-                format!("`{ty}` is not supported as an error field"),
-                vec!["error field types must be named types (e.g. `u256`, `Address`)".to_string()],
             ),
             ErrorDiagnosticKind::EventErrorAttrConflict => (
                 5,

--- a/crates/hir/src/analysis/semantic/ctfe/canonicalize.rs
+++ b/crates/hir/src/analysis/semantic/ctfe/canonicalize.rs
@@ -283,8 +283,9 @@ fn canonicalize_expr<'db>(
     mode: ConstCanonicalizationMode,
 ) -> (SExpr<'db>, Option<SemConstId<'db>>) {
     if let SExpr::Const(SConst::Ref(cref)) = expr {
-        let value = eval_const_ref(db, *cref)
-            .unwrap_or_else(|err| panic!("CTFE failed for {cref:?}: {err:?}"));
+        let Ok(value) = eval_const_ref(db, *cref) else {
+            return (SExpr::Const(SConst::Ref(*cref)), None);
+        };
         let value = canonicalize_const_value(db, instance, value);
         let runtime = reify_runtime_const_for_ty(db, instance, result_ty, value);
         return (

--- a/crates/hir/src/core/lower/abi_field.rs
+++ b/crates/hir/src/core/lower/abi_field.rs
@@ -1,0 +1,18 @@
+/// ABI field contexts that share field-type validation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum AbiFieldContext {
+    Event,
+    Error,
+}
+
+/// Diagnostics for unsupported field types in ABI-bearing structs.
+#[salsa::accumulator]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct AbiFieldDiagnostic {
+    pub context: AbiFieldContext,
+    pub ty: String,
+    pub file: common::file::File,
+    pub primary_range: parser::TextRange,
+    pub struct_name: Option<String>,
+    pub field_name: Option<String>,
+}

--- a/crates/hir/src/core/lower/error.rs
+++ b/crates/hir/src/core/lower/error.rs
@@ -2,7 +2,7 @@ use parser::ast::{self, prelude::*};
 use salsa::Accumulator as _;
 
 use super::{
-    FileLowerCtxt,
+    AbiFieldContext, AbiFieldDiagnostic, FileLowerCtxt,
     attr::{has_named_attr, lower_attrs_without_named, named_attr_specs},
     hir_builder::HirBuilder,
     msg::{
@@ -33,7 +33,6 @@ pub struct ErrorDiagnostic {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ErrorDiagnosticKind {
     GenericErrorStruct,
-    UnsupportedFieldType { ty: String },
     EventErrorAttrConflict,
 }
 
@@ -222,10 +221,9 @@ fn parse_error_fields<'db>(
         };
 
         let TypeKind::Path(Partial::Present(path)) = ty.data(db) else {
-            ErrorDiagnostic {
-                kind: ErrorDiagnosticKind::UnsupportedFieldType {
-                    ty: ty.pretty_print(db),
-                },
+            AbiFieldDiagnostic {
+                context: AbiFieldContext::Error,
+                ty: ty.pretty_print(db),
                 file,
                 primary_range: field
                     .ty()

--- a/crates/hir/src/core/lower/event.rs
+++ b/crates/hir/src/core/lower/event.rs
@@ -2,7 +2,7 @@ use parser::ast::{self, prelude::*};
 use salsa::Accumulator as _;
 
 use super::{
-    FileLowerCtxt,
+    AbiFieldContext, AbiFieldDiagnostic, FileLowerCtxt,
     attr::{
         AttrForm, AttrRule, AttrTarget, has_named_attr, lower_attrs_without_named,
         validate_attr_rules,
@@ -35,7 +35,6 @@ pub struct EventError {
 pub enum EventErrorKind {
     GenericEventStruct,
     TooManyIndexedFields { indexed_count: usize },
-    UnsupportedFieldType { ty: String },
 }
 
 pub(super) fn is_event_struct(ast: &ast::Struct) -> bool {
@@ -245,10 +244,9 @@ fn parse_event_fields<'db>(
         // in the TOPIC0 computation. Non-path types (tuples, etc.) are not
         // supported as event fields.
         let TypeKind::Path(Partial::Present(path)) = ty.data(db) else {
-            EventError {
-                kind: EventErrorKind::UnsupportedFieldType {
-                    ty: ty.pretty_print(db),
-                },
+            AbiFieldDiagnostic {
+                context: AbiFieldContext::Event,
+                ty: ty.pretty_print(db),
                 file,
                 primary_range: field
                     .ty()

--- a/crates/hir/src/core/lower/mod.rs
+++ b/crates/hir/src/core/lower/mod.rs
@@ -20,6 +20,7 @@ use crate::{
     },
     span::HirOrigin,
 };
+pub use abi_field::{AbiFieldContext, AbiFieldDiagnostic};
 pub use attr::{AttrMisuseError, AttrMisuseErrorKind};
 pub use error::{ErrorDiagnostic, ErrorDiagnosticKind};
 pub use event::{EventError, EventErrorKind};
@@ -28,6 +29,7 @@ pub use parse::parse_file_impl;
 
 pub(crate) mod parse;
 
+mod abi_field;
 mod attr;
 mod body;
 mod contract;

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -1,7 +1,8 @@
 use common::InputDb;
 pub use core::lower::{
-    AttrMisuseError, AttrMisuseErrorKind, ErrorDiagnostic, ErrorDiagnosticKind, EventError,
-    EventErrorKind, SelectorError, SelectorErrorKind, parse::ParserError,
+    AbiFieldContext, AbiFieldDiagnostic, AttrMisuseError, AttrMisuseErrorKind, ErrorDiagnostic,
+    ErrorDiagnosticKind, EventError, EventErrorKind, SelectorError, SelectorErrorKind,
+    parse::ParserError,
 };
 
 pub mod analysis;

--- a/crates/uitest/fixtures/ty_check/error_tuple_alias_field.fe
+++ b/crates/uitest/fixtures/ty_check/error_tuple_alias_field.fe
@@ -1,0 +1,6 @@
+type Pair = (u256, bool)
+
+#[error]
+struct Bad {
+    value: Pair,
+}

--- a/crates/uitest/fixtures/ty_check/error_tuple_alias_field.snap
+++ b/crates/uitest/fixtures/ty_check/error_tuple_alias_field.snap
@@ -1,0 +1,12 @@
+---
+source: crates/uitest/tests/ty_check.rs
+expression: diags
+input_file: fixtures/ty_check/error_tuple_alias_field.fe
+---
+error[16-0004]: unsupported ABI field type
+  ┌─ error_tuple_alias_field.fe:5:12
+  │
+5 │     value: Pair,
+  │            ^^^^ `(u256, bool)` is not supported as a custom error field
+  │
+  = tuples are not supported in event or custom error fields; use a struct type for grouped data

--- a/crates/uitest/fixtures/ty_check/error_tuple_field.fe
+++ b/crates/uitest/fixtures/ty_check/error_tuple_field.fe
@@ -1,0 +1,4 @@
+#[error]
+struct Bad {
+    value: (u256, bool),
+}

--- a/crates/uitest/fixtures/ty_check/error_tuple_field.snap
+++ b/crates/uitest/fixtures/ty_check/error_tuple_field.snap
@@ -1,0 +1,12 @@
+---
+source: crates/uitest/tests/ty_check.rs
+expression: diags
+input_file: fixtures/ty_check/error_tuple_field.fe
+---
+error[16-0004]: unsupported ABI field type
+  ┌─ error_tuple_field.fe:3:12
+  │
+3 │     value: (u256, bool),
+  │            ^^^^^^^^^^^^ `(u256, bool)` is not supported as a custom error field
+  │
+  = tuples are not supported in event or custom error fields; use a struct type for grouped data

--- a/crates/uitest/fixtures/ty_check/event_tuple_alias_field.fe
+++ b/crates/uitest/fixtures/ty_check/event_tuple_alias_field.fe
@@ -1,0 +1,8 @@
+use std::abi::DynString
+
+type SchemaRecord = (u256, bool, DynString)
+
+#[event]
+struct Registered {
+    schema: SchemaRecord,
+}

--- a/crates/uitest/fixtures/ty_check/event_tuple_alias_field.snap
+++ b/crates/uitest/fixtures/ty_check/event_tuple_alias_field.snap
@@ -1,0 +1,12 @@
+---
+source: crates/uitest/tests/ty_check.rs
+expression: diags
+input_file: fixtures/ty_check/event_tuple_alias_field.fe
+---
+error[10-0007]: unsupported ABI field type
+  ┌─ event_tuple_alias_field.fe:7:13
+  │
+7 │     schema: SchemaRecord,
+  │             ^^^^^^^^^^^^ `(u256, bool, DynString)` is not supported as an event field
+  │
+  = tuples are not supported in event or custom error fields; use a struct type for grouped data

--- a/crates/uitest/fixtures/ty_check/event_tuple_field.fe
+++ b/crates/uitest/fixtures/ty_check/event_tuple_field.fe
@@ -1,0 +1,4 @@
+#[event]
+struct Bad {
+    value: (u256, bool),
+}

--- a/crates/uitest/fixtures/ty_check/event_tuple_field.snap
+++ b/crates/uitest/fixtures/ty_check/event_tuple_field.snap
@@ -1,0 +1,12 @@
+---
+source: crates/uitest/tests/ty_check.rs
+expression: diags
+input_file: fixtures/ty_check/event_tuple_field.fe
+---
+error[10-0007]: unsupported ABI field type
+  ┌─ event_tuple_field.fe:3:12
+  │
+3 │     value: (u256, bool),
+  │            ^^^^^^^^^^^^ `(u256, bool)` is not supported as an event field
+  │
+  = tuples are not supported in event or custom error fields; use a struct type for grouped data

--- a/newsfragments/1481.bugfix.md
+++ b/newsfragments/1481.bugfix.md
@@ -1,0 +1,1 @@
+Fixed compiler panics when tuple type aliases were used as event or custom error fields.


### PR DESCRIPTION
Fixes a panic triggered by using a tuple type alias as an event field type. Tuple event fields were already rejected; but the check was path-based, not type-based.