### PR TITLE
Avoid scalar slots for read-only place reads

### DIFF
--- a/crates/codegen/tests/fixtures/sonatina_ir/alloc_self_assign.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/alloc_self_assign.snap
@@ -7,18 +7,12 @@ target = "evm-ethereum-osaka"
 
 func private %bump_self_assign(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v1 i256;
-        v4.*i8 = evm_malloc v3;
-        v5.i256 = ptr_to_int v4 i256;
-        mstore v2 v5 i256;
-        v6.i256 = mload v2 i256;
-        return v6;
+        v2.*i8 = evm_malloc v0;
+        v3.i256 = ptr_to_int v2 i256;
+        return v3;
 }
 
 func private %main() -> i256 {

--- a/crates/codegen/tests/fixtures/sonatina_ir/arg_bindings.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/arg_bindings.snap
@@ -7,17 +7,11 @@ target = "evm-ethereum-osaka"
 
 func private %arg_bindings(v0.i64, v1.i64) -> i64 {
     block0:
-        v2.*i64 = alloca i64;
-        v3.*i64 = alloca i64;
-        mstore v2 v0 i64;
-        mstore v3 v1 i64;
         jump block1;
 
     block1:
-        v4.i64 = mload v2 i64;
-        v5.i64 = mload v3 i64;
-        (v6.i64, v7.i1) = uaddo v4 v5;
-        br v7 block2 block3;
+        (v4.i64, v5.i1) = uaddo v0 v1;
+        br v5 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -25,7 +19,7 @@ func private %arg_bindings(v0.i64, v1.i64) -> i64 {
         evm_revert 0.i256 36.i256;
 
     block3:
-        return v6;
+        return v4;
 }
 
 func private %main() -> i64 {

--- a/crates/codegen/tests/fixtures/sonatina_ir/array_mut.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/array_mut.snap
@@ -7,17 +7,14 @@ target = "evm-ethereum-osaka"
 
 func private %array_mut(v0.i8) -> [i8; 4] {
     block0:
-        v1.*i8 = alloca i8;
-        mstore v1 v0 i8;
         jump block1;
 
     block1:
-        v2.i8 = mload v1 i8;
-        v8.[i8; 4] = insert_value undef.[i8; 4] 0.i256 v2;
-        v10.[i8; 4] = insert_value v8 1.i256 2.i8;
-        v12.[i8; 4] = insert_value v10 2.i256 3.i8;
-        v14.[i8; 4] = insert_value v12 3.i256 4.i8;
-        return v14;
+        v7.[i8; 4] = insert_value undef.[i8; 4] 0.i256 v0;
+        v9.[i8; 4] = insert_value v7 1.i256 2.i8;
+        v11.[i8; 4] = insert_value v9 2.i256 3.i8;
+        v13.[i8; 4] = insert_value v11 3.i256 4.i8;
+        return v13;
 }
 
 func private %main() -> [i8; 4] {

--- a/crates/codegen/tests/fixtures/sonatina_ir/aug_assign.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/aug_assign.snap
@@ -8,21 +8,15 @@ target = "evm-ethereum-osaka"
 func private %aug_assign(v0.i64, v1.i64) -> i64 {
     block0:
         v2.*i64 = alloca i64;
-        v3.*i64 = alloca i64;
-        v4.*i64 = alloca i64;
-        mstore v2 v0 i64;
-        mstore v3 v1 i64;
         jump block1;
 
     block1:
-        v5.i64 = mload v2 i64;
-        mstore v4 v5 i64;
-        v6.i256 = ptr_to_int v4 i256;
-        v7.i64 = mload v3 i64;
-        v8.i256 = mload v6 i256;
-        v9.i64 = trunc v8 i64;
-        (v10.i64, v11.i1) = uaddo v9 v7;
-        br v11 block2 block3;
+        mstore v2 v0 i64;
+        v4.i256 = ptr_to_int v2 i256;
+        v6.i256 = mload v4 i256;
+        v7.i64 = trunc v6 i64;
+        (v8.i64, v9.i1) = uaddo v7 v1;
+        br v9 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -30,20 +24,20 @@ func private %aug_assign(v0.i64, v1.i64) -> i64 {
         evm_revert 0.i256 36.i256;
 
     block3:
-        v18.i256 = zext v10 i256;
-        mstore v6 v18 i256;
-        v19.i256 = ptr_to_int v4 i256;
-        v21.i256 = mload v19 i256;
-        v22.i64 = trunc v21 i64;
-        (v23.i64, v24.i1) = umulo v22 2.i64;
-        br v24 block2 block4;
+        v16.i256 = zext v8 i256;
+        mstore v4 v16 i256;
+        v17.i256 = ptr_to_int v2 i256;
+        v19.i256 = mload v17 i256;
+        v20.i64 = trunc v19 i64;
+        (v21.i64, v22.i1) = umulo v20 2.i64;
+        br v22 block2 block4;
 
     block4:
-        v26.i256 = zext v23 i256;
-        mstore v19 v26 i256;
-        v27.i64 = mload v4 i64;
-        v29.i1 = eq 2.i64 0.i64;
-        br v29 block5 block6;
+        v24.i256 = zext v21 i256;
+        mstore v17 v24 i256;
+        v25.i64 = mload v2 i64;
+        v27.i1 = eq 2.i64 0.i64;
+        br v27 block5 block6;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -51,11 +45,11 @@ func private %aug_assign(v0.i64, v1.i64) -> i64 {
         evm_revert 0.i256 36.i256;
 
     block6:
-        (v31.i64, v32.i1) = evm_udivo v27 2.i64;
-        br v32 block2 block7;
+        (v29.i64, v30.i1) = evm_udivo v25 2.i64;
+        br v30 block2 block7;
 
     block7:
-        return v31;
+        return v29;
 }
 
 func private %main() -> i64 {

--- a/crates/codegen/tests/fixtures/sonatina_ir/aug_assign_bit_ops.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/aug_assign_bit_ops.snap
@@ -8,54 +8,48 @@ target = "evm-ethereum-osaka"
 func private %aug_assign_bit_ops(v0.i256, v1.i256) -> i256 {
     block0:
         v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v2 i256;
-        mstore v4 v5 i256;
-        v6.i256 = ptr_to_int v4 i256;
-        v7.i256 = mload v3 i256;
-        v8.i256 = mload v6 i256;
+        mstore v2 v0 i256;
+        v4.i256 = ptr_to_int v2 i256;
+        v6.i256 = mload v4 i256;
         jump block2;
 
     block2:
-        v11.i256 = phi (1.i256 block1) (v14 block6);
-        v12.i256 = phi (0.i256 block1) (v20 block6);
-        v13.i1 = eq v12 v7;
-        br v13 block4 block3;
+        v9.i256 = phi (1.i256 block1) (v12 block6);
+        v10.i256 = phi (0.i256 block1) (v18 block6);
+        v11.i1 = eq v10 v1;
+        br v11 block4 block3;
 
     block3:
-        (v14.i256, v15.i1) = umulo v11 v8;
-        br v15 block5 block6;
+        (v12.i256, v13.i1) = umulo v9 v6;
+        br v13 block5 block6;
 
     block4:
-        mstore v6 v11 i256;
-        v22.i256 = ptr_to_int v4 i256;
-        v24.i256 = mload v22 i256;
-        v25.i256 = shl 3.i256 v24;
-        mstore v22 v25 i256;
-        v26.i256 = ptr_to_int v4 i256;
-        v27.i256 = mload v26 i256;
-        v28.i256 = shr 1.i256 v27;
-        mstore v26 v28 i256;
-        v29.i256 = ptr_to_int v4 i256;
-        v31.i256 = mload v29 i256;
-        v32.i256 = and v31 255.i256;
-        mstore v29 v32 i256;
-        v33.i256 = ptr_to_int v4 i256;
-        v34.i256 = mload v33 i256;
-        v35.i256 = or v34 1.i256;
-        mstore v33 v35 i256;
-        v36.i256 = ptr_to_int v4 i256;
-        v38.i256 = mload v36 i256;
-        v39.i256 = xor v38 2.i256;
-        mstore v36 v39 i256;
-        v40.i256 = mload v4 i256;
-        return v40;
+        mstore v4 v9 i256;
+        v20.i256 = ptr_to_int v2 i256;
+        v22.i256 = mload v20 i256;
+        v23.i256 = shl 3.i256 v22;
+        mstore v20 v23 i256;
+        v24.i256 = ptr_to_int v2 i256;
+        v25.i256 = mload v24 i256;
+        v26.i256 = shr 1.i256 v25;
+        mstore v24 v26 i256;
+        v27.i256 = ptr_to_int v2 i256;
+        v29.i256 = mload v27 i256;
+        v30.i256 = and v29 255.i256;
+        mstore v27 v30 i256;
+        v31.i256 = ptr_to_int v2 i256;
+        v32.i256 = mload v31 i256;
+        v33.i256 = or v32 1.i256;
+        mstore v31 v33 i256;
+        v34.i256 = ptr_to_int v2 i256;
+        v36.i256 = mload v34 i256;
+        v37.i256 = xor v36 2.i256;
+        mstore v34 v37 i256;
+        v38.i256 = mload v2 i256;
+        return v38;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -63,7 +57,7 @@ func private %aug_assign_bit_ops(v0.i256, v1.i256) -> i256 {
         evm_revert 0.i256 36.i256;
 
     block6:
-        v20.i256 = add v12 1.i256;
+        v18.i256 = add v10 1.i256;
         jump block2;
 }
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/bit_ops.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/bit_ops.snap
@@ -9,32 +9,20 @@ type @layout_0 = {i256, i256, i256, i256, i256};
 
 func private %bit_ops(v0.i256, v1.i256) -> @layout_0 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        v6.i256 = and v4 v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = mload v3 i256;
-        v9.i256 = or v7 v8;
-        v10.i256 = mload v2 i256;
-        v11.i256 = mload v3 i256;
-        v12.i256 = xor v10 v11;
-        v13.i256 = mload v2 i256;
-        v15.i256 = shl 8.i256 v13;
-        v16.i256 = mload v2 i256;
-        v18.i256 = shr 2.i256 v16;
-        v21.@layout_0 = insert_value undef.@layout_0 0.i256 v6;
-        v23.@layout_0 = insert_value v21 1.i256 v9;
-        v24.@layout_0 = insert_value v23 2.i256 v12;
-        v26.@layout_0 = insert_value v24 3.i256 v15;
-        v28.@layout_0 = insert_value v26 4.i256 v18;
-        return v28;
+        v4.i256 = and v0 v1;
+        v5.i256 = or v0 v1;
+        v6.i256 = xor v0 v1;
+        v8.i256 = shl 8.i256 v0;
+        v10.i256 = shr 2.i256 v0;
+        v13.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
+        v15.@layout_0 = insert_value v13 1.i256 v5;
+        v16.@layout_0 = insert_value v15 2.i256 v6;
+        v18.@layout_0 = insert_value v16 3.i256 v8;
+        v20.@layout_0 = insert_value v18 4.i256 v10;
+        return v20;
 }
 
 func private %main() -> i256 {
@@ -58,29 +46,23 @@ func private %main_root() {
 
 func private %pow_op(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
         jump block2;
 
     block2:
-        v8.i256 = phi (1.i256 block1) (v11 block6);
-        v9.i256 = phi (0.i256 block1) (v17 block6);
-        v10.i1 = eq v9 v5;
-        br v10 block4 block3;
+        v6.i256 = phi (1.i256 block1) (v9 block6);
+        v7.i256 = phi (0.i256 block1) (v15 block6);
+        v8.i1 = eq v7 v1;
+        br v8 block4 block3;
 
     block3:
-        (v11.i256, v12.i1) = umulo v8 v4;
-        br v12 block5 block6;
+        (v9.i256, v10.i1) = umulo v6 v0;
+        br v10 block5 block6;
 
     block4:
-        return v8;
+        return v6;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -88,7 +70,7 @@ func private %pow_op(v0.i256, v1.i256) -> i256 {
         evm_revert 0.i256 36.i256;
 
     block6:
-        v17.i256 = add v9 1.i256;
+        v15.i256 = add v7 1.i256;
         jump block2;
 }
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/bitnot.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/bitnot.snap
@@ -7,14 +7,11 @@ target = "evm-ethereum-osaka"
 
 func private %bit_not(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = not v2;
-        return v3;
+        v2.i256 = not v0;
+        return v2;
 }
 
 func private %main() -> i256 {

--- a/crates/codegen/tests/fixtures/sonatina_ir/borrow_storage_field_handle.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/borrow_storage_field_handle.snap
@@ -27,13 +27,10 @@ func private %borrow_storage_field_handle(v0.i256) -> i256 {
 
 func private %from_raw(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        return v2;
+        return v0;
 }
 
 func private %main() -> i256 {
@@ -57,14 +54,11 @@ func private %main_root() {
 
 func private %stor_ptr(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = call %from_raw v2;
-        return v3;
+        v2.i256 = call %from_raw v0;
+        return v2;
 }
 
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/by_ref_trait_provider_storage_bug.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/by_ref_trait_provider_storage_bug.snap
@@ -43,24 +43,21 @@ func private %__ByRefTraitProviderStorageBug_recv_0_0(v0.i256) -> i256 {
 
 func private %abi_field_size(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_83d5_0 v2;
+        v2.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_83d5_0 v0;
         br 0.i1 block2 block3;
 
     block2:
-        (v7.i256, v8.i1) = uaddo 32.i256 v3;
-        br v8 block5 block6;
+        (v6.i256, v7.i1) = uaddo 32.i256 v2;
+        br v7 block5 block6;
 
     block3:
         jump block4;
 
     block4:
-        return v3;
+        return v2;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -68,19 +65,16 @@ func private %abi_field_size(v0.i256) -> i256 {
         evm_revert 0.i256 36.i256;
 
     block6:
-        return v7;
+        return v6;
 }
 
 func private %abi_single_root_size(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = call %abi_field_size v2;
-        return v3;
+        v2.i256 = call %abi_field_size v0;
+        return v2;
 }
 
 func private %abort() {
@@ -94,16 +88,12 @@ func private %abort() {
 
 func inline(always) private %at(v0.i256) -> @layout_0 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = mload v1 i256;
-        v6.@layout_0 = insert_value undef.@layout_0 0.i256 v2;
-        v8.@layout_0 = insert_value v6 1.i256 v3;
-        return v8;
+        v4.@layout_0 = insert_value undef.@layout_0 0.i256 v0;
+        v6.@layout_0 = insert_value v4 1.i256 v0;
+        return v6;
 }
 
 func private %base(v0.objref<@layout_0>) -> i256 {
@@ -194,8 +184,6 @@ func private %contract_runtime_root_ByRefTraitProviderStorageBug() {
 
 func inline(always) private %decode_from(v0.@layout_1, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
@@ -204,16 +192,10 @@ func inline(always) private %decode_from(v0.@layout_1, v1.i256) {
 
 func inline(always) private %decode_from_prechecked_head(v0.@layout_1, v1.i256, v2.i256) {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v4 i256;
-        v7.i256 = mload v3 i256;
-        call %decode_from v0 v7;
+        call %decode_from v0 v1;
         return;
 }
 
@@ -221,14 +203,12 @@ func inline(always) private %decode_runtime_args(v0.objref<@layout_3>) {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v4.@layout_1 = call %input;
-        v6.i256 = call %len v4;
-        mstore v1 v6 i256;
-        mstore v2 4.i256 i256;
+        v3.@layout_1 = call %input;
+        v5.i256 = call %len v3;
+        mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
 
     block2:
@@ -239,16 +219,14 @@ func inline(always) private %decode_runtime_args(v0.objref<@layout_3>) {
         jump block4;
 
     block4:
-        v11.i256 = mload v1 i256;
-        call %decode_from_prechecked_head v4 4.i256 v11;
+        call %decode_from_prechecked_head v3 4.i256 v5;
         return;
 
     block5:
-        v13.i256 = mload v1 i256;
-        mstore v3 v13 i256;
-        v15.i256 = mload v3 i256;
-        v16.i1 = gt 4.i256 v15;
-        br v16 block2 block3;
+        mstore v2 v5 i256;
+        v14.i256 = mload v2 i256;
+        v15.i1 = gt 4.i256 v14;
+        br v15 block2 block3;
 }
 
 func private %encode(v0.i256, v1.objref<@layout_0>) {
@@ -344,26 +322,20 @@ func private %encode_single_root_alloc(v0.i256) -> @layout_4 {
 
 func private %encode_to_ptr(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        call %store_word v3 v0;
+        call %store_word v1 v0;
         return;
 }
 
 func private %encoder_new(v0.i256) -> @layout_0 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.@layout_0 = call %impl_SolEncoder__new v2;
-        return v3;
+        v2.@layout_0 = call %impl_SolEncoder__new v0;
+        return v2;
 }
 
 func private %input() -> @layout_1 {
@@ -378,31 +350,27 @@ func private %input() -> @layout_1 {
 func inline(always) private %len(v0.@layout_1) -> i256 {
     block0:
         v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.i256 = extract_value v0 0.i256;
-        v7.i256 = mload v1 i256;
-        mstore v2 v7 i256;
-        v8.i256 = mload v2 i256;
-        v9.i1 = gt v6 v8;
-        br v9 block2 block3;
+        v2.i256 = evm_calldata_size;
+        v5.i256 = extract_value v0 0.i256;
+        mstore v1 v2 i256;
+        v6.i256 = mload v1 i256;
+        v7.i1 = gt v5 v6;
+        br v7 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v11.i256 = extract_value v0 0.i256;
-        v12.i256 = mload v1 i256;
-        (v13.i256, v14.i1) = usubo v12 v11;
-        br v14 block5 block6;
+        v9.i256 = extract_value v0 0.i256;
+        (v11.i256, v12.i1) = usubo v2 v9;
+        br v12 block5 block6;
 
     block4:
-        v19.i256 = phi (0.i256 block2) (v13 block6);
-        return v19;
+        v17.i256 = phi (0.i256 block2) (v11 block6);
+        return v17;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -427,34 +395,28 @@ func inline(always) private %impl_CallData__new() -> @layout_1 {
 
 func private %impl_SolEncoder__new(v0.i256) -> @layout_0 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v4.i1 = eq v2 0.i256;
-        br v4 block2 block3;
+        v3.i1 = eq v0 0.i256;
+        br v3 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v5.i256 = mload v1 i256;
-        v6.*i8 = evm_malloc v5;
-        v7.i256 = ptr_to_int v6 i256;
+        v5.*i8 = evm_malloc v0;
+        v6.i256 = ptr_to_int v5 i256;
         jump block4;
 
     block4:
-        v8.i256 = phi (0.i256 block2) (v7 block3);
-        v9.@layout_0 = call %at v8;
-        return v9;
+        v7.i256 = phi (0.i256 block2) (v6 block3);
+        v8.@layout_0 = call %at v7;
+        return v8;
 }
 
 func private %core__lib__abi__trait_AbiSize__payload_size__ge513_83d5(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
@@ -463,8 +425,6 @@ func private %core__lib__abi__trait_AbiSize__payload_size__ge513_83d5(v0.i256) -
 
 func private %core__lib__abi__trait_AbiSize__payload_size__ge513_83d5_0(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
@@ -483,56 +443,38 @@ func private %pos(v0.objref<@layout_0>) -> i256 {
 
 func private %revert(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        evm_revert v4 v5;
+        evm_revert v0 v1;
 }
 
 func private %set_base(v0.objref<@layout_0>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        obj.store v6 v3;
+        v5.objref<i256> = obj.proj v0 0.i256;
+        obj.store v5 v1;
         return;
 }
 
 func private %set_pos(v0.objref<@layout_0>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 1.i256;
-        obj.store v6 v3;
+        v5.objref<i256> = obj.proj v0 1.i256;
+        obj.store v5 v1;
         return;
 }
 
 func private %store_word(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        mstore v4 v5 i256;
+        mstore v0 v1 i256;
         return;
 }
 
@@ -567,35 +509,29 @@ func private %use_ctx(v0.i256) -> i256 {
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_7682(v0.objref<@layout_0>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 1.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        mstore v6 v7 i256;
-        v10.i256 = add v6 32.i256;
-        v11.objref<i256> = obj.proj v0 1.i256;
-        obj.store v11 v10;
+        v4.objref<i256> = obj.proj v0 1.i256;
+        v5.i256 = obj.load v4;
+        mstore v5 v1 i256;
+        v9.i256 = add v5 32.i256;
+        v10.objref<i256> = obj.proj v0 1.i256;
+        obj.store v10 v9;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_e918(v0.objref<@layout_0>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 1.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        mstore v6 v7 i256;
-        v10.i256 = add v6 32.i256;
-        v11.objref<i256> = obj.proj v0 1.i256;
-        obj.store v11 v10;
+        v4.objref<i256> = obj.proj v0 1.i256;
+        v5.i256 = obj.load v4;
+        mstore v5 v1 i256;
+        v9.i256 = add v5 32.i256;
+        v10.objref<i256> = obj.proj v0 1.i256;
+        obj.store v10 v9;
         return;
 }
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/cast_u8_usize_cmp.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/cast_u8_usize_cmp.snap
@@ -9,17 +9,12 @@ global private const [i8; 8] $const_region_0 = [1, 2, 3, 4, 5, 6, 7, 8];
 
 func private %cast_u8_usize_cmp(v0.constref<[i8; 8]>, v1.i256, v2.i256) -> i8 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v3 i256;
-        v8.i1 = lt v5 8.i256;
-        v9.i1 = is_zero v8;
-        br v9 block11 block12;
+        v6.i1 = lt v1 8.i256;
+        v7.i1 = is_zero v6;
+        br v7 block11 block12;
 
     block2:
         return 1.i8;
@@ -28,10 +23,9 @@ func private %cast_u8_usize_cmp(v0.constref<[i8; 8]>, v1.i256, v2.i256) -> i8 {
         jump block4;
 
     block4:
-        v17.i256 = mload v4 i256;
-        v19.i256 = zext v12 i256;
-        v20.i1 = eq v17 v19;
-        br v20 block5 block6;
+        v17.i256 = zext v10 i256;
+        v18.i1 = eq v2 v17;
+        br v18 block5 block6;
 
     block5:
         return 2.i8;
@@ -40,10 +34,9 @@ func private %cast_u8_usize_cmp(v0.constref<[i8; 8]>, v1.i256, v2.i256) -> i8 {
         jump block7;
 
     block7:
-        v22.i256 = mload v4 i256;
-        v24.i256 = zext v12 i256;
-        v25.i1 = gt v22 v24;
-        br v25 block8 block9;
+        v22.i256 = zext v10 i256;
+        v23.i1 = gt v2 v22;
+        br v23 block8 block9;
 
     block8:
         return 3.i8;
@@ -58,12 +51,11 @@ func private %cast_u8_usize_cmp(v0.constref<[i8; 8]>, v1.i256, v2.i256) -> i8 {
         evm_revert 0.i256 0.i256;
 
     block12:
-        v11.constref<i8> = const.index v0 v5;
-        v12.i8 = const.load v11;
-        v13.i256 = mload v4 i256;
-        v14.i256 = zext v12 i256;
-        v15.i1 = lt v13 v14;
-        br v15 block2 block3;
+        v9.constref<i8> = const.index v0 v1;
+        v10.i8 = const.load v9;
+        v12.i256 = zext v10 i256;
+        v13.i1 = lt v2 v12;
+        br v13 block2 block3;
 }
 
 func private %main() -> i8 {

--- a/crates/codegen/tests/fixtures/sonatina_ir/code_region.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/code_region.snap
@@ -18,32 +18,20 @@ func private %balance() {
 
 func private %calldatacopy(v0.i256, v1.i256, v2.i256) {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        mstore v3 v0 i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
         jump block1;
 
     block1:
-        v6.i256 = mload v3 i256;
-        v7.i256 = mload v4 i256;
-        v8.i256 = mload v5 i256;
-        evm_calldata_copy v6 v7 v8;
+        evm_calldata_copy v0 v1 v2;
         return;
 }
 
 func private %calldataload(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = evm_calldata_load v2;
-        return v3;
+        v2.i256 = evm_calldata_load v0;
+        return v2;
 }
 
 func private %child_init() {
@@ -72,60 +60,30 @@ func private %child_runtime() {
 
 func private %std__lib__evm__effects__impl_trait_Evm_0098__codecopy_7791(v0.i256, v1.i256, v2.i256) {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        mstore v3 v0 i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
         jump block1;
 
     block1:
-        v6.i256 = mload v3 i256;
-        v7.i256 = mload v4 i256;
-        v8.i256 = mload v5 i256;
-        evm_code_copy v6 v7 v8;
+        evm_code_copy v0 v1 v2;
         return;
 }
 
 func private %std__lib__evm__effects__impl_trait_Evm_0098__codecopy_7791_0(v0.i256, v1.i256, v2.i256) {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        mstore v3 v0 i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
         jump block1;
 
     block1:
-        v6.i256 = mload v3 i256;
-        v7.i256 = mload v4 i256;
-        v8.i256 = mload v5 i256;
-        evm_code_copy v6 v7 v8;
+        evm_code_copy v0 v1 v2;
         return;
 }
 
 func private %create2_raw(v0.i256, v1.i256, v2.i256, v3.i256) -> @layout_0 {
     block0:
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        v6.*i256 = alloca i256;
-        v7.*i256 = alloca i256;
-        mstore v4 v0 i256;
-        mstore v5 v1 i256;
-        mstore v6 v2 i256;
-        mstore v7 v3 i256;
         jump block1;
 
     block1:
-        v8.i256 = mload v4 i256;
-        v9.i256 = mload v5 i256;
-        v10.i256 = mload v6 i256;
-        v11.i256 = mload v7 i256;
-        v12.i256 = evm_create2 v8 v9 v10 v11;
-        v15.@layout_0 = insert_value undef.@layout_0 0.i256 v12;
-        return v15;
+        v8.i256 = evm_create2 v0 v1 v2 v3;
+        v11.@layout_0 = insert_value undef.@layout_0 0.i256 v8;
+        return v11;
 }
 
 func private %init() {
@@ -196,72 +154,42 @@ func private %read_selector() -> i256 {
 
 func private %std__lib__evm__effects__impl_trait_Evm_0098__return_data_2757(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        evm_return v4 v5;
+        evm_return v0 v1;
 }
 
 func private %std__lib__evm__effects__impl_trait_Evm_0098__return_data_5f25(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        evm_return v4 v5;
+        evm_return v0 v1;
 }
 
 func private %std__lib__evm__effects__impl_trait_Evm_0098__return_data_5f25_0(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        evm_return v4 v5;
+        evm_return v0 v1;
 }
 
 func private %std__lib__evm__effects__impl_trait_Evm_0098__return_data_5f25_1(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        evm_return v4 v5;
+        evm_return v0 v1;
 }
 
 func private %std__lib__evm__effects__impl_trait_Evm_0098__return_data_5f25_2(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        evm_return v4 v5;
+        evm_return v0 v1;
 }
 
 func private %runtime() {

--- a/crates/codegen/tests/fixtures/sonatina_ir/code_region_qualified.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/code_region_qualified.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/codegen/tests/sonatina_ir.rs
-assertion_line: 402
 expression: output
 input_file: crates/codegen/tests/fixtures/code_region_qualified.fe
 ---
@@ -8,19 +7,10 @@ target = "evm-ethereum-osaka"
 
 func private %codecopy(v0.i256, v1.i256, v2.i256) {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        mstore v3 v0 i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
         jump block1;
 
     block1:
-        v6.i256 = mload v3 i256;
-        v7.i256 = mload v4 i256;
-        v8.i256 = mload v5 i256;
-        evm_code_copy v6 v7 v8;
+        evm_code_copy v0 v1 v2;
         return;
 }
 
@@ -58,30 +48,18 @@ func private %manual_contract_runtime_root_Foo() {
 
 func private %std__lib__evm__effects__impl_trait_Evm_0098__return_data_cf61(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        evm_return v4 v5;
+        evm_return v0 v1;
 }
 
 func private %std__lib__evm__effects__impl_trait_Evm_0098__return_data_cf61_0(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        evm_return v4 v5;
+        evm_return v0 v1;
 }
 
 func private %runtime() {

--- a/crates/codegen/tests/fixtures/sonatina_ir/const_array.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/const_array.snap
@@ -27,36 +27,30 @@ func private %main_root() {
 
 func private %sum_two(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.constref<[i256; 3]> = const.ref $const_region_0;
-        v5.i256 = mload v2 i256;
-        v7.i1 = lt v5 3.i256;
-        v8.i1 = is_zero v7;
-        br v8 block2 block3;
+        v2.constref<[i256; 3]> = const.ref $const_region_0;
+        v5.i1 = lt v0 3.i256;
+        v6.i1 = is_zero v5;
+        br v6 block2 block3;
 
     block2:
         evm_revert 0.i256 0.i256;
 
     block3:
-        v10.constref<i256> = const.index v4 v5;
-        v11.i256 = const.load v10;
-        v12.constref<[i256; 3]> = const.ref $const_region_0;
-        v13.i256 = mload v3 i256;
-        v14.i1 = lt v13 3.i256;
-        v15.i1 = is_zero v14;
-        br v15 block2 block4;
+        v8.constref<i256> = const.index v2 v0;
+        v9.i256 = const.load v8;
+        v10.constref<[i256; 3]> = const.ref $const_region_0;
+        v12.i1 = lt v1 3.i256;
+        v13.i1 = is_zero v12;
+        br v13 block2 block4;
 
     block4:
-        v16.constref<i256> = const.index v12 v13;
-        v17.i256 = const.load v16;
-        (v19.i256, v20.i1) = uaddo v11 v17;
-        br v20 block5 block6;
+        v14.constref<i256> = const.index v10 v1;
+        v15.i256 = const.load v14;
+        (v17.i256, v18.i1) = uaddo v9 v15;
+        br v18 block5 block6;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -64,7 +58,7 @@ func private %sum_two(v0.i256, v1.i256) -> i256 {
         evm_revert 0.i256 36.i256;
 
     block6:
-        return v19;
+        return v17;
 }
 
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/const_array_branch.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/const_array_branch.snap
@@ -9,20 +9,17 @@ global private const [i256; 1] $const_region_0 = [1];
 
 func private %const_array_branch(v0.i1) -> i256 {
     block0:
-        v1.*i1 = alloca i1;
-        mstore v1 v0 i1;
         jump block1;
 
     block1:
-        v2.i1 = mload v1 i1;
-        br v2 block2 block3;
+        br v0 block2 block3;
 
     block2:
-        v3.constref<[i256; 1]> = const.ref $const_region_0;
+        v2.constref<[i256; 1]> = const.ref $const_region_0;
         jump block4;
 
     block3:
-        v6.constref<[i256; 1]> = const.ref $const_region_0;
+        v5.constref<[i256; 1]> = const.ref $const_region_0;
         jump block4;
 
     block4:

--- a/crates/codegen/tests/fixtures/sonatina_ir/const_array_loop.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/const_array_loop.snap
@@ -27,28 +27,23 @@ func private %main_root() {
 
 func private %sum_loop(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
         jump block2;
 
     block2:
-        v32.i256 = phi (0.i256 block1) (v25 block11);
-        v5.i256 = phi (0.i256 block1) (v30 block11);
-        v6.i256 = mload v1 i256;
-        v7.i1 = lt v5 v6;
-        br v7 block3 block4;
+        v28.i256 = phi (0.i256 block1) (v19 block11);
+        v2.i256 = phi (0.i256 block1) (v24 block11);
+        v4.i1 = lt v2 v0;
+        br v4 block3 block4;
 
     block3:
-        v10.i1 = eq 3.i256 0.i256;
-        br v10 block5 block6;
+        v7.i1 = eq 3.i256 0.i256;
+        br v7 block5 block6;
 
     block4:
-        return v32;
+        return v28;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -56,20 +51,20 @@ func private %sum_loop(v0.i256) -> i256 {
         evm_revert 0.i256 36.i256;
 
     block6:
-        v15.i256 = evm_umod v5 3.i256;
-        v16.constref<[i256; 3]> = const.ref $const_region_0;
-        v17.i1 = lt v15 3.i256;
-        v18.i1 = is_zero v17;
-        br v18 block7 block8;
+        v12.i256 = evm_umod v2 3.i256;
+        v13.constref<[i256; 3]> = const.ref $const_region_0;
+        v14.i1 = lt v12 3.i256;
+        v15.i1 = is_zero v14;
+        br v15 block7 block8;
 
     block7:
         evm_revert 0.i256 0.i256;
 
     block8:
-        v19.constref<i256> = const.index v16 v15;
-        v20.i256 = const.load v19;
-        (v22.i256, v23.i1) = uaddo v32 v20;
-        br v23 block9 block10;
+        v16.constref<i256> = const.index v13 v12;
+        v17.i256 = const.load v16;
+        (v19.i256, v20.i1) = uaddo v28 v17;
+        br v20 block9 block10;
 
     block9:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -77,14 +72,10 @@ func private %sum_loop(v0.i256) -> i256 {
         evm_revert 0.i256 36.i256;
 
     block10:
-        mstore v2 v22 i256;
-        v25.i256 = mload v2 i256;
-        (v28.i256, v29.i1) = uaddo v5 1.i256;
-        br v29 block9 block11;
+        (v24.i256, v25.i1) = uaddo v2 1.i256;
+        br v25 block9 block11;
 
     block11:
-        mstore v3 v28 i256;
-        v30.i256 = mload v3 i256;
         jump block2;
 }
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/create_contract.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/create_contract.snap
@@ -21,18 +21,12 @@ global private const @layout_6 $const_region_0 = {0};
 
 func private %__Child_init(v0.i256, v1.i256, v2.i256) {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v0 i256;
-        mstore v4 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v3 i256;
-        evm_sstore v2 v5;
-        v7.i256 = mload v4 i256;
-        v9.i256 = add v2 1.i256;
-        evm_sstore v9 v7;
+        evm_sstore v2 v0;
+        v7.i256 = add v2 1.i256;
+        evm_sstore v7 v1;
         return;
 }
 
@@ -123,30 +117,22 @@ func private %std__lib__evm__effects__impl_trait_Evm_c913__abort_9c27() {
 
 func inline(always) private %std__lib__abi__sol__impl_SolEncoder_ce34__at_4eb0(v0.i256) -> @layout_2 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = mload v1 i256;
-        v6.@layout_2 = insert_value undef.@layout_2 0.i256 v2;
-        v8.@layout_2 = insert_value v6 1.i256 v3;
-        return v8;
+        v4.@layout_2 = insert_value undef.@layout_2 0.i256 v0;
+        v6.@layout_2 = insert_value v4 1.i256 v0;
+        return v6;
 }
 
 func inline(always) private %std__lib__abi__sol__impl_SolEncoder_ce34__at_9565(v0.i256) -> @layout_2 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = mload v1 i256;
-        v6.@layout_2 = insert_value undef.@layout_2 0.i256 v2;
-        v8.@layout_2 = insert_value v6 1.i256 v3;
-        return v8;
+        v4.@layout_2 = insert_value undef.@layout_2 0.i256 v0;
+        v6.@layout_2 = insert_value v4 1.i256 v0;
+        return v6;
 }
 
 func private %base__g463e(v0.objref<@layout_5>) -> i256 {
@@ -191,19 +177,11 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_5cdf(v0.objre
 
 func inline(always) private %core__lib__abi__checked_frame_end__gf13e_056e(v0.i256, v1.i256, v2.i256) -> i256 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        mstore v3 v0 i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
         jump block1;
 
     block1:
-        v6.i256 = mload v3 i256;
-        v7.i256 = mload v4 i256;
-        (v8.i256, v9.i1) = uaddo v6 v7;
-        br v9 block6 block7;
+        (v5.i256, v6.i1) = uaddo v0 v1;
+        br v6 block6 block7;
 
     block2:
         call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_7064;
@@ -213,12 +191,11 @@ func inline(always) private %core__lib__abi__checked_frame_end__gf13e_056e(v0.i2
         jump block4;
 
     block4:
-        return v8;
+        return v5;
 
     block5:
-        v19.i256 = mload v5 i256;
-        v20.i1 = gt v8 v19;
-        br v20 block2 block3;
+        v17.i1 = gt v5 v2;
+        br v17 block2 block3;
 
     block6:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -226,26 +203,17 @@ func inline(always) private %core__lib__abi__checked_frame_end__gf13e_056e(v0.i2
         evm_revert 0.i256 36.i256;
 
     block7:
-        v15.i256 = mload v3 i256;
-        v16.i1 = lt v8 v15;
-        br v16 block2 block5;
+        v13.i1 = lt v5 v0;
+        br v13 block2 block5;
 }
 
 func inline(always) private %core__lib__abi__checked_frame_end__gf13e_352b(v0.i256, v1.i256, v2.i256) -> i256 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        mstore v3 v0 i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
         jump block1;
 
     block1:
-        v6.i256 = mload v3 i256;
-        v7.i256 = mload v4 i256;
-        (v8.i256, v9.i1) = uaddo v6 v7;
-        br v9 block6 block7;
+        (v5.i256, v6.i1) = uaddo v0 v1;
+        br v6 block6 block7;
 
     block2:
         call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_e3bb;
@@ -255,12 +223,11 @@ func inline(always) private %core__lib__abi__checked_frame_end__gf13e_352b(v0.i2
         jump block4;
 
     block4:
-        return v8;
+        return v5;
 
     block5:
-        v19.i256 = mload v5 i256;
-        v20.i1 = gt v8 v19;
-        br v20 block2 block3;
+        v17.i1 = gt v5 v2;
+        br v17 block2 block3;
 
     block6:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -268,24 +235,17 @@ func inline(always) private %core__lib__abi__checked_frame_end__gf13e_352b(v0.i2
         evm_revert 0.i256 36.i256;
 
     block7:
-        v15.i256 = mload v3 i256;
-        v16.i1 = lt v8 v15;
-        br v16 block2 block5;
+        v13.i1 = lt v5 v0;
+        br v13 block2 block5;
 }
 
 func inline(always) private %core__lib__abi__checked_tail__gf13e_4046(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        (v6.i256, v7.i1) = uaddo v4 v5;
-        br v7 block5 block6;
+        (v4.i256, v5.i1) = uaddo v0 v1;
+        br v5 block5 block6;
 
     block2:
         call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_43bf;
@@ -295,7 +255,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_4046(v0.i256, v
         jump block4;
 
     block4:
-        return v6;
+        return v4;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -303,24 +263,17 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_4046(v0.i256, v
         evm_revert 0.i256 36.i256;
 
     block6:
-        v13.i256 = mload v2 i256;
-        v14.i1 = lt v6 v13;
-        br v14 block2 block3;
+        v12.i1 = lt v4 v0;
+        br v12 block2 block3;
 }
 
 func inline(always) private %core__lib__abi__checked_tail__gf13e_4919(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        (v6.i256, v7.i1) = uaddo v4 v5;
-        br v7 block5 block6;
+        (v4.i256, v5.i1) = uaddo v0 v1;
+        br v5 block5 block6;
 
     block2:
         call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_8b22;
@@ -330,7 +283,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_4919(v0.i256, v
         jump block4;
 
     block4:
-        return v6;
+        return v4;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -338,9 +291,8 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_4919(v0.i256, v
         evm_revert 0.i256 36.i256;
 
     block6:
-        v13.i256 = mload v2 i256;
-        v14.i1 = lt v6 v13;
-        br v14 block2 block3;
+        v12.i1 = lt v4 v0;
+        br v12 block2 block3;
 }
 
 func inline(always) private %contract_init_abi_Child() {
@@ -550,29 +502,21 @@ func private %contract_runtime_root_Factory() {
 func private %copy_words(v0.i256, v1.i256, v2.i256) {
     block0:
         v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        v6.*i256 = alloca i256;
-        mstore v3 v0 i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
         jump block1;
 
     block1:
-        mstore v6 0.i256 i256;
+        mstore v3 0.i256 i256;
         jump block2;
 
     block2:
-        v8.i256 = mload v6 i256;
-        v9.i256 = mload v5 i256;
-        v10.i1 = lt v8 v9;
-        br v10 block3 block4;
+        v5.i256 = mload v3 i256;
+        v7.i1 = lt v5 v2;
+        br v7 block3 block4;
 
     block3:
-        v11.i256 = mload v3 i256;
-        v12.i256 = mload v6 i256;
-        (v13.i256, v14.i1) = uaddo v11 v12;
-        br v14 block5 block6;
+        v9.i256 = mload v3 i256;
+        (v10.i256, v11.i1) = uaddo v0 v9;
+        br v11 block5 block6;
 
     block4:
         return;
@@ -583,28 +527,94 @@ func private %copy_words(v0.i256, v1.i256, v2.i256) {
         evm_revert 0.i256 36.i256;
 
     block6:
-        v19.i256 = mload v4 i256;
-        v20.i256 = mload v6 i256;
-        (v21.i256, v22.i1) = uaddo v19 v20;
-        br v22 block5 block7;
+        v17.i256 = mload v3 i256;
+        (v18.i256, v19.i1) = uaddo v1 v17;
+        br v19 block5 block7;
 
     block7:
-        v23.i256 = mload v21 i256;
-        mstore v13 v23 i256;
-        v26.i256 = ptr_to_int v6 i256;
-        v28.i256 = mload v26 i256;
-        (v29.i256, v30.i1) = uaddo v28 32.i256;
-        br v30 block5 block8;
+        v20.i256 = mload v18 i256;
+        mstore v10 v20 i256;
+        v23.i256 = ptr_to_int v3 i256;
+        v25.i256 = mload v23 i256;
+        (v26.i256, v27.i1) = uaddo v25 32.i256;
+        br v27 block5 block8;
 
     block8:
-        mstore v26 v29 i256;
+        mstore v23 v26 i256;
         jump block2;
 }
 
 func private %create(v0.i256, v1.@layout_1) -> @layout_0 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v0 i256;
+        jump block1;
+
+    block1:
+        v2.i256 = sym_size &Child_init;
+        v3.i256 = sym_addr &Child_init;
+        br 1.i1 block5 block3;
+
+    block2:
+        v7.*i8 = evm_malloc v2;
+        v8.i256 = ptr_to_int v7 i256;
+        evm_code_copy v8 v3 v2;
+        v12.@layout_0 = call %create_raw v0 v8 v2;
+        jump block4;
+
+    block3:
+        v14.@layout_1 = call %encode_abi_payload v1;
+        v16.i256 = extract_value v14 1.i256;
+        (v18.i256, v19.i1) = uaddo v2 v16;
+        br v19 block9 block10;
+
+    block4:
+        v43.@layout_0 = phi (v12 block2) (v42 block12);
+        v44.i256 = extract_value v43 0.i256;
+        v45.i1 = eq v44 0.i256;
+        br v45 block6 block7;
+
+    block5:
+        br 0.i1 block2 block3;
+
+    block6:
+        v47.i256 = evm_return_data_size;
+        v48.*i8 = evm_malloc v47;
+        v49.i256 = ptr_to_int v48 i256;
+        evm_return_data_copy v49 0.i256 v47;
+        evm_revert v49 v47;
+
+    block7:
+        jump block8;
+
+    block8:
+        return v43;
+
+    block9:
+        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        mstore 4.i256 17.i256 i256;
+        evm_revert 0.i256 36.i256;
+
+    block10:
+        v25.*i8 = evm_malloc v18;
+        v26.i256 = ptr_to_int v25 i256;
+        evm_code_copy v26 v3 v2;
+        (v30.i256, v31.i1) = uaddo v26 v2;
+        br v31 block9 block11;
+
+    block11:
+        v33.i256 = extract_value v14 0.i256;
+        v34.i256 = extract_value v14 1.i256;
+        call %copy_words v30 v33 v34;
+        v36.i256 = extract_value v14 1.i256;
+        (v38.i256, v39.i1) = uaddo v2 v36;
+        br v39 block9 block12;
+
+    block12:
+        v42.@layout_0 = call %create_raw v0 v26 v38;
+        jump block4;
+}
+
+func private %create2(v0.i256, v1.@layout_1, v2.i256) -> @layout_0 {
+    block0:
         jump block1;
 
     block1:
@@ -616,37 +626,36 @@ func private %create(v0.i256, v1.@layout_1) -> @layout_0 {
         v8.*i8 = evm_malloc v3;
         v9.i256 = ptr_to_int v8 i256;
         evm_code_copy v9 v4 v3;
-        v12.i256 = mload v2 i256;
-        v13.@layout_0 = call %create_raw v12 v9 v3;
+        v14.@layout_0 = call %create2_raw v0 v9 v3 v2;
         jump block4;
 
     block3:
-        v15.@layout_1 = call %encode_abi_payload v1;
-        v17.i256 = extract_value v15 1.i256;
-        (v19.i256, v20.i1) = uaddo v3 v17;
-        br v20 block9 block10;
+        v16.@layout_1 = call %encode_abi_payload v1;
+        v18.i256 = extract_value v16 1.i256;
+        (v20.i256, v21.i1) = uaddo v3 v18;
+        br v21 block9 block10;
 
     block4:
-        v44.@layout_0 = phi (v13 block2) (v43 block12);
-        v45.i256 = extract_value v44 0.i256;
-        v46.i1 = eq v45 0.i256;
-        br v46 block6 block7;
+        v46.@layout_0 = phi (v14 block2) (v45 block12);
+        v47.i256 = extract_value v46 0.i256;
+        v48.i1 = eq v47 0.i256;
+        br v48 block6 block7;
 
     block5:
         br 0.i1 block2 block3;
 
     block6:
-        v48.i256 = evm_return_data_size;
-        v49.*i8 = evm_malloc v48;
-        v50.i256 = ptr_to_int v49 i256;
-        evm_return_data_copy v50 0.i256 v48;
-        evm_revert v50 v48;
+        v50.i256 = evm_return_data_size;
+        v51.*i8 = evm_malloc v50;
+        v52.i256 = ptr_to_int v51 i256;
+        evm_return_data_copy v52 0.i256 v50;
+        evm_revert v52 v50;
 
     block7:
         jump block8;
 
     block8:
-        return v44;
+        return v46;
 
     block9:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -654,142 +663,43 @@ func private %create(v0.i256, v1.@layout_1) -> @layout_0 {
         evm_revert 0.i256 36.i256;
 
     block10:
-        v26.*i8 = evm_malloc v19;
-        v27.i256 = ptr_to_int v26 i256;
-        evm_code_copy v27 v4 v3;
-        (v31.i256, v32.i1) = uaddo v27 v3;
-        br v32 block9 block11;
+        v27.*i8 = evm_malloc v20;
+        v28.i256 = ptr_to_int v27 i256;
+        evm_code_copy v28 v4 v3;
+        (v32.i256, v33.i1) = uaddo v28 v3;
+        br v33 block9 block11;
 
     block11:
-        v34.i256 = extract_value v15 0.i256;
-        v35.i256 = extract_value v15 1.i256;
-        call %copy_words v31 v34 v35;
-        v37.i256 = extract_value v15 1.i256;
-        (v39.i256, v40.i1) = uaddo v3 v37;
-        br v40 block9 block12;
+        v35.i256 = extract_value v16 0.i256;
+        v36.i256 = extract_value v16 1.i256;
+        call %copy_words v32 v35 v36;
+        v38.i256 = extract_value v16 1.i256;
+        (v40.i256, v41.i1) = uaddo v3 v38;
+        br v41 block9 block12;
 
     block12:
-        v41.i256 = mload v2 i256;
-        v43.@layout_0 = call %create_raw v41 v27 v39;
-        jump block4;
-}
-
-func private %create2(v0.i256, v1.@layout_1, v2.i256) -> @layout_0 {
-    block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v0 i256;
-        mstore v4 v2 i256;
-        jump block1;
-
-    block1:
-        v5.i256 = sym_size &Child_init;
-        v6.i256 = sym_addr &Child_init;
-        br 1.i1 block5 block3;
-
-    block2:
-        v10.*i8 = evm_malloc v5;
-        v11.i256 = ptr_to_int v10 i256;
-        evm_code_copy v11 v6 v5;
-        v14.i256 = mload v3 i256;
-        v15.i256 = mload v4 i256;
-        v16.@layout_0 = call %create2_raw v14 v11 v5 v15;
-        jump block4;
-
-    block3:
-        v18.@layout_1 = call %encode_abi_payload v1;
-        v20.i256 = extract_value v18 1.i256;
-        (v22.i256, v23.i1) = uaddo v5 v20;
-        br v23 block9 block10;
-
-    block4:
-        v48.@layout_0 = phi (v16 block2) (v47 block12);
-        v49.i256 = extract_value v48 0.i256;
-        v50.i1 = eq v49 0.i256;
-        br v50 block6 block7;
-
-    block5:
-        br 0.i1 block2 block3;
-
-    block6:
-        v52.i256 = evm_return_data_size;
-        v53.*i8 = evm_malloc v52;
-        v54.i256 = ptr_to_int v53 i256;
-        evm_return_data_copy v54 0.i256 v52;
-        evm_revert v54 v52;
-
-    block7:
-        jump block8;
-
-    block8:
-        return v48;
-
-    block9:
-        mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        mstore 4.i256 17.i256 i256;
-        evm_revert 0.i256 36.i256;
-
-    block10:
-        v29.*i8 = evm_malloc v22;
-        v30.i256 = ptr_to_int v29 i256;
-        evm_code_copy v30 v6 v5;
-        (v34.i256, v35.i1) = uaddo v30 v5;
-        br v35 block9 block11;
-
-    block11:
-        v37.i256 = extract_value v18 0.i256;
-        v38.i256 = extract_value v18 1.i256;
-        call %copy_words v34 v37 v38;
-        v40.i256 = extract_value v18 1.i256;
-        (v42.i256, v43.i1) = uaddo v5 v40;
-        br v43 block9 block12;
-
-    block12:
-        v44.i256 = mload v3 i256;
-        v45.i256 = mload v4 i256;
-        v47.@layout_0 = call %create2_raw v44 v30 v42 v45;
+        v45.@layout_0 = call %create2_raw v0 v28 v40 v2;
         jump block4;
 }
 
 func private %create2_raw(v0.i256, v1.i256, v2.i256, v3.i256) -> @layout_0 {
     block0:
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        v6.*i256 = alloca i256;
-        v7.*i256 = alloca i256;
-        mstore v4 v0 i256;
-        mstore v5 v1 i256;
-        mstore v6 v2 i256;
-        mstore v7 v3 i256;
         jump block1;
 
     block1:
-        v8.i256 = mload v4 i256;
-        v9.i256 = mload v5 i256;
-        v10.i256 = mload v6 i256;
-        v11.i256 = mload v7 i256;
-        v12.i256 = evm_create2 v8 v9 v10 v11;
-        v15.@layout_0 = insert_value undef.@layout_0 0.i256 v12;
-        return v15;
+        v8.i256 = evm_create2 v0 v1 v2 v3;
+        v11.@layout_0 = insert_value undef.@layout_0 0.i256 v8;
+        return v11;
 }
 
 func private %create_raw(v0.i256, v1.i256, v2.i256) -> @layout_0 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        mstore v3 v0 i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
         jump block1;
 
     block1:
-        v6.i256 = mload v3 i256;
-        v7.i256 = mload v4 i256;
-        v8.i256 = mload v5 i256;
-        v9.i256 = evm_create v6 v7 v8;
-        v12.@layout_0 = insert_value undef.@layout_0 0.i256 v9;
-        return v12;
+        v6.i256 = evm_create v0 v1 v2;
+        v9.@layout_0 = insert_value undef.@layout_0 0.i256 v6;
+        return v9;
 }
 
 func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_43bf() {
@@ -862,29 +772,22 @@ func inline(always) private %decode_field(v0.objref<@layout_5>) -> i256 {
 
 func inline(always) private %core__lib__abi__decode_field_from__g5385_0636(v0.@layout_6, v1.i256, v2.i256) -> i256 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v7.i256 = mload v4 i256;
-        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_32d2 v0 v7;
-        v9.i256 = mload v3 i256;
-        (v10.i256, v11.i1) = uaddo v9 v8;
-        br v11 block5 block6;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_32d2 v0 v2;
+        (v8.i256, v9.i1) = uaddo v1 v6;
+        br v9 block5 block6;
 
     block3:
         jump block4;
 
     block4:
-        v20.i256 = mload v4 i256;
-        v21.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_3180_0 v0 v20;
-        return v21;
+        v19.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_3180_0 v0 v2;
+        return v19;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -892,35 +795,28 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_0636(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v18.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_3180_0 v0 v10;
-        return v18;
+        v16.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_3180_0 v0 v8;
+        return v16;
 }
 
 func inline(always) private %core__lib__abi__decode_field_from__g5385_5caf(v0.@layout_6, v1.i256, v2.i256) -> i256 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v7.i256 = mload v4 i256;
-        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3368 v0 v7;
-        v9.i256 = mload v3 i256;
-        (v10.i256, v11.i1) = uaddo v9 v8;
-        br v11 block5 block6;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3368 v0 v2;
+        (v8.i256, v9.i1) = uaddo v1 v6;
+        br v9 block5 block6;
 
     block3:
         jump block4;
 
     block4:
-        v20.i256 = mload v4 i256;
-        v21.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8640_0 v0 v20;
-        return v21;
+        v19.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8640_0 v0 v2;
+        return v19;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -928,111 +824,79 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_5caf(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v18.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8640_0 v0 v10;
-        return v18;
+        v16.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8640_0 v0 v8;
+        return v16;
 }
 
 func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_0f32(v0.@layout_6, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        v6.*i256 = alloca i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
-        mstore v6 v3 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = mload v5 i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3368 v0 v9;
-        v11.i256 = mload v4 i256;
-        v12.i256 = call %core__lib__abi__checked_tail__gf13e_4046 v11 v10;
-        v13.i256 = mload v6 i256;
-        v14.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_7fc6 v0 v12 v13;
-        return v14;
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3368 v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_4046 v1 v7;
+        v11.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_7fc6 v0 v9 v3;
+        return v11;
 
     block3:
         jump block4;
 
     block4:
-        v16.i256 = mload v5 i256;
-        v17.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8640_0 v0 v16;
-        return v17;
+        v14.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8640_0 v0 v2;
+        return v14;
 }
 
 func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_f107(v0.@layout_6, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        v6.*i256 = alloca i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
-        mstore v6 v3 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = mload v5 i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_32d2 v0 v9;
-        v11.i256 = mload v4 i256;
-        v12.i256 = call %core__lib__abi__checked_tail__gf13e_4919 v11 v10;
-        v13.i256 = mload v6 i256;
-        v14.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_7780 v0 v12 v13;
-        return v14;
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_32d2 v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_4919 v1 v7;
+        v11.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_7780 v0 v9 v3;
+        return v11;
 
     block3:
         jump block4;
 
     block4:
-        v16.i256 = mload v5 i256;
-        v17.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_3180_0 v0 v16;
-        return v17;
+        v14.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_3180_0 v0 v2;
+        return v14;
 }
 
 func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_3180(v0.@layout_6, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_8c36 v0 v4;
-        return v5;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_8c36 v0 v1;
+        return v4;
 }
 
 func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_3180_0(v0.@layout_6, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_8c36_0 v0 v4;
-        return v5;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_8c36_0 v0 v1;
+        return v4;
 }
 
 func inline(always) private %impl_trait_Deploy2__decode_from__gd20d(v0.@layout_6, v1.i256) -> @layout_7 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_6f75 v0;
-        v5.i256 = mload v2 i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = call %core__lib__abi__decode_msg_field_from__g5385_f1db v0 v5 v6 v4;
-        v8.i256 = mload v2 i256;
-        v9.i256 = mload v2 i256;
-        (v11.i256, v12.i1) = uaddo v9 32.i256;
-        br v12 block2 block3;
+        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_6f75 v0;
+        v5.i256 = call %core__lib__abi__decode_msg_field_from__g5385_f1db v0 v1 v1 v3;
+        (v7.i256, v8.i1) = uaddo v1 32.i256;
+        br v8 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -1040,97 +904,69 @@ func inline(always) private %impl_trait_Deploy2__decode_from__gd20d(v0.@layout_6
         evm_revert 0.i256 36.i256;
 
     block3:
-        v21.i256 = call %core__lib__abi__decode_msg_field_from__g5385_f1db v0 v8 v11 v4;
-        v23.i256 = mload v2 i256;
-        v24.i256 = mload v2 i256;
-        (v25.i256, v26.i1) = uaddo v24 32.i256;
-        br v26 block2 block4;
+        v17.i256 = call %core__lib__abi__decode_msg_field_from__g5385_f1db v0 v1 v7 v3;
+        (v20.i256, v21.i1) = uaddo v1 32.i256;
+        br v21 block2 block4;
 
     block4:
-        (v27.i256, v28.i1) = uaddo v25 32.i256;
-        br v28 block2 block5;
+        (v22.i256, v23.i1) = uaddo v20 32.i256;
+        br v23 block2 block5;
 
     block5:
-        v32.i256 = call %core__lib__abi__decode_msg_field_from__g5385_f1db v0 v23 v27 v4;
-        v35.@layout_7 = insert_value undef.@layout_7 0.i256 v7;
-        v38.@layout_7 = insert_value v35 1.i256 v21;
-        v40.@layout_7 = insert_value v38 2.i256 v32;
-        return v40;
+        v27.i256 = call %core__lib__abi__decode_msg_field_from__g5385_f1db v0 v1 v22 v3;
+        v30.@layout_7 = insert_value undef.@layout_7 0.i256 v5;
+        v33.@layout_7 = insert_value v30 1.i256 v17;
+        v35.@layout_7 = insert_value v33 2.i256 v27;
+        return v35;
 }
 
 func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8640(v0.@layout_6, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b2da v0 v4;
-        return v5;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b2da v0 v1;
+        return v4;
 }
 
 func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8640_0(v0.@layout_6, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b2da_0 v0 v4;
-        return v5;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b2da_0 v0 v1;
+        return v4;
 }
 
 func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_7780(v0.@layout_6, v1.i256, v2.i256) -> i256 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v3 i256;
-        v7.i256 = mload v4 i256;
-        v8.i256 = call %core__lib__abi__checked_frame_end__gf13e_352b v5 32.i256 v7;
-        v10.i256 = mload v3 i256;
-        v11.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_3180 v0 v10;
-        return v11;
+        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_352b v1 32.i256 v2;
+        v8.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_3180 v0 v1;
+        return v8;
 }
 
 func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_7fc6(v0.@layout_6, v1.i256, v2.i256) -> i256 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v3 i256;
-        v7.i256 = mload v4 i256;
-        v8.i256 = call %core__lib__abi__checked_frame_end__gf13e_056e v5 32.i256 v7;
-        v10.i256 = mload v3 i256;
-        v11.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8640 v0 v10;
-        return v11;
+        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_056e v1 32.i256 v2;
+        v8.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8640 v0 v1;
+        return v8;
 }
 
 func inline(always) private %impl_trait_Deploy__decode_from__gd20d(v0.@layout_6, v1.i256) -> @layout_8 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_2577 v0;
-        v5.i256 = mload v2 i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = call %core__lib__abi__decode_msg_field_from__g5385_790c v0 v5 v6 v4;
-        v8.i256 = mload v2 i256;
-        v9.i256 = mload v2 i256;
-        (v11.i256, v12.i1) = uaddo v9 32.i256;
-        br v12 block2 block3;
+        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_2577 v0;
+        v5.i256 = call %core__lib__abi__decode_msg_field_from__g5385_790c v0 v1 v1 v3;
+        (v7.i256, v8.i1) = uaddo v1 32.i256;
+        br v8 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -1138,102 +974,66 @@ func inline(always) private %impl_trait_Deploy__decode_from__gd20d(v0.@layout_6,
         evm_revert 0.i256 36.i256;
 
     block3:
-        v21.i256 = call %core__lib__abi__decode_msg_field_from__g5385_790c v0 v8 v11 v4;
-        v24.@layout_8 = insert_value undef.@layout_8 0.i256 v7;
-        v26.@layout_8 = insert_value v24 1.i256 v21;
-        return v26;
+        v17.i256 = call %core__lib__abi__decode_msg_field_from__g5385_790c v0 v1 v7 v3;
+        v20.@layout_8 = insert_value undef.@layout_8 0.i256 v5;
+        v22.@layout_8 = insert_value v20 1.i256 v17;
+        return v22;
 }
 
 func inline(always) private %decode_from_prechecked_head__g4e6c(v0.@layout_6, v1.i256, v2.i256) -> @layout_7 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v4 i256;
-        v7.i256 = mload v3 i256;
-        v8.@layout_7 = call %impl_trait_Deploy2__decode_from__gd20d v0 v7;
-        return v8;
+        v6.@layout_7 = call %impl_trait_Deploy2__decode_from__gd20d v0 v1;
+        return v6;
 }
 
 func inline(always) private %decode_from_prechecked_head__gbecb(v0.@layout_6, v1.i256, v2.i256) -> @layout_8 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v4 i256;
-        v7.i256 = mload v3 i256;
-        v8.@layout_8 = call %impl_trait_Deploy__decode_from__gd20d v0 v7;
-        return v8;
+        v6.@layout_8 = call %impl_trait_Deploy__decode_from__gd20d v0 v1;
+        return v6;
 }
 
 func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_790c(v0.@layout_6, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        v6.*i256 = alloca i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
-        mstore v6 v3 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = mload v4 i256;
-        v10.i256 = mload v5 i256;
-        v11.i256 = mload v6 i256;
-        v12.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_f107 v0 v9 v10 v11;
-        return v12;
+        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_f107 v0 v1 v2 v3;
+        return v9;
 
     block3:
         jump block4;
 
     block4:
-        v13.i256 = mload v6 i256;
-        v15.i256 = mload v4 i256;
-        v16.i256 = mload v5 i256;
-        v17.i256 = call %core__lib__abi__decode_field_from__g5385_0636 v0 v15 v16;
-        return v17;
+        v14.i256 = call %core__lib__abi__decode_field_from__g5385_0636 v0 v1 v2;
+        return v14;
 }
 
 func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_f1db(v0.@layout_6, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        v6.*i256 = alloca i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
-        mstore v6 v3 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = mload v4 i256;
-        v10.i256 = mload v5 i256;
-        v11.i256 = mload v6 i256;
-        v12.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_0f32 v0 v9 v10 v11;
-        return v12;
+        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_0f32 v0 v1 v2 v3;
+        return v9;
 
     block3:
         jump block4;
 
     block4:
-        v13.i256 = mload v6 i256;
-        v15.i256 = mload v4 i256;
-        v16.i256 = mload v5 i256;
-        v17.i256 = call %core__lib__abi__decode_field_from__g5385_5caf v0 v15 v16;
-        return v17;
+        v14.i256 = call %core__lib__abi__decode_field_from__g5385_5caf v0 v1 v2;
+        return v14;
 }
 
 func inline(always) private %decode_payload__g407e(v0.objref<@layout_5>) -> i256 {
@@ -1261,14 +1061,12 @@ func inline(always) private %decode_runtime_args__gadcc(v0.objref<@layout_10>) -
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v4.@layout_6 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_b215;
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_847d v4;
-        mstore v1 v6 i256;
-        mstore v2 4.i256 i256;
+        v3.@layout_6 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_b215;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_847d v3;
+        mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
 
     block2:
@@ -1279,30 +1077,26 @@ func inline(always) private %decode_runtime_args__gadcc(v0.objref<@layout_10>) -
         jump block4;
 
     block4:
-        v12.i256 = mload v1 i256;
-        v13.@layout_7 = call %decode_from_prechecked_head__g4e6c v4 4.i256 v12;
-        return v13;
+        v12.@layout_7 = call %decode_from_prechecked_head__g4e6c v3 4.i256 v5;
+        return v12;
 
     block5:
-        v14.i256 = mload v1 i256;
-        mstore v3 v14 i256;
-        v16.i256 = mload v3 i256;
-        v17.i1 = gt 100.i256 v16;
-        br v17 block2 block3;
+        mstore v2 v5 i256;
+        v15.i256 = mload v2 i256;
+        v16.i1 = gt 100.i256 v15;
+        br v16 block2 block3;
 }
 
 func inline(always) private %decode_runtime_args__gbdfb(v0.objref<@layout_10>) -> @layout_8 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v4.@layout_6 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_2b2c;
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_8db5 v4;
-        mstore v1 v6 i256;
-        mstore v2 4.i256 i256;
+        v3.@layout_6 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_2b2c;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_8db5 v3;
+        mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
 
     block2:
@@ -1313,16 +1107,14 @@ func inline(always) private %decode_runtime_args__gbdfb(v0.objref<@layout_10>) -
         jump block4;
 
     block4:
-        v12.i256 = mload v1 i256;
-        v13.@layout_8 = call %decode_from_prechecked_head__gbecb v4 4.i256 v12;
-        return v13;
+        v12.@layout_8 = call %decode_from_prechecked_head__gbecb v3 4.i256 v5;
+        return v12;
 
     block5:
-        v14.i256 = mload v1 i256;
-        mstore v3 v14 i256;
-        v16.i256 = mload v3 i256;
-        v17.i1 = gt 68.i256 v16;
-        br v17 block2 block3;
+        mstore v2 v5 i256;
+        v15.i256 = mload v2 i256;
+        v16.i1 = gt 68.i256 v15;
+        br v16 block2 block3;
 }
 
 func private %decoder_new(v0.@layout_3) -> @layout_5 {
@@ -1336,17 +1128,14 @@ func private %decoder_new(v0.@layout_3) -> @layout_5 {
 
 func private %dynamic_payload_size(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v3.i256 = mload v1 i256;
-        v4.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_a376 v3;
-        return v4;
+        v3.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_a376 v0;
+        return v3;
 
     block3:
         jump block4;
@@ -1474,32 +1263,25 @@ func private %encode_field(v0.@layout_0, v1.objref<@layout_2>, v2.i256) {
 
 func inline(always) private %encode_field_at(v0.i256, v1.objref<@layout_2>, v2.i256, v3.i256, v4.i256) {
     block0:
-        v5.*i256 = alloca i256;
-        v6.*i256 = alloca i256;
-        mstore v5 v2 i256;
-        mstore v6 v3 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v10.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_ccad v0;
-        v11.i256 = mload v6 i256;
-        v12.i256 = mload v5 i256;
-        v13.i256 = mload v4 i256;
-        v14.i256 = sub v13 v12;
-        call %write_word_at v1 v11 v14;
+        v8.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_ccad v0;
+        v11.i256 = mload v4 i256;
+        v12.i256 = sub v11 v2;
+        call %write_word_at v1 v3 v12;
+        v15.i256 = mload v4 i256;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_3f4d v1 v15;
         v17.i256 = mload v4 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_3f4d v1 v17;
-        v19.i256 = mload v4 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_863e v1 v19;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_863e v1 v17;
         call %impl_trait_u256__encode__g426c v0 v1;
-        v22.i256 = mload v5 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_3f4d v1 v22;
-        v24.i256 = mload v4 i256;
-        v25.i256 = add v24 v10;
-        mstore v4 v25 i256;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_3f4d v1 v2;
+        v21.i256 = mload v4 i256;
+        v22.i256 = add v21 v8;
+        mstore v4 v22 i256;
         return;
 
     block3:
@@ -1509,16 +1291,14 @@ func inline(always) private %encode_field_at(v0.i256, v1.objref<@layout_2>, v2.i
         br 1.i1 block5 block6;
 
     block5:
-        v27.i256 = mload v6 i256;
-        call %impl_trait_u256__encode_to_ptr__gf13e v0 v27;
+        call %impl_trait_u256__encode_to_ptr__gf13e v0 v3;
         return;
 
     block6:
         jump block7;
 
     block7:
-        v30.i256 = mload v6 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_863e v1 v30;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_863e v1 v3;
         call %impl_trait_u256__encode__g426c v0 v1;
         return;
 }
@@ -1560,51 +1340,39 @@ func private %encode_single_root_alloc(v0.@layout_0) -> @layout_1 {
 
 func private %impl_trait_u256__encode_to_ptr__gf13e(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__store_word_bb6a v3 v0;
+        call %std__lib__abi__sol__impl_trait_Sol_1f5f__store_word_bb6a v1 v0;
         return;
 }
 
 func private %impl_trait_Address__encode_to_ptr__gf13e(v0.@layout_0, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.i256 = extract_value v0 0.i256;
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__store_word_d9ea v3 v6;
+        v5.i256 = extract_value v0 0.i256;
+        call %std__lib__abi__sol__impl_trait_Sol_1f5f__store_word_d9ea v1 v5;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_Sol_1f5f__encoder_new_8751(v0.i256) -> @layout_2 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.@layout_2 = call %std__lib__abi__sol__impl_SolEncoder_ce34__new_61f8 v2;
-        return v3;
+        v2.@layout_2 = call %std__lib__abi__sol__impl_SolEncoder_ce34__new_61f8 v0;
+        return v2;
 }
 
 func private %std__lib__abi__sol__impl_trait_Sol_1f5f__encoder_new_c533(v0.i256) -> @layout_2 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.@layout_2 = call %std__lib__abi__sol__impl_SolEncoder_ce34__new_aa27 v2;
-        return v3;
+        v2.@layout_2 = call %std__lib__abi__sol__impl_SolEncoder_ce34__new_aa27 v0;
+        return v2;
 }
 
 func private %std__lib__evm__effects__impl_trait_Evm_c913__input_2b2c() -> @layout_6 {
@@ -1638,31 +1406,27 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_1fd5
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_2577(v0.@layout_6) -> i256 {
     block0:
         v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.i256 = extract_value v0 0.i256;
-        v7.i256 = mload v1 i256;
-        mstore v2 v7 i256;
-        v8.i256 = mload v2 i256;
-        v9.i1 = gt v6 v8;
-        br v9 block2 block3;
+        v2.i256 = evm_calldata_size;
+        v5.i256 = extract_value v0 0.i256;
+        mstore v1 v2 i256;
+        v6.i256 = mload v1 i256;
+        v7.i1 = gt v5 v6;
+        br v7 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v11.i256 = extract_value v0 0.i256;
-        v12.i256 = mload v1 i256;
-        (v13.i256, v14.i1) = usubo v12 v11;
-        br v14 block5 block6;
+        v9.i256 = extract_value v0 0.i256;
+        (v11.i256, v12.i1) = usubo v2 v9;
+        br v12 block5 block6;
 
     block4:
-        v19.i256 = phi (0.i256 block2) (v13 block6);
-        return v19;
+        v17.i256 = phi (0.i256 block2) (v11 block6);
+        return v17;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -1686,31 +1450,27 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_3e84
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_6f75(v0.@layout_6) -> i256 {
     block0:
         v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.i256 = extract_value v0 0.i256;
-        v7.i256 = mload v1 i256;
-        mstore v2 v7 i256;
-        v8.i256 = mload v2 i256;
-        v9.i1 = gt v6 v8;
-        br v9 block2 block3;
+        v2.i256 = evm_calldata_size;
+        v5.i256 = extract_value v0 0.i256;
+        mstore v1 v2 i256;
+        v6.i256 = mload v1 i256;
+        v7.i1 = gt v5 v6;
+        br v7 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v11.i256 = extract_value v0 0.i256;
-        v12.i256 = mload v1 i256;
-        (v13.i256, v14.i1) = usubo v12 v11;
-        br v14 block5 block6;
+        v9.i256 = extract_value v0 0.i256;
+        (v11.i256, v12.i1) = usubo v2 v9;
+        br v12 block5 block6;
 
     block4:
-        v19.i256 = phi (0.i256 block2) (v13 block6);
-        return v19;
+        v17.i256 = phi (0.i256 block2) (v11 block6);
+        return v17;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -1724,31 +1484,27 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_847d(v0.@layout_6) -> i256 {
     block0:
         v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.i256 = extract_value v0 0.i256;
-        v7.i256 = mload v1 i256;
-        mstore v2 v7 i256;
-        v8.i256 = mload v2 i256;
-        v9.i1 = gt v6 v8;
-        br v9 block2 block3;
+        v2.i256 = evm_calldata_size;
+        v5.i256 = extract_value v0 0.i256;
+        mstore v1 v2 i256;
+        v6.i256 = mload v1 i256;
+        v7.i1 = gt v5 v6;
+        br v7 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v11.i256 = extract_value v0 0.i256;
-        v12.i256 = mload v1 i256;
-        (v13.i256, v14.i1) = usubo v12 v11;
-        br v14 block5 block6;
+        v9.i256 = extract_value v0 0.i256;
+        (v11.i256, v12.i1) = usubo v2 v9;
+        br v12 block5 block6;
 
     block4:
-        v19.i256 = phi (0.i256 block2) (v13 block6);
-        return v19;
+        v17.i256 = phi (0.i256 block2) (v11 block6);
+        return v17;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -1762,31 +1518,27 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_8db5(v0.@layout_6) -> i256 {
     block0:
         v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.i256 = extract_value v0 0.i256;
-        v7.i256 = mload v1 i256;
-        mstore v2 v7 i256;
-        v8.i256 = mload v2 i256;
-        v9.i1 = gt v6 v8;
-        br v9 block2 block3;
+        v2.i256 = evm_calldata_size;
+        v5.i256 = extract_value v0 0.i256;
+        mstore v1 v2 i256;
+        v6.i256 = mload v1 i256;
+        v7.i1 = gt v5 v6;
+        br v7 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v11.i256 = extract_value v0 0.i256;
-        v12.i256 = mload v1 i256;
-        (v13.i256, v14.i1) = usubo v12 v11;
-        br v14 block5 block6;
+        v9.i256 = extract_value v0 0.i256;
+        (v11.i256, v12.i1) = usubo v2 v9;
+        br v12 block5 block6;
 
     block4:
-        v19.i256 = phi (0.i256 block2) (v13 block6);
-        return v19;
+        v17.i256 = phi (0.i256 block2) (v11 block6);
+        return v17;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -1821,54 +1573,46 @@ func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_4d
 
 func private %std__lib__abi__sol__impl_SolEncoder_ce34__new_61f8(v0.i256) -> @layout_2 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v4.i1 = eq v2 0.i256;
-        br v4 block2 block3;
+        v3.i1 = eq v0 0.i256;
+        br v3 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v5.i256 = mload v1 i256;
-        v6.*i8 = evm_malloc v5;
-        v7.i256 = ptr_to_int v6 i256;
+        v5.*i8 = evm_malloc v0;
+        v6.i256 = ptr_to_int v5 i256;
         jump block4;
 
     block4:
-        v8.i256 = phi (0.i256 block2) (v7 block3);
-        v9.@layout_2 = call %std__lib__abi__sol__impl_SolEncoder_ce34__at_4eb0 v8;
-        return v9;
+        v7.i256 = phi (0.i256 block2) (v6 block3);
+        v8.@layout_2 = call %std__lib__abi__sol__impl_SolEncoder_ce34__at_4eb0 v7;
+        return v8;
 }
 
 func private %std__lib__abi__sol__impl_SolEncoder_ce34__new_aa27(v0.i256) -> @layout_2 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v4.i1 = eq v2 0.i256;
-        br v4 block2 block3;
+        v3.i1 = eq v0 0.i256;
+        br v3 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v5.i256 = mload v1 i256;
-        v6.*i8 = evm_malloc v5;
-        v7.i256 = ptr_to_int v6 i256;
+        v5.*i8 = evm_malloc v0;
+        v6.i256 = ptr_to_int v5 i256;
         jump block4;
 
     block4:
-        v8.i256 = phi (0.i256 block2) (v7 block3);
-        v9.@layout_2 = call %std__lib__abi__sol__impl_SolEncoder_ce34__at_9565 v8;
-        return v9;
+        v7.i256 = phi (0.i256 block2) (v6 block3);
+        v8.@layout_2 = call %std__lib__abi__sol__impl_SolEncoder_ce34__at_9565 v7;
+        return v8;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_b558() -> @layout_6 {
@@ -1926,8 +1670,6 @@ func private %core__lib__abi__trait_AbiSize__payload_size__g67a8_7f10_0(v0.@layo
 
 func private %core__lib__abi__trait_AbiSize__payload_size__ge513_a376(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
@@ -1936,8 +1678,6 @@ func private %core__lib__abi__trait_AbiSize__payload_size__ge513_a376(v0.i256) -
 
 func private %core__lib__abi__trait_AbiSize__payload_size__ge513_ccad(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
@@ -1968,22 +1708,20 @@ func private %impl_trait_SolEncoder__pos(v0.objref<@layout_2>) -> i256 {
 func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_272f(v0.objref<@layout_5>) -> i256 {
     block0:
         v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v5.objref<@layout_4> = obj.proj v0 0.i256;
-        v6.objref<@layout_3> = obj.proj v5 0.i256;
-        v7.@layout_3 = obj.load v6;
-        v8.objref<@layout_4> = obj.proj v0 0.i256;
-        v9.objref<@layout_3> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_1fd5 v9;
-        mstore v1 v10 i256;
-        v11.objref<@layout_4> = obj.proj v0 0.i256;
-        v13.objref<i256> = obj.proj v11 1.i256;
-        v14.i256 = obj.load v13;
-        (v16.i256, v17.i1) = uaddo v14 32.i256;
-        br v17 block6 block7;
+        v4.objref<@layout_4> = obj.proj v0 0.i256;
+        v5.objref<@layout_3> = obj.proj v4 0.i256;
+        v6.@layout_3 = obj.load v5;
+        v7.objref<@layout_4> = obj.proj v0 0.i256;
+        v8.objref<@layout_3> = obj.proj v7 0.i256;
+        v9.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_1fd5 v8;
+        v10.objref<@layout_4> = obj.proj v0 0.i256;
+        v12.objref<i256> = obj.proj v10 1.i256;
+        v13.i256 = obj.load v12;
+        (v15.i256, v16.i1) = uaddo v13 32.i256;
+        br v16 block6 block7;
 
     block2:
         evm_revert 0.i256 0.i256;
@@ -1992,26 +1730,25 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         jump block4;
 
     block4:
-        v28.objref<@layout_4> = obj.proj v0 0.i256;
-        v29.objref<@layout_3> = obj.proj v28 0.i256;
-        v30.@layout_3 = obj.load v29;
-        v31.objref<@layout_4> = obj.proj v0 0.i256;
-        v32.objref<i256> = obj.proj v31 1.i256;
-        v33.i256 = obj.load v32;
-        v34.objref<@layout_4> = obj.proj v0 0.i256;
-        v35.objref<@layout_3> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_d5b9 v35 v33;
-        v38.objref<@layout_4> = obj.proj v0 0.i256;
-        v39.objref<i256> = obj.proj v38 1.i256;
-        obj.store v39 v16;
-        return v36;
+        v27.objref<@layout_4> = obj.proj v0 0.i256;
+        v28.objref<@layout_3> = obj.proj v27 0.i256;
+        v29.@layout_3 = obj.load v28;
+        v30.objref<@layout_4> = obj.proj v0 0.i256;
+        v31.objref<i256> = obj.proj v30 1.i256;
+        v32.i256 = obj.load v31;
+        v33.objref<@layout_4> = obj.proj v0 0.i256;
+        v34.objref<@layout_3> = obj.proj v33 0.i256;
+        v35.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_d5b9 v34 v32;
+        v37.objref<@layout_4> = obj.proj v0 0.i256;
+        v38.objref<i256> = obj.proj v37 1.i256;
+        obj.store v38 v15;
+        return v35;
 
     block5:
-        v40.i256 = mload v1 i256;
-        mstore v2 v40 i256;
-        v42.i256 = mload v2 i256;
-        v43.i1 = gt v16 v42;
-        br v43 block2 block3;
+        mstore v1 v9 i256;
+        v41.i256 = mload v1 i256;
+        v42.i1 = gt v15 v41;
+        br v42 block2 block3;
 
     block6:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -2019,32 +1756,30 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         evm_revert 0.i256 36.i256;
 
     block7:
-        v23.objref<@layout_4> = obj.proj v0 0.i256;
-        v24.objref<i256> = obj.proj v23 1.i256;
-        v25.i256 = obj.load v24;
-        v26.i1 = lt v16 v25;
-        br v26 block2 block5;
+        v22.objref<@layout_4> = obj.proj v0 0.i256;
+        v23.objref<i256> = obj.proj v22 1.i256;
+        v24.i256 = obj.load v23;
+        v25.i1 = lt v15 v24;
+        br v25 block2 block5;
 }
 
 func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_7adc(v0.objref<@layout_5>) -> i256 {
     block0:
         v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v5.objref<@layout_4> = obj.proj v0 0.i256;
-        v6.objref<@layout_3> = obj.proj v5 0.i256;
-        v7.@layout_3 = obj.load v6;
-        v8.objref<@layout_4> = obj.proj v0 0.i256;
-        v9.objref<@layout_3> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_3e84 v9;
-        mstore v1 v10 i256;
-        v11.objref<@layout_4> = obj.proj v0 0.i256;
-        v13.objref<i256> = obj.proj v11 1.i256;
-        v14.i256 = obj.load v13;
-        (v16.i256, v17.i1) = uaddo v14 32.i256;
-        br v17 block6 block7;
+        v4.objref<@layout_4> = obj.proj v0 0.i256;
+        v5.objref<@layout_3> = obj.proj v4 0.i256;
+        v6.@layout_3 = obj.load v5;
+        v7.objref<@layout_4> = obj.proj v0 0.i256;
+        v8.objref<@layout_3> = obj.proj v7 0.i256;
+        v9.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_3e84 v8;
+        v10.objref<@layout_4> = obj.proj v0 0.i256;
+        v12.objref<i256> = obj.proj v10 1.i256;
+        v13.i256 = obj.load v12;
+        (v15.i256, v16.i1) = uaddo v13 32.i256;
+        br v16 block6 block7;
 
     block2:
         evm_revert 0.i256 0.i256;
@@ -2053,26 +1788,25 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         jump block4;
 
     block4:
-        v28.objref<@layout_4> = obj.proj v0 0.i256;
-        v29.objref<@layout_3> = obj.proj v28 0.i256;
-        v30.@layout_3 = obj.load v29;
-        v31.objref<@layout_4> = obj.proj v0 0.i256;
-        v32.objref<i256> = obj.proj v31 1.i256;
-        v33.i256 = obj.load v32;
-        v34.objref<@layout_4> = obj.proj v0 0.i256;
-        v35.objref<@layout_3> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_3db5 v35 v33;
-        v38.objref<@layout_4> = obj.proj v0 0.i256;
-        v39.objref<i256> = obj.proj v38 1.i256;
-        obj.store v39 v16;
-        return v36;
+        v27.objref<@layout_4> = obj.proj v0 0.i256;
+        v28.objref<@layout_3> = obj.proj v27 0.i256;
+        v29.@layout_3 = obj.load v28;
+        v30.objref<@layout_4> = obj.proj v0 0.i256;
+        v31.objref<i256> = obj.proj v30 1.i256;
+        v32.i256 = obj.load v31;
+        v33.objref<@layout_4> = obj.proj v0 0.i256;
+        v34.objref<@layout_3> = obj.proj v33 0.i256;
+        v35.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_3db5 v34 v32;
+        v37.objref<@layout_4> = obj.proj v0 0.i256;
+        v38.objref<i256> = obj.proj v37 1.i256;
+        obj.store v38 v15;
+        return v35;
 
     block5:
-        v40.i256 = mload v1 i256;
-        mstore v2 v40 i256;
-        v42.i256 = mload v2 i256;
-        v43.i1 = gt v16 v42;
-        br v43 block2 block3;
+        mstore v1 v9 i256;
+        v41.i256 = mload v1 i256;
+        v42.i1 = gt v15 v41;
+        br v42 block2 block3;
 
     block6:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -2080,327 +1814,246 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         evm_revert 0.i256 36.i256;
 
     block7:
-        v23.objref<@layout_4> = obj.proj v0 0.i256;
-        v24.objref<i256> = obj.proj v23 1.i256;
-        v25.i256 = obj.load v24;
-        v26.i1 = lt v16 v25;
-        br v26 block2 block5;
+        v22.objref<@layout_4> = obj.proj v0 0.i256;
+        v23.objref<i256> = obj.proj v22 1.i256;
+        v24.i256 = obj.load v23;
+        v25.i1 = lt v15 v24;
+        br v25 block2 block5;
 }
 
 func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_286a(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        evm_revert v4 v5;
+        evm_revert v0 v1;
 }
 
 func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_6bdb(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        evm_revert v4 v5;
+        evm_revert v0 v1;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_3f4d(v0.objref<@layout_2>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        obj.store v6 v3;
+        v5.objref<i256> = obj.proj v0 0.i256;
+        obj.store v5 v1;
         return;
 }
 
 func private %set_base__g463e(v0.objref<@layout_5>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 1.i256;
-        obj.store v6 v3;
+        v5.objref<i256> = obj.proj v0 1.i256;
+        obj.store v5 v1;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_b006(v0.objref<@layout_2>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        obj.store v6 v3;
+        v5.objref<i256> = obj.proj v0 0.i256;
+        obj.store v5 v1;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_863e(v0.objref<@layout_2>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 1.i256;
-        obj.store v6 v3;
+        v5.objref<i256> = obj.proj v0 1.i256;
+        obj.store v5 v1;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_d061(v0.objref<@layout_2>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 1.i256;
-        obj.store v6 v3;
+        v5.objref<i256> = obj.proj v0 1.i256;
+        obj.store v5 v1;
         return;
 }
 
 func private %set_pos__g463e(v0.objref<@layout_5>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<@layout_4> = obj.proj v0 0.i256;
-        v8.objref<i256> = obj.proj v6 1.i256;
-        obj.store v8 v3;
+        v5.objref<@layout_4> = obj.proj v0 0.i256;
+        v7.objref<i256> = obj.proj v5 1.i256;
+        obj.store v7 v1;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_Sol_1f5f__store_word_bb6a(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        mstore v4 v5 i256;
+        mstore v0 v1 i256;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_Sol_1f5f__store_word_d9ea(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        mstore v4 v5 i256;
+        mstore v0 v1 i256;
         return;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_32d2(v0.@layout_6, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3368(v0.@layout_6, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_3db5(v0.objref<@layout_3>, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = mload v8 i256;
-        return v9;
+        v4.objref<i256> = obj.proj v0 0.i256;
+        v5.i256 = obj.load v4;
+        v7.i256 = add v5 v1;
+        v8.i256 = mload v7 i256;
+        return v8;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_8c36(v0.@layout_6, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_8c36_0(v0.@layout_6, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b2da(v0.@layout_6, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b2da_0(v0.@layout_6, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_d5b9(v0.objref<@layout_3>, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = mload v8 i256;
-        return v9;
+        v4.objref<i256> = obj.proj v0 0.i256;
+        v5.i256 = obj.load v4;
+        v7.i256 = add v5 v1;
+        v8.i256 = mload v7 i256;
+        return v8;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_2c07(v0.objref<@layout_2>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 1.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        mstore v6 v7 i256;
-        v10.i256 = add v6 32.i256;
-        v11.objref<i256> = obj.proj v0 1.i256;
-        obj.store v11 v10;
+        v4.objref<i256> = obj.proj v0 1.i256;
+        v5.i256 = obj.load v4;
+        mstore v5 v1 i256;
+        v9.i256 = add v5 32.i256;
+        v10.objref<i256> = obj.proj v0 1.i256;
+        obj.store v10 v9;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_4070(v0.objref<@layout_2>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 1.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        mstore v6 v7 i256;
-        v10.i256 = add v6 32.i256;
-        v11.objref<i256> = obj.proj v0 1.i256;
-        obj.store v11 v10;
+        v4.objref<i256> = obj.proj v0 1.i256;
+        v5.i256 = obj.load v4;
+        mstore v5 v1 i256;
+        v9.i256 = add v5 32.i256;
+        v10.objref<i256> = obj.proj v0 1.i256;
+        obj.store v10 v9;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_528a(v0.objref<@layout_2>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 1.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        mstore v6 v7 i256;
-        v10.i256 = add v6 32.i256;
-        v11.objref<i256> = obj.proj v0 1.i256;
-        obj.store v11 v10;
+        v4.objref<i256> = obj.proj v0 1.i256;
+        v5.i256 = obj.load v4;
+        mstore v5 v1 i256;
+        v9.i256 = add v5 32.i256;
+        v10.objref<i256> = obj.proj v0 1.i256;
+        obj.store v10 v9;
         return;
 }
 
 func private %write_word_at(v0.objref<@layout_2>, v1.i256, v2.i256) {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v3 i256;
-        v6.i256 = mload v4 i256;
-        mstore v5 v6 i256;
+        mstore v1 v2 i256;
         return;
 }
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/effect_handle_field_deref.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/effect_handle_field_deref.snap
@@ -66,24 +66,21 @@ func private %__EffectHandleFieldDeref_recv_0_2(v0.i256, v1.i256) -> i256 {
 
 func private %abi_field_size(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_a8bc_0 v2;
+        v2.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_a8bc_0 v0;
         br 0.i1 block2 block3;
 
     block2:
-        (v7.i256, v8.i1) = uaddo 32.i256 v3;
-        br v8 block5 block6;
+        (v6.i256, v7.i1) = uaddo 32.i256 v2;
+        br v7 block5 block6;
 
     block3:
         jump block4;
 
     block4:
-        return v3;
+        return v2;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -91,19 +88,16 @@ func private %abi_field_size(v0.i256) -> i256 {
         evm_revert 0.i256 36.i256;
 
     block6:
-        return v7;
+        return v6;
 }
 
 func private %abi_single_root_size(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = call %abi_field_size v2;
-        return v3;
+        v2.i256 = call %abi_field_size v0;
+        return v2;
 }
 
 func private %std__lib__evm__effects__impl_trait_Evm_c913__abort_4c56() {
@@ -135,16 +129,12 @@ func private %std__lib__evm__effects__impl_trait_Evm_c913__abort_ffa6() {
 
 func inline(always) private %at(v0.i256) -> @layout_0 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = mload v1 i256;
-        v6.@layout_0 = insert_value undef.@layout_0 0.i256 v2;
-        v8.@layout_0 = insert_value v6 1.i256 v3;
-        return v8;
+        v4.@layout_0 = insert_value undef.@layout_0 0.i256 v0;
+        v6.@layout_0 = insert_value v4 1.i256 v0;
+        return v6;
 }
 
 func private %base(v0.objref<@layout_0>) -> i256 {
@@ -159,17 +149,14 @@ func private %base(v0.objref<@layout_0>) -> i256 {
 
 func private %bump(v0.objref<@layout_1>, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = evm_sload v6;
-        (v9.i256, v10.i1) = uaddo v8 v7;
-        br v10 block2 block3;
+        v4.objref<i256> = obj.proj v0 0.i256;
+        v5.i256 = obj.load v4;
+        v7.i256 = evm_sload v5;
+        (v8.i256, v9.i1) = uaddo v7 v1;
+        br v9 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -177,28 +164,20 @@ func private %bump(v0.objref<@layout_1>, v1.i256) -> i256 {
         evm_revert 0.i256 36.i256;
 
     block3:
-        evm_sstore v6 v9;
-        v17.objref<i256> = obj.proj v0 0.i256;
-        v18.i256 = obj.load v17;
-        v19.i256 = evm_sload v18;
-        return v19;
+        evm_sstore v5 v8;
+        v16.objref<i256> = obj.proj v0 0.i256;
+        v17.i256 = obj.load v16;
+        v18.i256 = evm_sload v17;
+        return v18;
 }
 
 func inline(always) private %core__lib__abi__checked_frame_end__gf13e_6c9f(v0.i256, v1.i256, v2.i256) -> i256 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        mstore v3 v0 i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
         jump block1;
 
     block1:
-        v6.i256 = mload v3 i256;
-        v7.i256 = mload v4 i256;
-        (v8.i256, v9.i1) = uaddo v6 v7;
-        br v9 block6 block7;
+        (v5.i256, v6.i1) = uaddo v0 v1;
+        br v6 block6 block7;
 
     block2:
         call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_5569;
@@ -208,12 +187,11 @@ func inline(always) private %core__lib__abi__checked_frame_end__gf13e_6c9f(v0.i2
         jump block4;
 
     block4:
-        return v8;
+        return v5;
 
     block5:
-        v19.i256 = mload v5 i256;
-        v20.i1 = gt v8 v19;
-        br v20 block2 block3;
+        v17.i1 = gt v5 v2;
+        br v17 block2 block3;
 
     block6:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -221,26 +199,17 @@ func inline(always) private %core__lib__abi__checked_frame_end__gf13e_6c9f(v0.i2
         evm_revert 0.i256 36.i256;
 
     block7:
-        v15.i256 = mload v3 i256;
-        v16.i1 = lt v8 v15;
-        br v16 block2 block5;
+        v13.i1 = lt v5 v0;
+        br v13 block2 block5;
 }
 
 func inline(always) private %core__lib__abi__checked_frame_end__gf13e_7613(v0.i256, v1.i256, v2.i256) -> i256 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        mstore v3 v0 i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
         jump block1;
 
     block1:
-        v6.i256 = mload v3 i256;
-        v7.i256 = mload v4 i256;
-        (v8.i256, v9.i1) = uaddo v6 v7;
-        br v9 block6 block7;
+        (v5.i256, v6.i1) = uaddo v0 v1;
+        br v6 block6 block7;
 
     block2:
         call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_1efd;
@@ -250,12 +219,11 @@ func inline(always) private %core__lib__abi__checked_frame_end__gf13e_7613(v0.i2
         jump block4;
 
     block4:
-        return v8;
+        return v5;
 
     block5:
-        v19.i256 = mload v5 i256;
-        v20.i1 = gt v8 v19;
-        br v20 block2 block3;
+        v17.i1 = gt v5 v2;
+        br v17 block2 block3;
 
     block6:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -263,26 +231,17 @@ func inline(always) private %core__lib__abi__checked_frame_end__gf13e_7613(v0.i2
         evm_revert 0.i256 36.i256;
 
     block7:
-        v15.i256 = mload v3 i256;
-        v16.i1 = lt v8 v15;
-        br v16 block2 block5;
+        v13.i1 = lt v5 v0;
+        br v13 block2 block5;
 }
 
 func inline(always) private %core__lib__abi__checked_frame_end__gf13e_d188(v0.i256, v1.i256, v2.i256) -> i256 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        mstore v3 v0 i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
         jump block1;
 
     block1:
-        v6.i256 = mload v3 i256;
-        v7.i256 = mload v4 i256;
-        (v8.i256, v9.i1) = uaddo v6 v7;
-        br v9 block6 block7;
+        (v5.i256, v6.i1) = uaddo v0 v1;
+        br v6 block6 block7;
 
     block2:
         call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_928c;
@@ -292,12 +251,11 @@ func inline(always) private %core__lib__abi__checked_frame_end__gf13e_d188(v0.i2
         jump block4;
 
     block4:
-        return v8;
+        return v5;
 
     block5:
-        v19.i256 = mload v5 i256;
-        v20.i1 = gt v8 v19;
-        br v20 block2 block3;
+        v17.i1 = gt v5 v2;
+        br v17 block2 block3;
 
     block6:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -305,24 +263,17 @@ func inline(always) private %core__lib__abi__checked_frame_end__gf13e_d188(v0.i2
         evm_revert 0.i256 36.i256;
 
     block7:
-        v15.i256 = mload v3 i256;
-        v16.i1 = lt v8 v15;
-        br v16 block2 block5;
+        v13.i1 = lt v5 v0;
+        br v13 block2 block5;
 }
 
 func inline(always) private %core__lib__abi__checked_tail__gf13e_3857(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        (v6.i256, v7.i1) = uaddo v4 v5;
-        br v7 block5 block6;
+        (v4.i256, v5.i1) = uaddo v0 v1;
+        br v5 block5 block6;
 
     block2:
         call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_bd08;
@@ -332,7 +283,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_3857(v0.i256, v
         jump block4;
 
     block4:
-        return v6;
+        return v4;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -340,24 +291,17 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_3857(v0.i256, v
         evm_revert 0.i256 36.i256;
 
     block6:
-        v13.i256 = mload v2 i256;
-        v14.i1 = lt v6 v13;
-        br v14 block2 block3;
+        v12.i1 = lt v4 v0;
+        br v12 block2 block3;
 }
 
 func inline(always) private %core__lib__abi__checked_tail__gf13e_931a(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        (v6.i256, v7.i1) = uaddo v4 v5;
-        br v7 block5 block6;
+        (v4.i256, v5.i1) = uaddo v0 v1;
+        br v5 block5 block6;
 
     block2:
         call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_9d46;
@@ -367,7 +311,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_931a(v0.i256, v
         jump block4;
 
     block4:
-        return v6;
+        return v4;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -375,24 +319,17 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_931a(v0.i256, v
         evm_revert 0.i256 36.i256;
 
     block6:
-        v13.i256 = mload v2 i256;
-        v14.i1 = lt v6 v13;
-        br v14 block2 block3;
+        v12.i1 = lt v4 v0;
+        br v12 block2 block3;
 }
 
 func inline(always) private %core__lib__abi__checked_tail__gf13e_c189(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        (v6.i256, v7.i1) = uaddo v4 v5;
-        br v7 block5 block6;
+        (v4.i256, v5.i1) = uaddo v0 v1;
+        br v5 block5 block6;
 
     block2:
         call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_a064;
@@ -402,7 +339,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_c189(v0.i256, v
         jump block4;
 
     block4:
-        return v6;
+        return v4;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -410,9 +347,8 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_c189(v0.i256, v
         evm_revert 0.i256 36.i256;
 
     block6:
-        v13.i256 = mload v2 i256;
-        v14.i1 = lt v6 v13;
-        br v14 block2 block3;
+        v12.i1 = lt v4 v0;
+        br v12 block2 block3;
 }
 
 func inline(always) private %contract_init_abi_EffectHandleFieldDeref() {
@@ -599,29 +535,22 @@ func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_bd08() {
 
 func inline(always) private %core__lib__abi__decode_field_from__g5385_1cc8(v0.@layout_2, v1.i256, v2.i256) -> i256 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v7.i256 = mload v4 i256;
-        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_7303 v0 v7;
-        v9.i256 = mload v3 i256;
-        (v10.i256, v11.i1) = uaddo v9 v8;
-        br v11 block5 block6;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_7303 v0 v2;
+        (v8.i256, v9.i1) = uaddo v1 v6;
+        br v9 block5 block6;
 
     block3:
         jump block4;
 
     block4:
-        v20.i256 = mload v4 i256;
-        v21.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f4af_0 v0 v20;
-        return v21;
+        v19.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f4af_0 v0 v2;
+        return v19;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -629,35 +558,28 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_1cc8(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v18.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f4af_0 v0 v10;
-        return v18;
+        v16.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f4af_0 v0 v8;
+        return v16;
 }
 
 func inline(always) private %core__lib__abi__decode_field_from__g5385_23bd(v0.@layout_2, v1.i256, v2.i256) -> i256 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v7.i256 = mload v4 i256;
-        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_dee9 v0 v7;
-        v9.i256 = mload v3 i256;
-        (v10.i256, v11.i1) = uaddo v9 v8;
-        br v11 block5 block6;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_dee9 v0 v2;
+        (v8.i256, v9.i1) = uaddo v1 v6;
+        br v9 block5 block6;
 
     block3:
         jump block4;
 
     block4:
-        v20.i256 = mload v4 i256;
-        v21.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f0a9_0 v0 v20;
-        return v21;
+        v19.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f0a9_0 v0 v2;
+        return v19;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -665,35 +587,28 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_23bd(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v18.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f0a9_0 v0 v10;
-        return v18;
+        v16.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f0a9_0 v0 v8;
+        return v16;
 }
 
 func inline(always) private %core__lib__abi__decode_field_from__g5385_48de(v0.@layout_2, v1.i256, v2.i256) -> i256 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v7.i256 = mload v4 i256;
-        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_7c41 v0 v7;
-        v9.i256 = mload v3 i256;
-        (v10.i256, v11.i1) = uaddo v9 v8;
-        br v11 block5 block6;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_7c41 v0 v2;
+        (v8.i256, v9.i1) = uaddo v1 v6;
+        br v9 block5 block6;
 
     block3:
         jump block4;
 
     block4:
-        v20.i256 = mload v4 i256;
-        v21.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_a878_0 v0 v20;
-        return v21;
+        v19.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_a878_0 v0 v2;
+        return v19;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -701,271 +616,188 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_48de(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v18.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_a878_0 v0 v10;
-        return v18;
+        v16.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_a878_0 v0 v8;
+        return v16;
 }
 
 func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_61db(v0.@layout_2, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        v6.*i256 = alloca i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
-        mstore v6 v3 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = mload v5 i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_dee9 v0 v9;
-        v11.i256 = mload v4 i256;
-        v12.i256 = call %core__lib__abi__checked_tail__gf13e_3857 v11 v10;
-        v13.i256 = mload v6 i256;
-        v14.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_dae2 v0 v12 v13;
-        return v14;
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_dee9 v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_3857 v1 v7;
+        v11.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_dae2 v0 v9 v3;
+        return v11;
 
     block3:
         jump block4;
 
     block4:
-        v16.i256 = mload v5 i256;
-        v17.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f0a9_0 v0 v16;
-        return v17;
+        v14.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f0a9_0 v0 v2;
+        return v14;
 }
 
 func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_d7e7(v0.@layout_2, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        v6.*i256 = alloca i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
-        mstore v6 v3 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = mload v5 i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_7c41 v0 v9;
-        v11.i256 = mload v4 i256;
-        v12.i256 = call %core__lib__abi__checked_tail__gf13e_c189 v11 v10;
-        v13.i256 = mload v6 i256;
-        v14.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_2684 v0 v12 v13;
-        return v14;
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_7c41 v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_c189 v1 v7;
+        v11.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_2684 v0 v9 v3;
+        return v11;
 
     block3:
         jump block4;
 
     block4:
-        v16.i256 = mload v5 i256;
-        v17.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_a878_0 v0 v16;
-        return v17;
+        v14.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_a878_0 v0 v2;
+        return v14;
 }
 
 func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_f2f8(v0.@layout_2, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        v6.*i256 = alloca i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
-        mstore v6 v3 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = mload v5 i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_7303 v0 v9;
-        v11.i256 = mload v4 i256;
-        v12.i256 = call %core__lib__abi__checked_tail__gf13e_931a v11 v10;
-        v13.i256 = mload v6 i256;
-        v14.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_89cb v0 v12 v13;
-        return v14;
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_7303 v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_931a v1 v7;
+        v11.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_89cb v0 v9 v3;
+        return v11;
 
     block3:
         jump block4;
 
     block4:
-        v16.i256 = mload v5 i256;
-        v17.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f4af_0 v0 v16;
-        return v17;
+        v14.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f4af_0 v0 v2;
+        return v14;
 }
 
 func inline(always) private %impl_trait_BumpMover__decode_from__gd20d(v0.@layout_2, v1.i256) -> @layout_3 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_9e81 v0;
-        v5.i256 = mload v2 i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = call %core__lib__abi__decode_msg_field_from__g5385_5108 v0 v5 v6 v4;
-        v10.@layout_3 = insert_value undef.@layout_3 0.i256 v7;
-        return v10;
+        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_9e81 v0;
+        v5.i256 = call %core__lib__abi__decode_msg_field_from__g5385_5108 v0 v1 v1 v3;
+        v8.@layout_3 = insert_value undef.@layout_3 0.i256 v5;
+        return v8;
 }
 
 func inline(always) private %impl_trait_ReadViaHolder__decode_from__gd20d(v0.@layout_2, v1.i256) -> @layout_4 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_392e v0;
-        v5.i256 = mload v2 i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = call %core__lib__abi__decode_msg_field_from__g5385_7d42 v0 v5 v6 v4;
-        v10.@layout_4 = insert_value undef.@layout_4 0.i256 v7;
-        return v10;
+        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_392e v0;
+        v5.i256 = call %core__lib__abi__decode_msg_field_from__g5385_7d42 v0 v1 v1 v3;
+        v8.@layout_4 = insert_value undef.@layout_4 0.i256 v5;
+        return v8;
 }
 
 func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_a878(v0.@layout_2, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_9c31 v0 v4;
-        return v5;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_9c31 v0 v1;
+        return v4;
 }
 
 func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_a878_0(v0.@layout_2, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_9c31_0 v0 v4;
-        return v5;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_9c31_0 v0 v1;
+        return v4;
 }
 
 func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_2684(v0.@layout_2, v1.i256, v2.i256) -> i256 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v3 i256;
-        v7.i256 = mload v4 i256;
-        v8.i256 = call %core__lib__abi__checked_frame_end__gf13e_6c9f v5 32.i256 v7;
-        v10.i256 = mload v3 i256;
-        v11.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_a878 v0 v10;
-        return v11;
+        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_6c9f v1 32.i256 v2;
+        v8.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_a878 v0 v1;
+        return v8;
 }
 
 func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_89cb(v0.@layout_2, v1.i256, v2.i256) -> i256 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v3 i256;
-        v7.i256 = mload v4 i256;
-        v8.i256 = call %core__lib__abi__checked_frame_end__gf13e_d188 v5 32.i256 v7;
-        v10.i256 = mload v3 i256;
-        v11.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f4af v0 v10;
-        return v11;
+        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_d188 v1 32.i256 v2;
+        v8.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f4af v0 v1;
+        return v8;
 }
 
 func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_dae2(v0.@layout_2, v1.i256, v2.i256) -> i256 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v3 i256;
-        v7.i256 = mload v4 i256;
-        v8.i256 = call %core__lib__abi__checked_frame_end__gf13e_7613 v5 32.i256 v7;
-        v10.i256 = mload v3 i256;
-        v11.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f0a9 v0 v10;
-        return v11;
+        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_7613 v1 32.i256 v2;
+        v8.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f0a9 v0 v1;
+        return v8;
 }
 
 func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f0a9(v0.@layout_2, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_950e v0 v4;
-        return v5;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_950e v0 v1;
+        return v4;
 }
 
 func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f0a9_0(v0.@layout_2, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_950e_0 v0 v4;
-        return v5;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_950e_0 v0 v1;
+        return v4;
 }
 
 func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f4af(v0.@layout_2, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_4e15 v0 v4;
-        return v5;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_4e15 v0 v1;
+        return v4;
 }
 
 func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_f4af_0(v0.@layout_2, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_4e15_0 v0 v4;
-        return v5;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_4e15_0 v0 v1;
+        return v4;
 }
 
 func inline(always) private %impl_trait_SeedSlot__decode_from__gd20d(v0.@layout_2, v1.i256) -> @layout_5 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_1933 v0;
-        v5.i256 = mload v2 i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = call %core__lib__abi__decode_msg_field_from__g5385_3605 v0 v5 v6 v4;
-        v8.i256 = mload v2 i256;
-        v9.i256 = mload v2 i256;
-        (v11.i256, v12.i1) = uaddo v9 32.i256;
-        br v12 block2 block3;
+        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_1933 v0;
+        v5.i256 = call %core__lib__abi__decode_msg_field_from__g5385_3605 v0 v1 v1 v3;
+        (v7.i256, v8.i1) = uaddo v1 32.i256;
+        br v8 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -973,162 +805,106 @@ func inline(always) private %impl_trait_SeedSlot__decode_from__gd20d(v0.@layout_
         evm_revert 0.i256 36.i256;
 
     block3:
-        v21.i256 = call %core__lib__abi__decode_msg_field_from__g5385_3605 v0 v8 v11 v4;
-        v24.@layout_5 = insert_value undef.@layout_5 0.i256 v7;
-        v26.@layout_5 = insert_value v24 1.i256 v21;
-        return v26;
+        v17.i256 = call %core__lib__abi__decode_msg_field_from__g5385_3605 v0 v1 v7 v3;
+        v20.@layout_5 = insert_value undef.@layout_5 0.i256 v5;
+        v22.@layout_5 = insert_value v20 1.i256 v17;
+        return v22;
 }
 
 func inline(always) private %decode_from_prechecked_head__gdaee(v0.@layout_2, v1.i256, v2.i256) -> @layout_3 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v4 i256;
-        v7.i256 = mload v3 i256;
-        v8.@layout_3 = call %impl_trait_BumpMover__decode_from__gd20d v0 v7;
-        return v8;
+        v6.@layout_3 = call %impl_trait_BumpMover__decode_from__gd20d v0 v1;
+        return v6;
 }
 
 func inline(always) private %decode_from_prechecked_head__ge273(v0.@layout_2, v1.i256, v2.i256) -> @layout_4 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v4 i256;
-        v7.i256 = mload v3 i256;
-        v8.@layout_4 = call %impl_trait_ReadViaHolder__decode_from__gd20d v0 v7;
-        return v8;
+        v6.@layout_4 = call %impl_trait_ReadViaHolder__decode_from__gd20d v0 v1;
+        return v6;
 }
 
 func inline(always) private %decode_from_prechecked_head__g1d15(v0.@layout_2, v1.i256, v2.i256) -> @layout_5 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v4 i256;
-        v7.i256 = mload v3 i256;
-        v8.@layout_5 = call %impl_trait_SeedSlot__decode_from__gd20d v0 v7;
-        return v8;
+        v6.@layout_5 = call %impl_trait_SeedSlot__decode_from__gd20d v0 v1;
+        return v6;
 }
 
 func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_3605(v0.@layout_2, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        v6.*i256 = alloca i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
-        mstore v6 v3 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = mload v4 i256;
-        v10.i256 = mload v5 i256;
-        v11.i256 = mload v6 i256;
-        v12.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_61db v0 v9 v10 v11;
-        return v12;
+        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_61db v0 v1 v2 v3;
+        return v9;
 
     block3:
         jump block4;
 
     block4:
-        v13.i256 = mload v6 i256;
-        v15.i256 = mload v4 i256;
-        v16.i256 = mload v5 i256;
-        v17.i256 = call %core__lib__abi__decode_field_from__g5385_23bd v0 v15 v16;
-        return v17;
+        v14.i256 = call %core__lib__abi__decode_field_from__g5385_23bd v0 v1 v2;
+        return v14;
 }
 
 func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_5108(v0.@layout_2, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        v6.*i256 = alloca i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
-        mstore v6 v3 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = mload v4 i256;
-        v10.i256 = mload v5 i256;
-        v11.i256 = mload v6 i256;
-        v12.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_f2f8 v0 v9 v10 v11;
-        return v12;
+        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_f2f8 v0 v1 v2 v3;
+        return v9;
 
     block3:
         jump block4;
 
     block4:
-        v13.i256 = mload v6 i256;
-        v15.i256 = mload v4 i256;
-        v16.i256 = mload v5 i256;
-        v17.i256 = call %core__lib__abi__decode_field_from__g5385_1cc8 v0 v15 v16;
-        return v17;
+        v14.i256 = call %core__lib__abi__decode_field_from__g5385_1cc8 v0 v1 v2;
+        return v14;
 }
 
 func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_7d42(v0.@layout_2, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        v6.*i256 = alloca i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
-        mstore v6 v3 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = mload v4 i256;
-        v10.i256 = mload v5 i256;
-        v11.i256 = mload v6 i256;
-        v12.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_d7e7 v0 v9 v10 v11;
-        return v12;
+        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_d7e7 v0 v1 v2 v3;
+        return v9;
 
     block3:
         jump block4;
 
     block4:
-        v13.i256 = mload v6 i256;
-        v15.i256 = mload v4 i256;
-        v16.i256 = mload v5 i256;
-        v17.i256 = call %core__lib__abi__decode_field_from__g5385_48de v0 v15 v16;
-        return v17;
+        v14.i256 = call %core__lib__abi__decode_field_from__g5385_48de v0 v1 v2;
+        return v14;
 }
 
 func inline(always) private %decode_runtime_args__g5aad(v0.objref<@layout_7>) -> @layout_5 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v4.@layout_2 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_dcd3;
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_960d v4;
-        mstore v1 v6 i256;
-        mstore v2 4.i256 i256;
+        v3.@layout_2 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_dcd3;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_960d v3;
+        mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
 
     block2:
@@ -1139,30 +915,26 @@ func inline(always) private %decode_runtime_args__g5aad(v0.objref<@layout_7>) ->
         jump block4;
 
     block4:
-        v12.i256 = mload v1 i256;
-        v13.@layout_5 = call %decode_from_prechecked_head__g1d15 v4 4.i256 v12;
-        return v13;
+        v12.@layout_5 = call %decode_from_prechecked_head__g1d15 v3 4.i256 v5;
+        return v12;
 
     block5:
-        v14.i256 = mload v1 i256;
-        mstore v3 v14 i256;
-        v16.i256 = mload v3 i256;
-        v17.i1 = gt 68.i256 v16;
-        br v17 block2 block3;
+        mstore v2 v5 i256;
+        v15.i256 = mload v2 i256;
+        v16.i1 = gt 68.i256 v15;
+        br v16 block2 block3;
 }
 
 func inline(always) private %decode_runtime_args__g01e9(v0.objref<@layout_7>) -> @layout_4 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v4.@layout_2 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_c5c0;
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_f59a v4;
-        mstore v1 v6 i256;
-        mstore v2 4.i256 i256;
+        v3.@layout_2 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_c5c0;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_f59a v3;
+        mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
 
     block2:
@@ -1173,30 +945,26 @@ func inline(always) private %decode_runtime_args__g01e9(v0.objref<@layout_7>) ->
         jump block4;
 
     block4:
-        v12.i256 = mload v1 i256;
-        v13.@layout_4 = call %decode_from_prechecked_head__ge273 v4 4.i256 v12;
-        return v13;
+        v12.@layout_4 = call %decode_from_prechecked_head__ge273 v3 4.i256 v5;
+        return v12;
 
     block5:
-        v14.i256 = mload v1 i256;
-        mstore v3 v14 i256;
-        v16.i256 = mload v3 i256;
-        v17.i1 = gt 36.i256 v16;
-        br v17 block2 block3;
+        mstore v2 v5 i256;
+        v15.i256 = mload v2 i256;
+        v16.i1 = gt 36.i256 v15;
+        br v16 block2 block3;
 }
 
 func inline(always) private %decode_runtime_args__g0392(v0.objref<@layout_7>) -> @layout_3 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v4.@layout_2 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_0e8a;
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_4133 v4;
-        mstore v1 v6 i256;
-        mstore v2 4.i256 i256;
+        v3.@layout_2 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_0e8a;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_4133 v3;
+        mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
 
     block2:
@@ -1207,16 +975,14 @@ func inline(always) private %decode_runtime_args__g0392(v0.objref<@layout_7>) ->
         jump block4;
 
     block4:
-        v12.i256 = mload v1 i256;
-        v13.@layout_3 = call %decode_from_prechecked_head__gdaee v4 4.i256 v12;
-        return v13;
+        v12.@layout_3 = call %decode_from_prechecked_head__gdaee v3 4.i256 v5;
+        return v12;
 
     block5:
-        v14.i256 = mload v1 i256;
-        mstore v3 v14 i256;
-        v16.i256 = mload v3 i256;
-        v17.i1 = gt 36.i256 v16;
-        br v17 block2 block3;
+        mstore v2 v5 i256;
+        v15.i256 = mload v2 i256;
+        v16.i1 = gt 36.i256 v15;
+        br v16 block2 block3;
 }
 
 func private %encode(v0.i256, v1.objref<@layout_0>) {
@@ -1312,26 +1078,20 @@ func private %encode_single_root_alloc(v0.i256) -> @layout_8 {
 
 func private %encode_to_ptr(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        call %store_word v3 v0;
+        call %store_word v1 v0;
         return;
 }
 
 func private %encoder_new(v0.i256) -> @layout_0 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.@layout_0 = call %impl_SolEncoder__new v2;
-        return v3;
+        v2.@layout_0 = call %impl_SolEncoder__new v0;
+        return v2;
 }
 
 func private %extract_ptr(v0.@layout_9) -> i256 {
@@ -1353,13 +1113,10 @@ func private %extract_ptr(v0.@layout_9) -> i256 {
 
 func private %from_raw(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        return v2;
+        return v0;
 }
 
 func private %std__lib__evm__effects__impl_trait_Evm_c913__input_0e8a() -> @layout_2 {
@@ -1392,31 +1149,27 @@ func private %std__lib__evm__effects__impl_trait_Evm_c913__input_dcd3() -> @layo
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_1933(v0.@layout_2) -> i256 {
     block0:
         v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.i256 = extract_value v0 0.i256;
-        v7.i256 = mload v1 i256;
-        mstore v2 v7 i256;
-        v8.i256 = mload v2 i256;
-        v9.i1 = gt v6 v8;
-        br v9 block2 block3;
+        v2.i256 = evm_calldata_size;
+        v5.i256 = extract_value v0 0.i256;
+        mstore v1 v2 i256;
+        v6.i256 = mload v1 i256;
+        v7.i1 = gt v5 v6;
+        br v7 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v11.i256 = extract_value v0 0.i256;
-        v12.i256 = mload v1 i256;
-        (v13.i256, v14.i1) = usubo v12 v11;
-        br v14 block5 block6;
+        v9.i256 = extract_value v0 0.i256;
+        (v11.i256, v12.i1) = usubo v2 v9;
+        br v12 block5 block6;
 
     block4:
-        v19.i256 = phi (0.i256 block2) (v13 block6);
-        return v19;
+        v17.i256 = phi (0.i256 block2) (v11 block6);
+        return v17;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -1430,31 +1183,27 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_392e(v0.@layout_2) -> i256 {
     block0:
         v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.i256 = extract_value v0 0.i256;
-        v7.i256 = mload v1 i256;
-        mstore v2 v7 i256;
-        v8.i256 = mload v2 i256;
-        v9.i1 = gt v6 v8;
-        br v9 block2 block3;
+        v2.i256 = evm_calldata_size;
+        v5.i256 = extract_value v0 0.i256;
+        mstore v1 v2 i256;
+        v6.i256 = mload v1 i256;
+        v7.i1 = gt v5 v6;
+        br v7 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v11.i256 = extract_value v0 0.i256;
-        v12.i256 = mload v1 i256;
-        (v13.i256, v14.i1) = usubo v12 v11;
-        br v14 block5 block6;
+        v9.i256 = extract_value v0 0.i256;
+        (v11.i256, v12.i1) = usubo v2 v9;
+        br v12 block5 block6;
 
     block4:
-        v19.i256 = phi (0.i256 block2) (v13 block6);
-        return v19;
+        v17.i256 = phi (0.i256 block2) (v11 block6);
+        return v17;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -1468,31 +1217,27 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_4133(v0.@layout_2) -> i256 {
     block0:
         v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.i256 = extract_value v0 0.i256;
-        v7.i256 = mload v1 i256;
-        mstore v2 v7 i256;
-        v8.i256 = mload v2 i256;
-        v9.i1 = gt v6 v8;
-        br v9 block2 block3;
+        v2.i256 = evm_calldata_size;
+        v5.i256 = extract_value v0 0.i256;
+        mstore v1 v2 i256;
+        v6.i256 = mload v1 i256;
+        v7.i1 = gt v5 v6;
+        br v7 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v11.i256 = extract_value v0 0.i256;
-        v12.i256 = mload v1 i256;
-        (v13.i256, v14.i1) = usubo v12 v11;
-        br v14 block5 block6;
+        v9.i256 = extract_value v0 0.i256;
+        (v11.i256, v12.i1) = usubo v2 v9;
+        br v12 block5 block6;
 
     block4:
-        v19.i256 = phi (0.i256 block2) (v13 block6);
-        return v19;
+        v17.i256 = phi (0.i256 block2) (v11 block6);
+        return v17;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -1506,31 +1251,27 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_960d(v0.@layout_2) -> i256 {
     block0:
         v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.i256 = extract_value v0 0.i256;
-        v7.i256 = mload v1 i256;
-        mstore v2 v7 i256;
-        v8.i256 = mload v2 i256;
-        v9.i1 = gt v6 v8;
-        br v9 block2 block3;
+        v2.i256 = evm_calldata_size;
+        v5.i256 = extract_value v0 0.i256;
+        mstore v1 v2 i256;
+        v6.i256 = mload v1 i256;
+        v7.i1 = gt v5 v6;
+        br v7 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v11.i256 = extract_value v0 0.i256;
-        v12.i256 = mload v1 i256;
-        (v13.i256, v14.i1) = usubo v12 v11;
-        br v14 block5 block6;
+        v9.i256 = extract_value v0 0.i256;
+        (v11.i256, v12.i1) = usubo v2 v9;
+        br v12 block5 block6;
 
     block4:
-        v19.i256 = phi (0.i256 block2) (v13 block6);
-        return v19;
+        v17.i256 = phi (0.i256 block2) (v11 block6);
+        return v17;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -1544,31 +1285,27 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_9e81(v0.@layout_2) -> i256 {
     block0:
         v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.i256 = extract_value v0 0.i256;
-        v7.i256 = mload v1 i256;
-        mstore v2 v7 i256;
-        v8.i256 = mload v2 i256;
-        v9.i1 = gt v6 v8;
-        br v9 block2 block3;
+        v2.i256 = evm_calldata_size;
+        v5.i256 = extract_value v0 0.i256;
+        mstore v1 v2 i256;
+        v6.i256 = mload v1 i256;
+        v7.i1 = gt v5 v6;
+        br v7 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v11.i256 = extract_value v0 0.i256;
-        v12.i256 = mload v1 i256;
-        (v13.i256, v14.i1) = usubo v12 v11;
-        br v14 block5 block6;
+        v9.i256 = extract_value v0 0.i256;
+        (v11.i256, v12.i1) = usubo v2 v9;
+        br v12 block5 block6;
 
     block4:
-        v19.i256 = phi (0.i256 block2) (v13 block6);
-        return v19;
+        v17.i256 = phi (0.i256 block2) (v11 block6);
+        return v17;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -1582,31 +1319,27 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_f59a(v0.@layout_2) -> i256 {
     block0:
         v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.i256 = extract_value v0 0.i256;
-        v7.i256 = mload v1 i256;
-        mstore v2 v7 i256;
-        v8.i256 = mload v2 i256;
-        v9.i1 = gt v6 v8;
-        br v9 block2 block3;
+        v2.i256 = evm_calldata_size;
+        v5.i256 = extract_value v0 0.i256;
+        mstore v1 v2 i256;
+        v6.i256 = mload v1 i256;
+        v7.i1 = gt v5 v6;
+        br v7 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v11.i256 = extract_value v0 0.i256;
-        v12.i256 = mload v1 i256;
-        (v13.i256, v14.i1) = usubo v12 v11;
-        br v14 block5 block6;
+        v9.i256 = extract_value v0 0.i256;
+        (v11.i256, v12.i1) = usubo v2 v9;
+        br v12 block5 block6;
 
     block4:
-        v19.i256 = phi (0.i256 block2) (v13 block6);
-        return v19;
+        v17.i256 = phi (0.i256 block2) (v11 block6);
+        return v17;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -1631,28 +1364,24 @@ func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_0a
 
 func private %impl_SolEncoder__new(v0.i256) -> @layout_0 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v4.i1 = eq v2 0.i256;
-        br v4 block2 block3;
+        v3.i1 = eq v0 0.i256;
+        br v3 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v5.i256 = mload v1 i256;
-        v6.*i8 = evm_malloc v5;
-        v7.i256 = ptr_to_int v6 i256;
+        v5.*i8 = evm_malloc v0;
+        v6.i256 = ptr_to_int v5 i256;
         jump block4;
 
     block4:
-        v8.i256 = phi (0.i256 block2) (v7 block3);
-        v9.@layout_0 = call %at v8;
-        return v9;
+        v7.i256 = phi (0.i256 block2) (v6 block3);
+        v8.@layout_0 = call %at v7;
+        return v8;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_ac71() -> @layout_2 {
@@ -1681,8 +1410,6 @@ func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_e1
 
 func private %core__lib__abi__trait_AbiSize__payload_size__ge513_a8bc(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
@@ -1691,8 +1418,6 @@ func private %core__lib__abi__trait_AbiSize__payload_size__ge513_a8bc(v0.i256) -
 
 func private %core__lib__abi__trait_AbiSize__payload_size__ge513_a8bc_0(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
@@ -1720,269 +1445,200 @@ func private %read_cell(v0.i256) -> i256 {
 
 func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_27e9(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        evm_revert v4 v5;
+        evm_revert v0 v1;
 }
 
 func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_a881(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        evm_revert v4 v5;
+        evm_revert v0 v1;
 }
 
 func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_ba8b(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        evm_revert v4 v5;
+        evm_revert v0 v1;
 }
 
 func private %set_base(v0.objref<@layout_0>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        obj.store v6 v3;
+        v5.objref<i256> = obj.proj v0 0.i256;
+        obj.store v5 v1;
         return;
 }
 
 func private %set_pos(v0.objref<@layout_0>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 1.i256;
-        obj.store v6 v3;
+        v5.objref<i256> = obj.proj v0 1.i256;
+        obj.store v5 v1;
         return;
 }
 
 func private %stor_ptr(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = call %from_raw v2;
-        return v3;
+        v2.i256 = call %from_raw v0;
+        return v2;
 }
 
 func private %store_word(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        mstore v4 v5 i256;
+        mstore v0 v1 i256;
         return;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_4e15(v0.@layout_2, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_4e15_0(v0.@layout_2, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_7303(v0.@layout_2, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_7c41(v0.@layout_2, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_950e(v0.@layout_2, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_950e_0(v0.@layout_2, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_9c31(v0.@layout_2, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_9c31_0(v0.@layout_2, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_dee9(v0.@layout_2, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func private %write_cell(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v0 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        evm_sstore v1 v3;
-        v5.i256 = evm_sload v1;
-        return v5;
+        evm_sstore v1 v0;
+        v4.i256 = evm_sload v1;
+        return v4;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_2aa5(v0.objref<@layout_0>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 1.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        mstore v6 v7 i256;
-        v10.i256 = add v6 32.i256;
-        v11.objref<i256> = obj.proj v0 1.i256;
-        obj.store v11 v10;
+        v4.objref<i256> = obj.proj v0 1.i256;
+        v5.i256 = obj.load v4;
+        mstore v5 v1 i256;
+        v9.i256 = add v5 32.i256;
+        v10.objref<i256> = obj.proj v0 1.i256;
+        obj.store v10 v9;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_8a50(v0.objref<@layout_0>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 1.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        mstore v6 v7 i256;
-        v10.i256 = add v6 32.i256;
-        v11.objref<i256> = obj.proj v0 1.i256;
-        obj.store v11 v10;
+        v4.objref<i256> = obj.proj v0 1.i256;
+        v5.i256 = obj.load v4;
+        mstore v5 v1 i256;
+        v9.i256 = add v5 32.i256;
+        v10.objref<i256> = obj.proj v0 1.i256;
+        obj.store v10 v9;
         return;
 }
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/effect_ptr_domains.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/effect_ptr_domains.snap
@@ -94,24 +94,18 @@ func private %bump__gaab0(v0.i256) {
 
 func private %impl_trait_StorPtr__from_raw__gb2d8(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        return v2;
+        return v0;
 }
 
 func private %impl_trait_MemPtr__from_raw__gb2d8(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        return v2;
+        return v0;
 }
 
 func private %main_root() {
@@ -125,26 +119,20 @@ func private %main_root() {
 
 func private %mem_ptr(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = call %impl_trait_MemPtr__from_raw__gb2d8 v2;
-        return v3;
+        v2.i256 = call %impl_trait_MemPtr__from_raw__gb2d8 v0;
+        return v2;
 }
 
 func private %stor_ptr(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = call %impl_trait_StorPtr__from_raw__gb2d8 v2;
-        return v3;
+        v2.i256 = call %impl_trait_StorPtr__from_raw__gb2d8 v0;
+        return v2;
 }
 
 func private %test_effect_ptr_domains() {

--- a/crates/codegen/tests/fixtures/sonatina_ir/enum_variant_contract.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/enum_variant_contract.snap
@@ -12,44 +12,29 @@ type @layout_0 = enum {
 
 func private %abi_encode_u256(v0.i256) {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v1 i256;
-        call %mstore 0.i256 v3;
+        call %mstore 0.i256 v0;
         call %std__lib__evm__effects__impl_trait_Evm_0098__return_data_44fe 0.i256 32.i256;
         unreachable;
 }
 
 func private %calldataload(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = evm_calldata_load v2;
-        return v3;
+        v2.i256 = evm_calldata_load v0;
+        return v2;
 }
 
 func private %codecopy(v0.i256, v1.i256, v2.i256) {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        mstore v3 v0 i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
         jump block1;
 
     block1:
-        v6.i256 = mload v3 i256;
-        v7.i256 = mload v4 i256;
-        v8.i256 = mload v5 i256;
-        evm_code_copy v6 v7 v8;
+        evm_code_copy v0 v1 v2;
         return;
 }
 
@@ -87,59 +72,35 @@ func private %manual_contract_runtime_root_EnumContract() {
 
 func private %mstore(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        mstore v4 v5 i256;
+        mstore v0 v1 i256;
         return;
 }
 
 func private %std__lib__evm__effects__impl_trait_Evm_0098__return_data_1461(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        evm_return v4 v5;
+        evm_return v0 v1;
 }
 
 func private %std__lib__evm__effects__impl_trait_Evm_0098__return_data_1461_0(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        evm_return v4 v5;
+        evm_return v0 v1;
 }
 
 func private %std__lib__evm__effects__impl_trait_Evm_0098__return_data_44fe(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        evm_return v4 v5;
+        evm_return v0 v1;
 }
 
 func private %runtime() {

--- a/crates/codegen/tests/fixtures/sonatina_ir/erc20.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/erc20.snap
@@ -34,20 +34,16 @@ global private const @layout_0 $const_region_1 = {0};
 
 func private %__CoolCoin_init(v0.i256, v1.@layout_0, v2.i256, v3.i256) {
     block0:
-        v4.*i256 = alloca i256;
-        mstore v4 v0 i256;
         jump block1;
 
     block1:
         call %grant v3 1.i256 v1;
         call %grant v3 2.i256 v1;
-        v11.i256 = mload v4 i256;
-        v13.i1 = gt v11 0.i256;
-        br v13 block2 block3;
+        v12.i1 = gt v0 0.i256;
+        br v12 block2 block3;
 
     block2:
-        v15.i256 = mload v4 i256;
-        call %standalone_erc20__erc20__mint__g5c3f_dd30 v1 v15 v2;
+        call %standalone_erc20__erc20__mint__g5c3f_dd30 v1 v0 v2;
         jump block4;
 
     block3:
@@ -198,36 +194,32 @@ func private %__CoolCoin_recv_1_3(v0.@layout_0, v1.i256, v2.i256) -> i1 {
 func private %__CoolCoin_recv_1_4(v0.@layout_0, v1.i256, v2.i256) -> i1 {
     block0:
         v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v5.@layout_0 = call %caller;
-        v8.@layout_22 = insert_value undef.@layout_22 0.i256 v5;
-        v11.@layout_22 = insert_value v8 1.i256 v0;
-        v12.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get__ga15b_b5d5_0 v11;
+        v4.@layout_0 = call %caller;
+        v7.@layout_22 = insert_value undef.@layout_22 0.i256 v4;
+        v10.@layout_22 = insert_value v7 1.i256 v0;
+        v11.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get__ga15b_b5d5_0 v10;
+        mstore v3 v1 i256;
         v13.i256 = mload v3 i256;
-        mstore v4 v13 i256;
-        v14.i256 = mload v4 i256;
-        v15.i1 = lt v12 v14;
-        v16.i1 = is_zero v15;
-        br v16 block2 block3;
+        v14.i1 = lt v11 v13;
+        v15.i1 = is_zero v14;
+        br v15 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v19.*i8 = evm_malloc 64.i256;
-        v20.i256 = ptr_to_int v19 i256;
-        mstore v20 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        (v24.i256, v25.i1) = uaddo v20 32.i256;
-        br v25 block5 block6;
+        v18.*i8 = evm_malloc 64.i256;
+        v19.i256 = ptr_to_int v18 i256;
+        mstore v19 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        (v23.i256, v24.i1) = uaddo v19 32.i256;
+        br v24 block5 block6;
 
     block4:
-        v33.i256 = mload v3 i256;
-        (v34.i256, v35.i1) = usubo v12 v33;
-        br v35 block5 block7;
+        (v33.i256, v34.i1) = usubo v11 v1;
+        br v34 block5 block7;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -235,34 +227,31 @@ func private %__CoolCoin_recv_1_4(v0.@layout_0, v1.i256, v2.i256) -> i1 {
         evm_revert 0.i256 36.i256;
 
     block6:
-        mstore v24 26959946667150639794667015087019630673637144422540572481103610249216.i256 i256;
-        evm_revert v20 36.i256;
+        mstore v23 26959946667150639794667015087019630673637144422540572481103610249216.i256 i256;
+        evm_revert v19 36.i256;
 
     block7:
-        call %standalone_erc20__erc20__approve__g5c3f_43cb v5 v0 v34 v2;
+        call %standalone_erc20__erc20__approve__g5c3f_43cb v4 v0 v33 v2;
         return 1.i1;
 }
 
 func private %abi_field_size__gda9b(v0.i1) -> i256 {
     block0:
-        v1.*i1 = alloca i1;
-        mstore v1 v0 i1;
         jump block1;
 
     block1:
-        v2.i1 = mload v1 i1;
-        v3.i256 = call %core__lib__abi__trait_AbiSize__payload_size__gda9b_b33d_0 v2;
+        v2.i256 = call %core__lib__abi__trait_AbiSize__payload_size__gda9b_b33d_0 v0;
         br 0.i1 block2 block3;
 
     block2:
-        (v7.i256, v8.i1) = uaddo 32.i256 v3;
-        br v8 block5 block6;
+        (v6.i256, v7.i1) = uaddo 32.i256 v2;
+        br v7 block5 block6;
 
     block3:
         jump block4;
 
     block4:
-        return v3;
+        return v2;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -270,29 +259,26 @@ func private %abi_field_size__gda9b(v0.i1) -> i256 {
         evm_revert 0.i256 36.i256;
 
     block6:
-        return v7;
+        return v6;
 }
 
 func private %abi_field_size__g79ff(v0.i8) -> i256 {
     block0:
-        v1.*i8 = alloca i8;
-        mstore v1 v0 i8;
         jump block1;
 
     block1:
-        v2.i8 = mload v1 i8;
-        v3.i256 = call %core__lib__abi__trait_AbiSize__payload_size__g79ff_f3e8_0 v2;
+        v2.i256 = call %core__lib__abi__trait_AbiSize__payload_size__g79ff_f3e8_0 v0;
         br 0.i1 block2 block3;
 
     block2:
-        (v7.i256, v8.i1) = uaddo 32.i256 v3;
-        br v8 block5 block6;
+        (v6.i256, v7.i1) = uaddo 32.i256 v2;
+        br v7 block5 block6;
 
     block3:
         jump block4;
 
     block4:
-        return v3;
+        return v2;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -300,29 +286,26 @@ func private %abi_field_size__g79ff(v0.i8) -> i256 {
         evm_revert 0.i256 36.i256;
 
     block6:
-        return v7;
+        return v6;
 }
 
 func private %abi_field_size__g65da(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = call %core__lib__abi__impl_trait_String_c06e__payload_size__gc7cf_4aab_0 v2;
+        v2.i256 = call %core__lib__abi__impl_trait_String_c06e__payload_size__gc7cf_4aab_0 v0;
         br 1.i1 block2 block3;
 
     block2:
-        (v7.i256, v8.i1) = uaddo 32.i256 v3;
-        br v8 block5 block6;
+        (v6.i256, v7.i1) = uaddo 32.i256 v2;
+        br v7 block5 block6;
 
     block3:
         jump block4;
 
     block4:
-        return v3;
+        return v2;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -330,29 +313,26 @@ func private %abi_field_size__g65da(v0.i256) -> i256 {
         evm_revert 0.i256 36.i256;
 
     block6:
-        return v7;
+        return v6;
 }
 
 func private %abi_field_size__g5535(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = call %core__lib__abi__impl_trait_String_c06e__payload_size__g3eb7_f656_0 v2;
+        v2.i256 = call %core__lib__abi__impl_trait_String_c06e__payload_size__g3eb7_f656_0 v0;
         br 1.i1 block2 block3;
 
     block2:
-        (v7.i256, v8.i1) = uaddo 32.i256 v3;
-        br v8 block5 block6;
+        (v6.i256, v7.i1) = uaddo 32.i256 v2;
+        br v7 block5 block6;
 
     block3:
         jump block4;
 
     block4:
-        return v3;
+        return v2;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -360,29 +340,26 @@ func private %abi_field_size__g5535(v0.i256) -> i256 {
         evm_revert 0.i256 36.i256;
 
     block6:
-        return v7;
+        return v6;
 }
 
 func private %abi_field_size__ge513(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_77e5_0 v2;
+        v2.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_77e5_0 v0;
         br 0.i1 block2 block3;
 
     block2:
-        (v7.i256, v8.i1) = uaddo 32.i256 v3;
-        br v8 block5 block6;
+        (v6.i256, v7.i1) = uaddo 32.i256 v2;
+        br v7 block5 block6;
 
     block3:
         jump block4;
 
     block4:
-        return v3;
+        return v2;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -390,91 +367,70 @@ func private %abi_field_size__ge513(v0.i256) -> i256 {
         evm_revert 0.i256 36.i256;
 
     block6:
-        return v7;
+        return v6;
 }
 
 func private %core__lib__abi__abi_payload_size__ge513_b9e3(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_a81c v2;
-        return v3;
+        v2.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_a81c v0;
+        return v2;
 }
 
 func private %core__lib__abi__abi_payload_size__ge513_cdf0(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_0454 v2;
-        return v3;
+        v2.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_0454 v0;
+        return v2;
 }
 
 func private %abi_single_root_size__gda9b(v0.i1) -> i256 {
     block0:
-        v1.*i1 = alloca i1;
-        mstore v1 v0 i1;
         jump block1;
 
     block1:
-        v2.i1 = mload v1 i1;
-        v3.i256 = call %abi_field_size__gda9b v2;
-        return v3;
+        v2.i256 = call %abi_field_size__gda9b v0;
+        return v2;
 }
 
 func private %abi_single_root_size__g65da(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = call %abi_field_size__g65da v2;
-        return v3;
+        v2.i256 = call %abi_field_size__g65da v0;
+        return v2;
 }
 
 func private %abi_single_root_size__g79ff(v0.i8) -> i256 {
     block0:
-        v1.*i8 = alloca i8;
-        mstore v1 v0 i8;
         jump block1;
 
     block1:
-        v2.i8 = mload v1 i8;
-        v3.i256 = call %abi_field_size__g79ff v2;
-        return v3;
+        v2.i256 = call %abi_field_size__g79ff v0;
+        return v2;
 }
 
 func private %abi_single_root_size__ge513(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = call %abi_field_size__ge513 v2;
-        return v3;
+        v2.i256 = call %abi_field_size__ge513 v0;
+        return v2;
 }
 
 func private %abi_single_root_size__g5535(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = call %abi_field_size__g5535 v2;
-        return v3;
+        v2.i256 = call %abi_field_size__g5535 v0;
+        return v2;
 }
 
 func private %std__lib__evm__effects__impl_trait_Evm_c913__abort_0a69() {
@@ -605,60 +561,56 @@ func private %std__lib__evm__effects__impl_trait_Evm_c913__abort_cf57() {
 
 func private %standalone_erc20__erc20__approve__g5c3f_1f37(v0.@layout_0, v1.@layout_0, v2.i256, v3.i256) {
     block0:
-        v4.*i256 = alloca i256;
+        v4.objref<@layout_0> = obj.alloc @layout_0;
         v5.objref<@layout_0> = obj.alloc @layout_0;
-        v6.objref<@layout_0> = obj.alloc @layout_0;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v8.@layout_0 = call %zero;
-        v10.objref<i256> = obj.proj v5 0.i256;
-        v11.i256 = extract_value v8 0.i256;
-        obj.store v10 v11;
-        v12.@layout_0 = obj.load v5;
-        v13.i1 = call %ne v0 v12;
-        br v13 block2 block3;
+        v7.@layout_0 = call %zero;
+        v9.objref<i256> = obj.proj v4 0.i256;
+        v10.i256 = extract_value v7 0.i256;
+        obj.store v9 v10;
+        v11.@layout_0 = obj.load v4;
+        v12.i1 = call %ne v0 v11;
+        br v12 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v16.*i8 = evm_malloc 64.i256;
-        v17.i256 = ptr_to_int v16 i256;
-        mstore v17 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        (v21.i256, v22.i1) = uaddo v17 32.i256;
-        br v22 block8 block9;
+        v15.*i8 = evm_malloc 64.i256;
+        v16.i256 = ptr_to_int v15 i256;
+        mstore v16 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        (v20.i256, v21.i1) = uaddo v16 32.i256;
+        br v21 block8 block9;
 
     block4:
-        v30.@layout_0 = call %zero;
-        v31.objref<i256> = obj.proj v6 0.i256;
-        v32.i256 = extract_value v30 0.i256;
-        obj.store v31 v32;
-        v33.@layout_0 = obj.load v6;
-        v34.i1 = call %ne v1 v33;
-        br v34 block5 block6;
+        v29.@layout_0 = call %zero;
+        v30.objref<i256> = obj.proj v5 0.i256;
+        v31.i256 = extract_value v29 0.i256;
+        obj.store v30 v31;
+        v32.@layout_0 = obj.load v5;
+        v33.i1 = call %ne v1 v32;
+        br v33 block5 block6;
 
     block5:
         jump block7;
 
     block6:
-        v35.*i8 = evm_malloc 64.i256;
-        v36.i256 = ptr_to_int v35 i256;
-        mstore v36 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        (v38.i256, v39.i1) = uaddo v36 32.i256;
-        br v39 block8 block10;
+        v34.*i8 = evm_malloc 64.i256;
+        v35.i256 = ptr_to_int v34 i256;
+        mstore v35 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        (v37.i256, v38.i1) = uaddo v35 32.i256;
+        br v38 block8 block10;
 
     block7:
-        v46.@layout_22 = insert_value undef.@layout_22 0.i256 v0;
-        v48.@layout_22 = insert_value v46 1.i256 v1;
-        v49.i256 = mload v4 i256;
-        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set__ga15b_f7f7_0 v48 v49;
-        v51.i256 = mload v4 i256;
-        v53.@layout_20 = insert_value undef.@layout_20 0.i256 v0;
-        v54.@layout_20 = insert_value v53 1.i256 v1;
-        v56.@layout_20 = insert_value v54 2.i256 v51;
-        call %emit__g9cd0 v56;
+        v45.@layout_22 = insert_value undef.@layout_22 0.i256 v0;
+        v47.@layout_22 = insert_value v45 1.i256 v1;
+        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set__ga15b_f7f7_0 v47 v2;
+        v51.@layout_20 = insert_value undef.@layout_20 0.i256 v0;
+        v52.@layout_20 = insert_value v51 1.i256 v1;
+        v54.@layout_20 = insert_value v52 2.i256 v2;
+        call %emit__g9cd0 v54;
         return;
 
     block8:
@@ -667,70 +619,66 @@ func private %standalone_erc20__erc20__approve__g5c3f_1f37(v0.@layout_0, v1.@lay
         evm_revert 0.i256 36.i256;
 
     block9:
-        mstore v21 26959946667150639794667015087019630673637144422540572481103610249216.i256 i256;
-        evm_revert v17 36.i256;
+        mstore v20 26959946667150639794667015087019630673637144422540572481103610249216.i256 i256;
+        evm_revert v16 36.i256;
 
     block10:
-        mstore v38 26959946667150639794667015087019630673637144422540572481103610249216.i256 i256;
-        evm_revert v36 36.i256;
+        mstore v37 26959946667150639794667015087019630673637144422540572481103610249216.i256 i256;
+        evm_revert v35 36.i256;
 }
 
 func private %standalone_erc20__erc20__approve__g5c3f_43cb(v0.@layout_0, v1.@layout_0, v2.i256, v3.i256) {
     block0:
-        v4.*i256 = alloca i256;
+        v4.objref<@layout_0> = obj.alloc @layout_0;
         v5.objref<@layout_0> = obj.alloc @layout_0;
-        v6.objref<@layout_0> = obj.alloc @layout_0;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v8.@layout_0 = call %zero;
-        v10.objref<i256> = obj.proj v5 0.i256;
-        v11.i256 = extract_value v8 0.i256;
-        obj.store v10 v11;
-        v12.@layout_0 = obj.load v5;
-        v13.i1 = call %ne v0 v12;
-        br v13 block2 block3;
+        v7.@layout_0 = call %zero;
+        v9.objref<i256> = obj.proj v4 0.i256;
+        v10.i256 = extract_value v7 0.i256;
+        obj.store v9 v10;
+        v11.@layout_0 = obj.load v4;
+        v12.i1 = call %ne v0 v11;
+        br v12 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v16.*i8 = evm_malloc 64.i256;
-        v17.i256 = ptr_to_int v16 i256;
-        mstore v17 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        (v21.i256, v22.i1) = uaddo v17 32.i256;
-        br v22 block8 block9;
+        v15.*i8 = evm_malloc 64.i256;
+        v16.i256 = ptr_to_int v15 i256;
+        mstore v16 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        (v20.i256, v21.i1) = uaddo v16 32.i256;
+        br v21 block8 block9;
 
     block4:
-        v30.@layout_0 = call %zero;
-        v31.objref<i256> = obj.proj v6 0.i256;
-        v32.i256 = extract_value v30 0.i256;
-        obj.store v31 v32;
-        v33.@layout_0 = obj.load v6;
-        v34.i1 = call %ne v1 v33;
-        br v34 block5 block6;
+        v29.@layout_0 = call %zero;
+        v30.objref<i256> = obj.proj v5 0.i256;
+        v31.i256 = extract_value v29 0.i256;
+        obj.store v30 v31;
+        v32.@layout_0 = obj.load v5;
+        v33.i1 = call %ne v1 v32;
+        br v33 block5 block6;
 
     block5:
         jump block7;
 
     block6:
-        v35.*i8 = evm_malloc 64.i256;
-        v36.i256 = ptr_to_int v35 i256;
-        mstore v36 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        (v38.i256, v39.i1) = uaddo v36 32.i256;
-        br v39 block8 block10;
+        v34.*i8 = evm_malloc 64.i256;
+        v35.i256 = ptr_to_int v34 i256;
+        mstore v35 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        (v37.i256, v38.i1) = uaddo v35 32.i256;
+        br v38 block8 block10;
 
     block7:
-        v46.@layout_22 = insert_value undef.@layout_22 0.i256 v0;
-        v48.@layout_22 = insert_value v46 1.i256 v1;
-        v49.i256 = mload v4 i256;
-        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set__ga15b_f7f7_0 v48 v49;
-        v51.i256 = mload v4 i256;
-        v53.@layout_20 = insert_value undef.@layout_20 0.i256 v0;
-        v54.@layout_20 = insert_value v53 1.i256 v1;
-        v56.@layout_20 = insert_value v54 2.i256 v51;
-        call %emit__g9cd0 v56;
+        v45.@layout_22 = insert_value undef.@layout_22 0.i256 v0;
+        v47.@layout_22 = insert_value v45 1.i256 v1;
+        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set__ga15b_f7f7_0 v47 v2;
+        v51.@layout_20 = insert_value undef.@layout_20 0.i256 v0;
+        v52.@layout_20 = insert_value v51 1.i256 v1;
+        v54.@layout_20 = insert_value v52 2.i256 v2;
+        call %emit__g9cd0 v54;
         return;
 
     block8:
@@ -739,70 +687,66 @@ func private %standalone_erc20__erc20__approve__g5c3f_43cb(v0.@layout_0, v1.@lay
         evm_revert 0.i256 36.i256;
 
     block9:
-        mstore v21 26959946667150639794667015087019630673637144422540572481103610249216.i256 i256;
-        evm_revert v17 36.i256;
+        mstore v20 26959946667150639794667015087019630673637144422540572481103610249216.i256 i256;
+        evm_revert v16 36.i256;
 
     block10:
-        mstore v38 26959946667150639794667015087019630673637144422540572481103610249216.i256 i256;
-        evm_revert v36 36.i256;
+        mstore v37 26959946667150639794667015087019630673637144422540572481103610249216.i256 i256;
+        evm_revert v35 36.i256;
 }
 
 func private %standalone_erc20__erc20__approve__g5c3f_7d3b(v0.@layout_0, v1.@layout_0, v2.i256, v3.i256) {
     block0:
-        v4.*i256 = alloca i256;
+        v4.objref<@layout_0> = obj.alloc @layout_0;
         v5.objref<@layout_0> = obj.alloc @layout_0;
-        v6.objref<@layout_0> = obj.alloc @layout_0;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v8.@layout_0 = call %zero;
-        v10.objref<i256> = obj.proj v5 0.i256;
-        v11.i256 = extract_value v8 0.i256;
-        obj.store v10 v11;
-        v12.@layout_0 = obj.load v5;
-        v13.i1 = call %ne v0 v12;
-        br v13 block2 block3;
+        v7.@layout_0 = call %zero;
+        v9.objref<i256> = obj.proj v4 0.i256;
+        v10.i256 = extract_value v7 0.i256;
+        obj.store v9 v10;
+        v11.@layout_0 = obj.load v4;
+        v12.i1 = call %ne v0 v11;
+        br v12 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v16.*i8 = evm_malloc 64.i256;
-        v17.i256 = ptr_to_int v16 i256;
-        mstore v17 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        (v21.i256, v22.i1) = uaddo v17 32.i256;
-        br v22 block8 block9;
+        v15.*i8 = evm_malloc 64.i256;
+        v16.i256 = ptr_to_int v15 i256;
+        mstore v16 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        (v20.i256, v21.i1) = uaddo v16 32.i256;
+        br v21 block8 block9;
 
     block4:
-        v30.@layout_0 = call %zero;
-        v31.objref<i256> = obj.proj v6 0.i256;
-        v32.i256 = extract_value v30 0.i256;
-        obj.store v31 v32;
-        v33.@layout_0 = obj.load v6;
-        v34.i1 = call %ne v1 v33;
-        br v34 block5 block6;
+        v29.@layout_0 = call %zero;
+        v30.objref<i256> = obj.proj v5 0.i256;
+        v31.i256 = extract_value v29 0.i256;
+        obj.store v30 v31;
+        v32.@layout_0 = obj.load v5;
+        v33.i1 = call %ne v1 v32;
+        br v33 block5 block6;
 
     block5:
         jump block7;
 
     block6:
-        v35.*i8 = evm_malloc 64.i256;
-        v36.i256 = ptr_to_int v35 i256;
-        mstore v36 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        (v38.i256, v39.i1) = uaddo v36 32.i256;
-        br v39 block8 block10;
+        v34.*i8 = evm_malloc 64.i256;
+        v35.i256 = ptr_to_int v34 i256;
+        mstore v35 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        (v37.i256, v38.i1) = uaddo v35 32.i256;
+        br v38 block8 block10;
 
     block7:
-        v46.@layout_22 = insert_value undef.@layout_22 0.i256 v0;
-        v48.@layout_22 = insert_value v46 1.i256 v1;
-        v49.i256 = mload v4 i256;
-        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set__ga15b_f7f7_0 v48 v49;
-        v51.i256 = mload v4 i256;
-        v53.@layout_20 = insert_value undef.@layout_20 0.i256 v0;
-        v54.@layout_20 = insert_value v53 1.i256 v1;
-        v56.@layout_20 = insert_value v54 2.i256 v51;
-        call %emit__g9cd0 v56;
+        v45.@layout_22 = insert_value undef.@layout_22 0.i256 v0;
+        v47.@layout_22 = insert_value v45 1.i256 v1;
+        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set__ga15b_f7f7_0 v47 v2;
+        v51.@layout_20 = insert_value undef.@layout_20 0.i256 v0;
+        v52.@layout_20 = insert_value v51 1.i256 v1;
+        v54.@layout_20 = insert_value v52 2.i256 v2;
+        call %emit__g9cd0 v54;
         return;
 
     block8:
@@ -811,12 +755,12 @@ func private %standalone_erc20__erc20__approve__g5c3f_7d3b(v0.@layout_0, v1.@lay
         evm_revert 0.i256 36.i256;
 
     block9:
-        mstore v21 26959946667150639794667015087019630673637144422540572481103610249216.i256 i256;
-        evm_revert v17 36.i256;
+        mstore v20 26959946667150639794667015087019630673637144422540572481103610249216.i256 i256;
+        evm_revert v16 36.i256;
 
     block10:
-        mstore v38 26959946667150639794667015087019630673637144422540572481103610249216.i256 i256;
-        evm_revert v36 36.i256;
+        mstore v37 26959946667150639794667015087019630673637144422540572481103610249216.i256 i256;
+        evm_revert v35 36.i256;
 }
 
 func private %std__lib__abi__sol__types__impl_trait_Address_0a07__as_topic_14ec(v0.@layout_0) -> i256 {
@@ -839,100 +783,72 @@ func private %std__lib__abi__sol__types__impl_trait_Address_0a07__as_topic_88ba(
 
 func inline(always) private %std__lib__abi__sol__impl_SolEncoder_ce34__at_0e5a(v0.i256) -> @layout_1 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = mload v1 i256;
-        v6.@layout_1 = insert_value undef.@layout_1 0.i256 v2;
-        v8.@layout_1 = insert_value v6 1.i256 v3;
-        return v8;
+        v4.@layout_1 = insert_value undef.@layout_1 0.i256 v0;
+        v6.@layout_1 = insert_value v4 1.i256 v0;
+        return v6;
 }
 
 func inline(always) private %std__lib__abi__sol__impl_SolEncoder_ce34__at_31d5(v0.i256) -> @layout_1 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = mload v1 i256;
-        v6.@layout_1 = insert_value undef.@layout_1 0.i256 v2;
-        v8.@layout_1 = insert_value v6 1.i256 v3;
-        return v8;
+        v4.@layout_1 = insert_value undef.@layout_1 0.i256 v0;
+        v6.@layout_1 = insert_value v4 1.i256 v0;
+        return v6;
 }
 
 func inline(always) private %std__lib__abi__sol__impl_SolEncoder_ce34__at_3361(v0.i256) -> @layout_1 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = mload v1 i256;
-        v6.@layout_1 = insert_value undef.@layout_1 0.i256 v2;
-        v8.@layout_1 = insert_value v6 1.i256 v3;
-        return v8;
+        v4.@layout_1 = insert_value undef.@layout_1 0.i256 v0;
+        v6.@layout_1 = insert_value v4 1.i256 v0;
+        return v6;
 }
 
 func inline(always) private %std__lib__abi__sol__impl_SolEncoder_ce34__at_65fb(v0.i256) -> @layout_1 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = mload v1 i256;
-        v6.@layout_1 = insert_value undef.@layout_1 0.i256 v2;
-        v8.@layout_1 = insert_value v6 1.i256 v3;
-        return v8;
+        v4.@layout_1 = insert_value undef.@layout_1 0.i256 v0;
+        v6.@layout_1 = insert_value v4 1.i256 v0;
+        return v6;
 }
 
 func inline(always) private %std__lib__abi__sol__impl_SolEncoder_ce34__at_6792(v0.i256) -> @layout_1 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = mload v1 i256;
-        v6.@layout_1 = insert_value undef.@layout_1 0.i256 v2;
-        v8.@layout_1 = insert_value v6 1.i256 v3;
-        return v8;
+        v4.@layout_1 = insert_value undef.@layout_1 0.i256 v0;
+        v6.@layout_1 = insert_value v4 1.i256 v0;
+        return v6;
 }
 
 func inline(always) private %std__lib__abi__sol__impl_SolEncoder_ce34__at_69c8(v0.i256) -> @layout_1 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = mload v1 i256;
-        v6.@layout_1 = insert_value undef.@layout_1 0.i256 v2;
-        v8.@layout_1 = insert_value v6 1.i256 v3;
-        return v8;
+        v4.@layout_1 = insert_value undef.@layout_1 0.i256 v0;
+        v6.@layout_1 = insert_value v4 1.i256 v0;
+        return v6;
 }
 
 func inline(always) private %std__lib__abi__sol__impl_SolEncoder_ce34__at_fb00(v0.i256) -> @layout_1 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = mload v1 i256;
-        v6.@layout_1 = insert_value undef.@layout_1 0.i256 v2;
-        v8.@layout_1 = insert_value v6 1.i256 v3;
-        return v8;
+        v4.@layout_1 = insert_value undef.@layout_1 0.i256 v0;
+        v6.@layout_1 = insert_value v4 1.i256 v0;
+        return v6;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_009f(v0.objref<@layout_1>) -> i256 {
@@ -1047,51 +963,47 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_fd6f(v0.objre
 
 func private %standalone_erc20__erc20__burn__g5c3f_7f45(v0.@layout_0, v1.i256, v2.i256) {
     block0:
-        v3.*i256 = alloca i256;
-        v4.objref<@layout_0> = obj.alloc @layout_0;
-        mstore v3 v1 i256;
+        v3.objref<@layout_0> = obj.alloc @layout_0;
         jump block1;
 
     block1:
-        v6.@layout_0 = call %zero;
-        v8.objref<i256> = obj.proj v4 0.i256;
-        v9.i256 = extract_value v6 0.i256;
-        obj.store v8 v9;
-        v10.@layout_0 = obj.load v4;
-        v11.i1 = call %ne v0 v10;
-        br v11 block2 block3;
+        v5.@layout_0 = call %zero;
+        v7.objref<i256> = obj.proj v3 0.i256;
+        v8.i256 = extract_value v5 0.i256;
+        obj.store v7 v8;
+        v9.@layout_0 = obj.load v3;
+        v10.i1 = call %ne v0 v9;
+        br v10 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v14.*i8 = evm_malloc 64.i256;
-        v15.i256 = ptr_to_int v14 i256;
-        mstore v15 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        (v19.i256, v20.i1) = uaddo v15 32.i256;
-        br v20 block8 block9;
+        v13.*i8 = evm_malloc 64.i256;
+        v14.i256 = ptr_to_int v13 i256;
+        mstore v14 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        (v18.i256, v19.i1) = uaddo v14 32.i256;
+        br v19 block8 block9;
 
     block4:
-        v28.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get__g2163_8a15 v0;
-        v29.i256 = mload v3 i256;
-        v30.i1 = lt v28 v29;
-        v31.i1 = is_zero v30;
-        br v31 block5 block6;
+        v27.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get__g2163_8a15 v0;
+        v29.i1 = lt v27 v1;
+        v30.i1 = is_zero v29;
+        br v30 block5 block6;
 
     block5:
         jump block7;
 
     block6:
-        v32.*i8 = evm_malloc 64.i256;
-        v33.i256 = ptr_to_int v32 i256;
-        mstore v33 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        (v35.i256, v36.i1) = uaddo v33 32.i256;
-        br v36 block8 block10;
+        v31.*i8 = evm_malloc 64.i256;
+        v32.i256 = ptr_to_int v31 i256;
+        mstore v32 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        (v34.i256, v35.i1) = uaddo v32 32.i256;
+        br v35 block8 block10;
 
     block7:
-        v41.i256 = mload v3 i256;
-        (v43.i256, v44.i1) = usubo v28 v41;
-        br v44 block8 block11;
+        (v42.i256, v43.i1) = usubo v27 v1;
+        br v43 block8 block11;
 
     block8:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -1099,78 +1011,72 @@ func private %standalone_erc20__erc20__burn__g5c3f_7f45(v0.@layout_0, v1.i256, v
         evm_revert 0.i256 36.i256;
 
     block9:
-        mstore v19 26959946667150639794667015087019630673637144422540572481103610249216.i256 i256;
-        evm_revert v15 36.i256;
+        mstore v18 26959946667150639794667015087019630673637144422540572481103610249216.i256 i256;
+        evm_revert v14 36.i256;
 
     block10:
-        mstore v35 26959946667150639794667015087019630673637144422540572481103610249216.i256 i256;
-        evm_revert v33 36.i256;
+        mstore v34 26959946667150639794667015087019630673637144422540572481103610249216.i256 i256;
+        evm_revert v32 36.i256;
 
     block11:
-        call %set__g2163 v0 v43;
-        v48.i256 = mload v3 i256;
-        v49.i256 = evm_sload v2;
-        (v50.i256, v51.i1) = usubo v49 v48;
-        br v51 block8 block12;
+        call %set__g2163 v0 v42;
+        v48.i256 = evm_sload v2;
+        (v49.i256, v50.i1) = usubo v48 v1;
+        br v50 block8 block12;
 
     block12:
-        evm_sstore v2 v50;
-        v54.@layout_0 = call %zero;
-        v55.i256 = mload v3 i256;
-        v57.@layout_19 = insert_value undef.@layout_19 0.i256 v0;
-        v59.@layout_19 = insert_value v57 1.i256 v54;
-        v61.@layout_19 = insert_value v59 2.i256 v55;
-        call %emit__g4c3d v61;
+        evm_sstore v2 v49;
+        v53.@layout_0 = call %zero;
+        v56.@layout_19 = insert_value undef.@layout_19 0.i256 v0;
+        v58.@layout_19 = insert_value v56 1.i256 v53;
+        v60.@layout_19 = insert_value v58 2.i256 v1;
+        call %emit__g4c3d v60;
         return;
 }
 
 func private %standalone_erc20__erc20__burn__g5c3f_97eb(v0.@layout_0, v1.i256, v2.i256) {
     block0:
-        v3.*i256 = alloca i256;
-        v4.objref<@layout_0> = obj.alloc @layout_0;
-        mstore v3 v1 i256;
+        v3.objref<@layout_0> = obj.alloc @layout_0;
         jump block1;
 
     block1:
-        v6.@layout_0 = call %zero;
-        v8.objref<i256> = obj.proj v4 0.i256;
-        v9.i256 = extract_value v6 0.i256;
-        obj.store v8 v9;
-        v10.@layout_0 = obj.load v4;
-        v11.i1 = call %ne v0 v10;
-        br v11 block2 block3;
+        v5.@layout_0 = call %zero;
+        v7.objref<i256> = obj.proj v3 0.i256;
+        v8.i256 = extract_value v5 0.i256;
+        obj.store v7 v8;
+        v9.@layout_0 = obj.load v3;
+        v10.i1 = call %ne v0 v9;
+        br v10 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v14.*i8 = evm_malloc 64.i256;
-        v15.i256 = ptr_to_int v14 i256;
-        mstore v15 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        (v19.i256, v20.i1) = uaddo v15 32.i256;
-        br v20 block8 block9;
+        v13.*i8 = evm_malloc 64.i256;
+        v14.i256 = ptr_to_int v13 i256;
+        mstore v14 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        (v18.i256, v19.i1) = uaddo v14 32.i256;
+        br v19 block8 block9;
 
     block4:
-        v28.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get__g2163_8a15 v0;
-        v29.i256 = mload v3 i256;
-        v30.i1 = lt v28 v29;
-        v31.i1 = is_zero v30;
-        br v31 block5 block6;
+        v27.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get__g2163_8a15 v0;
+        v29.i1 = lt v27 v1;
+        v30.i1 = is_zero v29;
+        br v30 block5 block6;
 
     block5:
         jump block7;
 
     block6:
-        v32.*i8 = evm_malloc 64.i256;
-        v33.i256 = ptr_to_int v32 i256;
-        mstore v33 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        (v35.i256, v36.i1) = uaddo v33 32.i256;
-        br v36 block8 block10;
+        v31.*i8 = evm_malloc 64.i256;
+        v32.i256 = ptr_to_int v31 i256;
+        mstore v32 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        (v34.i256, v35.i1) = uaddo v32 32.i256;
+        br v35 block8 block10;
 
     block7:
-        v41.i256 = mload v3 i256;
-        (v43.i256, v44.i1) = usubo v28 v41;
-        br v44 block8 block11;
+        (v42.i256, v43.i1) = usubo v27 v1;
+        br v43 block8 block11;
 
     block8:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -1178,28 +1084,26 @@ func private %standalone_erc20__erc20__burn__g5c3f_97eb(v0.@layout_0, v1.i256, v
         evm_revert 0.i256 36.i256;
 
     block9:
-        mstore v19 26959946667150639794667015087019630673637144422540572481103610249216.i256 i256;
-        evm_revert v15 36.i256;
+        mstore v18 26959946667150639794667015087019630673637144422540572481103610249216.i256 i256;
+        evm_revert v14 36.i256;
 
     block10:
-        mstore v35 26959946667150639794667015087019630673637144422540572481103610249216.i256 i256;
-        evm_revert v33 36.i256;
+        mstore v34 26959946667150639794667015087019630673637144422540572481103610249216.i256 i256;
+        evm_revert v32 36.i256;
 
     block11:
-        call %set__g2163 v0 v43;
-        v48.i256 = mload v3 i256;
-        v49.i256 = evm_sload v2;
-        (v50.i256, v51.i1) = usubo v49 v48;
-        br v51 block8 block12;
+        call %set__g2163 v0 v42;
+        v48.i256 = evm_sload v2;
+        (v49.i256, v50.i1) = usubo v48 v1;
+        br v50 block8 block12;
 
     block12:
-        evm_sstore v2 v50;
-        v54.@layout_0 = call %zero;
-        v55.i256 = mload v3 i256;
-        v57.@layout_19 = insert_value undef.@layout_19 0.i256 v0;
-        v59.@layout_19 = insert_value v57 1.i256 v54;
-        v61.@layout_19 = insert_value v59 2.i256 v55;
-        call %emit__g4c3d v61;
+        evm_sstore v2 v49;
+        v53.@layout_0 = call %zero;
+        v56.@layout_19 = insert_value undef.@layout_19 0.i256 v0;
+        v58.@layout_19 = insert_value v56 1.i256 v53;
+        v60.@layout_19 = insert_value v58 2.i256 v1;
+        call %emit__g4c3d v60;
         return;
 }
 
@@ -1215,19 +1119,11 @@ func private %caller() -> @layout_0 {
 
 func inline(always) private %core__lib__abi__checked_frame_end__gf13e_01a8(v0.i256, v1.i256, v2.i256) -> i256 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        mstore v3 v0 i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
         jump block1;
 
     block1:
-        v6.i256 = mload v3 i256;
-        v7.i256 = mload v4 i256;
-        (v8.i256, v9.i1) = uaddo v6 v7;
-        br v9 block6 block7;
+        (v5.i256, v6.i1) = uaddo v0 v1;
+        br v6 block6 block7;
 
     block2:
         call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_947f;
@@ -1237,12 +1133,11 @@ func inline(always) private %core__lib__abi__checked_frame_end__gf13e_01a8(v0.i2
         jump block4;
 
     block4:
-        return v8;
+        return v5;
 
     block5:
-        v19.i256 = mload v5 i256;
-        v20.i1 = gt v8 v19;
-        br v20 block2 block3;
+        v17.i1 = gt v5 v2;
+        br v17 block2 block3;
 
     block6:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -1250,26 +1145,17 @@ func inline(always) private %core__lib__abi__checked_frame_end__gf13e_01a8(v0.i2
         evm_revert 0.i256 36.i256;
 
     block7:
-        v15.i256 = mload v3 i256;
-        v16.i1 = lt v8 v15;
-        br v16 block2 block5;
+        v13.i1 = lt v5 v0;
+        br v13 block2 block5;
 }
 
 func inline(always) private %core__lib__abi__checked_frame_end__gf13e_4689(v0.i256, v1.i256, v2.i256) -> i256 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        mstore v3 v0 i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
         jump block1;
 
     block1:
-        v6.i256 = mload v3 i256;
-        v7.i256 = mload v4 i256;
-        (v8.i256, v9.i1) = uaddo v6 v7;
-        br v9 block6 block7;
+        (v5.i256, v6.i1) = uaddo v0 v1;
+        br v6 block6 block7;
 
     block2:
         call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_733d;
@@ -1279,12 +1165,11 @@ func inline(always) private %core__lib__abi__checked_frame_end__gf13e_4689(v0.i2
         jump block4;
 
     block4:
-        return v8;
+        return v5;
 
     block5:
-        v19.i256 = mload v5 i256;
-        v20.i1 = gt v8 v19;
-        br v20 block2 block3;
+        v17.i1 = gt v5 v2;
+        br v17 block2 block3;
 
     block6:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -1292,26 +1177,17 @@ func inline(always) private %core__lib__abi__checked_frame_end__gf13e_4689(v0.i2
         evm_revert 0.i256 36.i256;
 
     block7:
-        v15.i256 = mload v3 i256;
-        v16.i1 = lt v8 v15;
-        br v16 block2 block5;
+        v13.i1 = lt v5 v0;
+        br v13 block2 block5;
 }
 
 func inline(always) private %core__lib__abi__checked_frame_end__gf13e_60b4(v0.i256, v1.i256, v2.i256) -> i256 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        mstore v3 v0 i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
         jump block1;
 
     block1:
-        v6.i256 = mload v3 i256;
-        v7.i256 = mload v4 i256;
-        (v8.i256, v9.i1) = uaddo v6 v7;
-        br v9 block6 block7;
+        (v5.i256, v6.i1) = uaddo v0 v1;
+        br v6 block6 block7;
 
     block2:
         call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_a0e7;
@@ -1321,12 +1197,11 @@ func inline(always) private %core__lib__abi__checked_frame_end__gf13e_60b4(v0.i2
         jump block4;
 
     block4:
-        return v8;
+        return v5;
 
     block5:
-        v19.i256 = mload v5 i256;
-        v20.i1 = gt v8 v19;
-        br v20 block2 block3;
+        v17.i1 = gt v5 v2;
+        br v17 block2 block3;
 
     block6:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -1334,26 +1209,17 @@ func inline(always) private %core__lib__abi__checked_frame_end__gf13e_60b4(v0.i2
         evm_revert 0.i256 36.i256;
 
     block7:
-        v15.i256 = mload v3 i256;
-        v16.i1 = lt v8 v15;
-        br v16 block2 block5;
+        v13.i1 = lt v5 v0;
+        br v13 block2 block5;
 }
 
 func inline(always) private %core__lib__abi__checked_frame_end__gf13e_6403(v0.i256, v1.i256, v2.i256) -> i256 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        mstore v3 v0 i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
         jump block1;
 
     block1:
-        v6.i256 = mload v3 i256;
-        v7.i256 = mload v4 i256;
-        (v8.i256, v9.i1) = uaddo v6 v7;
-        br v9 block6 block7;
+        (v5.i256, v6.i1) = uaddo v0 v1;
+        br v6 block6 block7;
 
     block2:
         call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_2004;
@@ -1363,12 +1229,11 @@ func inline(always) private %core__lib__abi__checked_frame_end__gf13e_6403(v0.i2
         jump block4;
 
     block4:
-        return v8;
+        return v5;
 
     block5:
-        v19.i256 = mload v5 i256;
-        v20.i1 = gt v8 v19;
-        br v20 block2 block3;
+        v17.i1 = gt v5 v2;
+        br v17 block2 block3;
 
     block6:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -1376,26 +1241,17 @@ func inline(always) private %core__lib__abi__checked_frame_end__gf13e_6403(v0.i2
         evm_revert 0.i256 36.i256;
 
     block7:
-        v15.i256 = mload v3 i256;
-        v16.i1 = lt v8 v15;
-        br v16 block2 block5;
+        v13.i1 = lt v5 v0;
+        br v13 block2 block5;
 }
 
 func inline(always) private %core__lib__abi__checked_frame_end__gf13e_9284(v0.i256, v1.i256, v2.i256) -> i256 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        mstore v3 v0 i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
         jump block1;
 
     block1:
-        v6.i256 = mload v3 i256;
-        v7.i256 = mload v4 i256;
-        (v8.i256, v9.i1) = uaddo v6 v7;
-        br v9 block6 block7;
+        (v5.i256, v6.i1) = uaddo v0 v1;
+        br v6 block6 block7;
 
     block2:
         call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_929c;
@@ -1405,12 +1261,11 @@ func inline(always) private %core__lib__abi__checked_frame_end__gf13e_9284(v0.i2
         jump block4;
 
     block4:
-        return v8;
+        return v5;
 
     block5:
-        v19.i256 = mload v5 i256;
-        v20.i1 = gt v8 v19;
-        br v20 block2 block3;
+        v17.i1 = gt v5 v2;
+        br v17 block2 block3;
 
     block6:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -1418,26 +1273,17 @@ func inline(always) private %core__lib__abi__checked_frame_end__gf13e_9284(v0.i2
         evm_revert 0.i256 36.i256;
 
     block7:
-        v15.i256 = mload v3 i256;
-        v16.i1 = lt v8 v15;
-        br v16 block2 block5;
+        v13.i1 = lt v5 v0;
+        br v13 block2 block5;
 }
 
 func inline(always) private %core__lib__abi__checked_frame_end__gf13e_9888(v0.i256, v1.i256, v2.i256) -> i256 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        mstore v3 v0 i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
         jump block1;
 
     block1:
-        v6.i256 = mload v3 i256;
-        v7.i256 = mload v4 i256;
-        (v8.i256, v9.i1) = uaddo v6 v7;
-        br v9 block6 block7;
+        (v5.i256, v6.i1) = uaddo v0 v1;
+        br v6 block6 block7;
 
     block2:
         call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_7414;
@@ -1447,12 +1293,11 @@ func inline(always) private %core__lib__abi__checked_frame_end__gf13e_9888(v0.i2
         jump block4;
 
     block4:
-        return v8;
+        return v5;
 
     block5:
-        v19.i256 = mload v5 i256;
-        v20.i1 = gt v8 v19;
-        br v20 block2 block3;
+        v17.i1 = gt v5 v2;
+        br v17 block2 block3;
 
     block6:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -1460,26 +1305,17 @@ func inline(always) private %core__lib__abi__checked_frame_end__gf13e_9888(v0.i2
         evm_revert 0.i256 36.i256;
 
     block7:
-        v15.i256 = mload v3 i256;
-        v16.i1 = lt v8 v15;
-        br v16 block2 block5;
+        v13.i1 = lt v5 v0;
+        br v13 block2 block5;
 }
 
 func inline(always) private %core__lib__abi__checked_frame_end__gf13e_9b12(v0.i256, v1.i256, v2.i256) -> i256 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        mstore v3 v0 i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
         jump block1;
 
     block1:
-        v6.i256 = mload v3 i256;
-        v7.i256 = mload v4 i256;
-        (v8.i256, v9.i1) = uaddo v6 v7;
-        br v9 block6 block7;
+        (v5.i256, v6.i1) = uaddo v0 v1;
+        br v6 block6 block7;
 
     block2:
         call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_dc07;
@@ -1489,12 +1325,11 @@ func inline(always) private %core__lib__abi__checked_frame_end__gf13e_9b12(v0.i2
         jump block4;
 
     block4:
-        return v8;
+        return v5;
 
     block5:
-        v19.i256 = mload v5 i256;
-        v20.i1 = gt v8 v19;
-        br v20 block2 block3;
+        v17.i1 = gt v5 v2;
+        br v17 block2 block3;
 
     block6:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -1502,26 +1337,17 @@ func inline(always) private %core__lib__abi__checked_frame_end__gf13e_9b12(v0.i2
         evm_revert 0.i256 36.i256;
 
     block7:
-        v15.i256 = mload v3 i256;
-        v16.i1 = lt v8 v15;
-        br v16 block2 block5;
+        v13.i1 = lt v5 v0;
+        br v13 block2 block5;
 }
 
 func inline(always) private %core__lib__abi__checked_frame_end__gf13e_a584(v0.i256, v1.i256, v2.i256) -> i256 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        mstore v3 v0 i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
         jump block1;
 
     block1:
-        v6.i256 = mload v3 i256;
-        v7.i256 = mload v4 i256;
-        (v8.i256, v9.i1) = uaddo v6 v7;
-        br v9 block6 block7;
+        (v5.i256, v6.i1) = uaddo v0 v1;
+        br v6 block6 block7;
 
     block2:
         call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_4ce8;
@@ -1531,12 +1357,11 @@ func inline(always) private %core__lib__abi__checked_frame_end__gf13e_a584(v0.i2
         jump block4;
 
     block4:
-        return v8;
+        return v5;
 
     block5:
-        v19.i256 = mload v5 i256;
-        v20.i1 = gt v8 v19;
-        br v20 block2 block3;
+        v17.i1 = gt v5 v2;
+        br v17 block2 block3;
 
     block6:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -1544,26 +1369,17 @@ func inline(always) private %core__lib__abi__checked_frame_end__gf13e_a584(v0.i2
         evm_revert 0.i256 36.i256;
 
     block7:
-        v15.i256 = mload v3 i256;
-        v16.i1 = lt v8 v15;
-        br v16 block2 block5;
+        v13.i1 = lt v5 v0;
+        br v13 block2 block5;
 }
 
 func inline(always) private %core__lib__abi__checked_frame_end__gf13e_aaf5(v0.i256, v1.i256, v2.i256) -> i256 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        mstore v3 v0 i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
         jump block1;
 
     block1:
-        v6.i256 = mload v3 i256;
-        v7.i256 = mload v4 i256;
-        (v8.i256, v9.i1) = uaddo v6 v7;
-        br v9 block6 block7;
+        (v5.i256, v6.i1) = uaddo v0 v1;
+        br v6 block6 block7;
 
     block2:
         call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_39f6;
@@ -1573,12 +1389,11 @@ func inline(always) private %core__lib__abi__checked_frame_end__gf13e_aaf5(v0.i2
         jump block4;
 
     block4:
-        return v8;
+        return v5;
 
     block5:
-        v19.i256 = mload v5 i256;
-        v20.i1 = gt v8 v19;
-        br v20 block2 block3;
+        v17.i1 = gt v5 v2;
+        br v17 block2 block3;
 
     block6:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -1586,26 +1401,17 @@ func inline(always) private %core__lib__abi__checked_frame_end__gf13e_aaf5(v0.i2
         evm_revert 0.i256 36.i256;
 
     block7:
-        v15.i256 = mload v3 i256;
-        v16.i1 = lt v8 v15;
-        br v16 block2 block5;
+        v13.i1 = lt v5 v0;
+        br v13 block2 block5;
 }
 
 func inline(always) private %core__lib__abi__checked_frame_end__gf13e_b8aa(v0.i256, v1.i256, v2.i256) -> i256 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        mstore v3 v0 i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
         jump block1;
 
     block1:
-        v6.i256 = mload v3 i256;
-        v7.i256 = mload v4 i256;
-        (v8.i256, v9.i1) = uaddo v6 v7;
-        br v9 block6 block7;
+        (v5.i256, v6.i1) = uaddo v0 v1;
+        br v6 block6 block7;
 
     block2:
         call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_0b81;
@@ -1615,12 +1421,11 @@ func inline(always) private %core__lib__abi__checked_frame_end__gf13e_b8aa(v0.i2
         jump block4;
 
     block4:
-        return v8;
+        return v5;
 
     block5:
-        v19.i256 = mload v5 i256;
-        v20.i1 = gt v8 v19;
-        br v20 block2 block3;
+        v17.i1 = gt v5 v2;
+        br v17 block2 block3;
 
     block6:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -1628,26 +1433,17 @@ func inline(always) private %core__lib__abi__checked_frame_end__gf13e_b8aa(v0.i2
         evm_revert 0.i256 36.i256;
 
     block7:
-        v15.i256 = mload v3 i256;
-        v16.i1 = lt v8 v15;
-        br v16 block2 block5;
+        v13.i1 = lt v5 v0;
+        br v13 block2 block5;
 }
 
 func inline(always) private %core__lib__abi__checked_frame_end__gf13e_c0b4(v0.i256, v1.i256, v2.i256) -> i256 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        mstore v3 v0 i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
         jump block1;
 
     block1:
-        v6.i256 = mload v3 i256;
-        v7.i256 = mload v4 i256;
-        (v8.i256, v9.i1) = uaddo v6 v7;
-        br v9 block6 block7;
+        (v5.i256, v6.i1) = uaddo v0 v1;
+        br v6 block6 block7;
 
     block2:
         call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_12a9;
@@ -1657,12 +1453,11 @@ func inline(always) private %core__lib__abi__checked_frame_end__gf13e_c0b4(v0.i2
         jump block4;
 
     block4:
-        return v8;
+        return v5;
 
     block5:
-        v19.i256 = mload v5 i256;
-        v20.i1 = gt v8 v19;
-        br v20 block2 block3;
+        v17.i1 = gt v5 v2;
+        br v17 block2 block3;
 
     block6:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -1670,26 +1465,17 @@ func inline(always) private %core__lib__abi__checked_frame_end__gf13e_c0b4(v0.i2
         evm_revert 0.i256 36.i256;
 
     block7:
-        v15.i256 = mload v3 i256;
-        v16.i1 = lt v8 v15;
-        br v16 block2 block5;
+        v13.i1 = lt v5 v0;
+        br v13 block2 block5;
 }
 
 func inline(always) private %core__lib__abi__checked_frame_end__gf13e_c3cb(v0.i256, v1.i256, v2.i256) -> i256 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        mstore v3 v0 i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
         jump block1;
 
     block1:
-        v6.i256 = mload v3 i256;
-        v7.i256 = mload v4 i256;
-        (v8.i256, v9.i1) = uaddo v6 v7;
-        br v9 block6 block7;
+        (v5.i256, v6.i1) = uaddo v0 v1;
+        br v6 block6 block7;
 
     block2:
         call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_a63d;
@@ -1699,12 +1485,11 @@ func inline(always) private %core__lib__abi__checked_frame_end__gf13e_c3cb(v0.i2
         jump block4;
 
     block4:
-        return v8;
+        return v5;
 
     block5:
-        v19.i256 = mload v5 i256;
-        v20.i1 = gt v8 v19;
-        br v20 block2 block3;
+        v17.i1 = gt v5 v2;
+        br v17 block2 block3;
 
     block6:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -1712,26 +1497,17 @@ func inline(always) private %core__lib__abi__checked_frame_end__gf13e_c3cb(v0.i2
         evm_revert 0.i256 36.i256;
 
     block7:
-        v15.i256 = mload v3 i256;
-        v16.i1 = lt v8 v15;
-        br v16 block2 block5;
+        v13.i1 = lt v5 v0;
+        br v13 block2 block5;
 }
 
 func inline(always) private %core__lib__abi__checked_frame_end__gf13e_cc78(v0.i256, v1.i256, v2.i256) -> i256 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        mstore v3 v0 i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
         jump block1;
 
     block1:
-        v6.i256 = mload v3 i256;
-        v7.i256 = mload v4 i256;
-        (v8.i256, v9.i1) = uaddo v6 v7;
-        br v9 block6 block7;
+        (v5.i256, v6.i1) = uaddo v0 v1;
+        br v6 block6 block7;
 
     block2:
         call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_6a0c;
@@ -1741,12 +1517,11 @@ func inline(always) private %core__lib__abi__checked_frame_end__gf13e_cc78(v0.i2
         jump block4;
 
     block4:
-        return v8;
+        return v5;
 
     block5:
-        v19.i256 = mload v5 i256;
-        v20.i1 = gt v8 v19;
-        br v20 block2 block3;
+        v17.i1 = gt v5 v2;
+        br v17 block2 block3;
 
     block6:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -1754,26 +1529,17 @@ func inline(always) private %core__lib__abi__checked_frame_end__gf13e_cc78(v0.i2
         evm_revert 0.i256 36.i256;
 
     block7:
-        v15.i256 = mload v3 i256;
-        v16.i1 = lt v8 v15;
-        br v16 block2 block5;
+        v13.i1 = lt v5 v0;
+        br v13 block2 block5;
 }
 
 func inline(always) private %core__lib__abi__checked_frame_end__gf13e_d1eb(v0.i256, v1.i256, v2.i256) -> i256 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        mstore v3 v0 i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
         jump block1;
 
     block1:
-        v6.i256 = mload v3 i256;
-        v7.i256 = mload v4 i256;
-        (v8.i256, v9.i1) = uaddo v6 v7;
-        br v9 block6 block7;
+        (v5.i256, v6.i1) = uaddo v0 v1;
+        br v6 block6 block7;
 
     block2:
         call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_f9e7;
@@ -1783,12 +1549,11 @@ func inline(always) private %core__lib__abi__checked_frame_end__gf13e_d1eb(v0.i2
         jump block4;
 
     block4:
-        return v8;
+        return v5;
 
     block5:
-        v19.i256 = mload v5 i256;
-        v20.i1 = gt v8 v19;
-        br v20 block2 block3;
+        v17.i1 = gt v5 v2;
+        br v17 block2 block3;
 
     block6:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -1796,26 +1561,17 @@ func inline(always) private %core__lib__abi__checked_frame_end__gf13e_d1eb(v0.i2
         evm_revert 0.i256 36.i256;
 
     block7:
-        v15.i256 = mload v3 i256;
-        v16.i1 = lt v8 v15;
-        br v16 block2 block5;
+        v13.i1 = lt v5 v0;
+        br v13 block2 block5;
 }
 
 func inline(always) private %core__lib__abi__checked_frame_end__gf13e_de97(v0.i256, v1.i256, v2.i256) -> i256 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        mstore v3 v0 i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
         jump block1;
 
     block1:
-        v6.i256 = mload v3 i256;
-        v7.i256 = mload v4 i256;
-        (v8.i256, v9.i1) = uaddo v6 v7;
-        br v9 block6 block7;
+        (v5.i256, v6.i1) = uaddo v0 v1;
+        br v6 block6 block7;
 
     block2:
         call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_0d37;
@@ -1825,12 +1581,11 @@ func inline(always) private %core__lib__abi__checked_frame_end__gf13e_de97(v0.i2
         jump block4;
 
     block4:
-        return v8;
+        return v5;
 
     block5:
-        v19.i256 = mload v5 i256;
-        v20.i1 = gt v8 v19;
-        br v20 block2 block3;
+        v17.i1 = gt v5 v2;
+        br v17 block2 block3;
 
     block6:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -1838,26 +1593,17 @@ func inline(always) private %core__lib__abi__checked_frame_end__gf13e_de97(v0.i2
         evm_revert 0.i256 36.i256;
 
     block7:
-        v15.i256 = mload v3 i256;
-        v16.i1 = lt v8 v15;
-        br v16 block2 block5;
+        v13.i1 = lt v5 v0;
+        br v13 block2 block5;
 }
 
 func inline(always) private %core__lib__abi__checked_frame_end__gf13e_e706(v0.i256, v1.i256, v2.i256) -> i256 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        mstore v3 v0 i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
         jump block1;
 
     block1:
-        v6.i256 = mload v3 i256;
-        v7.i256 = mload v4 i256;
-        (v8.i256, v9.i1) = uaddo v6 v7;
-        br v9 block6 block7;
+        (v5.i256, v6.i1) = uaddo v0 v1;
+        br v6 block6 block7;
 
     block2:
         call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_27a8;
@@ -1867,12 +1613,11 @@ func inline(always) private %core__lib__abi__checked_frame_end__gf13e_e706(v0.i2
         jump block4;
 
     block4:
-        return v8;
+        return v5;
 
     block5:
-        v19.i256 = mload v5 i256;
-        v20.i1 = gt v8 v19;
-        br v20 block2 block3;
+        v17.i1 = gt v5 v2;
+        br v17 block2 block3;
 
     block6:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -1880,26 +1625,17 @@ func inline(always) private %core__lib__abi__checked_frame_end__gf13e_e706(v0.i2
         evm_revert 0.i256 36.i256;
 
     block7:
-        v15.i256 = mload v3 i256;
-        v16.i1 = lt v8 v15;
-        br v16 block2 block5;
+        v13.i1 = lt v5 v0;
+        br v13 block2 block5;
 }
 
 func inline(always) private %core__lib__abi__checked_frame_end__gf13e_f40a(v0.i256, v1.i256, v2.i256) -> i256 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        mstore v3 v0 i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
         jump block1;
 
     block1:
-        v6.i256 = mload v3 i256;
-        v7.i256 = mload v4 i256;
-        (v8.i256, v9.i1) = uaddo v6 v7;
-        br v9 block6 block7;
+        (v5.i256, v6.i1) = uaddo v0 v1;
+        br v6 block6 block7;
 
     block2:
         call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_23e2;
@@ -1909,12 +1645,11 @@ func inline(always) private %core__lib__abi__checked_frame_end__gf13e_f40a(v0.i2
         jump block4;
 
     block4:
-        return v8;
+        return v5;
 
     block5:
-        v19.i256 = mload v5 i256;
-        v20.i1 = gt v8 v19;
-        br v20 block2 block3;
+        v17.i1 = gt v5 v2;
+        br v17 block2 block3;
 
     block6:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -1922,24 +1657,17 @@ func inline(always) private %core__lib__abi__checked_frame_end__gf13e_f40a(v0.i2
         evm_revert 0.i256 36.i256;
 
     block7:
-        v15.i256 = mload v3 i256;
-        v16.i1 = lt v8 v15;
-        br v16 block2 block5;
+        v13.i1 = lt v5 v0;
+        br v13 block2 block5;
 }
 
 func inline(always) private %core__lib__abi__checked_tail__gf13e_134e(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        (v6.i256, v7.i1) = uaddo v4 v5;
-        br v7 block5 block6;
+        (v4.i256, v5.i1) = uaddo v0 v1;
+        br v5 block5 block6;
 
     block2:
         call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_fe05;
@@ -1949,7 +1677,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_134e(v0.i256, v
         jump block4;
 
     block4:
-        return v6;
+        return v4;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -1957,24 +1685,17 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_134e(v0.i256, v
         evm_revert 0.i256 36.i256;
 
     block6:
-        v13.i256 = mload v2 i256;
-        v14.i1 = lt v6 v13;
-        br v14 block2 block3;
+        v12.i1 = lt v4 v0;
+        br v12 block2 block3;
 }
 
 func inline(always) private %core__lib__abi__checked_tail__gf13e_15b4(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        (v6.i256, v7.i1) = uaddo v4 v5;
-        br v7 block5 block6;
+        (v4.i256, v5.i1) = uaddo v0 v1;
+        br v5 block5 block6;
 
     block2:
         call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_d2b1;
@@ -1984,7 +1705,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_15b4(v0.i256, v
         jump block4;
 
     block4:
-        return v6;
+        return v4;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -1992,24 +1713,17 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_15b4(v0.i256, v
         evm_revert 0.i256 36.i256;
 
     block6:
-        v13.i256 = mload v2 i256;
-        v14.i1 = lt v6 v13;
-        br v14 block2 block3;
+        v12.i1 = lt v4 v0;
+        br v12 block2 block3;
 }
 
 func inline(always) private %core__lib__abi__checked_tail__gf13e_2af0(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        (v6.i256, v7.i1) = uaddo v4 v5;
-        br v7 block5 block6;
+        (v4.i256, v5.i1) = uaddo v0 v1;
+        br v5 block5 block6;
 
     block2:
         call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_eb20;
@@ -2019,7 +1733,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_2af0(v0.i256, v
         jump block4;
 
     block4:
-        return v6;
+        return v4;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -2027,24 +1741,17 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_2af0(v0.i256, v
         evm_revert 0.i256 36.i256;
 
     block6:
-        v13.i256 = mload v2 i256;
-        v14.i1 = lt v6 v13;
-        br v14 block2 block3;
+        v12.i1 = lt v4 v0;
+        br v12 block2 block3;
 }
 
 func inline(always) private %core__lib__abi__checked_tail__gf13e_2d1a(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        (v6.i256, v7.i1) = uaddo v4 v5;
-        br v7 block5 block6;
+        (v4.i256, v5.i1) = uaddo v0 v1;
+        br v5 block5 block6;
 
     block2:
         call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_85bb;
@@ -2054,7 +1761,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_2d1a(v0.i256, v
         jump block4;
 
     block4:
-        return v6;
+        return v4;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -2062,24 +1769,17 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_2d1a(v0.i256, v
         evm_revert 0.i256 36.i256;
 
     block6:
-        v13.i256 = mload v2 i256;
-        v14.i1 = lt v6 v13;
-        br v14 block2 block3;
+        v12.i1 = lt v4 v0;
+        br v12 block2 block3;
 }
 
 func inline(always) private %core__lib__abi__checked_tail__gf13e_3749(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        (v6.i256, v7.i1) = uaddo v4 v5;
-        br v7 block5 block6;
+        (v4.i256, v5.i1) = uaddo v0 v1;
+        br v5 block5 block6;
 
     block2:
         call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_e087;
@@ -2089,7 +1789,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_3749(v0.i256, v
         jump block4;
 
     block4:
-        return v6;
+        return v4;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -2097,24 +1797,17 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_3749(v0.i256, v
         evm_revert 0.i256 36.i256;
 
     block6:
-        v13.i256 = mload v2 i256;
-        v14.i1 = lt v6 v13;
-        br v14 block2 block3;
+        v12.i1 = lt v4 v0;
+        br v12 block2 block3;
 }
 
 func inline(always) private %core__lib__abi__checked_tail__gf13e_45b0(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        (v6.i256, v7.i1) = uaddo v4 v5;
-        br v7 block5 block6;
+        (v4.i256, v5.i1) = uaddo v0 v1;
+        br v5 block5 block6;
 
     block2:
         call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_57f0;
@@ -2124,7 +1817,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_45b0(v0.i256, v
         jump block4;
 
     block4:
-        return v6;
+        return v4;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -2132,24 +1825,17 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_45b0(v0.i256, v
         evm_revert 0.i256 36.i256;
 
     block6:
-        v13.i256 = mload v2 i256;
-        v14.i1 = lt v6 v13;
-        br v14 block2 block3;
+        v12.i1 = lt v4 v0;
+        br v12 block2 block3;
 }
 
 func inline(always) private %core__lib__abi__checked_tail__gf13e_46df(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        (v6.i256, v7.i1) = uaddo v4 v5;
-        br v7 block5 block6;
+        (v4.i256, v5.i1) = uaddo v0 v1;
+        br v5 block5 block6;
 
     block2:
         call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_9af2;
@@ -2159,7 +1845,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_46df(v0.i256, v
         jump block4;
 
     block4:
-        return v6;
+        return v4;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -2167,24 +1853,17 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_46df(v0.i256, v
         evm_revert 0.i256 36.i256;
 
     block6:
-        v13.i256 = mload v2 i256;
-        v14.i1 = lt v6 v13;
-        br v14 block2 block3;
+        v12.i1 = lt v4 v0;
+        br v12 block2 block3;
 }
 
 func inline(always) private %core__lib__abi__checked_tail__gf13e_50a2(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        (v6.i256, v7.i1) = uaddo v4 v5;
-        br v7 block5 block6;
+        (v4.i256, v5.i1) = uaddo v0 v1;
+        br v5 block5 block6;
 
     block2:
         call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_60d9;
@@ -2194,7 +1873,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_50a2(v0.i256, v
         jump block4;
 
     block4:
-        return v6;
+        return v4;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -2202,24 +1881,17 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_50a2(v0.i256, v
         evm_revert 0.i256 36.i256;
 
     block6:
-        v13.i256 = mload v2 i256;
-        v14.i1 = lt v6 v13;
-        br v14 block2 block3;
+        v12.i1 = lt v4 v0;
+        br v12 block2 block3;
 }
 
 func inline(always) private %core__lib__abi__checked_tail__gf13e_7a36(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        (v6.i256, v7.i1) = uaddo v4 v5;
-        br v7 block5 block6;
+        (v4.i256, v5.i1) = uaddo v0 v1;
+        br v5 block5 block6;
 
     block2:
         call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_fd54;
@@ -2229,7 +1901,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_7a36(v0.i256, v
         jump block4;
 
     block4:
-        return v6;
+        return v4;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -2237,24 +1909,17 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_7a36(v0.i256, v
         evm_revert 0.i256 36.i256;
 
     block6:
-        v13.i256 = mload v2 i256;
-        v14.i1 = lt v6 v13;
-        br v14 block2 block3;
+        v12.i1 = lt v4 v0;
+        br v12 block2 block3;
 }
 
 func inline(always) private %core__lib__abi__checked_tail__gf13e_8bdb(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        (v6.i256, v7.i1) = uaddo v4 v5;
-        br v7 block5 block6;
+        (v4.i256, v5.i1) = uaddo v0 v1;
+        br v5 block5 block6;
 
     block2:
         call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_bf37;
@@ -2264,7 +1929,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_8bdb(v0.i256, v
         jump block4;
 
     block4:
-        return v6;
+        return v4;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -2272,24 +1937,17 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_8bdb(v0.i256, v
         evm_revert 0.i256 36.i256;
 
     block6:
-        v13.i256 = mload v2 i256;
-        v14.i1 = lt v6 v13;
-        br v14 block2 block3;
+        v12.i1 = lt v4 v0;
+        br v12 block2 block3;
 }
 
 func inline(always) private %core__lib__abi__checked_tail__gf13e_9611(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        (v6.i256, v7.i1) = uaddo v4 v5;
-        br v7 block5 block6;
+        (v4.i256, v5.i1) = uaddo v0 v1;
+        br v5 block5 block6;
 
     block2:
         call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_2515;
@@ -2299,7 +1957,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_9611(v0.i256, v
         jump block4;
 
     block4:
-        return v6;
+        return v4;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -2307,24 +1965,17 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_9611(v0.i256, v
         evm_revert 0.i256 36.i256;
 
     block6:
-        v13.i256 = mload v2 i256;
-        v14.i1 = lt v6 v13;
-        br v14 block2 block3;
+        v12.i1 = lt v4 v0;
+        br v12 block2 block3;
 }
 
 func inline(always) private %core__lib__abi__checked_tail__gf13e_9794(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        (v6.i256, v7.i1) = uaddo v4 v5;
-        br v7 block5 block6;
+        (v4.i256, v5.i1) = uaddo v0 v1;
+        br v5 block5 block6;
 
     block2:
         call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_6332;
@@ -2334,7 +1985,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_9794(v0.i256, v
         jump block4;
 
     block4:
-        return v6;
+        return v4;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -2342,24 +1993,17 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_9794(v0.i256, v
         evm_revert 0.i256 36.i256;
 
     block6:
-        v13.i256 = mload v2 i256;
-        v14.i1 = lt v6 v13;
-        br v14 block2 block3;
+        v12.i1 = lt v4 v0;
+        br v12 block2 block3;
 }
 
 func inline(always) private %core__lib__abi__checked_tail__gf13e_9c13(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        (v6.i256, v7.i1) = uaddo v4 v5;
-        br v7 block5 block6;
+        (v4.i256, v5.i1) = uaddo v0 v1;
+        br v5 block5 block6;
 
     block2:
         call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_7fdc;
@@ -2369,7 +2013,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_9c13(v0.i256, v
         jump block4;
 
     block4:
-        return v6;
+        return v4;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -2377,24 +2021,17 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_9c13(v0.i256, v
         evm_revert 0.i256 36.i256;
 
     block6:
-        v13.i256 = mload v2 i256;
-        v14.i1 = lt v6 v13;
-        br v14 block2 block3;
+        v12.i1 = lt v4 v0;
+        br v12 block2 block3;
 }
 
 func inline(always) private %core__lib__abi__checked_tail__gf13e_ad42(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        (v6.i256, v7.i1) = uaddo v4 v5;
-        br v7 block5 block6;
+        (v4.i256, v5.i1) = uaddo v0 v1;
+        br v5 block5 block6;
 
     block2:
         call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_3f2a;
@@ -2404,7 +2041,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_ad42(v0.i256, v
         jump block4;
 
     block4:
-        return v6;
+        return v4;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -2412,24 +2049,17 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_ad42(v0.i256, v
         evm_revert 0.i256 36.i256;
 
     block6:
-        v13.i256 = mload v2 i256;
-        v14.i1 = lt v6 v13;
-        br v14 block2 block3;
+        v12.i1 = lt v4 v0;
+        br v12 block2 block3;
 }
 
 func inline(always) private %core__lib__abi__checked_tail__gf13e_b743(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        (v6.i256, v7.i1) = uaddo v4 v5;
-        br v7 block5 block6;
+        (v4.i256, v5.i1) = uaddo v0 v1;
+        br v5 block5 block6;
 
     block2:
         call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_509b;
@@ -2439,7 +2069,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_b743(v0.i256, v
         jump block4;
 
     block4:
-        return v6;
+        return v4;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -2447,24 +2077,17 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_b743(v0.i256, v
         evm_revert 0.i256 36.i256;
 
     block6:
-        v13.i256 = mload v2 i256;
-        v14.i1 = lt v6 v13;
-        br v14 block2 block3;
+        v12.i1 = lt v4 v0;
+        br v12 block2 block3;
 }
 
 func inline(always) private %core__lib__abi__checked_tail__gf13e_c3ce(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        (v6.i256, v7.i1) = uaddo v4 v5;
-        br v7 block5 block6;
+        (v4.i256, v5.i1) = uaddo v0 v1;
+        br v5 block5 block6;
 
     block2:
         call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_2546;
@@ -2474,7 +2097,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_c3ce(v0.i256, v
         jump block4;
 
     block4:
-        return v6;
+        return v4;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -2482,24 +2105,17 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_c3ce(v0.i256, v
         evm_revert 0.i256 36.i256;
 
     block6:
-        v13.i256 = mload v2 i256;
-        v14.i1 = lt v6 v13;
-        br v14 block2 block3;
+        v12.i1 = lt v4 v0;
+        br v12 block2 block3;
 }
 
 func inline(always) private %core__lib__abi__checked_tail__gf13e_c89e(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        (v6.i256, v7.i1) = uaddo v4 v5;
-        br v7 block5 block6;
+        (v4.i256, v5.i1) = uaddo v0 v1;
+        br v5 block5 block6;
 
     block2:
         call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_def1;
@@ -2509,7 +2125,7 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_c89e(v0.i256, v
         jump block4;
 
     block4:
-        return v6;
+        return v4;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -2517,9 +2133,8 @@ func inline(always) private %core__lib__abi__checked_tail__gf13e_c89e(v0.i256, v
         evm_revert 0.i256 36.i256;
 
     block6:
-        v13.i256 = mload v2 i256;
-        v14.i1 = lt v6 v13;
-        br v14 block2 block3;
+        v12.i1 = lt v4 v0;
+        br v12 block2 block3;
 }
 
 func inline(always) private %contract_init_abi_CoolCoin() {
@@ -3362,29 +2977,22 @@ func inline(always) private %decode_field__g8463(v0.objref<@layout_4>) -> @layou
 
 func inline(always) private %core__lib__abi__decode_field_from__g5385_03a7(v0.@layout_5, v1.i256, v2.i256) -> i256 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v7.i256 = mload v4 i256;
-        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_9725 v0 v7;
-        v9.i256 = mload v3 i256;
-        (v10.i256, v11.i1) = uaddo v9 v8;
-        br v11 block5 block6;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_9725 v0 v2;
+        (v8.i256, v9.i1) = uaddo v1 v6;
+        br v9 block5 block6;
 
     block3:
         jump block4;
 
     block4:
-        v20.i256 = mload v4 i256;
-        v21.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_3a7c_0 v0 v20;
-        return v21;
+        v19.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_3a7c_0 v0 v2;
+        return v19;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -3392,35 +3000,28 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_03a7(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v18.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_3a7c_0 v0 v10;
-        return v18;
+        v16.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_3a7c_0 v0 v8;
+        return v16;
 }
 
 func inline(always) private %core__lib__abi__decode_field_from__gcfb5_2692(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v7.i256 = mload v4 i256;
-        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_69bf v0 v7;
-        v9.i256 = mload v3 i256;
-        (v10.i256, v11.i1) = uaddo v9 v8;
-        br v11 block5 block6;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_69bf v0 v2;
+        (v8.i256, v9.i1) = uaddo v1 v6;
+        br v9 block5 block6;
 
     block3:
         jump block4;
 
     block4:
-        v20.i256 = mload v4 i256;
-        v21.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_3716_0 v0 v20;
-        return v21;
+        v19.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_3716_0 v0 v2;
+        return v19;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -3428,35 +3029,28 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_2692(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v18.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_3716_0 v0 v10;
-        return v18;
+        v16.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_3716_0 v0 v8;
+        return v16;
 }
 
 func inline(always) private %core__lib__abi__decode_field_from__gcfb5_2eef(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v7.i256 = mload v4 i256;
-        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_ce64 v0 v7;
-        v9.i256 = mload v3 i256;
-        (v10.i256, v11.i1) = uaddo v9 v8;
-        br v11 block5 block6;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_ce64 v0 v2;
+        (v8.i256, v9.i1) = uaddo v1 v6;
+        br v9 block5 block6;
 
     block3:
         jump block4;
 
     block4:
-        v20.i256 = mload v4 i256;
-        v21.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_2519_0 v0 v20;
-        return v21;
+        v19.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_2519_0 v0 v2;
+        return v19;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -3464,35 +3058,28 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_2eef(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v18.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_2519_0 v0 v10;
-        return v18;
+        v16.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_2519_0 v0 v8;
+        return v16;
 }
 
 func inline(always) private %core__lib__abi__decode_field_from__g5385_4796(v0.@layout_5, v1.i256, v2.i256) -> i256 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v7.i256 = mload v4 i256;
-        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_27ad v0 v7;
-        v9.i256 = mload v3 i256;
-        (v10.i256, v11.i1) = uaddo v9 v8;
-        br v11 block5 block6;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_27ad v0 v2;
+        (v8.i256, v9.i1) = uaddo v1 v6;
+        br v9 block5 block6;
 
     block3:
         jump block4;
 
     block4:
-        v20.i256 = mload v4 i256;
-        v21.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8d9f_0 v0 v20;
-        return v21;
+        v19.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8d9f_0 v0 v2;
+        return v19;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -3500,35 +3087,28 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_4796(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v18.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8d9f_0 v0 v10;
-        return v18;
+        v16.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8d9f_0 v0 v8;
+        return v16;
 }
 
 func inline(always) private %core__lib__abi__decode_field_from__g5385_5cc4(v0.@layout_5, v1.i256, v2.i256) -> i256 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v7.i256 = mload v4 i256;
-        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_5ce9 v0 v7;
-        v9.i256 = mload v3 i256;
-        (v10.i256, v11.i1) = uaddo v9 v8;
-        br v11 block5 block6;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_5ce9 v0 v2;
+        (v8.i256, v9.i1) = uaddo v1 v6;
+        br v9 block5 block6;
 
     block3:
         jump block4;
 
     block4:
-        v20.i256 = mload v4 i256;
-        v21.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_b39f_0 v0 v20;
-        return v21;
+        v19.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_b39f_0 v0 v2;
+        return v19;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -3536,35 +3116,28 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_5cc4(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v18.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_b39f_0 v0 v10;
-        return v18;
+        v16.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_b39f_0 v0 v8;
+        return v16;
 }
 
 func inline(always) private %core__lib__abi__decode_field_from__gcfb5_7143(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v7.i256 = mload v4 i256;
-        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_faf2 v0 v7;
-        v9.i256 = mload v3 i256;
-        (v10.i256, v11.i1) = uaddo v9 v8;
-        br v11 block5 block6;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_faf2 v0 v2;
+        (v8.i256, v9.i1) = uaddo v1 v6;
+        br v9 block5 block6;
 
     block3:
         jump block4;
 
     block4:
-        v20.i256 = mload v4 i256;
-        v21.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_5535_0 v0 v20;
-        return v21;
+        v19.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_5535_0 v0 v2;
+        return v19;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -3572,35 +3145,28 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_7143(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v18.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_5535_0 v0 v10;
-        return v18;
+        v16.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_5535_0 v0 v8;
+        return v16;
 }
 
 func inline(always) private %core__lib__abi__decode_field_from__g5385_7366(v0.@layout_5, v1.i256, v2.i256) -> i256 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v7.i256 = mload v4 i256;
-        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c32c v0 v7;
-        v9.i256 = mload v3 i256;
-        (v10.i256, v11.i1) = uaddo v9 v8;
-        br v11 block5 block6;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c32c v0 v2;
+        (v8.i256, v9.i1) = uaddo v1 v6;
+        br v9 block5 block6;
 
     block3:
         jump block4;
 
     block4:
-        v20.i256 = mload v4 i256;
-        v21.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_5c31_0 v0 v20;
-        return v21;
+        v19.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_5c31_0 v0 v2;
+        return v19;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -3608,35 +3174,28 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_7366(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v18.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_5c31_0 v0 v10;
-        return v18;
+        v16.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_5c31_0 v0 v8;
+        return v16;
 }
 
 func inline(always) private %core__lib__abi__decode_field_from__gcfb5_786c(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v7.i256 = mload v4 i256;
-        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c2d4 v0 v7;
-        v9.i256 = mload v3 i256;
-        (v10.i256, v11.i1) = uaddo v9 v8;
-        br v11 block5 block6;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c2d4 v0 v2;
+        (v8.i256, v9.i1) = uaddo v1 v6;
+        br v9 block5 block6;
 
     block3:
         jump block4;
 
     block4:
-        v20.i256 = mload v4 i256;
-        v21.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_4e5e_0 v0 v20;
-        return v21;
+        v19.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_4e5e_0 v0 v2;
+        return v19;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -3644,35 +3203,28 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_786c(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v18.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_4e5e_0 v0 v10;
-        return v18;
+        v16.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_4e5e_0 v0 v8;
+        return v16;
 }
 
 func inline(always) private %core__lib__abi__decode_field_from__g5385_79b2(v0.@layout_5, v1.i256, v2.i256) -> i256 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v7.i256 = mload v4 i256;
-        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b870 v0 v7;
-        v9.i256 = mload v3 i256;
-        (v10.i256, v11.i1) = uaddo v9 v8;
-        br v11 block5 block6;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b870 v0 v2;
+        (v8.i256, v9.i1) = uaddo v1 v6;
+        br v9 block5 block6;
 
     block3:
         jump block4;
 
     block4:
-        v20.i256 = mload v4 i256;
-        v21.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_251a_0 v0 v20;
-        return v21;
+        v19.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_251a_0 v0 v2;
+        return v19;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -3680,35 +3232,28 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_79b2(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v18.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_251a_0 v0 v10;
-        return v18;
+        v16.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_251a_0 v0 v8;
+        return v16;
 }
 
 func inline(always) private %core__lib__abi__decode_field_from__gcfb5_7fa7(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v7.i256 = mload v4 i256;
-        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_fdcb v0 v7;
-        v9.i256 = mload v3 i256;
-        (v10.i256, v11.i1) = uaddo v9 v8;
-        br v11 block5 block6;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_fdcb v0 v2;
+        (v8.i256, v9.i1) = uaddo v1 v6;
+        br v9 block5 block6;
 
     block3:
         jump block4;
 
     block4:
-        v20.i256 = mload v4 i256;
-        v21.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_db93_0 v0 v20;
-        return v21;
+        v19.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_db93_0 v0 v2;
+        return v19;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -3716,35 +3261,28 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_7fa7(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v18.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_db93_0 v0 v10;
-        return v18;
+        v16.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_db93_0 v0 v8;
+        return v16;
 }
 
 func inline(always) private %core__lib__abi__decode_field_from__g5385_9270(v0.@layout_5, v1.i256, v2.i256) -> i256 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v7.i256 = mload v4 i256;
-        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_780b v0 v7;
-        v9.i256 = mload v3 i256;
-        (v10.i256, v11.i1) = uaddo v9 v8;
-        br v11 block5 block6;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_780b v0 v2;
+        (v8.i256, v9.i1) = uaddo v1 v6;
+        br v9 block5 block6;
 
     block3:
         jump block4;
 
     block4:
-        v20.i256 = mload v4 i256;
-        v21.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_0a95_0 v0 v20;
-        return v21;
+        v19.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_0a95_0 v0 v2;
+        return v19;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -3752,35 +3290,28 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_9270(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v18.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_0a95_0 v0 v10;
-        return v18;
+        v16.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_0a95_0 v0 v8;
+        return v16;
 }
 
 func inline(always) private %core__lib__abi__decode_field_from__gcfb5_b564(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v7.i256 = mload v4 i256;
-        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_88a1 v0 v7;
-        v9.i256 = mload v3 i256;
-        (v10.i256, v11.i1) = uaddo v9 v8;
-        br v11 block5 block6;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_88a1 v0 v2;
+        (v8.i256, v9.i1) = uaddo v1 v6;
+        br v9 block5 block6;
 
     block3:
         jump block4;
 
     block4:
-        v20.i256 = mload v4 i256;
-        v21.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_9286_0 v0 v20;
-        return v21;
+        v19.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_9286_0 v0 v2;
+        return v19;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -3788,35 +3319,28 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_b564(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v18.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_9286_0 v0 v10;
-        return v18;
+        v16.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_9286_0 v0 v8;
+        return v16;
 }
 
 func inline(always) private %core__lib__abi__decode_field_from__g5385_cb05(v0.@layout_5, v1.i256, v2.i256) -> i256 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v7.i256 = mload v4 i256;
-        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_49c5 v0 v7;
-        v9.i256 = mload v3 i256;
-        (v10.i256, v11.i1) = uaddo v9 v8;
-        br v11 block5 block6;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_49c5 v0 v2;
+        (v8.i256, v9.i1) = uaddo v1 v6;
+        br v9 block5 block6;
 
     block3:
         jump block4;
 
     block4:
-        v20.i256 = mload v4 i256;
-        v21.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_18e6_0 v0 v20;
-        return v21;
+        v19.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_18e6_0 v0 v2;
+        return v19;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -3824,35 +3348,28 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_cb05(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v18.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_18e6_0 v0 v10;
-        return v18;
+        v16.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_18e6_0 v0 v8;
+        return v16;
 }
 
 func inline(always) private %core__lib__abi__decode_field_from__gcfb5_d5a0(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v7.i256 = mload v4 i256;
-        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_0f5c v0 v7;
-        v9.i256 = mload v3 i256;
-        (v10.i256, v11.i1) = uaddo v9 v8;
-        br v11 block5 block6;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_0f5c v0 v2;
+        (v8.i256, v9.i1) = uaddo v1 v6;
+        br v9 block5 block6;
 
     block3:
         jump block4;
 
     block4:
-        v20.i256 = mload v4 i256;
-        v21.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_f4e0_0 v0 v20;
-        return v21;
+        v19.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_f4e0_0 v0 v2;
+        return v19;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -3860,35 +3377,28 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_d5a0(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v18.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_f4e0_0 v0 v10;
-        return v18;
+        v16.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_f4e0_0 v0 v8;
+        return v16;
 }
 
 func inline(always) private %core__lib__abi__decode_field_from__gcfb5_d5c8(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v7.i256 = mload v4 i256;
-        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_6dae v0 v7;
-        v9.i256 = mload v3 i256;
-        (v10.i256, v11.i1) = uaddo v9 v8;
-        br v11 block5 block6;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_6dae v0 v2;
+        (v8.i256, v9.i1) = uaddo v1 v6;
+        br v9 block5 block6;
 
     block3:
         jump block4;
 
     block4:
-        v20.i256 = mload v4 i256;
-        v21.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_3641_0 v0 v20;
-        return v21;
+        v19.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_3641_0 v0 v2;
+        return v19;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -3896,35 +3406,28 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_d5c8(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v18.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_3641_0 v0 v10;
-        return v18;
+        v16.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_3641_0 v0 v8;
+        return v16;
 }
 
 func inline(always) private %core__lib__abi__decode_field_from__g5385_d887(v0.@layout_5, v1.i256, v2.i256) -> i256 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v7.i256 = mload v4 i256;
-        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c259 v0 v7;
-        v9.i256 = mload v3 i256;
-        (v10.i256, v11.i1) = uaddo v9 v8;
-        br v11 block5 block6;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c259 v0 v2;
+        (v8.i256, v9.i1) = uaddo v1 v6;
+        br v9 block5 block6;
 
     block3:
         jump block4;
 
     block4:
-        v20.i256 = mload v4 i256;
-        v21.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_4e52_0 v0 v20;
-        return v21;
+        v19.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_4e52_0 v0 v2;
+        return v19;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -3932,35 +3435,28 @@ func inline(always) private %core__lib__abi__decode_field_from__g5385_d887(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v18.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_4e52_0 v0 v10;
-        return v18;
+        v16.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_4e52_0 v0 v8;
+        return v16;
 }
 
 func inline(always) private %core__lib__abi__decode_field_from__gcfb5_e784(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v7.i256 = mload v4 i256;
-        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_7946 v0 v7;
-        v9.i256 = mload v3 i256;
-        (v10.i256, v11.i1) = uaddo v9 v8;
-        br v11 block5 block6;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_7946 v0 v2;
+        (v8.i256, v9.i1) = uaddo v1 v6;
+        br v9 block5 block6;
 
     block3:
         jump block4;
 
     block4:
-        v20.i256 = mload v4 i256;
-        v21.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_b822_0 v0 v20;
-        return v21;
+        v19.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_b822_0 v0 v2;
+        return v19;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -3968,598 +3464,413 @@ func inline(always) private %core__lib__abi__decode_field_from__gcfb5_e784(v0.@l
         evm_revert 0.i256 36.i256;
 
     block6:
-        v18.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_b822_0 v0 v10;
-        return v18;
+        v16.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_b822_0 v0 v8;
+        return v16;
 }
 
 func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__gcfb5_07a0(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> @layout_0 {
     block0:
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        v6.*i256 = alloca i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
-        mstore v6 v3 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = mload v5 i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_88a1 v0 v9;
-        v11.i256 = mload v4 i256;
-        v12.i256 = call %core__lib__abi__checked_tail__gf13e_9794 v11 v10;
-        v13.i256 = mload v6 i256;
-        v14.@layout_0 = call %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_3fea v0 v12 v13;
-        return v14;
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_88a1 v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_9794 v1 v7;
+        v11.@layout_0 = call %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_3fea v0 v9 v3;
+        return v11;
 
     block3:
         jump block4;
 
     block4:
-        v16.i256 = mload v5 i256;
-        v17.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_9286_0 v0 v16;
-        return v17;
+        v14.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_9286_0 v0 v2;
+        return v14;
 }
 
 func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__gcfb5_18ef(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> @layout_0 {
     block0:
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        v6.*i256 = alloca i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
-        mstore v6 v3 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = mload v5 i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_69bf v0 v9;
-        v11.i256 = mload v4 i256;
-        v12.i256 = call %core__lib__abi__checked_tail__gf13e_46df v11 v10;
-        v13.i256 = mload v6 i256;
-        v14.@layout_0 = call %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_978c v0 v12 v13;
-        return v14;
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_69bf v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_46df v1 v7;
+        v11.@layout_0 = call %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_978c v0 v9 v3;
+        return v11;
 
     block3:
         jump block4;
 
     block4:
-        v16.i256 = mload v5 i256;
-        v17.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_3716_0 v0 v16;
-        return v17;
+        v14.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_3716_0 v0 v2;
+        return v14;
 }
 
 func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__gcfb5_2207(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> @layout_0 {
     block0:
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        v6.*i256 = alloca i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
-        mstore v6 v3 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = mload v5 i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_fdcb v0 v9;
-        v11.i256 = mload v4 i256;
-        v12.i256 = call %core__lib__abi__checked_tail__gf13e_45b0 v11 v10;
-        v13.i256 = mload v6 i256;
-        v14.@layout_0 = call %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_d676 v0 v12 v13;
-        return v14;
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_fdcb v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_45b0 v1 v7;
+        v11.@layout_0 = call %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_d676 v0 v9 v3;
+        return v11;
 
     block3:
         jump block4;
 
     block4:
-        v16.i256 = mload v5 i256;
-        v17.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_db93_0 v0 v16;
-        return v17;
+        v14.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_db93_0 v0 v2;
+        return v14;
 }
 
 func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__gcfb5_2724(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> @layout_0 {
     block0:
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        v6.*i256 = alloca i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
-        mstore v6 v3 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = mload v5 i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c2d4 v0 v9;
-        v11.i256 = mload v4 i256;
-        v12.i256 = call %core__lib__abi__checked_tail__gf13e_ad42 v11 v10;
-        v13.i256 = mload v6 i256;
-        v14.@layout_0 = call %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_64e6 v0 v12 v13;
-        return v14;
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c2d4 v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_ad42 v1 v7;
+        v11.@layout_0 = call %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_64e6 v0 v9 v3;
+        return v11;
 
     block3:
         jump block4;
 
     block4:
-        v16.i256 = mload v5 i256;
-        v17.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_4e5e_0 v0 v16;
-        return v17;
+        v14.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_4e5e_0 v0 v2;
+        return v14;
 }
 
 func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_34fc(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        v6.*i256 = alloca i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
-        mstore v6 v3 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = mload v5 i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c32c v0 v9;
-        v11.i256 = mload v4 i256;
-        v12.i256 = call %core__lib__abi__checked_tail__gf13e_b743 v11 v10;
-        v13.i256 = mload v6 i256;
-        v14.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_d01b v0 v12 v13;
-        return v14;
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c32c v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_b743 v1 v7;
+        v11.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_d01b v0 v9 v3;
+        return v11;
 
     block3:
         jump block4;
 
     block4:
-        v16.i256 = mload v5 i256;
-        v17.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_5c31_0 v0 v16;
-        return v17;
+        v14.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_5c31_0 v0 v2;
+        return v14;
 }
 
 func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_5db0(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        v6.*i256 = alloca i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
-        mstore v6 v3 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = mload v5 i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_27ad v0 v9;
-        v11.i256 = mload v4 i256;
-        v12.i256 = call %core__lib__abi__checked_tail__gf13e_9611 v11 v10;
-        v13.i256 = mload v6 i256;
-        v14.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_2374 v0 v12 v13;
-        return v14;
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_27ad v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_9611 v1 v7;
+        v11.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_2374 v0 v9 v3;
+        return v11;
 
     block3:
         jump block4;
 
     block4:
-        v16.i256 = mload v5 i256;
-        v17.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8d9f_0 v0 v16;
-        return v17;
+        v14.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8d9f_0 v0 v2;
+        return v14;
 }
 
 func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__gcfb5_764c(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> @layout_0 {
     block0:
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        v6.*i256 = alloca i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
-        mstore v6 v3 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = mload v5 i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_ce64 v0 v9;
-        v11.i256 = mload v4 i256;
-        v12.i256 = call %core__lib__abi__checked_tail__gf13e_3749 v11 v10;
-        v13.i256 = mload v6 i256;
-        v14.@layout_0 = call %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_3639 v0 v12 v13;
-        return v14;
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_ce64 v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_3749 v1 v7;
+        v11.@layout_0 = call %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_3639 v0 v9 v3;
+        return v11;
 
     block3:
         jump block4;
 
     block4:
-        v16.i256 = mload v5 i256;
-        v17.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_2519_0 v0 v16;
-        return v17;
+        v14.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_2519_0 v0 v2;
+        return v14;
 }
 
 func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_7760(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        v6.*i256 = alloca i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
-        mstore v6 v3 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = mload v5 i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_780b v0 v9;
-        v11.i256 = mload v4 i256;
-        v12.i256 = call %core__lib__abi__checked_tail__gf13e_8bdb v11 v10;
-        v13.i256 = mload v6 i256;
-        v14.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_1972 v0 v12 v13;
-        return v14;
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_780b v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_8bdb v1 v7;
+        v11.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_1972 v0 v9 v3;
+        return v11;
 
     block3:
         jump block4;
 
     block4:
-        v16.i256 = mload v5 i256;
-        v17.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_0a95_0 v0 v16;
-        return v17;
+        v14.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_0a95_0 v0 v2;
+        return v14;
 }
 
 func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_839e(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        v6.*i256 = alloca i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
-        mstore v6 v3 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = mload v5 i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_9725 v0 v9;
-        v11.i256 = mload v4 i256;
-        v12.i256 = call %core__lib__abi__checked_tail__gf13e_2af0 v11 v10;
-        v13.i256 = mload v6 i256;
-        v14.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_43c7 v0 v12 v13;
-        return v14;
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_9725 v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_2af0 v1 v7;
+        v11.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_43c7 v0 v9 v3;
+        return v11;
 
     block3:
         jump block4;
 
     block4:
-        v16.i256 = mload v5 i256;
-        v17.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_3a7c_0 v0 v16;
-        return v17;
+        v14.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_3a7c_0 v0 v2;
+        return v14;
 }
 
 func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_847c(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        v6.*i256 = alloca i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
-        mstore v6 v3 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = mload v5 i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b870 v0 v9;
-        v11.i256 = mload v4 i256;
-        v12.i256 = call %core__lib__abi__checked_tail__gf13e_9c13 v11 v10;
-        v13.i256 = mload v6 i256;
-        v14.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_8823 v0 v12 v13;
-        return v14;
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b870 v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_9c13 v1 v7;
+        v11.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_8823 v0 v9 v3;
+        return v11;
 
     block3:
         jump block4;
 
     block4:
-        v16.i256 = mload v5 i256;
-        v17.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_251a_0 v0 v16;
-        return v17;
+        v14.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_251a_0 v0 v2;
+        return v14;
 }
 
 func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__gcfb5_a4f7(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> @layout_0 {
     block0:
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        v6.*i256 = alloca i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
-        mstore v6 v3 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = mload v5 i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_faf2 v0 v9;
-        v11.i256 = mload v4 i256;
-        v12.i256 = call %core__lib__abi__checked_tail__gf13e_2d1a v11 v10;
-        v13.i256 = mload v6 i256;
-        v14.@layout_0 = call %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_2c09 v0 v12 v13;
-        return v14;
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_faf2 v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_2d1a v1 v7;
+        v11.@layout_0 = call %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_2c09 v0 v9 v3;
+        return v11;
 
     block3:
         jump block4;
 
     block4:
-        v16.i256 = mload v5 i256;
-        v17.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_5535_0 v0 v16;
-        return v17;
+        v14.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_5535_0 v0 v2;
+        return v14;
 }
 
 func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_b51a(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        v6.*i256 = alloca i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
-        mstore v6 v3 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = mload v5 i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_5ce9 v0 v9;
-        v11.i256 = mload v4 i256;
-        v12.i256 = call %core__lib__abi__checked_tail__gf13e_134e v11 v10;
-        v13.i256 = mload v6 i256;
-        v14.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_2360 v0 v12 v13;
-        return v14;
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_5ce9 v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_134e v1 v7;
+        v11.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_2360 v0 v9 v3;
+        return v11;
 
     block3:
         jump block4;
 
     block4:
-        v16.i256 = mload v5 i256;
-        v17.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_b39f_0 v0 v16;
-        return v17;
+        v14.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_b39f_0 v0 v2;
+        return v14;
 }
 
 func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_c7d5(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        v6.*i256 = alloca i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
-        mstore v6 v3 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = mload v5 i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_49c5 v0 v9;
-        v11.i256 = mload v4 i256;
-        v12.i256 = call %core__lib__abi__checked_tail__gf13e_15b4 v11 v10;
-        v13.i256 = mload v6 i256;
-        v14.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_38c3 v0 v12 v13;
-        return v14;
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_49c5 v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_15b4 v1 v7;
+        v11.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_38c3 v0 v9 v3;
+        return v11;
 
     block3:
         jump block4;
 
     block4:
-        v16.i256 = mload v5 i256;
-        v17.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_18e6_0 v0 v16;
-        return v17;
+        v14.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_18e6_0 v0 v2;
+        return v14;
 }
 
 func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__g5385_d4dc(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        v6.*i256 = alloca i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
-        mstore v6 v3 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = mload v5 i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c259 v0 v9;
-        v11.i256 = mload v4 i256;
-        v12.i256 = call %core__lib__abi__checked_tail__gf13e_50a2 v11 v10;
-        v13.i256 = mload v6 i256;
-        v14.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_6ea9 v0 v12 v13;
-        return v14;
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c259 v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_50a2 v1 v7;
+        v11.i256 = call %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_6ea9 v0 v9 v3;
+        return v11;
 
     block3:
         jump block4;
 
     block4:
-        v16.i256 = mload v5 i256;
-        v17.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_4e52_0 v0 v16;
-        return v17;
+        v14.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_4e52_0 v0 v2;
+        return v14;
 }
 
 func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__gcfb5_ed91(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> @layout_0 {
     block0:
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        v6.*i256 = alloca i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
-        mstore v6 v3 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = mload v5 i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_7946 v0 v9;
-        v11.i256 = mload v4 i256;
-        v12.i256 = call %core__lib__abi__checked_tail__gf13e_c3ce v11 v10;
-        v13.i256 = mload v6 i256;
-        v14.@layout_0 = call %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_8e68 v0 v12 v13;
-        return v14;
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_7946 v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_c3ce v1 v7;
+        v11.@layout_0 = call %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_8e68 v0 v9 v3;
+        return v11;
 
     block3:
         jump block4;
 
     block4:
-        v16.i256 = mload v5 i256;
-        v17.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_b822_0 v0 v16;
-        return v17;
+        v14.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_b822_0 v0 v2;
+        return v14;
 }
 
 func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__gcfb5_ef75(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> @layout_0 {
     block0:
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        v6.*i256 = alloca i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
-        mstore v6 v3 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = mload v5 i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_0f5c v0 v9;
-        v11.i256 = mload v4 i256;
-        v12.i256 = call %core__lib__abi__checked_tail__gf13e_7a36 v11 v10;
-        v13.i256 = mload v6 i256;
-        v14.@layout_0 = call %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_29bc v0 v12 v13;
-        return v14;
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_0f5c v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_7a36 v1 v7;
+        v11.@layout_0 = call %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_29bc v0 v9 v3;
+        return v11;
 
     block3:
         jump block4;
 
     block4:
-        v16.i256 = mload v5 i256;
-        v17.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_f4e0_0 v0 v16;
-        return v17;
+        v14.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_f4e0_0 v0 v2;
+        return v14;
 }
 
 func inline(always) private %core__lib__abi__decode_field_from_prechecked_head__gcfb5_faf8(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> @layout_0 {
     block0:
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        v6.*i256 = alloca i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
-        mstore v6 v3 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = mload v5 i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_6dae v0 v9;
-        v11.i256 = mload v4 i256;
-        v12.i256 = call %core__lib__abi__checked_tail__gf13e_c89e v11 v10;
-        v13.i256 = mload v6 i256;
-        v14.@layout_0 = call %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_a883 v0 v12 v13;
-        return v14;
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_6dae v0 v2;
+        v9.i256 = call %core__lib__abi__checked_tail__gf13e_c89e v1 v7;
+        v11.@layout_0 = call %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_a883 v0 v9 v3;
+        return v11;
 
     block3:
         jump block4;
 
     block4:
-        v16.i256 = mload v5 i256;
-        v17.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_3641_0 v0 v16;
-        return v17;
+        v14.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_3641_0 v0 v2;
+        return v14;
 }
 
 func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_0a95(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c700 v0 v4;
-        return v5;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c700 v0 v1;
+        return v4;
 }
 
 func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_0a95_0(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c700_0 v0 v4;
-        return v5;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c700_0 v0 v1;
+        return v4;
 }
 
 func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_18e6(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b705 v0 v4;
-        return v5;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b705 v0 v1;
+        return v4;
 }
 
 func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_18e6_0(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b705_0 v0 v4;
-        return v5;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b705_0 v0 v1;
+        return v4;
 }
 
 func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_2519(v0.@layout_5, v1.i256) -> @layout_0 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_8736 v0 v4;
-        v7.i256 = shr 160.i256 v5;
-        v9.i1 = eq v7 0.i256;
-        v10.i1 = is_zero v9;
-        br v10 block2 block3;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_8736 v0 v1;
+        v6.i256 = shr 160.i256 v4;
+        v8.i1 = eq v6 0.i256;
+        v9.i1 = is_zero v8;
+        br v9 block2 block3;
 
     block2:
         evm_revert 0.i256 0.i256;
@@ -4568,23 +3879,20 @@ func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__de
         jump block4;
 
     block4:
-        v13.@layout_0 = insert_value undef.@layout_0 0.i256 v5;
-        return v13;
+        v12.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
+        return v12;
 }
 
 func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_2519_0(v0.@layout_5, v1.i256) -> @layout_0 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_8736_0 v0 v4;
-        v7.i256 = shr 160.i256 v5;
-        v9.i1 = eq v7 0.i256;
-        v10.i1 = is_zero v9;
-        br v10 block2 block3;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_8736_0 v0 v1;
+        v6.i256 = shr 160.i256 v4;
+        v8.i1 = eq v6 0.i256;
+        v9.i1 = is_zero v8;
+        br v9 block2 block3;
 
     block2:
         evm_revert 0.i256 0.i256;
@@ -4593,38 +3901,30 @@ func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__de
         jump block4;
 
     block4:
-        v13.@layout_0 = insert_value undef.@layout_0 0.i256 v5;
-        return v13;
+        v12.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
+        return v12;
 }
 
 func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_251a(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3bad v0 v4;
-        return v5;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3bad v0 v1;
+        return v4;
 }
 
 func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_251a_0(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3bad_0 v0 v4;
-        return v5;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3bad_0 v0 v1;
+        return v4;
 }
 
 func inline(always) private %impl_trait_Symbol__decode_from__gd20d(v0.@layout_5, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
@@ -4633,17 +3933,14 @@ func inline(always) private %impl_trait_Symbol__decode_from__gd20d(v0.@layout_5,
 
 func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_3641(v0.@layout_5, v1.i256) -> @layout_0 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b9ca v0 v4;
-        v7.i256 = shr 160.i256 v5;
-        v9.i1 = eq v7 0.i256;
-        v10.i1 = is_zero v9;
-        br v10 block2 block3;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b9ca v0 v1;
+        v6.i256 = shr 160.i256 v4;
+        v8.i1 = eq v6 0.i256;
+        v9.i1 = is_zero v8;
+        br v9 block2 block3;
 
     block2:
         evm_revert 0.i256 0.i256;
@@ -4652,23 +3949,20 @@ func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__de
         jump block4;
 
     block4:
-        v13.@layout_0 = insert_value undef.@layout_0 0.i256 v5;
-        return v13;
+        v12.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
+        return v12;
 }
 
 func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_3641_0(v0.@layout_5, v1.i256) -> @layout_0 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b9ca_0 v0 v4;
-        v7.i256 = shr 160.i256 v5;
-        v9.i1 = eq v7 0.i256;
-        v10.i1 = is_zero v9;
-        br v10 block2 block3;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b9ca_0 v0 v1;
+        v6.i256 = shr 160.i256 v4;
+        v8.i1 = eq v6 0.i256;
+        v9.i1 = is_zero v8;
+        br v9 block2 block3;
 
     block2:
         evm_revert 0.i256 0.i256;
@@ -4677,23 +3971,20 @@ func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__de
         jump block4;
 
     block4:
-        v13.@layout_0 = insert_value undef.@layout_0 0.i256 v5;
-        return v13;
+        v12.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
+        return v12;
 }
 
 func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_3716(v0.@layout_5, v1.i256) -> @layout_0 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_d831 v0 v4;
-        v7.i256 = shr 160.i256 v5;
-        v9.i1 = eq v7 0.i256;
-        v10.i1 = is_zero v9;
-        br v10 block2 block3;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_d831 v0 v1;
+        v6.i256 = shr 160.i256 v4;
+        v8.i1 = eq v6 0.i256;
+        v9.i1 = is_zero v8;
+        br v9 block2 block3;
 
     block2:
         evm_revert 0.i256 0.i256;
@@ -4702,23 +3993,20 @@ func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__de
         jump block4;
 
     block4:
-        v13.@layout_0 = insert_value undef.@layout_0 0.i256 v5;
-        return v13;
+        v12.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
+        return v12;
 }
 
 func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_3716_0(v0.@layout_5, v1.i256) -> @layout_0 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_d831_0 v0 v4;
-        v7.i256 = shr 160.i256 v5;
-        v9.i1 = eq v7 0.i256;
-        v10.i1 = is_zero v9;
-        br v10 block2 block3;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_d831_0 v0 v1;
+        v6.i256 = shr 160.i256 v4;
+        v8.i1 = eq v6 0.i256;
+        v9.i1 = is_zero v8;
+        br v9 block2 block3;
 
     block2:
         evm_revert 0.i256 0.i256;
@@ -4727,71 +4015,56 @@ func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__de
         jump block4;
 
     block4:
-        v13.@layout_0 = insert_value undef.@layout_0 0.i256 v5;
-        return v13;
+        v12.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
+        return v12;
 }
 
 func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_3a7c(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_9757 v0 v4;
-        return v5;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_9757 v0 v1;
+        return v4;
 }
 
 func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_3a7c_0(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_9757_0 v0 v4;
-        return v5;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_9757_0 v0 v1;
+        return v4;
 }
 
 func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_4e52(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_790f v0 v4;
-        return v5;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_790f v0 v1;
+        return v4;
 }
 
 func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_4e52_0(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_790f_0 v0 v4;
-        return v5;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_790f_0 v0 v1;
+        return v4;
 }
 
 func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_4e5e(v0.@layout_5, v1.i256) -> @layout_0 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_fec2 v0 v4;
-        v7.i256 = shr 160.i256 v5;
-        v9.i1 = eq v7 0.i256;
-        v10.i1 = is_zero v9;
-        br v10 block2 block3;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_fec2 v0 v1;
+        v6.i256 = shr 160.i256 v4;
+        v8.i1 = eq v6 0.i256;
+        v9.i1 = is_zero v8;
+        br v9 block2 block3;
 
     block2:
         evm_revert 0.i256 0.i256;
@@ -4800,23 +4073,20 @@ func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__de
         jump block4;
 
     block4:
-        v13.@layout_0 = insert_value undef.@layout_0 0.i256 v5;
-        return v13;
+        v12.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
+        return v12;
 }
 
 func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_4e5e_0(v0.@layout_5, v1.i256) -> @layout_0 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_fec2_0 v0 v4;
-        v7.i256 = shr 160.i256 v5;
-        v9.i1 = eq v7 0.i256;
-        v10.i1 = is_zero v9;
-        br v10 block2 block3;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_fec2_0 v0 v1;
+        v6.i256 = shr 160.i256 v4;
+        v8.i1 = eq v6 0.i256;
+        v9.i1 = is_zero v8;
+        br v9 block2 block3;
 
     block2:
         evm_revert 0.i256 0.i256;
@@ -4825,23 +4095,20 @@ func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__de
         jump block4;
 
     block4:
-        v13.@layout_0 = insert_value undef.@layout_0 0.i256 v5;
-        return v13;
+        v12.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
+        return v12;
 }
 
 func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_5535(v0.@layout_5, v1.i256) -> @layout_0 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_a6b2 v0 v4;
-        v7.i256 = shr 160.i256 v5;
-        v9.i1 = eq v7 0.i256;
-        v10.i1 = is_zero v9;
-        br v10 block2 block3;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_a6b2 v0 v1;
+        v6.i256 = shr 160.i256 v4;
+        v8.i1 = eq v6 0.i256;
+        v9.i1 = is_zero v8;
+        br v9 block2 block3;
 
     block2:
         evm_revert 0.i256 0.i256;
@@ -4850,23 +4117,20 @@ func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__de
         jump block4;
 
     block4:
-        v13.@layout_0 = insert_value undef.@layout_0 0.i256 v5;
-        return v13;
+        v12.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
+        return v12;
 }
 
 func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_5535_0(v0.@layout_5, v1.i256) -> @layout_0 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_a6b2_0 v0 v4;
-        v7.i256 = shr 160.i256 v5;
-        v9.i1 = eq v7 0.i256;
-        v10.i1 = is_zero v9;
-        br v10 block2 block3;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_a6b2_0 v0 v1;
+        v6.i256 = shr 160.i256 v4;
+        v8.i1 = eq v6 0.i256;
+        v9.i1 = is_zero v8;
+        br v9 block2 block3;
 
     block2:
         evm_revert 0.i256 0.i256;
@@ -4875,49 +4139,37 @@ func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__de
         jump block4;
 
     block4:
-        v13.@layout_0 = insert_value undef.@layout_0 0.i256 v5;
-        return v13;
+        v12.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
+        return v12;
 }
 
 func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_5c31(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3a1f v0 v4;
-        return v5;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3a1f v0 v1;
+        return v4;
 }
 
 func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_5c31_0(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3a1f_0 v0 v4;
-        return v5;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3a1f_0 v0 v1;
+        return v4;
 }
 
 func inline(always) private %impl_trait_Allowance__decode_from__gd20d(v0.@layout_5, v1.i256) -> @layout_6 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_e949 v0;
-        v5.i256 = mload v2 i256;
-        v6.i256 = mload v2 i256;
-        v7.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_6698 v0 v5 v6 v4;
-        v8.i256 = mload v2 i256;
-        v9.i256 = mload v2 i256;
-        (v11.i256, v12.i1) = uaddo v9 32.i256;
-        br v12 block2 block3;
+        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_e949 v0;
+        v5.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_6698 v0 v1 v1 v3;
+        (v7.i256, v8.i1) = uaddo v1 32.i256;
+        br v8 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -4925,27 +4177,21 @@ func inline(always) private %impl_trait_Allowance__decode_from__gd20d(v0.@layout
         evm_revert 0.i256 36.i256;
 
     block3:
-        v21.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_6698 v0 v8 v11 v4;
-        v24.@layout_6 = insert_value undef.@layout_6 0.i256 v7;
-        v26.@layout_6 = insert_value v24 1.i256 v21;
-        return v26;
+        v17.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_6698 v0 v1 v7 v3;
+        v20.@layout_6 = insert_value undef.@layout_6 0.i256 v5;
+        v22.@layout_6 = insert_value v20 1.i256 v17;
+        return v22;
 }
 
 func inline(always) private %impl_trait_Approve__decode_from__gd20d(v0.@layout_5, v1.i256) -> @layout_7 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_aa47 v0;
-        v5.i256 = mload v2 i256;
-        v6.i256 = mload v2 i256;
-        v7.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_329a v0 v5 v6 v4;
-        v8.i256 = mload v2 i256;
-        v9.i256 = mload v2 i256;
-        (v11.i256, v12.i1) = uaddo v9 32.i256;
-        br v12 block2 block3;
+        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_aa47 v0;
+        v5.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_329a v0 v1 v1 v3;
+        (v7.i256, v8.i1) = uaddo v1 32.i256;
+        br v8 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -4953,49 +4199,40 @@ func inline(always) private %impl_trait_Approve__decode_from__gd20d(v0.@layout_5
         evm_revert 0.i256 36.i256;
 
     block3:
-        v21.i256 = call %core__lib__abi__decode_msg_field_from__g5385_0219 v0 v8 v11 v4;
-        v24.@layout_7 = insert_value undef.@layout_7 0.i256 v7;
-        v26.@layout_7 = insert_value v24 1.i256 v21;
-        return v26;
+        v17.i256 = call %core__lib__abi__decode_msg_field_from__g5385_0219 v0 v1 v7 v3;
+        v20.@layout_7 = insert_value undef.@layout_7 0.i256 v5;
+        v22.@layout_7 = insert_value v20 1.i256 v17;
+        return v22;
 }
 
 func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8d9f(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b461 v0 v4;
-        return v5;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b461 v0 v1;
+        return v4;
 }
 
 func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8d9f_0(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b461_0 v0 v4;
-        return v5;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b461_0 v0 v1;
+        return v4;
 }
 
 func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_9286(v0.@layout_5, v1.i256) -> @layout_0 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_a8d6 v0 v4;
-        v7.i256 = shr 160.i256 v5;
-        v9.i1 = eq v7 0.i256;
-        v10.i1 = is_zero v9;
-        br v10 block2 block3;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_a8d6 v0 v1;
+        v6.i256 = shr 160.i256 v4;
+        v8.i1 = eq v6 0.i256;
+        v9.i1 = is_zero v8;
+        br v9 block2 block3;
 
     block2:
         evm_revert 0.i256 0.i256;
@@ -5004,23 +4241,20 @@ func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__de
         jump block4;
 
     block4:
-        v13.@layout_0 = insert_value undef.@layout_0 0.i256 v5;
-        return v13;
+        v12.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
+        return v12;
 }
 
 func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_9286_0(v0.@layout_5, v1.i256) -> @layout_0 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_a8d6_0 v0 v4;
-        v7.i256 = shr 160.i256 v5;
-        v9.i1 = eq v7 0.i256;
-        v10.i1 = is_zero v9;
-        br v10 block2 block3;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_a8d6_0 v0 v1;
+        v6.i256 = shr 160.i256 v4;
+        v8.i1 = eq v6 0.i256;
+        v9.i1 = is_zero v8;
+        br v9 block2 block3;
 
     block2:
         evm_revert 0.i256 0.i256;
@@ -5029,25 +4263,19 @@ func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__de
         jump block4;
 
     block4:
-        v13.@layout_0 = insert_value undef.@layout_0 0.i256 v5;
-        return v13;
+        v12.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
+        return v12;
 }
 
 func inline(always) private %impl_trait_Mint__decode_from__gd20d(v0.@layout_5, v1.i256) -> @layout_8 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_779e v0;
-        v5.i256 = mload v2 i256;
-        v6.i256 = mload v2 i256;
-        v7.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_0358 v0 v5 v6 v4;
-        v8.i256 = mload v2 i256;
-        v9.i256 = mload v2 i256;
-        (v11.i256, v12.i1) = uaddo v9 32.i256;
-        br v12 block2 block3;
+        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_779e v0;
+        v5.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_0358 v0 v1 v1 v3;
+        (v7.i256, v8.i1) = uaddo v1 32.i256;
+        br v8 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -5055,64 +4283,51 @@ func inline(always) private %impl_trait_Mint__decode_from__gd20d(v0.@layout_5, v
         evm_revert 0.i256 36.i256;
 
     block3:
-        v21.i256 = call %core__lib__abi__decode_msg_field_from__g5385_9796 v0 v8 v11 v4;
-        v24.@layout_8 = insert_value undef.@layout_8 0.i256 v7;
-        v26.@layout_8 = insert_value v24 1.i256 v21;
-        return v26;
+        v17.i256 = call %core__lib__abi__decode_msg_field_from__g5385_9796 v0 v1 v7 v3;
+        v20.@layout_8 = insert_value undef.@layout_8 0.i256 v5;
+        v22.@layout_8 = insert_value v20 1.i256 v17;
+        return v22;
 }
 
 func inline(always) private %impl_trait_Burn__decode_from__gd20d(v0.@layout_5, v1.i256) -> @layout_9 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_6f43 v0;
-        v5.i256 = mload v2 i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = call %core__lib__abi__decode_msg_field_from__g5385_ce42 v0 v5 v6 v4;
-        v10.@layout_9 = insert_value undef.@layout_9 0.i256 v7;
-        return v10;
+        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_6f43 v0;
+        v5.i256 = call %core__lib__abi__decode_msg_field_from__g5385_ce42 v0 v1 v1 v3;
+        v8.@layout_9 = insert_value undef.@layout_9 0.i256 v5;
+        return v8;
 }
 
 func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_b39f(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_e134 v0 v4;
-        return v5;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_e134 v0 v1;
+        return v4;
 }
 
 func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_b39f_0(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_e134_0 v0 v4;
-        return v5;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_e134_0 v0 v1;
+        return v4;
 }
 
 func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_b822(v0.@layout_5, v1.i256) -> @layout_0 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_40a0 v0 v4;
-        v7.i256 = shr 160.i256 v5;
-        v9.i1 = eq v7 0.i256;
-        v10.i1 = is_zero v9;
-        br v10 block2 block3;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_40a0 v0 v1;
+        v6.i256 = shr 160.i256 v4;
+        v8.i1 = eq v6 0.i256;
+        v9.i1 = is_zero v8;
+        br v9 block2 block3;
 
     block2:
         evm_revert 0.i256 0.i256;
@@ -5121,23 +4336,20 @@ func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__de
         jump block4;
 
     block4:
-        v13.@layout_0 = insert_value undef.@layout_0 0.i256 v5;
-        return v13;
+        v12.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
+        return v12;
 }
 
 func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_b822_0(v0.@layout_5, v1.i256) -> @layout_0 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_40a0_0 v0 v4;
-        v7.i256 = shr 160.i256 v5;
-        v9.i1 = eq v7 0.i256;
-        v10.i1 = is_zero v9;
-        br v10 block2 block3;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_40a0_0 v0 v1;
+        v6.i256 = shr 160.i256 v4;
+        v8.i1 = eq v6 0.i256;
+        v9.i1 = is_zero v8;
+        br v9 block2 block3;
 
     block2:
         evm_revert 0.i256 0.i256;
@@ -5146,25 +4358,19 @@ func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__de
         jump block4;
 
     block4:
-        v13.@layout_0 = insert_value undef.@layout_0 0.i256 v5;
-        return v13;
+        v12.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
+        return v12;
 }
 
 func inline(always) private %impl_trait_BurnFrom__decode_from__gd20d(v0.@layout_5, v1.i256) -> @layout_10 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_e065 v0;
-        v5.i256 = mload v2 i256;
-        v6.i256 = mload v2 i256;
-        v7.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_059c v0 v5 v6 v4;
-        v8.i256 = mload v2 i256;
-        v9.i256 = mload v2 i256;
-        (v11.i256, v12.i1) = uaddo v9 32.i256;
-        br v12 block2 block3;
+        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_e065 v0;
+        v5.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_059c v0 v1 v1 v3;
+        (v7.i256, v8.i1) = uaddo v1 32.i256;
+        br v8 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -5172,305 +4378,184 @@ func inline(always) private %impl_trait_BurnFrom__decode_from__gd20d(v0.@layout_
         evm_revert 0.i256 36.i256;
 
     block3:
-        v21.i256 = call %core__lib__abi__decode_msg_field_from__g5385_745e v0 v8 v11 v4;
-        v24.@layout_10 = insert_value undef.@layout_10 0.i256 v7;
-        v26.@layout_10 = insert_value v24 1.i256 v21;
-        return v26;
+        v17.i256 = call %core__lib__abi__decode_msg_field_from__g5385_745e v0 v1 v7 v3;
+        v20.@layout_10 = insert_value undef.@layout_10 0.i256 v5;
+        v22.@layout_10 = insert_value v20 1.i256 v17;
+        return v22;
 }
 
 func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_1972(v0.@layout_5, v1.i256, v2.i256) -> i256 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v3 i256;
-        v7.i256 = mload v4 i256;
-        v8.i256 = call %core__lib__abi__checked_frame_end__gf13e_aaf5 v5 32.i256 v7;
-        v10.i256 = mload v3 i256;
-        v11.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_0a95 v0 v10;
-        return v11;
+        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_aaf5 v1 32.i256 v2;
+        v8.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_0a95 v0 v1;
+        return v8;
 }
 
 func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_2360(v0.@layout_5, v1.i256, v2.i256) -> i256 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v3 i256;
-        v7.i256 = mload v4 i256;
-        v8.i256 = call %core__lib__abi__checked_frame_end__gf13e_01a8 v5 32.i256 v7;
-        v10.i256 = mload v3 i256;
-        v11.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_b39f v0 v10;
-        return v11;
+        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_01a8 v1 32.i256 v2;
+        v8.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_b39f v0 v1;
+        return v8;
 }
 
 func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_2374(v0.@layout_5, v1.i256, v2.i256) -> i256 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v3 i256;
-        v7.i256 = mload v4 i256;
-        v8.i256 = call %core__lib__abi__checked_frame_end__gf13e_a584 v5 32.i256 v7;
-        v10.i256 = mload v3 i256;
-        v11.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8d9f v0 v10;
-        return v11;
+        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_a584 v1 32.i256 v2;
+        v8.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_8d9f v0 v1;
+        return v8;
 }
 
 func private %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_29bc(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v3 i256;
-        v7.i256 = mload v4 i256;
-        v8.i256 = call %core__lib__abi__checked_frame_end__gf13e_e706 v5 32.i256 v7;
-        v10.i256 = mload v3 i256;
-        v11.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_f4e0 v0 v10;
-        return v11;
+        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_e706 v1 32.i256 v2;
+        v8.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_f4e0 v0 v1;
+        return v8;
 }
 
 func private %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_2c09(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v3 i256;
-        v7.i256 = mload v4 i256;
-        v8.i256 = call %core__lib__abi__checked_frame_end__gf13e_cc78 v5 32.i256 v7;
-        v10.i256 = mload v3 i256;
-        v11.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_5535 v0 v10;
-        return v11;
+        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_cc78 v1 32.i256 v2;
+        v8.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_5535 v0 v1;
+        return v8;
 }
 
 func private %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_3639(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v3 i256;
-        v7.i256 = mload v4 i256;
-        v8.i256 = call %core__lib__abi__checked_frame_end__gf13e_4689 v5 32.i256 v7;
-        v10.i256 = mload v3 i256;
-        v11.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_2519 v0 v10;
-        return v11;
+        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_4689 v1 32.i256 v2;
+        v8.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_2519 v0 v1;
+        return v8;
 }
 
 func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_38c3(v0.@layout_5, v1.i256, v2.i256) -> i256 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v3 i256;
-        v7.i256 = mload v4 i256;
-        v8.i256 = call %core__lib__abi__checked_frame_end__gf13e_c0b4 v5 32.i256 v7;
-        v10.i256 = mload v3 i256;
-        v11.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_18e6 v0 v10;
-        return v11;
+        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_c0b4 v1 32.i256 v2;
+        v8.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_18e6 v0 v1;
+        return v8;
 }
 
 func private %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_3fea(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v3 i256;
-        v7.i256 = mload v4 i256;
-        v8.i256 = call %core__lib__abi__checked_frame_end__gf13e_de97 v5 32.i256 v7;
-        v10.i256 = mload v3 i256;
-        v11.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_9286 v0 v10;
-        return v11;
+        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_de97 v1 32.i256 v2;
+        v8.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_9286 v0 v1;
+        return v8;
 }
 
 func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_43c7(v0.@layout_5, v1.i256, v2.i256) -> i256 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v3 i256;
-        v7.i256 = mload v4 i256;
-        v8.i256 = call %core__lib__abi__checked_frame_end__gf13e_f40a v5 32.i256 v7;
-        v10.i256 = mload v3 i256;
-        v11.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_3a7c v0 v10;
-        return v11;
+        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_f40a v1 32.i256 v2;
+        v8.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_3a7c v0 v1;
+        return v8;
 }
 
 func private %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_64e6(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v3 i256;
-        v7.i256 = mload v4 i256;
-        v8.i256 = call %core__lib__abi__checked_frame_end__gf13e_6403 v5 32.i256 v7;
-        v10.i256 = mload v3 i256;
-        v11.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_4e5e v0 v10;
-        return v11;
+        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_6403 v1 32.i256 v2;
+        v8.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_4e5e v0 v1;
+        return v8;
 }
 
 func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_6ea9(v0.@layout_5, v1.i256, v2.i256) -> i256 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v3 i256;
-        v7.i256 = mload v4 i256;
-        v8.i256 = call %core__lib__abi__checked_frame_end__gf13e_9888 v5 32.i256 v7;
-        v10.i256 = mload v3 i256;
-        v11.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_4e52 v0 v10;
-        return v11;
+        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_9888 v1 32.i256 v2;
+        v8.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_4e52 v0 v1;
+        return v8;
 }
 
 func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_8823(v0.@layout_5, v1.i256, v2.i256) -> i256 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v3 i256;
-        v7.i256 = mload v4 i256;
-        v8.i256 = call %core__lib__abi__checked_frame_end__gf13e_9284 v5 32.i256 v7;
-        v10.i256 = mload v3 i256;
-        v11.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_251a v0 v10;
-        return v11;
+        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_9284 v1 32.i256 v2;
+        v8.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_251a v0 v1;
+        return v8;
 }
 
 func private %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_8e68(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v3 i256;
-        v7.i256 = mload v4 i256;
-        v8.i256 = call %core__lib__abi__checked_frame_end__gf13e_c3cb v5 32.i256 v7;
-        v10.i256 = mload v3 i256;
-        v11.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_b822 v0 v10;
-        return v11;
+        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_c3cb v1 32.i256 v2;
+        v8.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_b822 v0 v1;
+        return v8;
 }
 
 func private %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_978c(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v3 i256;
-        v7.i256 = mload v4 i256;
-        v8.i256 = call %core__lib__abi__checked_frame_end__gf13e_60b4 v5 32.i256 v7;
-        v10.i256 = mload v3 i256;
-        v11.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_3716 v0 v10;
-        return v11;
+        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_60b4 v1 32.i256 v2;
+        v8.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_3716 v0 v1;
+        return v8;
 }
 
 func private %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_a883(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v3 i256;
-        v7.i256 = mload v4 i256;
-        v8.i256 = call %core__lib__abi__checked_frame_end__gf13e_9b12 v5 32.i256 v7;
-        v10.i256 = mload v3 i256;
-        v11.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_3641 v0 v10;
-        return v11;
+        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_9b12 v1 32.i256 v2;
+        v8.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_3641 v0 v1;
+        return v8;
 }
 
 func private %core__lib__abi__trait_Decode__decode_from_bounded__g8bef_d01b(v0.@layout_5, v1.i256, v2.i256) -> i256 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v3 i256;
-        v7.i256 = mload v4 i256;
-        v8.i256 = call %core__lib__abi__checked_frame_end__gf13e_d1eb v5 32.i256 v7;
-        v10.i256 = mload v3 i256;
-        v11.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_5c31 v0 v10;
-        return v11;
+        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_d1eb v1 32.i256 v2;
+        v8.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_5c31 v0 v1;
+        return v8;
 }
 
 func private %core__lib__abi__trait_Decode__decode_from_bounded__gd2f7_d676(v0.@layout_5, v1.i256, v2.i256) -> @layout_0 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v3 i256;
-        v7.i256 = mload v4 i256;
-        v8.i256 = call %core__lib__abi__checked_frame_end__gf13e_b8aa v5 32.i256 v7;
-        v10.i256 = mload v3 i256;
-        v11.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_db93 v0 v10;
-        return v11;
+        v6.i256 = call %core__lib__abi__checked_frame_end__gf13e_b8aa v1 32.i256 v2;
+        v8.@layout_0 = call %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_db93 v0 v1;
+        return v8;
 }
 
 func inline(always) private %impl_trait_Decimals__decode_from__gd20d(v0.@layout_5, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
@@ -5479,23 +4564,17 @@ func inline(always) private %impl_trait_Decimals__decode_from__gd20d(v0.@layout_
 
 func inline(always) private %impl_trait_BalanceOf__decode_from__gd20d(v0.@layout_5, v1.i256) -> @layout_11 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_e9e0 v0;
-        v5.i256 = mload v2 i256;
-        v6.i256 = mload v2 i256;
-        v7.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_6f66 v0 v5 v6 v4;
-        v10.@layout_11 = insert_value undef.@layout_11 0.i256 v7;
-        return v10;
+        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_e9e0 v0;
+        v5.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_6f66 v0 v1 v1 v3;
+        v8.@layout_11 = insert_value undef.@layout_11 0.i256 v5;
+        return v8;
 }
 
 func inline(always) private %impl_trait_Name__decode_from__gd20d(v0.@layout_5, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
@@ -5504,19 +4583,13 @@ func inline(always) private %impl_trait_Name__decode_from__gd20d(v0.@layout_5, v
 
 func inline(always) private %impl_trait_IncreaseAllowance__decode_from__gd20d(v0.@layout_5, v1.i256) -> @layout_12 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_de6d v0;
-        v5.i256 = mload v2 i256;
-        v6.i256 = mload v2 i256;
-        v7.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_f58a v0 v5 v6 v4;
-        v8.i256 = mload v2 i256;
-        v9.i256 = mload v2 i256;
-        (v11.i256, v12.i1) = uaddo v9 32.i256;
-        br v12 block2 block3;
+        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_de6d v0;
+        v5.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_f58a v0 v1 v1 v3;
+        (v7.i256, v8.i1) = uaddo v1 32.i256;
+        br v8 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -5524,27 +4597,21 @@ func inline(always) private %impl_trait_IncreaseAllowance__decode_from__gd20d(v0
         evm_revert 0.i256 36.i256;
 
     block3:
-        v21.i256 = call %core__lib__abi__decode_msg_field_from__g5385_0929 v0 v8 v11 v4;
-        v24.@layout_12 = insert_value undef.@layout_12 0.i256 v7;
-        v26.@layout_12 = insert_value v24 1.i256 v21;
-        return v26;
+        v17.i256 = call %core__lib__abi__decode_msg_field_from__g5385_0929 v0 v1 v7 v3;
+        v20.@layout_12 = insert_value undef.@layout_12 0.i256 v5;
+        v22.@layout_12 = insert_value v20 1.i256 v17;
+        return v22;
 }
 
 func inline(always) private %impl_trait_TransferFrom__decode_from__gd20d(v0.@layout_5, v1.i256) -> @layout_13 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_36c4 v0;
-        v5.i256 = mload v2 i256;
-        v6.i256 = mload v2 i256;
-        v7.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_3b80 v0 v5 v6 v4;
-        v8.i256 = mload v2 i256;
-        v9.i256 = mload v2 i256;
-        (v11.i256, v12.i1) = uaddo v9 32.i256;
-        br v12 block2 block3;
+        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_36c4 v0;
+        v5.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_3b80 v0 v1 v1 v3;
+        (v7.i256, v8.i1) = uaddo v1 32.i256;
+        br v8 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -5552,39 +4619,31 @@ func inline(always) private %impl_trait_TransferFrom__decode_from__gd20d(v0.@lay
         evm_revert 0.i256 36.i256;
 
     block3:
-        v21.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_3b80 v0 v8 v11 v4;
-        v23.i256 = mload v2 i256;
-        v24.i256 = mload v2 i256;
-        (v25.i256, v26.i1) = uaddo v24 32.i256;
-        br v26 block2 block4;
+        v17.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_3b80 v0 v1 v7 v3;
+        (v20.i256, v21.i1) = uaddo v1 32.i256;
+        br v21 block2 block4;
 
     block4:
-        (v27.i256, v28.i1) = uaddo v25 32.i256;
-        br v28 block2 block5;
+        (v22.i256, v23.i1) = uaddo v20 32.i256;
+        br v23 block2 block5;
 
     block5:
-        v32.i256 = call %core__lib__abi__decode_msg_field_from__g5385_2a48 v0 v23 v27 v4;
-        v35.@layout_13 = insert_value undef.@layout_13 0.i256 v7;
-        v38.@layout_13 = insert_value v35 1.i256 v21;
-        v40.@layout_13 = insert_value v38 2.i256 v32;
-        return v40;
+        v27.i256 = call %core__lib__abi__decode_msg_field_from__g5385_2a48 v0 v1 v22 v3;
+        v30.@layout_13 = insert_value undef.@layout_13 0.i256 v5;
+        v33.@layout_13 = insert_value v30 1.i256 v17;
+        v35.@layout_13 = insert_value v33 2.i256 v27;
+        return v35;
 }
 
 func inline(always) private %impl_trait_Transfer__decode_from__gd20d(v0.@layout_5, v1.i256) -> @layout_14 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_0eff v0;
-        v5.i256 = mload v2 i256;
-        v6.i256 = mload v2 i256;
-        v7.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_bede v0 v5 v6 v4;
-        v8.i256 = mload v2 i256;
-        v9.i256 = mload v2 i256;
-        (v11.i256, v12.i1) = uaddo v9 32.i256;
-        br v12 block2 block3;
+        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_0eff v0;
+        v5.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_bede v0 v1 v1 v3;
+        (v7.i256, v8.i1) = uaddo v1 32.i256;
+        br v8 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -5592,25 +4651,22 @@ func inline(always) private %impl_trait_Transfer__decode_from__gd20d(v0.@layout_
         evm_revert 0.i256 36.i256;
 
     block3:
-        v21.i256 = call %core__lib__abi__decode_msg_field_from__g5385_252f v0 v8 v11 v4;
-        v24.@layout_14 = insert_value undef.@layout_14 0.i256 v7;
-        v26.@layout_14 = insert_value v24 1.i256 v21;
-        return v26;
+        v17.i256 = call %core__lib__abi__decode_msg_field_from__g5385_252f v0 v1 v7 v3;
+        v20.@layout_14 = insert_value undef.@layout_14 0.i256 v5;
+        v22.@layout_14 = insert_value v20 1.i256 v17;
+        return v22;
 }
 
 func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_db93(v0.@layout_5, v1.i256) -> @layout_0 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3ba3 v0 v4;
-        v7.i256 = shr 160.i256 v5;
-        v9.i1 = eq v7 0.i256;
-        v10.i1 = is_zero v9;
-        br v10 block2 block3;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3ba3 v0 v1;
+        v6.i256 = shr 160.i256 v4;
+        v8.i1 = eq v6 0.i256;
+        v9.i1 = is_zero v8;
+        br v9 block2 block3;
 
     block2:
         evm_revert 0.i256 0.i256;
@@ -5619,23 +4675,20 @@ func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__de
         jump block4;
 
     block4:
-        v13.@layout_0 = insert_value undef.@layout_0 0.i256 v5;
-        return v13;
+        v12.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
+        return v12;
 }
 
 func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_db93_0(v0.@layout_5, v1.i256) -> @layout_0 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3ba3_0 v0 v4;
-        v7.i256 = shr 160.i256 v5;
-        v9.i1 = eq v7 0.i256;
-        v10.i1 = is_zero v9;
-        br v10 block2 block3;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3ba3_0 v0 v1;
+        v6.i256 = shr 160.i256 v4;
+        v8.i1 = eq v6 0.i256;
+        v9.i1 = is_zero v8;
+        br v9 block2 block3;
 
     block2:
         evm_revert 0.i256 0.i256;
@@ -5644,25 +4697,19 @@ func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__de
         jump block4;
 
     block4:
-        v13.@layout_0 = insert_value undef.@layout_0 0.i256 v5;
-        return v13;
+        v12.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
+        return v12;
 }
 
 func inline(always) private %impl_trait_DecreaseAllowance__decode_from__gd20d(v0.@layout_5, v1.i256) -> @layout_15 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_e83e v0;
-        v5.i256 = mload v2 i256;
-        v6.i256 = mload v2 i256;
-        v7.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_7904 v0 v5 v6 v4;
-        v8.i256 = mload v2 i256;
-        v9.i256 = mload v2 i256;
-        (v11.i256, v12.i1) = uaddo v9 32.i256;
-        br v12 block2 block3;
+        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_e83e v0;
+        v5.@layout_0 = call %core__lib__abi__decode_msg_field_from__gcfb5_7904 v0 v1 v1 v3;
+        (v7.i256, v8.i1) = uaddo v1 32.i256;
+        br v8 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -5670,16 +4717,14 @@ func inline(always) private %impl_trait_DecreaseAllowance__decode_from__gd20d(v0
         evm_revert 0.i256 36.i256;
 
     block3:
-        v21.i256 = call %core__lib__abi__decode_msg_field_from__g5385_9aa8 v0 v8 v11 v4;
-        v24.@layout_15 = insert_value undef.@layout_15 0.i256 v7;
-        v26.@layout_15 = insert_value v24 1.i256 v21;
-        return v26;
+        v17.i256 = call %core__lib__abi__decode_msg_field_from__g5385_9aa8 v0 v1 v7 v3;
+        v20.@layout_15 = insert_value undef.@layout_15 0.i256 v5;
+        v22.@layout_15 = insert_value v20 1.i256 v17;
+        return v22;
 }
 
 func inline(always) private %impl_trait_TotalSupply__decode_from__gd20d(v0.@layout_5, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
@@ -5688,17 +4733,14 @@ func inline(always) private %impl_trait_TotalSupply__decode_from__gd20d(v0.@layo
 
 func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_f4e0(v0.@layout_5, v1.i256) -> @layout_0 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_bae8 v0 v4;
-        v7.i256 = shr 160.i256 v5;
-        v9.i1 = eq v7 0.i256;
-        v10.i1 = is_zero v9;
-        br v10 block2 block3;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_bae8 v0 v1;
+        v6.i256 = shr 160.i256 v4;
+        v8.i1 = eq v6 0.i256;
+        v9.i1 = is_zero v8;
+        br v9 block2 block3;
 
     block2:
         evm_revert 0.i256 0.i256;
@@ -5707,23 +4749,20 @@ func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__de
         jump block4;
 
     block4:
-        v13.@layout_0 = insert_value undef.@layout_0 0.i256 v5;
-        return v13;
+        v12.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
+        return v12;
 }
 
 func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__decode_from__g72ab_f4e0_0(v0.@layout_5, v1.i256) -> @layout_0 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_bae8_0 v0 v4;
-        v7.i256 = shr 160.i256 v5;
-        v9.i1 = eq v7 0.i256;
-        v10.i1 = is_zero v9;
-        br v10 block2 block3;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_bae8_0 v0 v1;
+        v6.i256 = shr 160.i256 v4;
+        v8.i1 = eq v6 0.i256;
+        v9.i1 = is_zero v8;
+        br v9 block2 block3;
 
     block2:
         evm_revert 0.i256 0.i256;
@@ -5732,745 +4771,457 @@ func inline(always) private %std__lib__evm__effects__impl_trait_Address_9c1b__de
         jump block4;
 
     block4:
-        v13.@layout_0 = insert_value undef.@layout_0 0.i256 v5;
-        return v13;
+        v12.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
+        return v12;
 }
 
 func inline(always) private %decode_from_prechecked_head__gbd88(v0.@layout_5, v1.i256, v2.i256) {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v4 i256;
-        v7.i256 = mload v3 i256;
-        call %impl_trait_Name__decode_from__gd20d v0 v7;
+        call %impl_trait_Name__decode_from__gd20d v0 v1;
         return;
 }
 
 func inline(always) private %decode_from_prechecked_head__g76d6(v0.@layout_5, v1.i256, v2.i256) -> @layout_8 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v4 i256;
-        v7.i256 = mload v3 i256;
-        v8.@layout_8 = call %impl_trait_Mint__decode_from__gd20d v0 v7;
-        return v8;
+        v6.@layout_8 = call %impl_trait_Mint__decode_from__gd20d v0 v1;
+        return v6;
 }
 
 func inline(always) private %decode_from_prechecked_head__g41f8(v0.@layout_5, v1.i256, v2.i256) -> @layout_9 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v4 i256;
-        v7.i256 = mload v3 i256;
-        v8.@layout_9 = call %impl_trait_Burn__decode_from__gd20d v0 v7;
-        return v8;
+        v6.@layout_9 = call %impl_trait_Burn__decode_from__gd20d v0 v1;
+        return v6;
 }
 
 func inline(always) private %decode_from_prechecked_head__g205f(v0.@layout_5, v1.i256, v2.i256) -> @layout_14 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v4 i256;
-        v7.i256 = mload v3 i256;
-        v8.@layout_14 = call %impl_trait_Transfer__decode_from__gd20d v0 v7;
-        return v8;
+        v6.@layout_14 = call %impl_trait_Transfer__decode_from__gd20d v0 v1;
+        return v6;
 }
 
 func inline(always) private %decode_from_prechecked_head__g5470(v0.@layout_5, v1.i256, v2.i256) -> @layout_6 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v4 i256;
-        v7.i256 = mload v3 i256;
-        v8.@layout_6 = call %impl_trait_Allowance__decode_from__gd20d v0 v7;
-        return v8;
+        v6.@layout_6 = call %impl_trait_Allowance__decode_from__gd20d v0 v1;
+        return v6;
 }
 
 func inline(always) private %decode_from_prechecked_head__g6690(v0.@layout_5, v1.i256, v2.i256) -> @layout_13 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v4 i256;
-        v7.i256 = mload v3 i256;
-        v8.@layout_13 = call %impl_trait_TransferFrom__decode_from__gd20d v0 v7;
-        return v8;
+        v6.@layout_13 = call %impl_trait_TransferFrom__decode_from__gd20d v0 v1;
+        return v6;
 }
 
 func inline(always) private %decode_from_prechecked_head__g7ea0(v0.@layout_5, v1.i256, v2.i256) -> @layout_11 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v4 i256;
-        v7.i256 = mload v3 i256;
-        v8.@layout_11 = call %impl_trait_BalanceOf__decode_from__gd20d v0 v7;
-        return v8;
+        v6.@layout_11 = call %impl_trait_BalanceOf__decode_from__gd20d v0 v1;
+        return v6;
 }
 
 func inline(always) private %decode_from_prechecked_head__g691a(v0.@layout_5, v1.i256, v2.i256) {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v4 i256;
-        v7.i256 = mload v3 i256;
-        call %impl_trait_Symbol__decode_from__gd20d v0 v7;
+        call %impl_trait_Symbol__decode_from__gd20d v0 v1;
         return;
 }
 
 func inline(always) private %decode_from_prechecked_head__g7d8c(v0.@layout_5, v1.i256, v2.i256) -> @layout_12 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v4 i256;
-        v7.i256 = mload v3 i256;
-        v8.@layout_12 = call %impl_trait_IncreaseAllowance__decode_from__gd20d v0 v7;
-        return v8;
+        v6.@layout_12 = call %impl_trait_IncreaseAllowance__decode_from__gd20d v0 v1;
+        return v6;
 }
 
 func inline(always) private %decode_from_prechecked_head__gab8c(v0.@layout_5, v1.i256, v2.i256) -> @layout_7 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v4 i256;
-        v7.i256 = mload v3 i256;
-        v8.@layout_7 = call %impl_trait_Approve__decode_from__gd20d v0 v7;
-        return v8;
+        v6.@layout_7 = call %impl_trait_Approve__decode_from__gd20d v0 v1;
+        return v6;
 }
 
 func inline(always) private %decode_from_prechecked_head__g4997(v0.@layout_5, v1.i256, v2.i256) {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v4 i256;
-        v7.i256 = mload v3 i256;
-        call %impl_trait_Decimals__decode_from__gd20d v0 v7;
+        call %impl_trait_Decimals__decode_from__gd20d v0 v1;
         return;
 }
 
 func inline(always) private %decode_from_prechecked_head__gad59(v0.@layout_5, v1.i256, v2.i256) -> @layout_10 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v4 i256;
-        v7.i256 = mload v3 i256;
-        v8.@layout_10 = call %impl_trait_BurnFrom__decode_from__gd20d v0 v7;
-        return v8;
+        v6.@layout_10 = call %impl_trait_BurnFrom__decode_from__gd20d v0 v1;
+        return v6;
 }
 
 func inline(always) private %decode_from_prechecked_head__g051e(v0.@layout_5, v1.i256, v2.i256) {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v4 i256;
-        v7.i256 = mload v3 i256;
-        call %impl_trait_TotalSupply__decode_from__gd20d v0 v7;
+        call %impl_trait_TotalSupply__decode_from__gd20d v0 v1;
         return;
 }
 
 func inline(always) private %decode_from_prechecked_head__g383e(v0.@layout_5, v1.i256, v2.i256) -> @layout_15 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v4 i256;
-        v7.i256 = mload v3 i256;
-        v8.@layout_15 = call %impl_trait_DecreaseAllowance__decode_from__gd20d v0 v7;
-        return v8;
+        v6.@layout_15 = call %impl_trait_DecreaseAllowance__decode_from__gd20d v0 v1;
+        return v6;
 }
 
 func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_0219(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        v6.*i256 = alloca i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
-        mstore v6 v3 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = mload v4 i256;
-        v10.i256 = mload v5 i256;
-        v11.i256 = mload v6 i256;
-        v12.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_5db0 v0 v9 v10 v11;
-        return v12;
+        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_5db0 v0 v1 v2 v3;
+        return v9;
 
     block3:
         jump block4;
 
     block4:
-        v13.i256 = mload v6 i256;
-        v15.i256 = mload v4 i256;
-        v16.i256 = mload v5 i256;
-        v17.i256 = call %core__lib__abi__decode_field_from__g5385_4796 v0 v15 v16;
-        return v17;
+        v14.i256 = call %core__lib__abi__decode_field_from__g5385_4796 v0 v1 v2;
+        return v14;
 }
 
 func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_0358(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> @layout_0 {
     block0:
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        v6.*i256 = alloca i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
-        mstore v6 v3 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = mload v4 i256;
-        v10.i256 = mload v5 i256;
-        v11.i256 = mload v6 i256;
-        v12.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_18ef v0 v9 v10 v11;
-        return v12;
+        v9.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_18ef v0 v1 v2 v3;
+        return v9;
 
     block3:
         jump block4;
 
     block4:
-        v13.i256 = mload v6 i256;
-        v15.i256 = mload v4 i256;
-        v16.i256 = mload v5 i256;
-        v17.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_2692 v0 v15 v16;
-        return v17;
+        v14.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_2692 v0 v1 v2;
+        return v14;
 }
 
 func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_059c(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> @layout_0 {
     block0:
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        v6.*i256 = alloca i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
-        mstore v6 v3 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = mload v4 i256;
-        v10.i256 = mload v5 i256;
-        v11.i256 = mload v6 i256;
-        v12.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_2724 v0 v9 v10 v11;
-        return v12;
+        v9.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_2724 v0 v1 v2 v3;
+        return v9;
 
     block3:
         jump block4;
 
     block4:
-        v13.i256 = mload v6 i256;
-        v15.i256 = mload v4 i256;
-        v16.i256 = mload v5 i256;
-        v17.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_786c v0 v15 v16;
-        return v17;
+        v14.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_786c v0 v1 v2;
+        return v14;
 }
 
 func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_0929(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        v6.*i256 = alloca i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
-        mstore v6 v3 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = mload v4 i256;
-        v10.i256 = mload v5 i256;
-        v11.i256 = mload v6 i256;
-        v12.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_7760 v0 v9 v10 v11;
-        return v12;
+        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_7760 v0 v1 v2 v3;
+        return v9;
 
     block3:
         jump block4;
 
     block4:
-        v13.i256 = mload v6 i256;
-        v15.i256 = mload v4 i256;
-        v16.i256 = mload v5 i256;
-        v17.i256 = call %core__lib__abi__decode_field_from__g5385_9270 v0 v15 v16;
-        return v17;
+        v14.i256 = call %core__lib__abi__decode_field_from__g5385_9270 v0 v1 v2;
+        return v14;
 }
 
 func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_252f(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        v6.*i256 = alloca i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
-        mstore v6 v3 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = mload v4 i256;
-        v10.i256 = mload v5 i256;
-        v11.i256 = mload v6 i256;
-        v12.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_847c v0 v9 v10 v11;
-        return v12;
+        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_847c v0 v1 v2 v3;
+        return v9;
 
     block3:
         jump block4;
 
     block4:
-        v13.i256 = mload v6 i256;
-        v15.i256 = mload v4 i256;
-        v16.i256 = mload v5 i256;
-        v17.i256 = call %core__lib__abi__decode_field_from__g5385_79b2 v0 v15 v16;
-        return v17;
+        v14.i256 = call %core__lib__abi__decode_field_from__g5385_79b2 v0 v1 v2;
+        return v14;
 }
 
 func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_2a48(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        v6.*i256 = alloca i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
-        mstore v6 v3 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = mload v4 i256;
-        v10.i256 = mload v5 i256;
-        v11.i256 = mload v6 i256;
-        v12.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_839e v0 v9 v10 v11;
-        return v12;
+        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_839e v0 v1 v2 v3;
+        return v9;
 
     block3:
         jump block4;
 
     block4:
-        v13.i256 = mload v6 i256;
-        v15.i256 = mload v4 i256;
-        v16.i256 = mload v5 i256;
-        v17.i256 = call %core__lib__abi__decode_field_from__g5385_03a7 v0 v15 v16;
-        return v17;
+        v14.i256 = call %core__lib__abi__decode_field_from__g5385_03a7 v0 v1 v2;
+        return v14;
 }
 
 func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_329a(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> @layout_0 {
     block0:
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        v6.*i256 = alloca i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
-        mstore v6 v3 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = mload v4 i256;
-        v10.i256 = mload v5 i256;
-        v11.i256 = mload v6 i256;
-        v12.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_2207 v0 v9 v10 v11;
-        return v12;
+        v9.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_2207 v0 v1 v2 v3;
+        return v9;
 
     block3:
         jump block4;
 
     block4:
-        v13.i256 = mload v6 i256;
-        v15.i256 = mload v4 i256;
-        v16.i256 = mload v5 i256;
-        v17.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_7fa7 v0 v15 v16;
-        return v17;
+        v14.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_7fa7 v0 v1 v2;
+        return v14;
 }
 
 func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_3b80(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> @layout_0 {
     block0:
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        v6.*i256 = alloca i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
-        mstore v6 v3 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = mload v4 i256;
-        v10.i256 = mload v5 i256;
-        v11.i256 = mload v6 i256;
-        v12.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_a4f7 v0 v9 v10 v11;
-        return v12;
+        v9.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_a4f7 v0 v1 v2 v3;
+        return v9;
 
     block3:
         jump block4;
 
     block4:
-        v13.i256 = mload v6 i256;
-        v15.i256 = mload v4 i256;
-        v16.i256 = mload v5 i256;
-        v17.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_7143 v0 v15 v16;
-        return v17;
+        v14.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_7143 v0 v1 v2;
+        return v14;
 }
 
 func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_6698(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> @layout_0 {
     block0:
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        v6.*i256 = alloca i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
-        mstore v6 v3 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = mload v4 i256;
-        v10.i256 = mload v5 i256;
-        v11.i256 = mload v6 i256;
-        v12.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_07a0 v0 v9 v10 v11;
-        return v12;
+        v9.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_07a0 v0 v1 v2 v3;
+        return v9;
 
     block3:
         jump block4;
 
     block4:
-        v13.i256 = mload v6 i256;
-        v15.i256 = mload v4 i256;
-        v16.i256 = mload v5 i256;
-        v17.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_b564 v0 v15 v16;
-        return v17;
+        v14.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_b564 v0 v1 v2;
+        return v14;
 }
 
 func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_6f66(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> @layout_0 {
     block0:
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        v6.*i256 = alloca i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
-        mstore v6 v3 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = mload v4 i256;
-        v10.i256 = mload v5 i256;
-        v11.i256 = mload v6 i256;
-        v12.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_faf8 v0 v9 v10 v11;
-        return v12;
+        v9.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_faf8 v0 v1 v2 v3;
+        return v9;
 
     block3:
         jump block4;
 
     block4:
-        v13.i256 = mload v6 i256;
-        v15.i256 = mload v4 i256;
-        v16.i256 = mload v5 i256;
-        v17.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_d5c8 v0 v15 v16;
-        return v17;
+        v14.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_d5c8 v0 v1 v2;
+        return v14;
 }
 
 func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_745e(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        v6.*i256 = alloca i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
-        mstore v6 v3 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = mload v4 i256;
-        v10.i256 = mload v5 i256;
-        v11.i256 = mload v6 i256;
-        v12.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_c7d5 v0 v9 v10 v11;
-        return v12;
+        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_c7d5 v0 v1 v2 v3;
+        return v9;
 
     block3:
         jump block4;
 
     block4:
-        v13.i256 = mload v6 i256;
-        v15.i256 = mload v4 i256;
-        v16.i256 = mload v5 i256;
-        v17.i256 = call %core__lib__abi__decode_field_from__g5385_cb05 v0 v15 v16;
-        return v17;
+        v14.i256 = call %core__lib__abi__decode_field_from__g5385_cb05 v0 v1 v2;
+        return v14;
 }
 
 func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_7904(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> @layout_0 {
     block0:
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        v6.*i256 = alloca i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
-        mstore v6 v3 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = mload v4 i256;
-        v10.i256 = mload v5 i256;
-        v11.i256 = mload v6 i256;
-        v12.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_ef75 v0 v9 v10 v11;
-        return v12;
+        v9.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_ef75 v0 v1 v2 v3;
+        return v9;
 
     block3:
         jump block4;
 
     block4:
-        v13.i256 = mload v6 i256;
-        v15.i256 = mload v4 i256;
-        v16.i256 = mload v5 i256;
-        v17.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_d5a0 v0 v15 v16;
-        return v17;
+        v14.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_d5a0 v0 v1 v2;
+        return v14;
 }
 
 func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_9796(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        v6.*i256 = alloca i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
-        mstore v6 v3 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = mload v4 i256;
-        v10.i256 = mload v5 i256;
-        v11.i256 = mload v6 i256;
-        v12.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_34fc v0 v9 v10 v11;
-        return v12;
+        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_34fc v0 v1 v2 v3;
+        return v9;
 
     block3:
         jump block4;
 
     block4:
-        v13.i256 = mload v6 i256;
-        v15.i256 = mload v4 i256;
-        v16.i256 = mload v5 i256;
-        v17.i256 = call %core__lib__abi__decode_field_from__g5385_7366 v0 v15 v16;
-        return v17;
+        v14.i256 = call %core__lib__abi__decode_field_from__g5385_7366 v0 v1 v2;
+        return v14;
 }
 
 func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_9aa8(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        v6.*i256 = alloca i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
-        mstore v6 v3 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = mload v4 i256;
-        v10.i256 = mload v5 i256;
-        v11.i256 = mload v6 i256;
-        v12.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_b51a v0 v9 v10 v11;
-        return v12;
+        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_b51a v0 v1 v2 v3;
+        return v9;
 
     block3:
         jump block4;
 
     block4:
-        v13.i256 = mload v6 i256;
-        v15.i256 = mload v4 i256;
-        v16.i256 = mload v5 i256;
-        v17.i256 = call %core__lib__abi__decode_field_from__g5385_5cc4 v0 v15 v16;
-        return v17;
+        v14.i256 = call %core__lib__abi__decode_field_from__g5385_5cc4 v0 v1 v2;
+        return v14;
 }
 
 func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_bede(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> @layout_0 {
     block0:
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        v6.*i256 = alloca i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
-        mstore v6 v3 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = mload v4 i256;
-        v10.i256 = mload v5 i256;
-        v11.i256 = mload v6 i256;
-        v12.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_ed91 v0 v9 v10 v11;
-        return v12;
+        v9.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_ed91 v0 v1 v2 v3;
+        return v9;
 
     block3:
         jump block4;
 
     block4:
-        v13.i256 = mload v6 i256;
-        v15.i256 = mload v4 i256;
-        v16.i256 = mload v5 i256;
-        v17.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_e784 v0 v15 v16;
-        return v17;
+        v14.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_e784 v0 v1 v2;
+        return v14;
 }
 
 func inline(always) private %core__lib__abi__decode_msg_field_from__g5385_ce42(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        v6.*i256 = alloca i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
-        mstore v6 v3 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = mload v4 i256;
-        v10.i256 = mload v5 i256;
-        v11.i256 = mload v6 i256;
-        v12.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_d4dc v0 v9 v10 v11;
-        return v12;
+        v9.i256 = call %core__lib__abi__decode_field_from_prechecked_head__g5385_d4dc v0 v1 v2 v3;
+        return v9;
 
     block3:
         jump block4;
 
     block4:
-        v13.i256 = mload v6 i256;
-        v15.i256 = mload v4 i256;
-        v16.i256 = mload v5 i256;
-        v17.i256 = call %core__lib__abi__decode_field_from__g5385_d887 v0 v15 v16;
-        return v17;
+        v14.i256 = call %core__lib__abi__decode_field_from__g5385_d887 v0 v1 v2;
+        return v14;
 }
 
 func inline(always) private %core__lib__abi__decode_msg_field_from__gcfb5_f58a(v0.@layout_5, v1.i256, v2.i256, v3.i256) -> @layout_0 {
     block0:
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        v6.*i256 = alloca i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
-        mstore v6 v3 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = mload v4 i256;
-        v10.i256 = mload v5 i256;
-        v11.i256 = mload v6 i256;
-        v12.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_764c v0 v9 v10 v11;
-        return v12;
+        v9.@layout_0 = call %core__lib__abi__decode_field_from_prechecked_head__gcfb5_764c v0 v1 v2 v3;
+        return v9;
 
     block3:
         jump block4;
 
     block4:
-        v13.i256 = mload v6 i256;
-        v15.i256 = mload v4 i256;
-        v16.i256 = mload v5 i256;
-        v17.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_2eef v0 v15 v16;
-        return v17;
+        v14.@layout_0 = call %core__lib__abi__decode_field_from__gcfb5_2eef v0 v1 v2;
+        return v14;
 }
 
 func inline(always) private %impl_trait_u256__decode_payload__g407e(v0.objref<@layout_4>) -> i256 {
@@ -6520,14 +5271,12 @@ func inline(always) private %decode_runtime_args__g5a0b(v0.objref<@layout_18>) {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v4.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_cd56;
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_fc14 v4;
-        mstore v1 v6 i256;
-        mstore v2 4.i256 i256;
+        v3.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_cd56;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_fc14 v3;
+        mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
 
     block2:
@@ -6538,30 +5287,26 @@ func inline(always) private %decode_runtime_args__g5a0b(v0.objref<@layout_18>) {
         jump block4;
 
     block4:
-        v11.i256 = mload v1 i256;
-        call %decode_from_prechecked_head__g4997 v4 4.i256 v11;
+        call %decode_from_prechecked_head__g4997 v3 4.i256 v5;
         return;
 
     block5:
-        v13.i256 = mload v1 i256;
-        mstore v3 v13 i256;
-        v15.i256 = mload v3 i256;
-        v16.i1 = gt 4.i256 v15;
-        br v16 block2 block3;
+        mstore v2 v5 i256;
+        v14.i256 = mload v2 i256;
+        v15.i1 = gt 4.i256 v14;
+        br v15 block2 block3;
 }
 
 func inline(always) private %decode_runtime_args__g6a7c(v0.objref<@layout_18>) -> @layout_15 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v4.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_663b;
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_5dcb v4;
-        mstore v1 v6 i256;
-        mstore v2 4.i256 i256;
+        v3.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_663b;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_5dcb v3;
+        mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
 
     block2:
@@ -6572,30 +5317,26 @@ func inline(always) private %decode_runtime_args__g6a7c(v0.objref<@layout_18>) -
         jump block4;
 
     block4:
-        v12.i256 = mload v1 i256;
-        v13.@layout_15 = call %decode_from_prechecked_head__g383e v4 4.i256 v12;
-        return v13;
+        v12.@layout_15 = call %decode_from_prechecked_head__g383e v3 4.i256 v5;
+        return v12;
 
     block5:
-        v14.i256 = mload v1 i256;
-        mstore v3 v14 i256;
-        v16.i256 = mload v3 i256;
-        v17.i1 = gt 68.i256 v16;
-        br v17 block2 block3;
+        mstore v2 v5 i256;
+        v15.i256 = mload v2 i256;
+        v16.i1 = gt 68.i256 v15;
+        br v16 block2 block3;
 }
 
 func inline(always) private %decode_runtime_args__g7a2c(v0.objref<@layout_18>) -> @layout_7 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v4.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_a580;
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_22ff v4;
-        mstore v1 v6 i256;
-        mstore v2 4.i256 i256;
+        v3.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_a580;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_22ff v3;
+        mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
 
     block2:
@@ -6606,30 +5347,26 @@ func inline(always) private %decode_runtime_args__g7a2c(v0.objref<@layout_18>) -
         jump block4;
 
     block4:
-        v12.i256 = mload v1 i256;
-        v13.@layout_7 = call %decode_from_prechecked_head__gab8c v4 4.i256 v12;
-        return v13;
+        v12.@layout_7 = call %decode_from_prechecked_head__gab8c v3 4.i256 v5;
+        return v12;
 
     block5:
-        v14.i256 = mload v1 i256;
-        mstore v3 v14 i256;
-        v16.i256 = mload v3 i256;
-        v17.i1 = gt 68.i256 v16;
-        br v17 block2 block3;
+        mstore v2 v5 i256;
+        v15.i256 = mload v2 i256;
+        v16.i1 = gt 68.i256 v15;
+        br v16 block2 block3;
 }
 
 func inline(always) private %decode_runtime_args__g295c(v0.objref<@layout_18>) {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v4.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_5bd8;
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_ae2f v4;
-        mstore v1 v6 i256;
-        mstore v2 4.i256 i256;
+        v3.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_5bd8;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_ae2f v3;
+        mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
 
     block2:
@@ -6640,30 +5377,26 @@ func inline(always) private %decode_runtime_args__g295c(v0.objref<@layout_18>) {
         jump block4;
 
     block4:
-        v11.i256 = mload v1 i256;
-        call %decode_from_prechecked_head__g691a v4 4.i256 v11;
+        call %decode_from_prechecked_head__g691a v3 4.i256 v5;
         return;
 
     block5:
-        v13.i256 = mload v1 i256;
-        mstore v3 v13 i256;
-        v15.i256 = mload v3 i256;
-        v16.i1 = gt 4.i256 v15;
-        br v16 block2 block3;
+        mstore v2 v5 i256;
+        v14.i256 = mload v2 i256;
+        v15.i1 = gt 4.i256 v14;
+        br v15 block2 block3;
 }
 
 func inline(always) private %decode_runtime_args__gce7d(v0.objref<@layout_18>) {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v4.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_88e5;
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_9efd v4;
-        mstore v1 v6 i256;
-        mstore v2 4.i256 i256;
+        v3.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_88e5;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_9efd v3;
+        mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
 
     block2:
@@ -6674,30 +5407,26 @@ func inline(always) private %decode_runtime_args__gce7d(v0.objref<@layout_18>) {
         jump block4;
 
     block4:
-        v11.i256 = mload v1 i256;
-        call %decode_from_prechecked_head__g051e v4 4.i256 v11;
+        call %decode_from_prechecked_head__g051e v3 4.i256 v5;
         return;
 
     block5:
-        v13.i256 = mload v1 i256;
-        mstore v3 v13 i256;
-        v15.i256 = mload v3 i256;
-        v16.i1 = gt 4.i256 v15;
-        br v16 block2 block3;
+        mstore v2 v5 i256;
+        v14.i256 = mload v2 i256;
+        v15.i1 = gt 4.i256 v14;
+        br v15 block2 block3;
 }
 
 func inline(always) private %decode_runtime_args__g2273(v0.objref<@layout_18>) -> @layout_8 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v4.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_f89e;
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_5742 v4;
-        mstore v1 v6 i256;
-        mstore v2 4.i256 i256;
+        v3.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_f89e;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_5742 v3;
+        mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
 
     block2:
@@ -6708,30 +5437,26 @@ func inline(always) private %decode_runtime_args__g2273(v0.objref<@layout_18>) -
         jump block4;
 
     block4:
-        v12.i256 = mload v1 i256;
-        v13.@layout_8 = call %decode_from_prechecked_head__g76d6 v4 4.i256 v12;
-        return v13;
+        v12.@layout_8 = call %decode_from_prechecked_head__g76d6 v3 4.i256 v5;
+        return v12;
 
     block5:
-        v14.i256 = mload v1 i256;
-        mstore v3 v14 i256;
-        v16.i256 = mload v3 i256;
-        v17.i1 = gt 68.i256 v16;
-        br v17 block2 block3;
+        mstore v2 v5 i256;
+        v15.i256 = mload v2 i256;
+        v16.i1 = gt 68.i256 v15;
+        br v16 block2 block3;
 }
 
 func inline(always) private %decode_runtime_args__g4e54(v0.objref<@layout_18>) -> @layout_13 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v4.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_3dc9;
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_ce93 v4;
-        mstore v1 v6 i256;
-        mstore v2 4.i256 i256;
+        v3.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_3dc9;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_ce93 v3;
+        mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
 
     block2:
@@ -6742,30 +5467,26 @@ func inline(always) private %decode_runtime_args__g4e54(v0.objref<@layout_18>) -
         jump block4;
 
     block4:
-        v12.i256 = mload v1 i256;
-        v13.@layout_13 = call %decode_from_prechecked_head__g6690 v4 4.i256 v12;
-        return v13;
+        v12.@layout_13 = call %decode_from_prechecked_head__g6690 v3 4.i256 v5;
+        return v12;
 
     block5:
-        v14.i256 = mload v1 i256;
-        mstore v3 v14 i256;
-        v16.i256 = mload v3 i256;
-        v17.i1 = gt 100.i256 v16;
-        br v17 block2 block3;
+        mstore v2 v5 i256;
+        v15.i256 = mload v2 i256;
+        v16.i1 = gt 100.i256 v15;
+        br v16 block2 block3;
 }
 
 func inline(always) private %decode_runtime_args__g698d(v0.objref<@layout_18>) -> @layout_12 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v4.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_d673;
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_f03b v4;
-        mstore v1 v6 i256;
-        mstore v2 4.i256 i256;
+        v3.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_d673;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_f03b v3;
+        mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
 
     block2:
@@ -6776,30 +5497,26 @@ func inline(always) private %decode_runtime_args__g698d(v0.objref<@layout_18>) -
         jump block4;
 
     block4:
-        v12.i256 = mload v1 i256;
-        v13.@layout_12 = call %decode_from_prechecked_head__g7d8c v4 4.i256 v12;
-        return v13;
+        v12.@layout_12 = call %decode_from_prechecked_head__g7d8c v3 4.i256 v5;
+        return v12;
 
     block5:
-        v14.i256 = mload v1 i256;
-        mstore v3 v14 i256;
-        v16.i256 = mload v3 i256;
-        v17.i1 = gt 68.i256 v16;
-        br v17 block2 block3;
+        mstore v2 v5 i256;
+        v15.i256 = mload v2 i256;
+        v16.i1 = gt 68.i256 v15;
+        br v16 block2 block3;
 }
 
 func inline(always) private %decode_runtime_args__gc772(v0.objref<@layout_18>) -> @layout_6 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v4.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_3347;
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_4a91 v4;
-        mstore v1 v6 i256;
-        mstore v2 4.i256 i256;
+        v3.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_3347;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_4a91 v3;
+        mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
 
     block2:
@@ -6810,30 +5527,26 @@ func inline(always) private %decode_runtime_args__gc772(v0.objref<@layout_18>) -
         jump block4;
 
     block4:
-        v12.i256 = mload v1 i256;
-        v13.@layout_6 = call %decode_from_prechecked_head__g5470 v4 4.i256 v12;
-        return v13;
+        v12.@layout_6 = call %decode_from_prechecked_head__g5470 v3 4.i256 v5;
+        return v12;
 
     block5:
-        v14.i256 = mload v1 i256;
-        mstore v3 v14 i256;
-        v16.i256 = mload v3 i256;
-        v17.i1 = gt 68.i256 v16;
-        br v17 block2 block3;
+        mstore v2 v5 i256;
+        v15.i256 = mload v2 i256;
+        v16.i1 = gt 68.i256 v15;
+        br v16 block2 block3;
 }
 
 func inline(always) private %decode_runtime_args__g953d(v0.objref<@layout_18>) -> @layout_11 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v4.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_b73f;
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_6107 v4;
-        mstore v1 v6 i256;
-        mstore v2 4.i256 i256;
+        v3.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_b73f;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_6107 v3;
+        mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
 
     block2:
@@ -6844,30 +5557,26 @@ func inline(always) private %decode_runtime_args__g953d(v0.objref<@layout_18>) -
         jump block4;
 
     block4:
-        v12.i256 = mload v1 i256;
-        v13.@layout_11 = call %decode_from_prechecked_head__g7ea0 v4 4.i256 v12;
-        return v13;
+        v12.@layout_11 = call %decode_from_prechecked_head__g7ea0 v3 4.i256 v5;
+        return v12;
 
     block5:
-        v14.i256 = mload v1 i256;
-        mstore v3 v14 i256;
-        v16.i256 = mload v3 i256;
-        v17.i1 = gt 36.i256 v16;
-        br v17 block2 block3;
+        mstore v2 v5 i256;
+        v15.i256 = mload v2 i256;
+        v16.i1 = gt 36.i256 v15;
+        br v16 block2 block3;
 }
 
 func inline(always) private %decode_runtime_args__g216b(v0.objref<@layout_18>) -> @layout_10 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v4.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_6a54;
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_7388 v4;
-        mstore v1 v6 i256;
-        mstore v2 4.i256 i256;
+        v3.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_6a54;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_7388 v3;
+        mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
 
     block2:
@@ -6878,30 +5587,26 @@ func inline(always) private %decode_runtime_args__g216b(v0.objref<@layout_18>) -
         jump block4;
 
     block4:
-        v12.i256 = mload v1 i256;
-        v13.@layout_10 = call %decode_from_prechecked_head__gad59 v4 4.i256 v12;
-        return v13;
+        v12.@layout_10 = call %decode_from_prechecked_head__gad59 v3 4.i256 v5;
+        return v12;
 
     block5:
-        v14.i256 = mload v1 i256;
-        mstore v3 v14 i256;
-        v16.i256 = mload v3 i256;
-        v17.i1 = gt 68.i256 v16;
-        br v17 block2 block3;
+        mstore v2 v5 i256;
+        v15.i256 = mload v2 i256;
+        v16.i1 = gt 68.i256 v15;
+        br v16 block2 block3;
 }
 
 func inline(always) private %decode_runtime_args__gf629(v0.objref<@layout_18>) -> @layout_9 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v4.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_e029;
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_c018 v4;
-        mstore v1 v6 i256;
-        mstore v2 4.i256 i256;
+        v3.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_e029;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_c018 v3;
+        mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
 
     block2:
@@ -6912,30 +5617,26 @@ func inline(always) private %decode_runtime_args__gf629(v0.objref<@layout_18>) -
         jump block4;
 
     block4:
-        v12.i256 = mload v1 i256;
-        v13.@layout_9 = call %decode_from_prechecked_head__g41f8 v4 4.i256 v12;
-        return v13;
+        v12.@layout_9 = call %decode_from_prechecked_head__g41f8 v3 4.i256 v5;
+        return v12;
 
     block5:
-        v14.i256 = mload v1 i256;
-        mstore v3 v14 i256;
-        v16.i256 = mload v3 i256;
-        v17.i1 = gt 36.i256 v16;
-        br v17 block2 block3;
+        mstore v2 v5 i256;
+        v15.i256 = mload v2 i256;
+        v16.i1 = gt 36.i256 v15;
+        br v16 block2 block3;
 }
 
 func inline(always) private %decode_runtime_args__gce2e(v0.objref<@layout_18>) {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v4.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_844a;
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_b318 v4;
-        mstore v1 v6 i256;
-        mstore v2 4.i256 i256;
+        v3.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_844a;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_b318 v3;
+        mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
 
     block2:
@@ -6946,30 +5647,26 @@ func inline(always) private %decode_runtime_args__gce2e(v0.objref<@layout_18>) {
         jump block4;
 
     block4:
-        v11.i256 = mload v1 i256;
-        call %decode_from_prechecked_head__gbd88 v4 4.i256 v11;
+        call %decode_from_prechecked_head__gbd88 v3 4.i256 v5;
         return;
 
     block5:
-        v13.i256 = mload v1 i256;
-        mstore v3 v13 i256;
-        v15.i256 = mload v3 i256;
-        v16.i1 = gt 4.i256 v15;
-        br v16 block2 block3;
+        mstore v2 v5 i256;
+        v14.i256 = mload v2 i256;
+        v15.i1 = gt 4.i256 v14;
+        br v15 block2 block3;
 }
 
 func inline(always) private %decode_runtime_args__ge035(v0.objref<@layout_18>) -> @layout_14 {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v4.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_dac7;
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_1a14 v4;
-        mstore v1 v6 i256;
-        mstore v2 4.i256 i256;
+        v3.@layout_5 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_dac7;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_1a14 v3;
+        mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
 
     block2:
@@ -6980,16 +5677,14 @@ func inline(always) private %decode_runtime_args__ge035(v0.objref<@layout_18>) -
         jump block4;
 
     block4:
-        v12.i256 = mload v1 i256;
-        v13.@layout_14 = call %decode_from_prechecked_head__g205f v4 4.i256 v12;
-        return v13;
+        v12.@layout_14 = call %decode_from_prechecked_head__g205f v3 4.i256 v5;
+        return v12;
 
     block5:
-        v14.i256 = mload v1 i256;
-        mstore v3 v14 i256;
-        v16.i256 = mload v3 i256;
-        v17.i1 = gt 68.i256 v16;
-        br v17 block2 block3;
+        mstore v2 v5 i256;
+        v15.i256 = mload v2 i256;
+        v16.i1 = gt 68.i256 v15;
+        br v16 block2 block3;
 }
 
 func private %decoder_new(v0.@layout_2) -> @layout_4 {
@@ -7633,20 +6328,15 @@ func private %encode_single_root_alloc__g472d(v0.i256) -> @layout_21 {
 
 func private %impl_trait_u256__encode_to_ptr__gf13e(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__store_word_2361 v3 v0;
+        call %std__lib__abi__sol__impl_trait_Sol_1f5f__store_word_2361 v1 v0;
         return;
 }
 
 func private %encode_to_ptr__g4320(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
@@ -7655,21 +6345,17 @@ func private %encode_to_ptr__g4320(v0.i256, v1.i256) {
 
 func private %impl_trait_bool__encode_to_ptr__gf13e(v0.i1, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
         br v0 block2 block3;
 
     block2:
-        v4.i256 = mload v2 i256;
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__store_word_be96 v4 1.i256;
+        call %std__lib__abi__sol__impl_trait_Sol_1f5f__store_word_be96 v1 1.i256;
         jump block4;
 
     block3:
-        v7.i256 = mload v2 i256;
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__store_word_be96 v7 0.i256;
+        call %std__lib__abi__sol__impl_trait_Sol_1f5f__store_word_be96 v1 0.i256;
         jump block4;
 
     block4:
@@ -7678,8 +6364,6 @@ func private %impl_trait_bool__encode_to_ptr__gf13e(v0.i1, v1.i256) {
 
 func private %encode_to_ptr__g30cc(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
@@ -7688,99 +6372,75 @@ func private %encode_to_ptr__g30cc(v0.i256, v1.i256) {
 
 func private %impl_trait_u8__encode_to_ptr__gf13e(v0.i8, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v5.i256 = zext v0 i256;
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__store_word_2c7e v3 v5;
+        v4.i256 = zext v0 i256;
+        call %std__lib__abi__sol__impl_trait_Sol_1f5f__store_word_2c7e v1 v4;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_Sol_1f5f__encoder_new_1514(v0.i256) -> @layout_1 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.@layout_1 = call %std__lib__abi__sol__impl_SolEncoder_ce34__new_978f v2;
-        return v3;
+        v2.@layout_1 = call %std__lib__abi__sol__impl_SolEncoder_ce34__new_978f v0;
+        return v2;
 }
 
 func private %std__lib__abi__sol__impl_trait_Sol_1f5f__encoder_new_30df(v0.i256) -> @layout_1 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.@layout_1 = call %std__lib__abi__sol__impl_SolEncoder_ce34__new_c575 v2;
-        return v3;
+        v2.@layout_1 = call %std__lib__abi__sol__impl_SolEncoder_ce34__new_c575 v0;
+        return v2;
 }
 
 func private %std__lib__abi__sol__impl_trait_Sol_1f5f__encoder_new_513f(v0.i256) -> @layout_1 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.@layout_1 = call %std__lib__abi__sol__impl_SolEncoder_ce34__new_f042 v2;
-        return v3;
+        v2.@layout_1 = call %std__lib__abi__sol__impl_SolEncoder_ce34__new_f042 v0;
+        return v2;
 }
 
 func private %std__lib__abi__sol__impl_trait_Sol_1f5f__encoder_new_94e9(v0.i256) -> @layout_1 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.@layout_1 = call %std__lib__abi__sol__impl_SolEncoder_ce34__new_c2ff v2;
-        return v3;
+        v2.@layout_1 = call %std__lib__abi__sol__impl_SolEncoder_ce34__new_c2ff v0;
+        return v2;
 }
 
 func private %std__lib__abi__sol__impl_trait_Sol_1f5f__encoder_new_9a7a(v0.i256) -> @layout_1 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.@layout_1 = call %std__lib__abi__sol__impl_SolEncoder_ce34__new_1301 v2;
-        return v3;
+        v2.@layout_1 = call %std__lib__abi__sol__impl_SolEncoder_ce34__new_1301 v0;
+        return v2;
 }
 
 func private %std__lib__abi__sol__impl_trait_Sol_1f5f__encoder_new_a4f7(v0.i256) -> @layout_1 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.@layout_1 = call %std__lib__abi__sol__impl_SolEncoder_ce34__new_24a6 v2;
-        return v3;
+        v2.@layout_1 = call %std__lib__abi__sol__impl_SolEncoder_ce34__new_24a6 v0;
+        return v2;
 }
 
 func private %std__lib__abi__sol__impl_trait_Sol_1f5f__encoder_new_a948(v0.i256) -> @layout_1 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.@layout_1 = call %std__lib__abi__sol__impl_SolEncoder_ce34__new_8670 v2;
-        return v3;
+        v2.@layout_1 = call %std__lib__abi__sol__impl_SolEncoder_ce34__new_8670 v0;
+        return v2;
 }
 
 func private %eq(v0.@layout_0, v1.@layout_0) -> i1 {
@@ -7796,70 +6456,52 @@ func private %eq(v0.@layout_0, v1.@layout_0) -> i1 {
 
 func private %std__lib__evm__word__impl_trait_u256_1f9e__from_word_2f17(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        return v2;
+        return v0;
 }
 
 func private %std__lib__evm__word__impl_trait_u256_1f9e__from_word_4030(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        return v2;
+        return v0;
 }
 
 func private %std__lib__evm__word__impl_trait_u256_1f9e__from_word_4030_0(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        return v2;
+        return v0;
 }
 
 func private %std__lib__evm__word__impl_trait_u256_1f9e__from_word_83e7(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        return v2;
+        return v0;
 }
 
 func private %impl_trait_bool__from_word(v0.i256) -> i1 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v4.i1 = eq v2 0.i256;
-        v5.i1 = is_zero v4;
-        return v5;
+        v3.i1 = eq v0 0.i256;
+        v4.i1 = is_zero v3;
+        return v4;
 }
 
 func private %std__lib__evm__word__impl_trait_u256_1f9e__from_word_c764(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        return v2;
+        return v0;
 }
 
 func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__get__g2163_8a15(v0.@layout_0) -> i256 {
@@ -7924,15 +6566,12 @@ func inline(always) private %get__gc9ba(v0.@layout_16) -> i1 {
 
 func private %grant(v0.i256, v1.i256, v2.@layout_0) {
     block0:
-        v3.*i256 = alloca i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v3 i256;
-        v8.@layout_16 = insert_value undef.@layout_16 0.i256 v4;
-        v10.@layout_16 = insert_value v8 1.i256 v2;
-        call %set__gc9ba v10 1.i1;
+        v7.@layout_16 = insert_value undef.@layout_16 0.i256 v1;
+        v9.@layout_16 = insert_value v7 1.i256 v2;
+        call %set__gc9ba v9 1.i1;
         return;
 }
 
@@ -8065,31 +6704,27 @@ func private %std__lib__evm__effects__impl_trait_Evm_c913__input_f89e() -> @layo
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_0eff(v0.@layout_5) -> i256 {
     block0:
         v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.i256 = extract_value v0 0.i256;
-        v7.i256 = mload v1 i256;
-        mstore v2 v7 i256;
-        v8.i256 = mload v2 i256;
-        v9.i1 = gt v6 v8;
-        br v9 block2 block3;
+        v2.i256 = evm_calldata_size;
+        v5.i256 = extract_value v0 0.i256;
+        mstore v1 v2 i256;
+        v6.i256 = mload v1 i256;
+        v7.i1 = gt v5 v6;
+        br v7 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v11.i256 = extract_value v0 0.i256;
-        v12.i256 = mload v1 i256;
-        (v13.i256, v14.i1) = usubo v12 v11;
-        br v14 block5 block6;
+        v9.i256 = extract_value v0 0.i256;
+        (v11.i256, v12.i1) = usubo v2 v9;
+        br v12 block5 block6;
 
     block4:
-        v19.i256 = phi (0.i256 block2) (v13 block6);
-        return v19;
+        v17.i256 = phi (0.i256 block2) (v11 block6);
+        return v17;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -8103,31 +6738,27 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_1a14(v0.@layout_5) -> i256 {
     block0:
         v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.i256 = extract_value v0 0.i256;
-        v7.i256 = mload v1 i256;
-        mstore v2 v7 i256;
-        v8.i256 = mload v2 i256;
-        v9.i1 = gt v6 v8;
-        br v9 block2 block3;
+        v2.i256 = evm_calldata_size;
+        v5.i256 = extract_value v0 0.i256;
+        mstore v1 v2 i256;
+        v6.i256 = mload v1 i256;
+        v7.i1 = gt v5 v6;
+        br v7 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v11.i256 = extract_value v0 0.i256;
-        v12.i256 = mload v1 i256;
-        (v13.i256, v14.i1) = usubo v12 v11;
-        br v14 block5 block6;
+        v9.i256 = extract_value v0 0.i256;
+        (v11.i256, v12.i1) = usubo v2 v9;
+        br v12 block5 block6;
 
     block4:
-        v19.i256 = phi (0.i256 block2) (v13 block6);
-        return v19;
+        v17.i256 = phi (0.i256 block2) (v11 block6);
+        return v17;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -8141,31 +6772,27 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_22ff(v0.@layout_5) -> i256 {
     block0:
         v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.i256 = extract_value v0 0.i256;
-        v7.i256 = mload v1 i256;
-        mstore v2 v7 i256;
-        v8.i256 = mload v2 i256;
-        v9.i1 = gt v6 v8;
-        br v9 block2 block3;
+        v2.i256 = evm_calldata_size;
+        v5.i256 = extract_value v0 0.i256;
+        mstore v1 v2 i256;
+        v6.i256 = mload v1 i256;
+        v7.i1 = gt v5 v6;
+        br v7 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v11.i256 = extract_value v0 0.i256;
-        v12.i256 = mload v1 i256;
-        (v13.i256, v14.i1) = usubo v12 v11;
-        br v14 block5 block6;
+        v9.i256 = extract_value v0 0.i256;
+        (v11.i256, v12.i1) = usubo v2 v9;
+        br v12 block5 block6;
 
     block4:
-        v19.i256 = phi (0.i256 block2) (v13 block6);
-        return v19;
+        v17.i256 = phi (0.i256 block2) (v11 block6);
+        return v17;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -8179,31 +6806,27 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_36c4(v0.@layout_5) -> i256 {
     block0:
         v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.i256 = extract_value v0 0.i256;
-        v7.i256 = mload v1 i256;
-        mstore v2 v7 i256;
-        v8.i256 = mload v2 i256;
-        v9.i1 = gt v6 v8;
-        br v9 block2 block3;
+        v2.i256 = evm_calldata_size;
+        v5.i256 = extract_value v0 0.i256;
+        mstore v1 v2 i256;
+        v6.i256 = mload v1 i256;
+        v7.i1 = gt v5 v6;
+        br v7 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v11.i256 = extract_value v0 0.i256;
-        v12.i256 = mload v1 i256;
-        (v13.i256, v14.i1) = usubo v12 v11;
-        br v14 block5 block6;
+        v9.i256 = extract_value v0 0.i256;
+        (v11.i256, v12.i1) = usubo v2 v9;
+        br v12 block5 block6;
 
     block4:
-        v19.i256 = phi (0.i256 block2) (v13 block6);
-        return v19;
+        v17.i256 = phi (0.i256 block2) (v11 block6);
+        return v17;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -8227,31 +6850,27 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_48ab
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_4a91(v0.@layout_5) -> i256 {
     block0:
         v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.i256 = extract_value v0 0.i256;
-        v7.i256 = mload v1 i256;
-        mstore v2 v7 i256;
-        v8.i256 = mload v2 i256;
-        v9.i1 = gt v6 v8;
-        br v9 block2 block3;
+        v2.i256 = evm_calldata_size;
+        v5.i256 = extract_value v0 0.i256;
+        mstore v1 v2 i256;
+        v6.i256 = mload v1 i256;
+        v7.i1 = gt v5 v6;
+        br v7 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v11.i256 = extract_value v0 0.i256;
-        v12.i256 = mload v1 i256;
-        (v13.i256, v14.i1) = usubo v12 v11;
-        br v14 block5 block6;
+        v9.i256 = extract_value v0 0.i256;
+        (v11.i256, v12.i1) = usubo v2 v9;
+        br v12 block5 block6;
 
     block4:
-        v19.i256 = phi (0.i256 block2) (v13 block6);
-        return v19;
+        v17.i256 = phi (0.i256 block2) (v11 block6);
+        return v17;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -8265,31 +6884,27 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_5742(v0.@layout_5) -> i256 {
     block0:
         v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.i256 = extract_value v0 0.i256;
-        v7.i256 = mload v1 i256;
-        mstore v2 v7 i256;
-        v8.i256 = mload v2 i256;
-        v9.i1 = gt v6 v8;
-        br v9 block2 block3;
+        v2.i256 = evm_calldata_size;
+        v5.i256 = extract_value v0 0.i256;
+        mstore v1 v2 i256;
+        v6.i256 = mload v1 i256;
+        v7.i1 = gt v5 v6;
+        br v7 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v11.i256 = extract_value v0 0.i256;
-        v12.i256 = mload v1 i256;
-        (v13.i256, v14.i1) = usubo v12 v11;
-        br v14 block5 block6;
+        v9.i256 = extract_value v0 0.i256;
+        (v11.i256, v12.i1) = usubo v2 v9;
+        br v12 block5 block6;
 
     block4:
-        v19.i256 = phi (0.i256 block2) (v13 block6);
-        return v19;
+        v17.i256 = phi (0.i256 block2) (v11 block6);
+        return v17;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -8303,31 +6918,27 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_5dcb(v0.@layout_5) -> i256 {
     block0:
         v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.i256 = extract_value v0 0.i256;
-        v7.i256 = mload v1 i256;
-        mstore v2 v7 i256;
-        v8.i256 = mload v2 i256;
-        v9.i1 = gt v6 v8;
-        br v9 block2 block3;
+        v2.i256 = evm_calldata_size;
+        v5.i256 = extract_value v0 0.i256;
+        mstore v1 v2 i256;
+        v6.i256 = mload v1 i256;
+        v7.i1 = gt v5 v6;
+        br v7 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v11.i256 = extract_value v0 0.i256;
-        v12.i256 = mload v1 i256;
-        (v13.i256, v14.i1) = usubo v12 v11;
-        br v14 block5 block6;
+        v9.i256 = extract_value v0 0.i256;
+        (v11.i256, v12.i1) = usubo v2 v9;
+        br v12 block5 block6;
 
     block4:
-        v19.i256 = phi (0.i256 block2) (v13 block6);
-        return v19;
+        v17.i256 = phi (0.i256 block2) (v11 block6);
+        return v17;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -8341,31 +6952,27 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_6107(v0.@layout_5) -> i256 {
     block0:
         v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.i256 = extract_value v0 0.i256;
-        v7.i256 = mload v1 i256;
-        mstore v2 v7 i256;
-        v8.i256 = mload v2 i256;
-        v9.i1 = gt v6 v8;
-        br v9 block2 block3;
+        v2.i256 = evm_calldata_size;
+        v5.i256 = extract_value v0 0.i256;
+        mstore v1 v2 i256;
+        v6.i256 = mload v1 i256;
+        v7.i1 = gt v5 v6;
+        br v7 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v11.i256 = extract_value v0 0.i256;
-        v12.i256 = mload v1 i256;
-        (v13.i256, v14.i1) = usubo v12 v11;
-        br v14 block5 block6;
+        v9.i256 = extract_value v0 0.i256;
+        (v11.i256, v12.i1) = usubo v2 v9;
+        br v12 block5 block6;
 
     block4:
-        v19.i256 = phi (0.i256 block2) (v13 block6);
-        return v19;
+        v17.i256 = phi (0.i256 block2) (v11 block6);
+        return v17;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -8379,31 +6986,27 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_6f43(v0.@layout_5) -> i256 {
     block0:
         v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.i256 = extract_value v0 0.i256;
-        v7.i256 = mload v1 i256;
-        mstore v2 v7 i256;
-        v8.i256 = mload v2 i256;
-        v9.i1 = gt v6 v8;
-        br v9 block2 block3;
+        v2.i256 = evm_calldata_size;
+        v5.i256 = extract_value v0 0.i256;
+        mstore v1 v2 i256;
+        v6.i256 = mload v1 i256;
+        v7.i1 = gt v5 v6;
+        br v7 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v11.i256 = extract_value v0 0.i256;
-        v12.i256 = mload v1 i256;
-        (v13.i256, v14.i1) = usubo v12 v11;
-        br v14 block5 block6;
+        v9.i256 = extract_value v0 0.i256;
+        (v11.i256, v12.i1) = usubo v2 v9;
+        br v12 block5 block6;
 
     block4:
-        v19.i256 = phi (0.i256 block2) (v13 block6);
-        return v19;
+        v17.i256 = phi (0.i256 block2) (v11 block6);
+        return v17;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -8417,31 +7020,27 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_7388(v0.@layout_5) -> i256 {
     block0:
         v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.i256 = extract_value v0 0.i256;
-        v7.i256 = mload v1 i256;
-        mstore v2 v7 i256;
-        v8.i256 = mload v2 i256;
-        v9.i1 = gt v6 v8;
-        br v9 block2 block3;
+        v2.i256 = evm_calldata_size;
+        v5.i256 = extract_value v0 0.i256;
+        mstore v1 v2 i256;
+        v6.i256 = mload v1 i256;
+        v7.i1 = gt v5 v6;
+        br v7 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v11.i256 = extract_value v0 0.i256;
-        v12.i256 = mload v1 i256;
-        (v13.i256, v14.i1) = usubo v12 v11;
-        br v14 block5 block6;
+        v9.i256 = extract_value v0 0.i256;
+        (v11.i256, v12.i1) = usubo v2 v9;
+        br v12 block5 block6;
 
     block4:
-        v19.i256 = phi (0.i256 block2) (v13 block6);
-        return v19;
+        v17.i256 = phi (0.i256 block2) (v11 block6);
+        return v17;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -8455,31 +7054,27 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_779e(v0.@layout_5) -> i256 {
     block0:
         v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.i256 = extract_value v0 0.i256;
-        v7.i256 = mload v1 i256;
-        mstore v2 v7 i256;
-        v8.i256 = mload v2 i256;
-        v9.i1 = gt v6 v8;
-        br v9 block2 block3;
+        v2.i256 = evm_calldata_size;
+        v5.i256 = extract_value v0 0.i256;
+        mstore v1 v2 i256;
+        v6.i256 = mload v1 i256;
+        v7.i1 = gt v5 v6;
+        br v7 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v11.i256 = extract_value v0 0.i256;
-        v12.i256 = mload v1 i256;
-        (v13.i256, v14.i1) = usubo v12 v11;
-        br v14 block5 block6;
+        v9.i256 = extract_value v0 0.i256;
+        (v11.i256, v12.i1) = usubo v2 v9;
+        br v12 block5 block6;
 
     block4:
-        v19.i256 = phi (0.i256 block2) (v13 block6);
-        return v19;
+        v17.i256 = phi (0.i256 block2) (v11 block6);
+        return v17;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -8513,31 +7108,27 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_7b50
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_9efd(v0.@layout_5) -> i256 {
     block0:
         v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.i256 = extract_value v0 0.i256;
-        v7.i256 = mload v1 i256;
-        mstore v2 v7 i256;
-        v8.i256 = mload v2 i256;
-        v9.i1 = gt v6 v8;
-        br v9 block2 block3;
+        v2.i256 = evm_calldata_size;
+        v5.i256 = extract_value v0 0.i256;
+        mstore v1 v2 i256;
+        v6.i256 = mload v1 i256;
+        v7.i1 = gt v5 v6;
+        br v7 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v11.i256 = extract_value v0 0.i256;
-        v12.i256 = mload v1 i256;
-        (v13.i256, v14.i1) = usubo v12 v11;
-        br v14 block5 block6;
+        v9.i256 = extract_value v0 0.i256;
+        (v11.i256, v12.i1) = usubo v2 v9;
+        br v12 block5 block6;
 
     block4:
-        v19.i256 = phi (0.i256 block2) (v13 block6);
-        return v19;
+        v17.i256 = phi (0.i256 block2) (v11 block6);
+        return v17;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -8561,31 +7152,27 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_a4fa
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_aa47(v0.@layout_5) -> i256 {
     block0:
         v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.i256 = extract_value v0 0.i256;
-        v7.i256 = mload v1 i256;
-        mstore v2 v7 i256;
-        v8.i256 = mload v2 i256;
-        v9.i1 = gt v6 v8;
-        br v9 block2 block3;
+        v2.i256 = evm_calldata_size;
+        v5.i256 = extract_value v0 0.i256;
+        mstore v1 v2 i256;
+        v6.i256 = mload v1 i256;
+        v7.i1 = gt v5 v6;
+        br v7 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v11.i256 = extract_value v0 0.i256;
-        v12.i256 = mload v1 i256;
-        (v13.i256, v14.i1) = usubo v12 v11;
-        br v14 block5 block6;
+        v9.i256 = extract_value v0 0.i256;
+        (v11.i256, v12.i1) = usubo v2 v9;
+        br v12 block5 block6;
 
     block4:
-        v19.i256 = phi (0.i256 block2) (v13 block6);
-        return v19;
+        v17.i256 = phi (0.i256 block2) (v11 block6);
+        return v17;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -8599,31 +7186,27 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_ae2f(v0.@layout_5) -> i256 {
     block0:
         v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.i256 = extract_value v0 0.i256;
-        v7.i256 = mload v1 i256;
-        mstore v2 v7 i256;
-        v8.i256 = mload v2 i256;
-        v9.i1 = gt v6 v8;
-        br v9 block2 block3;
+        v2.i256 = evm_calldata_size;
+        v5.i256 = extract_value v0 0.i256;
+        mstore v1 v2 i256;
+        v6.i256 = mload v1 i256;
+        v7.i1 = gt v5 v6;
+        br v7 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v11.i256 = extract_value v0 0.i256;
-        v12.i256 = mload v1 i256;
-        (v13.i256, v14.i1) = usubo v12 v11;
-        br v14 block5 block6;
+        v9.i256 = extract_value v0 0.i256;
+        (v11.i256, v12.i1) = usubo v2 v9;
+        br v12 block5 block6;
 
     block4:
-        v19.i256 = phi (0.i256 block2) (v13 block6);
-        return v19;
+        v17.i256 = phi (0.i256 block2) (v11 block6);
+        return v17;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -8637,31 +7220,27 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_b318(v0.@layout_5) -> i256 {
     block0:
         v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.i256 = extract_value v0 0.i256;
-        v7.i256 = mload v1 i256;
-        mstore v2 v7 i256;
-        v8.i256 = mload v2 i256;
-        v9.i1 = gt v6 v8;
-        br v9 block2 block3;
+        v2.i256 = evm_calldata_size;
+        v5.i256 = extract_value v0 0.i256;
+        mstore v1 v2 i256;
+        v6.i256 = mload v1 i256;
+        v7.i1 = gt v5 v6;
+        br v7 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v11.i256 = extract_value v0 0.i256;
-        v12.i256 = mload v1 i256;
-        (v13.i256, v14.i1) = usubo v12 v11;
-        br v14 block5 block6;
+        v9.i256 = extract_value v0 0.i256;
+        (v11.i256, v12.i1) = usubo v2 v9;
+        br v12 block5 block6;
 
     block4:
-        v19.i256 = phi (0.i256 block2) (v13 block6);
-        return v19;
+        v17.i256 = phi (0.i256 block2) (v11 block6);
+        return v17;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -8675,31 +7254,27 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_c018(v0.@layout_5) -> i256 {
     block0:
         v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.i256 = extract_value v0 0.i256;
-        v7.i256 = mload v1 i256;
-        mstore v2 v7 i256;
-        v8.i256 = mload v2 i256;
-        v9.i1 = gt v6 v8;
-        br v9 block2 block3;
+        v2.i256 = evm_calldata_size;
+        v5.i256 = extract_value v0 0.i256;
+        mstore v1 v2 i256;
+        v6.i256 = mload v1 i256;
+        v7.i1 = gt v5 v6;
+        br v7 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v11.i256 = extract_value v0 0.i256;
-        v12.i256 = mload v1 i256;
-        (v13.i256, v14.i1) = usubo v12 v11;
-        br v14 block5 block6;
+        v9.i256 = extract_value v0 0.i256;
+        (v11.i256, v12.i1) = usubo v2 v9;
+        br v12 block5 block6;
 
     block4:
-        v19.i256 = phi (0.i256 block2) (v13 block6);
-        return v19;
+        v17.i256 = phi (0.i256 block2) (v11 block6);
+        return v17;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -8713,31 +7288,27 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_ce93(v0.@layout_5) -> i256 {
     block0:
         v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.i256 = extract_value v0 0.i256;
-        v7.i256 = mload v1 i256;
-        mstore v2 v7 i256;
-        v8.i256 = mload v2 i256;
-        v9.i1 = gt v6 v8;
-        br v9 block2 block3;
+        v2.i256 = evm_calldata_size;
+        v5.i256 = extract_value v0 0.i256;
+        mstore v1 v2 i256;
+        v6.i256 = mload v1 i256;
+        v7.i1 = gt v5 v6;
+        br v7 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v11.i256 = extract_value v0 0.i256;
-        v12.i256 = mload v1 i256;
-        (v13.i256, v14.i1) = usubo v12 v11;
-        br v14 block5 block6;
+        v9.i256 = extract_value v0 0.i256;
+        (v11.i256, v12.i1) = usubo v2 v9;
+        br v12 block5 block6;
 
     block4:
-        v19.i256 = phi (0.i256 block2) (v13 block6);
-        return v19;
+        v17.i256 = phi (0.i256 block2) (v11 block6);
+        return v17;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -8751,31 +7322,27 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_de6d(v0.@layout_5) -> i256 {
     block0:
         v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.i256 = extract_value v0 0.i256;
-        v7.i256 = mload v1 i256;
-        mstore v2 v7 i256;
-        v8.i256 = mload v2 i256;
-        v9.i1 = gt v6 v8;
-        br v9 block2 block3;
+        v2.i256 = evm_calldata_size;
+        v5.i256 = extract_value v0 0.i256;
+        mstore v1 v2 i256;
+        v6.i256 = mload v1 i256;
+        v7.i1 = gt v5 v6;
+        br v7 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v11.i256 = extract_value v0 0.i256;
-        v12.i256 = mload v1 i256;
-        (v13.i256, v14.i1) = usubo v12 v11;
-        br v14 block5 block6;
+        v9.i256 = extract_value v0 0.i256;
+        (v11.i256, v12.i1) = usubo v2 v9;
+        br v12 block5 block6;
 
     block4:
-        v19.i256 = phi (0.i256 block2) (v13 block6);
-        return v19;
+        v17.i256 = phi (0.i256 block2) (v11 block6);
+        return v17;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -8789,31 +7356,27 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_e065(v0.@layout_5) -> i256 {
     block0:
         v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.i256 = extract_value v0 0.i256;
-        v7.i256 = mload v1 i256;
-        mstore v2 v7 i256;
-        v8.i256 = mload v2 i256;
-        v9.i1 = gt v6 v8;
-        br v9 block2 block3;
+        v2.i256 = evm_calldata_size;
+        v5.i256 = extract_value v0 0.i256;
+        mstore v1 v2 i256;
+        v6.i256 = mload v1 i256;
+        v7.i1 = gt v5 v6;
+        br v7 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v11.i256 = extract_value v0 0.i256;
-        v12.i256 = mload v1 i256;
-        (v13.i256, v14.i1) = usubo v12 v11;
-        br v14 block5 block6;
+        v9.i256 = extract_value v0 0.i256;
+        (v11.i256, v12.i1) = usubo v2 v9;
+        br v12 block5 block6;
 
     block4:
-        v19.i256 = phi (0.i256 block2) (v13 block6);
-        return v19;
+        v17.i256 = phi (0.i256 block2) (v11 block6);
+        return v17;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -8827,31 +7390,27 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_e83e(v0.@layout_5) -> i256 {
     block0:
         v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.i256 = extract_value v0 0.i256;
-        v7.i256 = mload v1 i256;
-        mstore v2 v7 i256;
-        v8.i256 = mload v2 i256;
-        v9.i1 = gt v6 v8;
-        br v9 block2 block3;
+        v2.i256 = evm_calldata_size;
+        v5.i256 = extract_value v0 0.i256;
+        mstore v1 v2 i256;
+        v6.i256 = mload v1 i256;
+        v7.i1 = gt v5 v6;
+        br v7 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v11.i256 = extract_value v0 0.i256;
-        v12.i256 = mload v1 i256;
-        (v13.i256, v14.i1) = usubo v12 v11;
-        br v14 block5 block6;
+        v9.i256 = extract_value v0 0.i256;
+        (v11.i256, v12.i1) = usubo v2 v9;
+        br v12 block5 block6;
 
     block4:
-        v19.i256 = phi (0.i256 block2) (v13 block6);
-        return v19;
+        v17.i256 = phi (0.i256 block2) (v11 block6);
+        return v17;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -8865,31 +7424,27 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_e949(v0.@layout_5) -> i256 {
     block0:
         v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.i256 = extract_value v0 0.i256;
-        v7.i256 = mload v1 i256;
-        mstore v2 v7 i256;
-        v8.i256 = mload v2 i256;
-        v9.i1 = gt v6 v8;
-        br v9 block2 block3;
+        v2.i256 = evm_calldata_size;
+        v5.i256 = extract_value v0 0.i256;
+        mstore v1 v2 i256;
+        v6.i256 = mload v1 i256;
+        v7.i1 = gt v5 v6;
+        br v7 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v11.i256 = extract_value v0 0.i256;
-        v12.i256 = mload v1 i256;
-        (v13.i256, v14.i1) = usubo v12 v11;
-        br v14 block5 block6;
+        v9.i256 = extract_value v0 0.i256;
+        (v11.i256, v12.i1) = usubo v2 v9;
+        br v12 block5 block6;
 
     block4:
-        v19.i256 = phi (0.i256 block2) (v13 block6);
-        return v19;
+        v17.i256 = phi (0.i256 block2) (v11 block6);
+        return v17;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -8903,31 +7458,27 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_e9e0(v0.@layout_5) -> i256 {
     block0:
         v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.i256 = extract_value v0 0.i256;
-        v7.i256 = mload v1 i256;
-        mstore v2 v7 i256;
-        v8.i256 = mload v2 i256;
-        v9.i1 = gt v6 v8;
-        br v9 block2 block3;
+        v2.i256 = evm_calldata_size;
+        v5.i256 = extract_value v0 0.i256;
+        mstore v1 v2 i256;
+        v6.i256 = mload v1 i256;
+        v7.i1 = gt v5 v6;
+        br v7 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v11.i256 = extract_value v0 0.i256;
-        v12.i256 = mload v1 i256;
-        (v13.i256, v14.i1) = usubo v12 v11;
-        br v14 block5 block6;
+        v9.i256 = extract_value v0 0.i256;
+        (v11.i256, v12.i1) = usubo v2 v9;
+        br v12 block5 block6;
 
     block4:
-        v19.i256 = phi (0.i256 block2) (v13 block6);
-        return v19;
+        v17.i256 = phi (0.i256 block2) (v11 block6);
+        return v17;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -8941,31 +7492,27 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_f03b(v0.@layout_5) -> i256 {
     block0:
         v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.i256 = extract_value v0 0.i256;
-        v7.i256 = mload v1 i256;
-        mstore v2 v7 i256;
-        v8.i256 = mload v2 i256;
-        v9.i1 = gt v6 v8;
-        br v9 block2 block3;
+        v2.i256 = evm_calldata_size;
+        v5.i256 = extract_value v0 0.i256;
+        mstore v1 v2 i256;
+        v6.i256 = mload v1 i256;
+        v7.i1 = gt v5 v6;
+        br v7 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v11.i256 = extract_value v0 0.i256;
-        v12.i256 = mload v1 i256;
-        (v13.i256, v14.i1) = usubo v12 v11;
-        br v14 block5 block6;
+        v9.i256 = extract_value v0 0.i256;
+        (v11.i256, v12.i1) = usubo v2 v9;
+        br v12 block5 block6;
 
     block4:
-        v19.i256 = phi (0.i256 block2) (v13 block6);
-        return v19;
+        v17.i256 = phi (0.i256 block2) (v11 block6);
+        return v17;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -8979,31 +7526,27 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_fc14(v0.@layout_5) -> i256 {
     block0:
         v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.i256 = extract_value v0 0.i256;
-        v7.i256 = mload v1 i256;
-        mstore v2 v7 i256;
-        v8.i256 = mload v2 i256;
-        v9.i1 = gt v6 v8;
-        br v9 block2 block3;
+        v2.i256 = evm_calldata_size;
+        v5.i256 = extract_value v0 0.i256;
+        mstore v1 v2 i256;
+        v6.i256 = mload v1 i256;
+        v7.i1 = gt v5 v6;
+        br v7 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v11.i256 = extract_value v0 0.i256;
-        v12.i256 = mload v1 i256;
-        (v13.i256, v14.i1) = usubo v12 v11;
-        br v14 block5 block6;
+        v9.i256 = extract_value v0 0.i256;
+        (v11.i256, v12.i1) = usubo v2 v9;
+        br v12 block5 block6;
 
     block4:
-        v19.i256 = phi (0.i256 block2) (v13 block6);
-        return v19;
+        v17.i256 = phi (0.i256 block2) (v11 block6);
+        return v17;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -9016,83 +7559,50 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
 
 func private %std__lib__evm__effects__impl_trait_Evm_476c__log3_af49(v0.i256, v1.i256, v2.i256, v3.i256, v4.i256) {
     block0:
-        v5.*i256 = alloca i256;
-        v6.*i256 = alloca i256;
-        v7.*i256 = alloca i256;
-        v8.*i256 = alloca i256;
-        v9.*i256 = alloca i256;
-        mstore v5 v0 i256;
-        mstore v6 v1 i256;
-        mstore v7 v2 i256;
-        mstore v8 v3 i256;
-        mstore v9 v4 i256;
         jump block1;
 
     block1:
-        v10.i256 = mload v5 i256;
-        v11.i256 = mload v6 i256;
-        v12.i256 = mload v7 i256;
-        v13.i256 = mload v8 i256;
-        v14.i256 = mload v9 i256;
-        evm_log3 v10 v11 v12 v13 v14;
+        evm_log3 v0 v1 v2 v3 v4;
         return;
 }
 
 func private %std__lib__evm__effects__impl_trait_Evm_476c__log3_fca8(v0.i256, v1.i256, v2.i256, v3.i256, v4.i256) {
     block0:
-        v5.*i256 = alloca i256;
-        v6.*i256 = alloca i256;
-        v7.*i256 = alloca i256;
-        v8.*i256 = alloca i256;
-        v9.*i256 = alloca i256;
-        mstore v5 v0 i256;
-        mstore v6 v1 i256;
-        mstore v7 v2 i256;
-        mstore v8 v3 i256;
-        mstore v9 v4 i256;
         jump block1;
 
     block1:
-        v10.i256 = mload v5 i256;
-        v11.i256 = mload v6 i256;
-        v12.i256 = mload v7 i256;
-        v13.i256 = mload v8 i256;
-        v14.i256 = mload v9 i256;
-        evm_log3 v10 v11 v12 v13 v14;
+        evm_log3 v0 v1 v2 v3 v4;
         return;
 }
 
 func private %standalone_erc20__erc20__mint__g5c3f_3140(v0.@layout_0, v1.i256, v2.i256) {
     block0:
-        v3.*i256 = alloca i256;
-        v4.objref<@layout_0> = obj.alloc @layout_0;
-        mstore v3 v1 i256;
+        v3.objref<@layout_0> = obj.alloc @layout_0;
         jump block1;
 
     block1:
-        v6.@layout_0 = call %zero;
-        v8.objref<i256> = obj.proj v4 0.i256;
-        v9.i256 = extract_value v6 0.i256;
-        obj.store v8 v9;
-        v10.@layout_0 = obj.load v4;
-        v11.i1 = call %ne v0 v10;
-        br v11 block2 block3;
+        v5.@layout_0 = call %zero;
+        v7.objref<i256> = obj.proj v3 0.i256;
+        v8.i256 = extract_value v5 0.i256;
+        obj.store v7 v8;
+        v9.@layout_0 = obj.load v3;
+        v10.i1 = call %ne v0 v9;
+        br v10 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v14.*i8 = evm_malloc 64.i256;
-        v15.i256 = ptr_to_int v14 i256;
-        mstore v15 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        (v19.i256, v20.i1) = uaddo v15 32.i256;
-        br v20 block5 block6;
+        v13.*i8 = evm_malloc 64.i256;
+        v14.i256 = ptr_to_int v13 i256;
+        mstore v14 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        (v18.i256, v19.i1) = uaddo v14 32.i256;
+        br v19 block5 block6;
 
     block4:
-        v28.i256 = mload v3 i256;
-        v29.i256 = evm_sload v2;
-        (v30.i256, v31.i1) = uaddo v29 v28;
-        br v31 block5 block7;
+        v28.i256 = evm_sload v2;
+        (v29.i256, v30.i1) = uaddo v28 v1;
+        br v30 block5 block7;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -9100,58 +7610,53 @@ func private %standalone_erc20__erc20__mint__g5c3f_3140(v0.@layout_0, v1.i256, v
         evm_revert 0.i256 36.i256;
 
     block6:
-        mstore v19 26959946667150639794667015087019630673637144422540572481103610249216.i256 i256;
-        evm_revert v15 36.i256;
+        mstore v18 26959946667150639794667015087019630673637144422540572481103610249216.i256 i256;
+        evm_revert v14 36.i256;
 
     block7:
-        evm_sstore v2 v30;
-        v34.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get__g2163_8a15 v0;
-        v35.i256 = mload v3 i256;
-        (v36.i256, v37.i1) = uaddo v34 v35;
-        br v37 block5 block8;
+        evm_sstore v2 v29;
+        v33.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get__g2163_8a15 v0;
+        (v35.i256, v36.i1) = uaddo v33 v1;
+        br v36 block5 block8;
 
     block8:
-        call %set__g2163 v0 v36;
-        v40.@layout_0 = call %zero;
-        v42.i256 = mload v3 i256;
-        v44.@layout_19 = insert_value undef.@layout_19 0.i256 v40;
-        v46.@layout_19 = insert_value v44 1.i256 v0;
-        v48.@layout_19 = insert_value v46 2.i256 v42;
-        call %emit__g4c3d v48;
+        call %set__g2163 v0 v35;
+        v39.@layout_0 = call %zero;
+        v43.@layout_19 = insert_value undef.@layout_19 0.i256 v39;
+        v45.@layout_19 = insert_value v43 1.i256 v0;
+        v47.@layout_19 = insert_value v45 2.i256 v1;
+        call %emit__g4c3d v47;
         return;
 }
 
 func private %standalone_erc20__erc20__mint__g5c3f_dd30(v0.@layout_0, v1.i256, v2.i256) {
     block0:
-        v3.*i256 = alloca i256;
-        v4.objref<@layout_0> = obj.alloc @layout_0;
-        mstore v3 v1 i256;
+        v3.objref<@layout_0> = obj.alloc @layout_0;
         jump block1;
 
     block1:
-        v6.@layout_0 = call %zero;
-        v8.objref<i256> = obj.proj v4 0.i256;
-        v9.i256 = extract_value v6 0.i256;
-        obj.store v8 v9;
-        v10.@layout_0 = obj.load v4;
-        v11.i1 = call %ne v0 v10;
-        br v11 block2 block3;
+        v5.@layout_0 = call %zero;
+        v7.objref<i256> = obj.proj v3 0.i256;
+        v8.i256 = extract_value v5 0.i256;
+        obj.store v7 v8;
+        v9.@layout_0 = obj.load v3;
+        v10.i1 = call %ne v0 v9;
+        br v10 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v14.*i8 = evm_malloc 64.i256;
-        v15.i256 = ptr_to_int v14 i256;
-        mstore v15 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        (v19.i256, v20.i1) = uaddo v15 32.i256;
-        br v20 block5 block6;
+        v13.*i8 = evm_malloc 64.i256;
+        v14.i256 = ptr_to_int v13 i256;
+        mstore v14 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        (v18.i256, v19.i1) = uaddo v14 32.i256;
+        br v19 block5 block6;
 
     block4:
-        v28.i256 = mload v3 i256;
-        v29.i256 = evm_sload v2;
-        (v30.i256, v31.i1) = uaddo v29 v28;
-        br v31 block5 block7;
+        v28.i256 = evm_sload v2;
+        (v29.i256, v30.i1) = uaddo v28 v1;
+        br v30 block5 block7;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -9159,24 +7664,22 @@ func private %standalone_erc20__erc20__mint__g5c3f_dd30(v0.@layout_0, v1.i256, v
         evm_revert 0.i256 36.i256;
 
     block6:
-        mstore v19 26959946667150639794667015087019630673637144422540572481103610249216.i256 i256;
-        evm_revert v15 36.i256;
+        mstore v18 26959946667150639794667015087019630673637144422540572481103610249216.i256 i256;
+        evm_revert v14 36.i256;
 
     block7:
-        evm_sstore v2 v30;
-        v34.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get__g2163_8a15 v0;
-        v35.i256 = mload v3 i256;
-        (v36.i256, v37.i1) = uaddo v34 v35;
-        br v37 block5 block8;
+        evm_sstore v2 v29;
+        v33.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get__g2163_8a15 v0;
+        (v35.i256, v36.i1) = uaddo v33 v1;
+        br v36 block5 block8;
 
     block8:
-        call %set__g2163 v0 v36;
-        v40.@layout_0 = call %zero;
-        v42.i256 = mload v3 i256;
-        v44.@layout_19 = insert_value undef.@layout_19 0.i256 v40;
-        v46.@layout_19 = insert_value v44 1.i256 v0;
-        v48.@layout_19 = insert_value v46 2.i256 v42;
-        call %emit__g4c3d v48;
+        call %set__g2163 v0 v35;
+        v39.@layout_0 = call %zero;
+        v43.@layout_19 = insert_value undef.@layout_19 0.i256 v39;
+        v45.@layout_19 = insert_value v43 1.i256 v0;
+        v47.@layout_19 = insert_value v45 2.i256 v1;
+        call %emit__g4c3d v47;
         return;
 }
 
@@ -9228,28 +7731,24 @@ func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_0f
 
 func private %std__lib__abi__sol__impl_SolEncoder_ce34__new_1301(v0.i256) -> @layout_1 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v4.i1 = eq v2 0.i256;
-        br v4 block2 block3;
+        v3.i1 = eq v0 0.i256;
+        br v3 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v5.i256 = mload v1 i256;
-        v6.*i8 = evm_malloc v5;
-        v7.i256 = ptr_to_int v6 i256;
+        v5.*i8 = evm_malloc v0;
+        v6.i256 = ptr_to_int v5 i256;
         jump block4;
 
     block4:
-        v8.i256 = phi (0.i256 block2) (v7 block3);
-        v9.@layout_1 = call %std__lib__abi__sol__impl_SolEncoder_ce34__at_6792 v8;
-        return v9;
+        v7.i256 = phi (0.i256 block2) (v6 block3);
+        v8.@layout_1 = call %std__lib__abi__sol__impl_SolEncoder_ce34__at_6792 v7;
+        return v8;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_147c() -> @layout_5 {
@@ -9266,28 +7765,24 @@ func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_14
 
 func private %std__lib__abi__sol__impl_SolEncoder_ce34__new_24a6(v0.i256) -> @layout_1 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v4.i1 = eq v2 0.i256;
-        br v4 block2 block3;
+        v3.i1 = eq v0 0.i256;
+        br v3 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v5.i256 = mload v1 i256;
-        v6.*i8 = evm_malloc v5;
-        v7.i256 = ptr_to_int v6 i256;
+        v5.*i8 = evm_malloc v0;
+        v6.i256 = ptr_to_int v5 i256;
         jump block4;
 
     block4:
-        v8.i256 = phi (0.i256 block2) (v7 block3);
-        v9.@layout_1 = call %std__lib__abi__sol__impl_SolEncoder_ce34__at_0e5a v8;
-        return v9;
+        v7.i256 = phi (0.i256 block2) (v6 block3);
+        v8.@layout_1 = call %std__lib__abi__sol__impl_SolEncoder_ce34__at_0e5a v7;
+        return v8;
 }
 
 func inline(always) private %impl_SolDecoder__new__g463e(v0.@layout_2) -> @layout_4 {
@@ -9339,28 +7834,24 @@ func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_81
 
 func private %std__lib__abi__sol__impl_SolEncoder_ce34__new_8670(v0.i256) -> @layout_1 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v4.i1 = eq v2 0.i256;
-        br v4 block2 block3;
+        v3.i1 = eq v0 0.i256;
+        br v3 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v5.i256 = mload v1 i256;
-        v6.*i8 = evm_malloc v5;
-        v7.i256 = ptr_to_int v6 i256;
+        v5.*i8 = evm_malloc v0;
+        v6.i256 = ptr_to_int v5 i256;
         jump block4;
 
     block4:
-        v8.i256 = phi (0.i256 block2) (v7 block3);
-        v9.@layout_1 = call %std__lib__abi__sol__impl_SolEncoder_ce34__at_65fb v8;
-        return v9;
+        v7.i256 = phi (0.i256 block2) (v6 block3);
+        v8.@layout_1 = call %std__lib__abi__sol__impl_SolEncoder_ce34__at_65fb v7;
+        return v8;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_923b() -> @layout_5 {
@@ -9377,28 +7868,24 @@ func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_92
 
 func private %std__lib__abi__sol__impl_SolEncoder_ce34__new_978f(v0.i256) -> @layout_1 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v4.i1 = eq v2 0.i256;
-        br v4 block2 block3;
+        v3.i1 = eq v0 0.i256;
+        br v3 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v5.i256 = mload v1 i256;
-        v6.*i8 = evm_malloc v5;
-        v7.i256 = ptr_to_int v6 i256;
+        v5.*i8 = evm_malloc v0;
+        v6.i256 = ptr_to_int v5 i256;
         jump block4;
 
     block4:
-        v8.i256 = phi (0.i256 block2) (v7 block3);
-        v9.@layout_1 = call %std__lib__abi__sol__impl_SolEncoder_ce34__at_fb00 v8;
-        return v9;
+        v7.i256 = phi (0.i256 block2) (v6 block3);
+        v8.@layout_1 = call %std__lib__abi__sol__impl_SolEncoder_ce34__at_fb00 v7;
+        return v8;
 }
 
 func inline(always) private %impl_Cursor__new__g463e(v0.@layout_2) -> @layout_3 {
@@ -9449,54 +7936,46 @@ func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_bc
 
 func private %std__lib__abi__sol__impl_SolEncoder_ce34__new_c2ff(v0.i256) -> @layout_1 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v4.i1 = eq v2 0.i256;
-        br v4 block2 block3;
+        v3.i1 = eq v0 0.i256;
+        br v3 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v5.i256 = mload v1 i256;
-        v6.*i8 = evm_malloc v5;
-        v7.i256 = ptr_to_int v6 i256;
+        v5.*i8 = evm_malloc v0;
+        v6.i256 = ptr_to_int v5 i256;
         jump block4;
 
     block4:
-        v8.i256 = phi (0.i256 block2) (v7 block3);
-        v9.@layout_1 = call %std__lib__abi__sol__impl_SolEncoder_ce34__at_69c8 v8;
-        return v9;
+        v7.i256 = phi (0.i256 block2) (v6 block3);
+        v8.@layout_1 = call %std__lib__abi__sol__impl_SolEncoder_ce34__at_69c8 v7;
+        return v8;
 }
 
 func private %std__lib__abi__sol__impl_SolEncoder_ce34__new_c575(v0.i256) -> @layout_1 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v4.i1 = eq v2 0.i256;
-        br v4 block2 block3;
+        v3.i1 = eq v0 0.i256;
+        br v3 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v5.i256 = mload v1 i256;
-        v6.*i8 = evm_malloc v5;
-        v7.i256 = ptr_to_int v6 i256;
+        v5.*i8 = evm_malloc v0;
+        v6.i256 = ptr_to_int v5 i256;
         jump block4;
 
     block4:
-        v8.i256 = phi (0.i256 block2) (v7 block3);
-        v9.@layout_1 = call %std__lib__abi__sol__impl_SolEncoder_ce34__at_3361 v8;
-        return v9;
+        v7.i256 = phi (0.i256 block2) (v6 block3);
+        v8.@layout_1 = call %std__lib__abi__sol__impl_SolEncoder_ce34__at_3361 v7;
+        return v8;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_d306() -> @layout_5 {
@@ -9513,28 +7992,24 @@ func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_d3
 
 func private %std__lib__abi__sol__impl_SolEncoder_ce34__new_f042(v0.i256) -> @layout_1 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v4.i1 = eq v2 0.i256;
-        br v4 block2 block3;
+        v3.i1 = eq v0 0.i256;
+        br v3 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v5.i256 = mload v1 i256;
-        v6.*i8 = evm_malloc v5;
-        v7.i256 = ptr_to_int v6 i256;
+        v5.*i8 = evm_malloc v0;
+        v6.i256 = ptr_to_int v5 i256;
         jump block4;
 
     block4:
-        v8.i256 = phi (0.i256 block2) (v7 block3);
-        v9.@layout_1 = call %std__lib__abi__sol__impl_SolEncoder_ce34__at_31d5 v8;
-        return v9;
+        v7.i256 = phi (0.i256 block2) (v6 block3);
+        v8.@layout_1 = call %std__lib__abi__sol__impl_SolEncoder_ce34__at_31d5 v7;
+        return v8;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_f11a() -> @layout_5 {
@@ -9564,31 +8039,27 @@ func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_f3
 func private %core__lib__abi__packed_string_len_225d(v0.i256) -> i256 {
     block0:
         v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        mstore v2 0.i256 i256;
-        v5.i256 = mload v1 i256;
+        mstore v1 0.i256 i256;
         jump block2;
 
     block2:
-        v6.i256 = phi (v5 block1) (v22 block6);
-        v7.i1 = eq v6 0.i256;
-        v8.i1 = is_zero v7;
-        br v8 block3 block4;
+        v4.i256 = phi (v0 block1) (v19 block6);
+        v5.i1 = eq v4 0.i256;
+        v6.i1 = is_zero v5;
+        br v6 block3 block4;
 
     block3:
-        v9.i256 = ptr_to_int v2 i256;
-        v11.i256 = mload v9 i256;
-        (v12.i256, v13.i1) = uaddo v11 1.i256;
-        br v13 block5 block6;
+        v7.i256 = ptr_to_int v1 i256;
+        v9.i256 = mload v7 i256;
+        (v10.i256, v11.i1) = uaddo v9 1.i256;
+        br v11 block5 block6;
 
     block4:
-        v23.i256 = mload v2 i256;
-        return v23;
+        v20.i256 = mload v1 i256;
+        return v20;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -9596,41 +8067,35 @@ func private %core__lib__abi__packed_string_len_225d(v0.i256) -> i256 {
         evm_revert 0.i256 36.i256;
 
     block6:
-        mstore v9 v12 i256;
-        v21.i256 = shr 8.i256 v6;
-        mstore v3 v21 i256;
-        v22.i256 = mload v3 i256;
+        mstore v7 v10 i256;
+        v19.i256 = shr 8.i256 v4;
         jump block2;
 }
 
 func private %core__lib__abi__packed_string_len_225d_0(v0.i256) -> i256 {
     block0:
         v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        mstore v2 0.i256 i256;
-        v5.i256 = mload v1 i256;
+        mstore v1 0.i256 i256;
         jump block2;
 
     block2:
-        v6.i256 = phi (v5 block1) (v22 block6);
-        v7.i1 = eq v6 0.i256;
-        v8.i1 = is_zero v7;
-        br v8 block3 block4;
+        v4.i256 = phi (v0 block1) (v19 block6);
+        v5.i1 = eq v4 0.i256;
+        v6.i1 = is_zero v5;
+        br v6 block3 block4;
 
     block3:
-        v9.i256 = ptr_to_int v2 i256;
-        v11.i256 = mload v9 i256;
-        (v12.i256, v13.i1) = uaddo v11 1.i256;
-        br v13 block5 block6;
+        v7.i256 = ptr_to_int v1 i256;
+        v9.i256 = mload v7 i256;
+        (v10.i256, v11.i1) = uaddo v9 1.i256;
+        br v11 block5 block6;
 
     block4:
-        v23.i256 = mload v2 i256;
-        return v23;
+        v20.i256 = mload v1 i256;
+        return v20;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -9638,41 +8103,35 @@ func private %core__lib__abi__packed_string_len_225d_0(v0.i256) -> i256 {
         evm_revert 0.i256 36.i256;
 
     block6:
-        mstore v9 v12 i256;
-        v21.i256 = shr 8.i256 v6;
-        mstore v3 v21 i256;
-        v22.i256 = mload v3 i256;
+        mstore v7 v10 i256;
+        v19.i256 = shr 8.i256 v4;
         jump block2;
 }
 
 func private %core__lib__abi__packed_string_len_29ef(v0.i256) -> i256 {
     block0:
         v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        mstore v2 0.i256 i256;
-        v5.i256 = mload v1 i256;
+        mstore v1 0.i256 i256;
         jump block2;
 
     block2:
-        v6.i256 = phi (v5 block1) (v22 block6);
-        v7.i1 = eq v6 0.i256;
-        v8.i1 = is_zero v7;
-        br v8 block3 block4;
+        v4.i256 = phi (v0 block1) (v19 block6);
+        v5.i1 = eq v4 0.i256;
+        v6.i1 = is_zero v5;
+        br v6 block3 block4;
 
     block3:
-        v9.i256 = ptr_to_int v2 i256;
-        v11.i256 = mload v9 i256;
-        (v12.i256, v13.i1) = uaddo v11 1.i256;
-        br v13 block5 block6;
+        v7.i256 = ptr_to_int v1 i256;
+        v9.i256 = mload v7 i256;
+        (v10.i256, v11.i1) = uaddo v9 1.i256;
+        br v11 block5 block6;
 
     block4:
-        v23.i256 = mload v2 i256;
-        return v23;
+        v20.i256 = mload v1 i256;
+        return v20;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -9680,41 +8139,35 @@ func private %core__lib__abi__packed_string_len_29ef(v0.i256) -> i256 {
         evm_revert 0.i256 36.i256;
 
     block6:
-        mstore v9 v12 i256;
-        v21.i256 = shr 8.i256 v6;
-        mstore v3 v21 i256;
-        v22.i256 = mload v3 i256;
+        mstore v7 v10 i256;
+        v19.i256 = shr 8.i256 v4;
         jump block2;
 }
 
 func private %core__lib__abi__packed_string_len_c13a(v0.i256) -> i256 {
     block0:
         v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        mstore v2 0.i256 i256;
-        v5.i256 = mload v1 i256;
+        mstore v1 0.i256 i256;
         jump block2;
 
     block2:
-        v6.i256 = phi (v5 block1) (v22 block6);
-        v7.i1 = eq v6 0.i256;
-        v8.i1 = is_zero v7;
-        br v8 block3 block4;
+        v4.i256 = phi (v0 block1) (v19 block6);
+        v5.i1 = eq v4 0.i256;
+        v6.i1 = is_zero v5;
+        br v6 block3 block4;
 
     block3:
-        v9.i256 = ptr_to_int v2 i256;
-        v11.i256 = mload v9 i256;
-        (v12.i256, v13.i1) = uaddo v11 1.i256;
-        br v13 block5 block6;
+        v7.i256 = ptr_to_int v1 i256;
+        v9.i256 = mload v7 i256;
+        (v10.i256, v11.i1) = uaddo v9 1.i256;
+        br v11 block5 block6;
 
     block4:
-        v23.i256 = mload v2 i256;
-        return v23;
+        v20.i256 = mload v1 i256;
+        return v20;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -9722,41 +8175,35 @@ func private %core__lib__abi__packed_string_len_c13a(v0.i256) -> i256 {
         evm_revert 0.i256 36.i256;
 
     block6:
-        mstore v9 v12 i256;
-        v21.i256 = shr 8.i256 v6;
-        mstore v3 v21 i256;
-        v22.i256 = mload v3 i256;
+        mstore v7 v10 i256;
+        v19.i256 = shr 8.i256 v4;
         jump block2;
 }
 
 func private %core__lib__abi__packed_string_len_ecb6(v0.i256) -> i256 {
     block0:
         v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        mstore v2 0.i256 i256;
-        v5.i256 = mload v1 i256;
+        mstore v1 0.i256 i256;
         jump block2;
 
     block2:
-        v6.i256 = phi (v5 block1) (v22 block6);
-        v7.i1 = eq v6 0.i256;
-        v8.i1 = is_zero v7;
-        br v8 block3 block4;
+        v4.i256 = phi (v0 block1) (v19 block6);
+        v5.i1 = eq v4 0.i256;
+        v6.i1 = is_zero v5;
+        br v6 block3 block4;
 
     block3:
-        v9.i256 = ptr_to_int v2 i256;
-        v11.i256 = mload v9 i256;
-        (v12.i256, v13.i1) = uaddo v11 1.i256;
-        br v13 block5 block6;
+        v7.i256 = ptr_to_int v1 i256;
+        v9.i256 = mload v7 i256;
+        (v10.i256, v11.i1) = uaddo v9 1.i256;
+        br v11 block5 block6;
 
     block4:
-        v23.i256 = mload v2 i256;
-        return v23;
+        v20.i256 = mload v1 i256;
+        return v20;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -9764,41 +8211,35 @@ func private %core__lib__abi__packed_string_len_ecb6(v0.i256) -> i256 {
         evm_revert 0.i256 36.i256;
 
     block6:
-        mstore v9 v12 i256;
-        v21.i256 = shr 8.i256 v6;
-        mstore v3 v21 i256;
-        v22.i256 = mload v3 i256;
+        mstore v7 v10 i256;
+        v19.i256 = shr 8.i256 v4;
         jump block2;
 }
 
 func private %core__lib__abi__packed_string_len_ecb6_0(v0.i256) -> i256 {
     block0:
         v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        mstore v2 0.i256 i256;
-        v5.i256 = mload v1 i256;
+        mstore v1 0.i256 i256;
         jump block2;
 
     block2:
-        v6.i256 = phi (v5 block1) (v22 block6);
-        v7.i1 = eq v6 0.i256;
-        v8.i1 = is_zero v7;
-        br v8 block3 block4;
+        v4.i256 = phi (v0 block1) (v19 block6);
+        v5.i1 = eq v4 0.i256;
+        v6.i1 = is_zero v5;
+        br v6 block3 block4;
 
     block3:
-        v9.i256 = ptr_to_int v2 i256;
-        v11.i256 = mload v9 i256;
-        (v12.i256, v13.i1) = uaddo v11 1.i256;
-        br v13 block5 block6;
+        v7.i256 = ptr_to_int v1 i256;
+        v9.i256 = mload v7 i256;
+        (v10.i256, v11.i1) = uaddo v9 1.i256;
+        br v11 block5 block6;
 
     block4:
-        v23.i256 = mload v2 i256;
-        return v23;
+        v20.i256 = mload v1 i256;
+        return v20;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -9806,17 +8247,13 @@ func private %core__lib__abi__packed_string_len_ecb6_0(v0.i256) -> i256 {
         evm_revert 0.i256 36.i256;
 
     block6:
-        mstore v9 v12 i256;
-        v21.i256 = shr 8.i256 v6;
-        mstore v3 v21 i256;
-        v22.i256 = mload v3 i256;
+        mstore v7 v10 i256;
+        v19.i256 = shr 8.i256 v4;
         jump block2;
 }
 
 func private %core__lib__abi__trait_AbiSize__payload_size__ge513_0454(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
@@ -9825,17 +8262,14 @@ func private %core__lib__abi__trait_AbiSize__payload_size__ge513_0454(v0.i256) -
 
 func private %core__lib__abi__impl_trait_String_c06e__payload_size__gc7cf_4aab(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v1 i256;
-        v4.i256 = call %core__lib__num__impl_trait_String_8f88__to_word__gc7cf_518a v3;
-        v5.i256 = call %core__lib__abi__packed_string_len_ecb6 v4;
-        v6.i256 = call %core__lib__abi__round_up_words_a41d v5;
-        (v7.i256, v8.i1) = uaddo 32.i256 v6;
-        br v8 block2 block3;
+        v3.i256 = call %core__lib__num__impl_trait_String_8f88__to_word__gc7cf_518a v0;
+        v4.i256 = call %core__lib__abi__packed_string_len_ecb6 v3;
+        v5.i256 = call %core__lib__abi__round_up_words_a41d v4;
+        (v6.i256, v7.i1) = uaddo 32.i256 v5;
+        br v7 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -9843,22 +8277,19 @@ func private %core__lib__abi__impl_trait_String_c06e__payload_size__gc7cf_4aab(v
         evm_revert 0.i256 36.i256;
 
     block3:
-        return v7;
+        return v6;
 }
 
 func private %core__lib__abi__impl_trait_String_c06e__payload_size__gc7cf_4aab_0(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v1 i256;
-        v4.i256 = call %core__lib__num__impl_trait_String_8f88__to_word__gc7cf_518a_0 v3;
-        v5.i256 = call %core__lib__abi__packed_string_len_ecb6_0 v4;
-        v6.i256 = call %core__lib__abi__round_up_words_a41d_0 v5;
-        (v7.i256, v8.i1) = uaddo 32.i256 v6;
-        br v8 block2 block3;
+        v3.i256 = call %core__lib__num__impl_trait_String_8f88__to_word__gc7cf_518a_0 v0;
+        v4.i256 = call %core__lib__abi__packed_string_len_ecb6_0 v3;
+        v5.i256 = call %core__lib__abi__round_up_words_a41d_0 v4;
+        (v6.i256, v7.i1) = uaddo 32.i256 v5;
+        br v7 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -9866,13 +8297,11 @@ func private %core__lib__abi__impl_trait_String_c06e__payload_size__gc7cf_4aab_0
         evm_revert 0.i256 36.i256;
 
     block3:
-        return v7;
+        return v6;
 }
 
 func private %core__lib__abi__trait_AbiSize__payload_size__ge513_77e5(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
@@ -9881,8 +8310,6 @@ func private %core__lib__abi__trait_AbiSize__payload_size__ge513_77e5(v0.i256) -
 
 func private %core__lib__abi__trait_AbiSize__payload_size__ge513_77e5_0(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
@@ -9891,8 +8318,6 @@ func private %core__lib__abi__trait_AbiSize__payload_size__ge513_77e5_0(v0.i256)
 
 func private %core__lib__abi__trait_AbiSize__payload_size__ge513_a81c(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
@@ -9901,8 +8326,6 @@ func private %core__lib__abi__trait_AbiSize__payload_size__ge513_a81c(v0.i256) -
 
 func private %core__lib__abi__trait_AbiSize__payload_size__gda9b_b33d(v0.i1) -> i256 {
     block0:
-        v1.*i1 = alloca i1;
-        mstore v1 v0 i1;
         jump block1;
 
     block1:
@@ -9911,8 +8334,6 @@ func private %core__lib__abi__trait_AbiSize__payload_size__gda9b_b33d(v0.i1) -> 
 
 func private %core__lib__abi__trait_AbiSize__payload_size__gda9b_b33d_0(v0.i1) -> i256 {
     block0:
-        v1.*i1 = alloca i1;
-        mstore v1 v0 i1;
         jump block1;
 
     block1:
@@ -9921,8 +8342,6 @@ func private %core__lib__abi__trait_AbiSize__payload_size__gda9b_b33d_0(v0.i1) -
 
 func private %core__lib__abi__trait_AbiSize__payload_size__g79ff_f3e8(v0.i8) -> i256 {
     block0:
-        v1.*i8 = alloca i8;
-        mstore v1 v0 i8;
         jump block1;
 
     block1:
@@ -9931,8 +8350,6 @@ func private %core__lib__abi__trait_AbiSize__payload_size__g79ff_f3e8(v0.i8) -> 
 
 func private %core__lib__abi__trait_AbiSize__payload_size__g79ff_f3e8_0(v0.i8) -> i256 {
     block0:
-        v1.*i8 = alloca i8;
-        mstore v1 v0 i8;
         jump block1;
 
     block1:
@@ -9941,17 +8358,14 @@ func private %core__lib__abi__trait_AbiSize__payload_size__g79ff_f3e8_0(v0.i8) -
 
 func private %core__lib__abi__impl_trait_String_c06e__payload_size__g3eb7_f656(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v1 i256;
-        v4.i256 = call %core__lib__num__impl_trait_String_8f88__to_word__g3eb7_38b3 v3;
-        v5.i256 = call %core__lib__abi__packed_string_len_225d v4;
-        v6.i256 = call %core__lib__abi__round_up_words_b13c v5;
-        (v7.i256, v8.i1) = uaddo 32.i256 v6;
-        br v8 block2 block3;
+        v3.i256 = call %core__lib__num__impl_trait_String_8f88__to_word__g3eb7_38b3 v0;
+        v4.i256 = call %core__lib__abi__packed_string_len_225d v3;
+        v5.i256 = call %core__lib__abi__round_up_words_b13c v4;
+        (v6.i256, v7.i1) = uaddo 32.i256 v5;
+        br v7 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -9959,22 +8373,19 @@ func private %core__lib__abi__impl_trait_String_c06e__payload_size__g3eb7_f656(v
         evm_revert 0.i256 36.i256;
 
     block3:
-        return v7;
+        return v6;
 }
 
 func private %core__lib__abi__impl_trait_String_c06e__payload_size__g3eb7_f656_0(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v1 i256;
-        v4.i256 = call %core__lib__num__impl_trait_String_8f88__to_word__g3eb7_38b3_0 v3;
-        v5.i256 = call %core__lib__abi__packed_string_len_225d_0 v4;
-        v6.i256 = call %core__lib__abi__round_up_words_b13c_0 v5;
-        (v7.i256, v8.i1) = uaddo 32.i256 v6;
-        br v8 block2 block3;
+        v3.i256 = call %core__lib__num__impl_trait_String_8f88__to_word__g3eb7_38b3_0 v0;
+        v4.i256 = call %core__lib__abi__packed_string_len_225d_0 v3;
+        v5.i256 = call %core__lib__abi__round_up_words_b13c_0 v4;
+        (v6.i256, v7.i1) = uaddo 32.i256 v5;
+        br v7 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -9982,7 +8393,7 @@ func private %core__lib__abi__impl_trait_String_c06e__payload_size__g3eb7_f656_0
         evm_revert 0.i256 36.i256;
 
     block3:
-        return v7;
+        return v6;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_0de4(v0.objref<@layout_1>) -> i256 {
@@ -10060,22 +8471,20 @@ func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__pos_d8ed(v0.objref
 func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_0a1c(v0.objref<@layout_4>) -> i256 {
     block0:
         v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v5.objref<@layout_3> = obj.proj v0 0.i256;
-        v6.objref<@layout_2> = obj.proj v5 0.i256;
-        v7.@layout_2 = obj.load v6;
-        v8.objref<@layout_3> = obj.proj v0 0.i256;
-        v9.objref<@layout_2> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_7b50 v9;
-        mstore v1 v10 i256;
-        v11.objref<@layout_3> = obj.proj v0 0.i256;
-        v13.objref<i256> = obj.proj v11 1.i256;
-        v14.i256 = obj.load v13;
-        (v16.i256, v17.i1) = uaddo v14 32.i256;
-        br v17 block6 block7;
+        v4.objref<@layout_3> = obj.proj v0 0.i256;
+        v5.objref<@layout_2> = obj.proj v4 0.i256;
+        v6.@layout_2 = obj.load v5;
+        v7.objref<@layout_3> = obj.proj v0 0.i256;
+        v8.objref<@layout_2> = obj.proj v7 0.i256;
+        v9.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_7b50 v8;
+        v10.objref<@layout_3> = obj.proj v0 0.i256;
+        v12.objref<i256> = obj.proj v10 1.i256;
+        v13.i256 = obj.load v12;
+        (v15.i256, v16.i1) = uaddo v13 32.i256;
+        br v16 block6 block7;
 
     block2:
         evm_revert 0.i256 0.i256;
@@ -10084,26 +8493,25 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         jump block4;
 
     block4:
-        v28.objref<@layout_3> = obj.proj v0 0.i256;
-        v29.objref<@layout_2> = obj.proj v28 0.i256;
-        v30.@layout_2 = obj.load v29;
-        v31.objref<@layout_3> = obj.proj v0 0.i256;
-        v32.objref<i256> = obj.proj v31 1.i256;
-        v33.i256 = obj.load v32;
-        v34.objref<@layout_3> = obj.proj v0 0.i256;
-        v35.objref<@layout_2> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_7f19 v35 v33;
-        v38.objref<@layout_3> = obj.proj v0 0.i256;
-        v39.objref<i256> = obj.proj v38 1.i256;
-        obj.store v39 v16;
-        return v36;
+        v27.objref<@layout_3> = obj.proj v0 0.i256;
+        v28.objref<@layout_2> = obj.proj v27 0.i256;
+        v29.@layout_2 = obj.load v28;
+        v30.objref<@layout_3> = obj.proj v0 0.i256;
+        v31.objref<i256> = obj.proj v30 1.i256;
+        v32.i256 = obj.load v31;
+        v33.objref<@layout_3> = obj.proj v0 0.i256;
+        v34.objref<@layout_2> = obj.proj v33 0.i256;
+        v35.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_7f19 v34 v32;
+        v37.objref<@layout_3> = obj.proj v0 0.i256;
+        v38.objref<i256> = obj.proj v37 1.i256;
+        obj.store v38 v15;
+        return v35;
 
     block5:
-        v40.i256 = mload v1 i256;
-        mstore v2 v40 i256;
-        v42.i256 = mload v2 i256;
-        v43.i1 = gt v16 v42;
-        br v43 block2 block3;
+        mstore v1 v9 i256;
+        v41.i256 = mload v1 i256;
+        v42.i1 = gt v15 v41;
+        br v42 block2 block3;
 
     block6:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -10111,32 +8519,30 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         evm_revert 0.i256 36.i256;
 
     block7:
-        v23.objref<@layout_3> = obj.proj v0 0.i256;
-        v24.objref<i256> = obj.proj v23 1.i256;
-        v25.i256 = obj.load v24;
-        v26.i1 = lt v16 v25;
-        br v26 block2 block5;
+        v22.objref<@layout_3> = obj.proj v0 0.i256;
+        v23.objref<i256> = obj.proj v22 1.i256;
+        v24.i256 = obj.load v23;
+        v25.i1 = lt v15 v24;
+        br v25 block2 block5;
 }
 
 func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_0a1c_0(v0.objref<@layout_4>) -> i256 {
     block0:
         v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v5.objref<@layout_3> = obj.proj v0 0.i256;
-        v6.objref<@layout_2> = obj.proj v5 0.i256;
-        v7.@layout_2 = obj.load v6;
-        v8.objref<@layout_3> = obj.proj v0 0.i256;
-        v9.objref<@layout_2> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_7b50_0 v9;
-        mstore v1 v10 i256;
-        v11.objref<@layout_3> = obj.proj v0 0.i256;
-        v13.objref<i256> = obj.proj v11 1.i256;
-        v14.i256 = obj.load v13;
-        (v16.i256, v17.i1) = uaddo v14 32.i256;
-        br v17 block6 block7;
+        v4.objref<@layout_3> = obj.proj v0 0.i256;
+        v5.objref<@layout_2> = obj.proj v4 0.i256;
+        v6.@layout_2 = obj.load v5;
+        v7.objref<@layout_3> = obj.proj v0 0.i256;
+        v8.objref<@layout_2> = obj.proj v7 0.i256;
+        v9.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_7b50_0 v8;
+        v10.objref<@layout_3> = obj.proj v0 0.i256;
+        v12.objref<i256> = obj.proj v10 1.i256;
+        v13.i256 = obj.load v12;
+        (v15.i256, v16.i1) = uaddo v13 32.i256;
+        br v16 block6 block7;
 
     block2:
         evm_revert 0.i256 0.i256;
@@ -10145,26 +8551,25 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         jump block4;
 
     block4:
-        v28.objref<@layout_3> = obj.proj v0 0.i256;
-        v29.objref<@layout_2> = obj.proj v28 0.i256;
-        v30.@layout_2 = obj.load v29;
-        v31.objref<@layout_3> = obj.proj v0 0.i256;
-        v32.objref<i256> = obj.proj v31 1.i256;
-        v33.i256 = obj.load v32;
-        v34.objref<@layout_3> = obj.proj v0 0.i256;
-        v35.objref<@layout_2> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_7f19_0 v35 v33;
-        v38.objref<@layout_3> = obj.proj v0 0.i256;
-        v39.objref<i256> = obj.proj v38 1.i256;
-        obj.store v39 v16;
-        return v36;
+        v27.objref<@layout_3> = obj.proj v0 0.i256;
+        v28.objref<@layout_2> = obj.proj v27 0.i256;
+        v29.@layout_2 = obj.load v28;
+        v30.objref<@layout_3> = obj.proj v0 0.i256;
+        v31.objref<i256> = obj.proj v30 1.i256;
+        v32.i256 = obj.load v31;
+        v33.objref<@layout_3> = obj.proj v0 0.i256;
+        v34.objref<@layout_2> = obj.proj v33 0.i256;
+        v35.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_7f19_0 v34 v32;
+        v37.objref<@layout_3> = obj.proj v0 0.i256;
+        v38.objref<i256> = obj.proj v37 1.i256;
+        obj.store v38 v15;
+        return v35;
 
     block5:
-        v40.i256 = mload v1 i256;
-        mstore v2 v40 i256;
-        v42.i256 = mload v2 i256;
-        v43.i1 = gt v16 v42;
-        br v43 block2 block3;
+        mstore v1 v9 i256;
+        v41.i256 = mload v1 i256;
+        v42.i1 = gt v15 v41;
+        br v42 block2 block3;
 
     block6:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -10172,32 +8577,30 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         evm_revert 0.i256 36.i256;
 
     block7:
-        v23.objref<@layout_3> = obj.proj v0 0.i256;
-        v24.objref<i256> = obj.proj v23 1.i256;
-        v25.i256 = obj.load v24;
-        v26.i1 = lt v16 v25;
-        br v26 block2 block5;
+        v22.objref<@layout_3> = obj.proj v0 0.i256;
+        v23.objref<i256> = obj.proj v22 1.i256;
+        v24.i256 = obj.load v23;
+        v25.i1 = lt v15 v24;
+        br v25 block2 block5;
 }
 
 func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_85d9(v0.objref<@layout_4>) -> i256 {
     block0:
         v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v5.objref<@layout_3> = obj.proj v0 0.i256;
-        v6.objref<@layout_2> = obj.proj v5 0.i256;
-        v7.@layout_2 = obj.load v6;
-        v8.objref<@layout_3> = obj.proj v0 0.i256;
-        v9.objref<@layout_2> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_48ab v9;
-        mstore v1 v10 i256;
-        v11.objref<@layout_3> = obj.proj v0 0.i256;
-        v13.objref<i256> = obj.proj v11 1.i256;
-        v14.i256 = obj.load v13;
-        (v16.i256, v17.i1) = uaddo v14 32.i256;
-        br v17 block6 block7;
+        v4.objref<@layout_3> = obj.proj v0 0.i256;
+        v5.objref<@layout_2> = obj.proj v4 0.i256;
+        v6.@layout_2 = obj.load v5;
+        v7.objref<@layout_3> = obj.proj v0 0.i256;
+        v8.objref<@layout_2> = obj.proj v7 0.i256;
+        v9.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_48ab v8;
+        v10.objref<@layout_3> = obj.proj v0 0.i256;
+        v12.objref<i256> = obj.proj v10 1.i256;
+        v13.i256 = obj.load v12;
+        (v15.i256, v16.i1) = uaddo v13 32.i256;
+        br v16 block6 block7;
 
     block2:
         evm_revert 0.i256 0.i256;
@@ -10206,26 +8609,25 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         jump block4;
 
     block4:
-        v28.objref<@layout_3> = obj.proj v0 0.i256;
-        v29.objref<@layout_2> = obj.proj v28 0.i256;
-        v30.@layout_2 = obj.load v29;
-        v31.objref<@layout_3> = obj.proj v0 0.i256;
-        v32.objref<i256> = obj.proj v31 1.i256;
-        v33.i256 = obj.load v32;
-        v34.objref<@layout_3> = obj.proj v0 0.i256;
-        v35.objref<@layout_2> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_6576 v35 v33;
-        v38.objref<@layout_3> = obj.proj v0 0.i256;
-        v39.objref<i256> = obj.proj v38 1.i256;
-        obj.store v39 v16;
-        return v36;
+        v27.objref<@layout_3> = obj.proj v0 0.i256;
+        v28.objref<@layout_2> = obj.proj v27 0.i256;
+        v29.@layout_2 = obj.load v28;
+        v30.objref<@layout_3> = obj.proj v0 0.i256;
+        v31.objref<i256> = obj.proj v30 1.i256;
+        v32.i256 = obj.load v31;
+        v33.objref<@layout_3> = obj.proj v0 0.i256;
+        v34.objref<@layout_2> = obj.proj v33 0.i256;
+        v35.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_6576 v34 v32;
+        v37.objref<@layout_3> = obj.proj v0 0.i256;
+        v38.objref<i256> = obj.proj v37 1.i256;
+        obj.store v38 v15;
+        return v35;
 
     block5:
-        v40.i256 = mload v1 i256;
-        mstore v2 v40 i256;
-        v42.i256 = mload v2 i256;
-        v43.i1 = gt v16 v42;
-        br v43 block2 block3;
+        mstore v1 v9 i256;
+        v41.i256 = mload v1 i256;
+        v42.i1 = gt v15 v41;
+        br v42 block2 block3;
 
     block6:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -10233,32 +8635,30 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         evm_revert 0.i256 36.i256;
 
     block7:
-        v23.objref<@layout_3> = obj.proj v0 0.i256;
-        v24.objref<i256> = obj.proj v23 1.i256;
-        v25.i256 = obj.load v24;
-        v26.i1 = lt v16 v25;
-        br v26 block2 block5;
+        v22.objref<@layout_3> = obj.proj v0 0.i256;
+        v23.objref<i256> = obj.proj v22 1.i256;
+        v24.i256 = obj.load v23;
+        v25.i1 = lt v15 v24;
+        br v25 block2 block5;
 }
 
 func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_87b3(v0.objref<@layout_4>) -> i256 {
     block0:
         v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v5.objref<@layout_3> = obj.proj v0 0.i256;
-        v6.objref<@layout_2> = obj.proj v5 0.i256;
-        v7.@layout_2 = obj.load v6;
-        v8.objref<@layout_3> = obj.proj v0 0.i256;
-        v9.objref<@layout_2> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_a4fa v9;
-        mstore v1 v10 i256;
-        v11.objref<@layout_3> = obj.proj v0 0.i256;
-        v13.objref<i256> = obj.proj v11 1.i256;
-        v14.i256 = obj.load v13;
-        (v16.i256, v17.i1) = uaddo v14 32.i256;
-        br v17 block6 block7;
+        v4.objref<@layout_3> = obj.proj v0 0.i256;
+        v5.objref<@layout_2> = obj.proj v4 0.i256;
+        v6.@layout_2 = obj.load v5;
+        v7.objref<@layout_3> = obj.proj v0 0.i256;
+        v8.objref<@layout_2> = obj.proj v7 0.i256;
+        v9.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_a4fa v8;
+        v10.objref<@layout_3> = obj.proj v0 0.i256;
+        v12.objref<i256> = obj.proj v10 1.i256;
+        v13.i256 = obj.load v12;
+        (v15.i256, v16.i1) = uaddo v13 32.i256;
+        br v16 block6 block7;
 
     block2:
         evm_revert 0.i256 0.i256;
@@ -10267,26 +8667,25 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         jump block4;
 
     block4:
-        v28.objref<@layout_3> = obj.proj v0 0.i256;
-        v29.objref<@layout_2> = obj.proj v28 0.i256;
-        v30.@layout_2 = obj.load v29;
-        v31.objref<@layout_3> = obj.proj v0 0.i256;
-        v32.objref<i256> = obj.proj v31 1.i256;
-        v33.i256 = obj.load v32;
-        v34.objref<@layout_3> = obj.proj v0 0.i256;
-        v35.objref<@layout_2> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_fb71 v35 v33;
-        v38.objref<@layout_3> = obj.proj v0 0.i256;
-        v39.objref<i256> = obj.proj v38 1.i256;
-        obj.store v39 v16;
-        return v36;
+        v27.objref<@layout_3> = obj.proj v0 0.i256;
+        v28.objref<@layout_2> = obj.proj v27 0.i256;
+        v29.@layout_2 = obj.load v28;
+        v30.objref<@layout_3> = obj.proj v0 0.i256;
+        v31.objref<i256> = obj.proj v30 1.i256;
+        v32.i256 = obj.load v31;
+        v33.objref<@layout_3> = obj.proj v0 0.i256;
+        v34.objref<@layout_2> = obj.proj v33 0.i256;
+        v35.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_fb71 v34 v32;
+        v37.objref<@layout_3> = obj.proj v0 0.i256;
+        v38.objref<i256> = obj.proj v37 1.i256;
+        obj.store v38 v15;
+        return v35;
 
     block5:
-        v40.i256 = mload v1 i256;
-        mstore v2 v40 i256;
-        v42.i256 = mload v2 i256;
-        v43.i1 = gt v16 v42;
-        br v43 block2 block3;
+        mstore v1 v9 i256;
+        v41.i256 = mload v1 i256;
+        v42.i1 = gt v15 v41;
+        br v42 block2 block3;
 
     block6:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -10294,37 +8693,34 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         evm_revert 0.i256 36.i256;
 
     block7:
-        v23.objref<@layout_3> = obj.proj v0 0.i256;
-        v24.objref<i256> = obj.proj v23 1.i256;
-        v25.i256 = obj.load v24;
-        v26.i1 = lt v16 v25;
-        br v26 block2 block5;
+        v22.objref<@layout_3> = obj.proj v0 0.i256;
+        v23.objref<i256> = obj.proj v22 1.i256;
+        v24.i256 = obj.load v23;
+        v25.i1 = lt v15 v24;
+        br v25 block2 block5;
 }
 
 func private %require(v0.i256) {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.@layout_0 = call %caller;
-        v6.@layout_16 = insert_value undef.@layout_16 0.i256 v2;
-        v8.@layout_16 = insert_value v6 1.i256 v3;
-        v9.i1 = call %get__gc9ba v8;
-        v11.i1 = eq v9 1.i1;
-        br v11 block2 block3;
+        v2.@layout_0 = call %caller;
+        v5.@layout_16 = insert_value undef.@layout_16 0.i256 v0;
+        v7.@layout_16 = insert_value v5 1.i256 v2;
+        v8.i1 = call %get__gc9ba v7;
+        v10.i1 = eq v8 1.i1;
+        br v10 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v14.*i8 = evm_malloc 64.i256;
-        v15.i256 = ptr_to_int v14 i256;
-        mstore v15 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        (v19.i256, v20.i1) = uaddo v15 32.i256;
-        br v20 block5 block6;
+        v13.*i8 = evm_malloc 64.i256;
+        v14.i256 = ptr_to_int v13 i256;
+        mstore v14 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        (v18.i256, v19.i1) = uaddo v14 32.i256;
+        br v19 block5 block6;
 
     block4:
         return;
@@ -10335,216 +8731,129 @@ func private %require(v0.i256) {
         evm_revert 0.i256 36.i256;
 
     block6:
-        mstore v19 26959946667150639794667015087019630673637144422540572481103610249216.i256 i256;
-        evm_revert v15 36.i256;
+        mstore v18 26959946667150639794667015087019630673637144422540572481103610249216.i256 i256;
+        evm_revert v14 36.i256;
 }
 
 func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_0ea2(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        evm_revert v4 v5;
+        evm_revert v0 v1;
 }
 
 func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_2b5d(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        evm_revert v4 v5;
+        evm_revert v0 v1;
 }
 
 func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_2efa(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        evm_revert v4 v5;
+        evm_revert v0 v1;
 }
 
 func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_34f1(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        evm_revert v4 v5;
+        evm_revert v0 v1;
 }
 
 func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_35af(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        evm_revert v4 v5;
+        evm_revert v0 v1;
 }
 
 func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_3bd1(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        evm_revert v4 v5;
+        evm_revert v0 v1;
 }
 
 func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_41e6(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        evm_revert v4 v5;
+        evm_revert v0 v1;
 }
 
 func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_62f4(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        evm_revert v4 v5;
+        evm_revert v0 v1;
 }
 
 func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_6471(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        evm_revert v4 v5;
+        evm_revert v0 v1;
 }
 
 func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_9e6f(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        evm_revert v4 v5;
+        evm_revert v0 v1;
 }
 
 func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_9fb4(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        evm_revert v4 v5;
+        evm_revert v0 v1;
 }
 
 func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_a28f(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        evm_revert v4 v5;
+        evm_revert v0 v1;
 }
 
 func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_cab9(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        evm_revert v4 v5;
+        evm_revert v0 v1;
 }
 
 func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_cb12(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        evm_revert v4 v5;
+        evm_revert v0 v1;
 }
 
 func private %core__lib__abi__round_up_words_a41d(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v4.i1 = eq v2 0.i256;
-        br v4 block2 block3;
+        v3.i1 = eq v0 0.i256;
+        br v3 block2 block3;
 
     block2:
         return 0.i256;
@@ -10553,9 +8862,8 @@ func private %core__lib__abi__round_up_words_a41d(v0.i256) -> i256 {
         jump block4;
 
     block4:
-        v5.i256 = mload v1 i256;
-        (v7.i256, v8.i1) = usubo v5 1.i256;
-        br v8 block5 block6;
+        (v6.i256, v7.i1) = usubo v0 1.i256;
+        br v7 block5 block6;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -10563,8 +8871,8 @@ func private %core__lib__abi__round_up_words_a41d(v0.i256) -> i256 {
         evm_revert 0.i256 36.i256;
 
     block6:
-        v14.i1 = eq 32.i256 0.i256;
-        br v14 block7 block8;
+        v13.i1 = eq 32.i256 0.i256;
+        br v13 block7 block8;
 
     block7:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -10572,31 +8880,28 @@ func private %core__lib__abi__round_up_words_a41d(v0.i256) -> i256 {
         evm_revert 0.i256 36.i256;
 
     block8:
-        (v16.i256, v17.i1) = evm_udivo v7 32.i256;
-        br v17 block5 block9;
+        (v15.i256, v16.i1) = evm_udivo v6 32.i256;
+        br v16 block5 block9;
 
     block9:
-        (v18.i256, v19.i1) = uaddo v16 1.i256;
-        br v19 block5 block10;
+        (v17.i256, v18.i1) = uaddo v15 1.i256;
+        br v18 block5 block10;
 
     block10:
-        (v20.i256, v21.i1) = umulo v18 32.i256;
-        br v21 block5 block11;
+        (v19.i256, v20.i1) = umulo v17 32.i256;
+        br v20 block5 block11;
 
     block11:
-        return v20;
+        return v19;
 }
 
 func private %core__lib__abi__round_up_words_a41d_0(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v4.i1 = eq v2 0.i256;
-        br v4 block2 block3;
+        v3.i1 = eq v0 0.i256;
+        br v3 block2 block3;
 
     block2:
         return 0.i256;
@@ -10605,9 +8910,8 @@ func private %core__lib__abi__round_up_words_a41d_0(v0.i256) -> i256 {
         jump block4;
 
     block4:
-        v5.i256 = mload v1 i256;
-        (v7.i256, v8.i1) = usubo v5 1.i256;
-        br v8 block5 block6;
+        (v6.i256, v7.i1) = usubo v0 1.i256;
+        br v7 block5 block6;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -10615,8 +8919,8 @@ func private %core__lib__abi__round_up_words_a41d_0(v0.i256) -> i256 {
         evm_revert 0.i256 36.i256;
 
     block6:
-        v14.i1 = eq 32.i256 0.i256;
-        br v14 block7 block8;
+        v13.i1 = eq 32.i256 0.i256;
+        br v13 block7 block8;
 
     block7:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -10624,31 +8928,28 @@ func private %core__lib__abi__round_up_words_a41d_0(v0.i256) -> i256 {
         evm_revert 0.i256 36.i256;
 
     block8:
-        (v16.i256, v17.i1) = evm_udivo v7 32.i256;
-        br v17 block5 block9;
+        (v15.i256, v16.i1) = evm_udivo v6 32.i256;
+        br v16 block5 block9;
 
     block9:
-        (v18.i256, v19.i1) = uaddo v16 1.i256;
-        br v19 block5 block10;
+        (v17.i256, v18.i1) = uaddo v15 1.i256;
+        br v18 block5 block10;
 
     block10:
-        (v20.i256, v21.i1) = umulo v18 32.i256;
-        br v21 block5 block11;
+        (v19.i256, v20.i1) = umulo v17 32.i256;
+        br v20 block5 block11;
 
     block11:
-        return v20;
+        return v19;
 }
 
 func private %core__lib__abi__round_up_words_b13c(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v4.i1 = eq v2 0.i256;
-        br v4 block2 block3;
+        v3.i1 = eq v0 0.i256;
+        br v3 block2 block3;
 
     block2:
         return 0.i256;
@@ -10657,9 +8958,8 @@ func private %core__lib__abi__round_up_words_b13c(v0.i256) -> i256 {
         jump block4;
 
     block4:
-        v5.i256 = mload v1 i256;
-        (v7.i256, v8.i1) = usubo v5 1.i256;
-        br v8 block5 block6;
+        (v6.i256, v7.i1) = usubo v0 1.i256;
+        br v7 block5 block6;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -10667,8 +8967,8 @@ func private %core__lib__abi__round_up_words_b13c(v0.i256) -> i256 {
         evm_revert 0.i256 36.i256;
 
     block6:
-        v14.i1 = eq 32.i256 0.i256;
-        br v14 block7 block8;
+        v13.i1 = eq 32.i256 0.i256;
+        br v13 block7 block8;
 
     block7:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -10676,31 +8976,28 @@ func private %core__lib__abi__round_up_words_b13c(v0.i256) -> i256 {
         evm_revert 0.i256 36.i256;
 
     block8:
-        (v16.i256, v17.i1) = evm_udivo v7 32.i256;
-        br v17 block5 block9;
+        (v15.i256, v16.i1) = evm_udivo v6 32.i256;
+        br v16 block5 block9;
 
     block9:
-        (v18.i256, v19.i1) = uaddo v16 1.i256;
-        br v19 block5 block10;
+        (v17.i256, v18.i1) = uaddo v15 1.i256;
+        br v18 block5 block10;
 
     block10:
-        (v20.i256, v21.i1) = umulo v18 32.i256;
-        br v21 block5 block11;
+        (v19.i256, v20.i1) = umulo v17 32.i256;
+        br v20 block5 block11;
 
     block11:
-        return v20;
+        return v19;
 }
 
 func private %core__lib__abi__round_up_words_b13c_0(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v4.i1 = eq v2 0.i256;
-        br v4 block2 block3;
+        v3.i1 = eq v0 0.i256;
+        br v3 block2 block3;
 
     block2:
         return 0.i256;
@@ -10709,9 +9006,8 @@ func private %core__lib__abi__round_up_words_b13c_0(v0.i256) -> i256 {
         jump block4;
 
     block4:
-        v5.i256 = mload v1 i256;
-        (v7.i256, v8.i1) = usubo v5 1.i256;
-        br v8 block5 block6;
+        (v6.i256, v7.i1) = usubo v0 1.i256;
+        br v7 block5 block6;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -10719,8 +9015,8 @@ func private %core__lib__abi__round_up_words_b13c_0(v0.i256) -> i256 {
         evm_revert 0.i256 36.i256;
 
     block6:
-        v14.i1 = eq 32.i256 0.i256;
-        br v14 block7 block8;
+        v13.i1 = eq 32.i256 0.i256;
+        br v13 block7 block8;
 
     block7:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -10728,19 +9024,19 @@ func private %core__lib__abi__round_up_words_b13c_0(v0.i256) -> i256 {
         evm_revert 0.i256 36.i256;
 
     block8:
-        (v16.i256, v17.i1) = evm_udivo v7 32.i256;
-        br v17 block5 block9;
+        (v15.i256, v16.i1) = evm_udivo v6 32.i256;
+        br v16 block5 block9;
 
     block9:
-        (v18.i256, v19.i1) = uaddo v16 1.i256;
-        br v19 block5 block10;
+        (v17.i256, v18.i1) = uaddo v15 1.i256;
+        br v18 block5 block10;
 
     block10:
-        (v20.i256, v21.i1) = umulo v18 32.i256;
-        br v21 block5 block11;
+        (v19.i256, v20.i1) = umulo v17 32.i256;
+        br v20 block5 block11;
 
     block11:
-        return v20;
+        return v19;
 }
 
 func inline(always) private %set__g2163(v0.@layout_0, v1.i256) {
@@ -10755,92 +9051,71 @@ func inline(always) private %set__g2163(v0.@layout_0, v1.i256) {
 
 func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_4735(v0.objref<@layout_4>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 1.i256;
-        obj.store v6 v3;
+        v5.objref<i256> = obj.proj v0 1.i256;
+        obj.store v5 v1;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_4735_0(v0.objref<@layout_4>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 1.i256;
-        obj.store v6 v3;
+        v5.objref<i256> = obj.proj v0 1.i256;
+        obj.store v5 v1;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_750c(v0.objref<@layout_1>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        obj.store v6 v3;
+        v5.objref<i256> = obj.proj v0 0.i256;
+        obj.store v5 v1;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_844b(v0.objref<@layout_1>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        obj.store v6 v3;
+        v5.objref<i256> = obj.proj v0 0.i256;
+        obj.store v5 v1;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_c5ff(v0.objref<@layout_1>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        obj.store v6 v3;
+        v5.objref<i256> = obj.proj v0 0.i256;
+        obj.store v5 v1;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_cc2c(v0.objref<@layout_1>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        obj.store v6 v3;
+        v5.objref<i256> = obj.proj v0 0.i256;
+        obj.store v5 v1;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_fa20(v0.objref<@layout_1>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        obj.store v6 v3;
+        v5.objref<i256> = obj.proj v0 0.i256;
+        obj.store v5 v1;
         return;
 }
 
@@ -10876,128 +9151,103 @@ func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__s
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_0f4a(v0.objref<@layout_1>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 1.i256;
-        obj.store v6 v3;
+        v5.objref<i256> = obj.proj v0 1.i256;
+        obj.store v5 v1;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_3857(v0.objref<@layout_1>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 1.i256;
-        obj.store v6 v3;
+        v5.objref<i256> = obj.proj v0 1.i256;
+        obj.store v5 v1;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_597d(v0.objref<@layout_1>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 1.i256;
-        obj.store v6 v3;
+        v5.objref<i256> = obj.proj v0 1.i256;
+        obj.store v5 v1;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_7410(v0.objref<@layout_1>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 1.i256;
-        obj.store v6 v3;
+        v5.objref<i256> = obj.proj v0 1.i256;
+        obj.store v5 v1;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_ae9c(v0.objref<@layout_4>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<@layout_3> = obj.proj v0 0.i256;
-        v8.objref<i256> = obj.proj v6 1.i256;
-        obj.store v8 v3;
+        v5.objref<@layout_3> = obj.proj v0 0.i256;
+        v7.objref<i256> = obj.proj v5 1.i256;
+        obj.store v7 v1;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_ae9c_0(v0.objref<@layout_4>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<@layout_3> = obj.proj v0 0.i256;
-        v8.objref<i256> = obj.proj v6 1.i256;
-        obj.store v8 v3;
+        v5.objref<@layout_3> = obj.proj v0 0.i256;
+        v7.objref<i256> = obj.proj v5 1.i256;
+        obj.store v7 v1;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_b6ef(v0.objref<@layout_1>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 1.i256;
-        obj.store v6 v3;
+        v5.objref<i256> = obj.proj v0 1.i256;
+        obj.store v5 v1;
         return;
 }
 
 func private %standalone_erc20__erc20__spend_allowance__ga033_1943(v0.@layout_0, v1.@layout_0, v2.i256, v3.i256) {
     block0:
-        v4.*i256 = alloca i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v9.@layout_22 = insert_value undef.@layout_22 0.i256 v0;
-        v11.@layout_22 = insert_value v9 1.i256 v1;
-        v12.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get__ga15b_b5d5 v11;
-        v13.i256 = mload v4 i256;
-        v14.i1 = lt v12 v13;
-        v15.i1 = is_zero v14;
-        br v15 block2 block3;
+        v8.@layout_22 = insert_value undef.@layout_22 0.i256 v0;
+        v10.@layout_22 = insert_value v8 1.i256 v1;
+        v11.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get__ga15b_b5d5 v10;
+        v13.i1 = lt v11 v2;
+        v14.i1 = is_zero v13;
+        br v14 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v18.*i8 = evm_malloc 64.i256;
-        v19.i256 = ptr_to_int v18 i256;
-        mstore v19 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        (v23.i256, v24.i1) = uaddo v19 32.i256;
-        br v24 block5 block6;
+        v17.*i8 = evm_malloc 64.i256;
+        v18.i256 = ptr_to_int v17 i256;
+        mstore v18 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        (v22.i256, v23.i1) = uaddo v18 32.i256;
+        br v23 block5 block6;
 
     block4:
-        v34.@layout_22 = insert_value undef.@layout_22 0.i256 v0;
-        v35.@layout_22 = insert_value v34 1.i256 v1;
-        v36.i256 = mload v4 i256;
-        (v38.i256, v39.i1) = usubo v12 v36;
-        br v39 block5 block7;
+        v33.@layout_22 = insert_value undef.@layout_22 0.i256 v0;
+        v34.@layout_22 = insert_value v33 1.i256 v1;
+        (v37.i256, v38.i1) = usubo v11 v2;
+        br v38 block5 block7;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -11005,45 +9255,41 @@ func private %standalone_erc20__erc20__spend_allowance__ga033_1943(v0.@layout_0,
         evm_revert 0.i256 36.i256;
 
     block6:
-        mstore v23 26959946667150639794667015087019630673637144422540572481103610249216.i256 i256;
-        evm_revert v19 36.i256;
+        mstore v22 26959946667150639794667015087019630673637144422540572481103610249216.i256 i256;
+        evm_revert v18 36.i256;
 
     block7:
-        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set__ga15b_f7f7 v35 v38;
+        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set__ga15b_f7f7 v34 v37;
         return;
 }
 
 func private %standalone_erc20__erc20__spend_allowance__ga033_1943_0(v0.@layout_0, v1.@layout_0, v2.i256, v3.i256) {
     block0:
-        v4.*i256 = alloca i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v9.@layout_22 = insert_value undef.@layout_22 0.i256 v0;
-        v11.@layout_22 = insert_value v9 1.i256 v1;
-        v12.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get__ga15b_b5d5 v11;
-        v13.i256 = mload v4 i256;
-        v14.i1 = lt v12 v13;
-        v15.i1 = is_zero v14;
-        br v15 block2 block3;
+        v8.@layout_22 = insert_value undef.@layout_22 0.i256 v0;
+        v10.@layout_22 = insert_value v8 1.i256 v1;
+        v11.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get__ga15b_b5d5 v10;
+        v13.i1 = lt v11 v2;
+        v14.i1 = is_zero v13;
+        br v14 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v18.*i8 = evm_malloc 64.i256;
-        v19.i256 = ptr_to_int v18 i256;
-        mstore v19 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        (v23.i256, v24.i1) = uaddo v19 32.i256;
-        br v24 block5 block6;
+        v17.*i8 = evm_malloc 64.i256;
+        v18.i256 = ptr_to_int v17 i256;
+        mstore v18 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        (v22.i256, v23.i1) = uaddo v18 32.i256;
+        br v23 block5 block6;
 
     block4:
-        v34.@layout_22 = insert_value undef.@layout_22 0.i256 v0;
-        v35.@layout_22 = insert_value v34 1.i256 v1;
-        v36.i256 = mload v4 i256;
-        (v38.i256, v39.i1) = usubo v12 v36;
-        br v39 block5 block7;
+        v33.@layout_22 = insert_value undef.@layout_22 0.i256 v0;
+        v34.@layout_22 = insert_value v33 1.i256 v1;
+        (v37.i256, v38.i1) = usubo v11 v2;
+        br v38 block5 block7;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -11051,168 +9297,124 @@ func private %standalone_erc20__erc20__spend_allowance__ga033_1943_0(v0.@layout_
         evm_revert 0.i256 36.i256;
 
     block6:
-        mstore v23 26959946667150639794667015087019630673637144422540572481103610249216.i256 i256;
-        evm_revert v19 36.i256;
+        mstore v22 26959946667150639794667015087019630673637144422540572481103610249216.i256 i256;
+        evm_revert v18 36.i256;
 
     block7:
-        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set__ga15b_f7f7 v35 v38;
+        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set__ga15b_f7f7 v34 v37;
         return;
 }
 
 func inline(always) private %std__lib__evm__storage_map__storagemap_get_word_with_salt__g7bf4_09af(v0.@layout_22, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v5.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_e3d6 v0 v3;
-        v6.i256 = evm_sload v5;
-        return v6;
+        v4.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_e3d6 v0 v1;
+        v5.i256 = evm_sload v4;
+        return v5;
 }
 
 func inline(always) private %std__lib__evm__storage_map__storagemap_get_word_with_salt__g7bf4_09af_0(v0.@layout_22, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v5.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_e3d6_1 v0 v3;
-        v6.i256 = evm_sload v5;
-        return v6;
+        v4.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_e3d6_1 v0 v1;
+        v5.i256 = evm_sload v4;
+        return v5;
 }
 
 func inline(always) private %std__lib__evm__storage_map__storagemap_get_word_with_salt__g67a8_4599(v0.@layout_0, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v5.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g67a8_9f5e v0 v3;
-        v6.i256 = evm_sload v5;
-        return v6;
+        v4.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g67a8_9f5e v0 v1;
+        v5.i256 = evm_sload v4;
+        return v5;
 }
 
 func inline(always) private %storagemap_get_word_with_salt__g9379(v0.@layout_16, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v5.i256 = call %storagemap_storage_slot_with_salt__g9379 v0 v3;
-        v6.i256 = evm_sload v5;
-        return v6;
+        v4.i256 = call %storagemap_storage_slot_with_salt__g9379 v0 v1;
+        v5.i256 = evm_sload v4;
+        return v5;
 }
 
 func inline(always) private %std__lib__evm__storage_map__storagemap_get_word_with_salt__g67a8_7941(v0.@layout_0, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v5.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g67a8_2dee v0 v3;
-        v6.i256 = evm_sload v5;
-        return v6;
+        v4.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g67a8_2dee v0 v1;
+        v5.i256 = evm_sload v4;
+        return v5;
 }
 
 func inline(always) private %std__lib__evm__storage_map__storagemap_get_word_with_salt__g7bf4_af75(v0.@layout_22, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v5.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_2a19 v0 v3;
-        v6.i256 = evm_sload v5;
-        return v6;
+        v4.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_2a19 v0 v1;
+        v5.i256 = evm_sload v4;
+        return v5;
 }
 
 func inline(always) private %storagemap_set_word_with_salt__g67a8(v0.@layout_0, v1.i256, v2.i256) {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v3 i256;
-        v7.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g67a8_2dee v0 v5;
-        v8.i256 = mload v4 i256;
-        evm_sstore v7 v8;
+        v5.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g67a8_2dee v0 v1;
+        evm_sstore v5 v2;
         return;
 }
 
 func inline(always) private %std__lib__evm__storage_map__storagemap_set_word_with_salt__g7bf4_7aa4(v0.@layout_22, v1.i256, v2.i256) {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v3 i256;
-        v7.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_e3d6 v0 v5;
-        v8.i256 = mload v4 i256;
-        evm_sstore v7 v8;
+        v5.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_e3d6 v0 v1;
+        evm_sstore v5 v2;
         return;
 }
 
 func inline(always) private %std__lib__evm__storage_map__storagemap_set_word_with_salt__g7bf4_7aa4_0(v0.@layout_22, v1.i256, v2.i256) {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v3 i256;
-        v7.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_e3d6_0 v0 v5;
-        v8.i256 = mload v4 i256;
-        evm_sstore v7 v8;
+        v5.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_e3d6_0 v0 v1;
+        evm_sstore v5 v2;
         return;
 }
 
 func inline(always) private %storagemap_set_word_with_salt__g9379(v0.@layout_16, v1.i256, v2.i256) {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v3 i256;
-        v7.i256 = call %storagemap_storage_slot_with_salt__g9379 v0 v5;
-        v8.i256 = mload v4 i256;
-        evm_sstore v7 v8;
+        v5.i256 = call %storagemap_storage_slot_with_salt__g9379 v0 v1;
+        evm_sstore v5 v2;
         return;
 }
 
 func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_2a19(v0.@layout_22, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.*i8 = evm_malloc 0.i256;
-        v5.i256 = ptr_to_int v4 i256;
-        v7.i256 = call %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_2c8a v5 v0;
-        (v8.i256, v9.i1) = uaddo v5 v7;
-        br v9 block2 block3;
+        v3.*i8 = evm_malloc 0.i256;
+        v4.i256 = ptr_to_int v3 i256;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_2c8a v4 v0;
+        (v7.i256, v8.i1) = uaddo v4 v6;
+        br v8 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -11220,28 +9422,25 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot
         evm_revert 0.i256 36.i256;
 
     block3:
-        v14.i256 = mload v2 i256;
-        mstore v8 v14 i256;
-        (v18.i256, v19.i1) = uaddo v7 32.i256;
-        br v19 block2 block4;
+        mstore v7 v1 i256;
+        (v17.i256, v18.i1) = uaddo v6 32.i256;
+        br v18 block2 block4;
 
     block4:
-        v21.i256 = evm_keccak256 v5 v18;
-        return v21;
+        v20.i256 = evm_keccak256 v4 v17;
+        return v20;
 }
 
 func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g67a8_2dee(v0.@layout_0, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.*i8 = evm_malloc 0.i256;
-        v5.i256 = ptr_to_int v4 i256;
-        v7.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_686a v5 v0;
-        (v8.i256, v9.i1) = uaddo v5 v7;
-        br v9 block2 block3;
+        v3.*i8 = evm_malloc 0.i256;
+        v4.i256 = ptr_to_int v3 i256;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_686a v4 v0;
+        (v7.i256, v8.i1) = uaddo v4 v6;
+        br v8 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -11249,28 +9448,25 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot
         evm_revert 0.i256 36.i256;
 
     block3:
-        v14.i256 = mload v2 i256;
-        mstore v8 v14 i256;
-        (v18.i256, v19.i1) = uaddo v7 32.i256;
-        br v19 block2 block4;
+        mstore v7 v1 i256;
+        (v17.i256, v18.i1) = uaddo v6 32.i256;
+        br v18 block2 block4;
 
     block4:
-        v21.i256 = evm_keccak256 v5 v18;
-        return v21;
+        v20.i256 = evm_keccak256 v4 v17;
+        return v20;
 }
 
 func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g67a8_9f5e(v0.@layout_0, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.*i8 = evm_malloc 0.i256;
-        v5.i256 = ptr_to_int v4 i256;
-        v7.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_3658 v5 v0;
-        (v8.i256, v9.i1) = uaddo v5 v7;
-        br v9 block2 block3;
+        v3.*i8 = evm_malloc 0.i256;
+        v4.i256 = ptr_to_int v3 i256;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_3658 v4 v0;
+        (v7.i256, v8.i1) = uaddo v4 v6;
+        br v8 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -11278,28 +9474,25 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot
         evm_revert 0.i256 36.i256;
 
     block3:
-        v14.i256 = mload v2 i256;
-        mstore v8 v14 i256;
-        (v18.i256, v19.i1) = uaddo v7 32.i256;
-        br v19 block2 block4;
+        mstore v7 v1 i256;
+        (v17.i256, v18.i1) = uaddo v6 32.i256;
+        br v18 block2 block4;
 
     block4:
-        v21.i256 = evm_keccak256 v5 v18;
-        return v21;
+        v20.i256 = evm_keccak256 v4 v17;
+        return v20;
 }
 
 func inline(always) private %storagemap_storage_slot_with_salt__g9379(v0.@layout_16, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.*i8 = evm_malloc 0.i256;
-        v5.i256 = ptr_to_int v4 i256;
-        v7.i256 = call %write_key__g6d15 v5 v0;
-        (v8.i256, v9.i1) = uaddo v5 v7;
-        br v9 block2 block3;
+        v3.*i8 = evm_malloc 0.i256;
+        v4.i256 = ptr_to_int v3 i256;
+        v6.i256 = call %write_key__g6d15 v4 v0;
+        (v7.i256, v8.i1) = uaddo v4 v6;
+        br v8 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -11307,28 +9500,25 @@ func inline(always) private %storagemap_storage_slot_with_salt__g9379(v0.@layout
         evm_revert 0.i256 36.i256;
 
     block3:
-        v14.i256 = mload v2 i256;
-        mstore v8 v14 i256;
-        (v18.i256, v19.i1) = uaddo v7 32.i256;
-        br v19 block2 block4;
+        mstore v7 v1 i256;
+        (v17.i256, v18.i1) = uaddo v6 32.i256;
+        br v18 block2 block4;
 
     block4:
-        v21.i256 = evm_keccak256 v5 v18;
-        return v21;
+        v20.i256 = evm_keccak256 v4 v17;
+        return v20;
 }
 
 func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_e3d6(v0.@layout_22, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.*i8 = evm_malloc 0.i256;
-        v5.i256 = ptr_to_int v4 i256;
-        v7.i256 = call %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_ba59 v5 v0;
-        (v8.i256, v9.i1) = uaddo v5 v7;
-        br v9 block2 block3;
+        v3.*i8 = evm_malloc 0.i256;
+        v4.i256 = ptr_to_int v3 i256;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_ba59 v4 v0;
+        (v7.i256, v8.i1) = uaddo v4 v6;
+        br v8 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -11336,28 +9526,25 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot
         evm_revert 0.i256 36.i256;
 
     block3:
-        v14.i256 = mload v2 i256;
-        mstore v8 v14 i256;
-        (v18.i256, v19.i1) = uaddo v7 32.i256;
-        br v19 block2 block4;
+        mstore v7 v1 i256;
+        (v17.i256, v18.i1) = uaddo v6 32.i256;
+        br v18 block2 block4;
 
     block4:
-        v21.i256 = evm_keccak256 v5 v18;
-        return v21;
+        v20.i256 = evm_keccak256 v4 v17;
+        return v20;
 }
 
 func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_e3d6_0(v0.@layout_22, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.*i8 = evm_malloc 0.i256;
-        v5.i256 = ptr_to_int v4 i256;
-        v7.i256 = call %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_ba59_0 v5 v0;
-        (v8.i256, v9.i1) = uaddo v5 v7;
-        br v9 block2 block3;
+        v3.*i8 = evm_malloc 0.i256;
+        v4.i256 = ptr_to_int v3 i256;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_ba59_0 v4 v0;
+        (v7.i256, v8.i1) = uaddo v4 v6;
+        br v8 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -11365,28 +9552,25 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot
         evm_revert 0.i256 36.i256;
 
     block3:
-        v14.i256 = mload v2 i256;
-        mstore v8 v14 i256;
-        (v18.i256, v19.i1) = uaddo v7 32.i256;
-        br v19 block2 block4;
+        mstore v7 v1 i256;
+        (v17.i256, v18.i1) = uaddo v6 32.i256;
+        br v18 block2 block4;
 
     block4:
-        v21.i256 = evm_keccak256 v5 v18;
-        return v21;
+        v20.i256 = evm_keccak256 v4 v17;
+        return v20;
 }
 
 func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_e3d6_1(v0.@layout_22, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.*i8 = evm_malloc 0.i256;
-        v5.i256 = ptr_to_int v4 i256;
-        v7.i256 = call %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_ba59_1 v5 v0;
-        (v8.i256, v9.i1) = uaddo v5 v7;
-        br v9 block2 block3;
+        v3.*i8 = evm_malloc 0.i256;
+        v4.i256 = ptr_to_int v3 i256;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_ba59_1 v4 v0;
+        (v7.i256, v8.i1) = uaddo v4 v6;
+        br v8 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -11394,58 +9578,39 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot
         evm_revert 0.i256 36.i256;
 
     block3:
-        v14.i256 = mload v2 i256;
-        mstore v8 v14 i256;
-        (v18.i256, v19.i1) = uaddo v7 32.i256;
-        br v19 block2 block4;
+        mstore v7 v1 i256;
+        (v17.i256, v18.i1) = uaddo v6 32.i256;
+        br v18 block2 block4;
 
     block4:
-        v21.i256 = evm_keccak256 v5 v18;
-        return v21;
+        v20.i256 = evm_keccak256 v4 v17;
+        return v20;
 }
 
 func private %std__lib__abi__sol__impl_trait_Sol_1f5f__store_word_2361(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        mstore v4 v5 i256;
+        mstore v0 v1 i256;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_Sol_1f5f__store_word_2c7e(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        mstore v4 v5 i256;
+        mstore v0 v1 i256;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_Sol_1f5f__store_word_be96(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        mstore v4 v5 i256;
+        mstore v0 v1 i256;
         return;
 }
 
@@ -11467,26 +9632,20 @@ func private %std__lib__evm__word__impl_trait_u256_1f9e__to_word_05d2_0(v0.i256)
 
 func private %core__lib__num__impl_trait_String_8f88__to_word__g3eb7_38b3(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v9.i256 = and v2 452312848583266388373324160190187140051835877600158453279131187530910662655.i256;
-        return v9;
+        v8.i256 = and v0 452312848583266388373324160190187140051835877600158453279131187530910662655.i256;
+        return v8;
 }
 
 func private %core__lib__num__impl_trait_String_8f88__to_word__g3eb7_38b3_0(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v9.i256 = and v2 452312848583266388373324160190187140051835877600158453279131187530910662655.i256;
-        return v9;
+        v8.i256 = and v0 452312848583266388373324160190187140051835877600158453279131187530910662655.i256;
+        return v8;
 }
 
 func private %std__lib__evm__word__impl_trait_u256_1f9e__to_word_3e9f(v0.i256) -> i256 {
@@ -11499,50 +9658,38 @@ func private %std__lib__evm__word__impl_trait_u256_1f9e__to_word_3e9f(v0.i256) -
 
 func private %core__lib__num__impl_trait_String_8f88__to_word__g3eb7_4283(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v9.i256 = and v2 452312848583266388373324160190187140051835877600158453279131187530910662655.i256;
-        return v9;
+        v8.i256 = and v0 452312848583266388373324160190187140051835877600158453279131187530910662655.i256;
+        return v8;
 }
 
 func private %core__lib__num__impl_trait_String_8f88__to_word__gc7cf_518a(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v8.i256 = and v2 18446744073709551615.i256;
-        return v8;
+        v7.i256 = and v0 18446744073709551615.i256;
+        return v7;
 }
 
 func private %core__lib__num__impl_trait_String_8f88__to_word__gc7cf_518a_0(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v8.i256 = and v2 18446744073709551615.i256;
-        return v8;
+        v7.i256 = and v0 18446744073709551615.i256;
+        return v7;
 }
 
 func private %core__lib__num__impl_trait_String_8f88__to_word__gc7cf_de49(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v8.i256 = and v2 18446744073709551615.i256;
-        return v8;
+        v7.i256 = and v0 18446744073709551615.i256;
+        return v7;
 }
 
 func private %impl_trait_bool__to_word(v0.i1) -> i256 {
@@ -11565,71 +9712,67 @@ func private %impl_trait_bool__to_word(v0.i1) -> i256 {
 
 func private %standalone_erc20__erc20__transfer__g5c3f_3bfd(v0.@layout_0, v1.@layout_0, v2.i256, v3.i256) {
     block0:
-        v4.*i256 = alloca i256;
+        v4.objref<@layout_0> = obj.alloc @layout_0;
         v5.objref<@layout_0> = obj.alloc @layout_0;
-        v6.objref<@layout_0> = obj.alloc @layout_0;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v8.@layout_0 = call %zero;
-        v10.objref<i256> = obj.proj v5 0.i256;
-        v11.i256 = extract_value v8 0.i256;
-        obj.store v10 v11;
-        v12.@layout_0 = obj.load v5;
-        v13.i1 = call %ne v0 v12;
-        br v13 block2 block3;
+        v7.@layout_0 = call %zero;
+        v9.objref<i256> = obj.proj v4 0.i256;
+        v10.i256 = extract_value v7 0.i256;
+        obj.store v9 v10;
+        v11.@layout_0 = obj.load v4;
+        v12.i1 = call %ne v0 v11;
+        br v12 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v16.*i8 = evm_malloc 64.i256;
-        v17.i256 = ptr_to_int v16 i256;
-        mstore v17 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        (v21.i256, v22.i1) = uaddo v17 32.i256;
-        br v22 block11 block12;
+        v15.*i8 = evm_malloc 64.i256;
+        v16.i256 = ptr_to_int v15 i256;
+        mstore v16 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        (v20.i256, v21.i1) = uaddo v16 32.i256;
+        br v21 block11 block12;
 
     block4:
-        v30.@layout_0 = call %zero;
-        v31.objref<i256> = obj.proj v6 0.i256;
-        v32.i256 = extract_value v30 0.i256;
-        obj.store v31 v32;
-        v33.@layout_0 = obj.load v6;
-        v34.i1 = call %ne v1 v33;
-        br v34 block5 block6;
+        v29.@layout_0 = call %zero;
+        v30.objref<i256> = obj.proj v5 0.i256;
+        v31.i256 = extract_value v29 0.i256;
+        obj.store v30 v31;
+        v32.@layout_0 = obj.load v5;
+        v33.i1 = call %ne v1 v32;
+        br v33 block5 block6;
 
     block5:
         jump block7;
 
     block6:
-        v35.*i8 = evm_malloc 64.i256;
-        v36.i256 = ptr_to_int v35 i256;
-        mstore v36 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        (v38.i256, v39.i1) = uaddo v36 32.i256;
-        br v39 block11 block13;
+        v34.*i8 = evm_malloc 64.i256;
+        v35.i256 = ptr_to_int v34 i256;
+        mstore v35 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        (v37.i256, v38.i1) = uaddo v35 32.i256;
+        br v38 block11 block13;
 
     block7:
-        v44.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get__g2163_8a15 v0;
-        v45.i256 = mload v4 i256;
-        v46.i1 = lt v44 v45;
-        v47.i1 = is_zero v46;
-        br v47 block8 block9;
+        v43.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get__g2163_8a15 v0;
+        v45.i1 = lt v43 v2;
+        v46.i1 = is_zero v45;
+        br v46 block8 block9;
 
     block8:
         jump block10;
 
     block9:
-        v48.*i8 = evm_malloc 64.i256;
-        v49.i256 = ptr_to_int v48 i256;
-        mstore v49 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        (v51.i256, v52.i1) = uaddo v49 32.i256;
-        br v52 block11 block14;
+        v47.*i8 = evm_malloc 64.i256;
+        v48.i256 = ptr_to_int v47 i256;
+        mstore v48 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        (v50.i256, v51.i1) = uaddo v48 32.i256;
+        br v51 block11 block14;
 
     block10:
-        v57.i256 = mload v4 i256;
-        (v59.i256, v60.i1) = usubo v44 v57;
-        br v60 block11 block15;
+        (v58.i256, v59.i1) = usubo v43 v2;
+        br v59 block11 block15;
 
     block11:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -11637,101 +9780,95 @@ func private %standalone_erc20__erc20__transfer__g5c3f_3bfd(v0.@layout_0, v1.@la
         evm_revert 0.i256 36.i256;
 
     block12:
-        mstore v21 26959946667150639794667015087019630673637144422540572481103610249216.i256 i256;
-        evm_revert v17 36.i256;
+        mstore v20 26959946667150639794667015087019630673637144422540572481103610249216.i256 i256;
+        evm_revert v16 36.i256;
 
     block13:
-        mstore v38 26959946667150639794667015087019630673637144422540572481103610249216.i256 i256;
-        evm_revert v36 36.i256;
+        mstore v37 26959946667150639794667015087019630673637144422540572481103610249216.i256 i256;
+        evm_revert v35 36.i256;
 
     block14:
-        mstore v51 26959946667150639794667015087019630673637144422540572481103610249216.i256 i256;
-        evm_revert v49 36.i256;
+        mstore v50 26959946667150639794667015087019630673637144422540572481103610249216.i256 i256;
+        evm_revert v48 36.i256;
 
     block15:
-        call %set__g2163 v0 v59;
-        v64.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get__g2163_8a15 v1;
-        v65.i256 = mload v4 i256;
-        (v66.i256, v67.i1) = uaddo v64 v65;
-        br v67 block11 block16;
+        call %set__g2163 v0 v58;
+        v63.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get__g2163_8a15 v1;
+        (v65.i256, v66.i1) = uaddo v63 v2;
+        br v66 block11 block16;
 
     block16:
-        call %set__g2163 v1 v66;
-        v72.i256 = mload v4 i256;
-        v74.@layout_19 = insert_value undef.@layout_19 0.i256 v0;
-        v76.@layout_19 = insert_value v74 1.i256 v1;
-        v78.@layout_19 = insert_value v76 2.i256 v72;
-        call %emit__g4c3d v78;
+        call %set__g2163 v1 v65;
+        v73.@layout_19 = insert_value undef.@layout_19 0.i256 v0;
+        v75.@layout_19 = insert_value v73 1.i256 v1;
+        v77.@layout_19 = insert_value v75 2.i256 v2;
+        call %emit__g4c3d v77;
         return;
 }
 
 func private %standalone_erc20__erc20__transfer__g5c3f_d8a9(v0.@layout_0, v1.@layout_0, v2.i256, v3.i256) {
     block0:
-        v4.*i256 = alloca i256;
+        v4.objref<@layout_0> = obj.alloc @layout_0;
         v5.objref<@layout_0> = obj.alloc @layout_0;
-        v6.objref<@layout_0> = obj.alloc @layout_0;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v8.@layout_0 = call %zero;
-        v10.objref<i256> = obj.proj v5 0.i256;
-        v11.i256 = extract_value v8 0.i256;
-        obj.store v10 v11;
-        v12.@layout_0 = obj.load v5;
-        v13.i1 = call %ne v0 v12;
-        br v13 block2 block3;
+        v7.@layout_0 = call %zero;
+        v9.objref<i256> = obj.proj v4 0.i256;
+        v10.i256 = extract_value v7 0.i256;
+        obj.store v9 v10;
+        v11.@layout_0 = obj.load v4;
+        v12.i1 = call %ne v0 v11;
+        br v12 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v16.*i8 = evm_malloc 64.i256;
-        v17.i256 = ptr_to_int v16 i256;
-        mstore v17 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        (v21.i256, v22.i1) = uaddo v17 32.i256;
-        br v22 block11 block12;
+        v15.*i8 = evm_malloc 64.i256;
+        v16.i256 = ptr_to_int v15 i256;
+        mstore v16 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        (v20.i256, v21.i1) = uaddo v16 32.i256;
+        br v21 block11 block12;
 
     block4:
-        v30.@layout_0 = call %zero;
-        v31.objref<i256> = obj.proj v6 0.i256;
-        v32.i256 = extract_value v30 0.i256;
-        obj.store v31 v32;
-        v33.@layout_0 = obj.load v6;
-        v34.i1 = call %ne v1 v33;
-        br v34 block5 block6;
+        v29.@layout_0 = call %zero;
+        v30.objref<i256> = obj.proj v5 0.i256;
+        v31.i256 = extract_value v29 0.i256;
+        obj.store v30 v31;
+        v32.@layout_0 = obj.load v5;
+        v33.i1 = call %ne v1 v32;
+        br v33 block5 block6;
 
     block5:
         jump block7;
 
     block6:
-        v35.*i8 = evm_malloc 64.i256;
-        v36.i256 = ptr_to_int v35 i256;
-        mstore v36 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        (v38.i256, v39.i1) = uaddo v36 32.i256;
-        br v39 block11 block13;
+        v34.*i8 = evm_malloc 64.i256;
+        v35.i256 = ptr_to_int v34 i256;
+        mstore v35 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        (v37.i256, v38.i1) = uaddo v35 32.i256;
+        br v38 block11 block13;
 
     block7:
-        v44.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get__g2163_8a15 v0;
-        v45.i256 = mload v4 i256;
-        v46.i1 = lt v44 v45;
-        v47.i1 = is_zero v46;
-        br v47 block8 block9;
+        v43.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get__g2163_8a15 v0;
+        v45.i1 = lt v43 v2;
+        v46.i1 = is_zero v45;
+        br v46 block8 block9;
 
     block8:
         jump block10;
 
     block9:
-        v48.*i8 = evm_malloc 64.i256;
-        v49.i256 = ptr_to_int v48 i256;
-        mstore v49 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
-        (v51.i256, v52.i1) = uaddo v49 32.i256;
-        br v52 block11 block14;
+        v47.*i8 = evm_malloc 64.i256;
+        v48.i256 = ptr_to_int v47 i256;
+        mstore v48 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
+        (v50.i256, v51.i1) = uaddo v48 32.i256;
+        br v51 block11 block14;
 
     block10:
-        v57.i256 = mload v4 i256;
-        (v59.i256, v60.i1) = usubo v44 v57;
-        br v60 block11 block15;
+        (v58.i256, v59.i1) = usubo v43 v2;
+        br v59 block11 block15;
 
     block11:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -11739,834 +9876,660 @@ func private %standalone_erc20__erc20__transfer__g5c3f_d8a9(v0.@layout_0, v1.@la
         evm_revert 0.i256 36.i256;
 
     block12:
-        mstore v21 26959946667150639794667015087019630673637144422540572481103610249216.i256 i256;
-        evm_revert v17 36.i256;
+        mstore v20 26959946667150639794667015087019630673637144422540572481103610249216.i256 i256;
+        evm_revert v16 36.i256;
 
     block13:
-        mstore v38 26959946667150639794667015087019630673637144422540572481103610249216.i256 i256;
-        evm_revert v36 36.i256;
+        mstore v37 26959946667150639794667015087019630673637144422540572481103610249216.i256 i256;
+        evm_revert v35 36.i256;
 
     block14:
-        mstore v51 26959946667150639794667015087019630673637144422540572481103610249216.i256 i256;
-        evm_revert v49 36.i256;
+        mstore v50 26959946667150639794667015087019630673637144422540572481103610249216.i256 i256;
+        evm_revert v48 36.i256;
 
     block15:
-        call %set__g2163 v0 v59;
-        v64.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get__g2163_8a15 v1;
-        v65.i256 = mload v4 i256;
-        (v66.i256, v67.i1) = uaddo v64 v65;
-        br v67 block11 block16;
+        call %set__g2163 v0 v58;
+        v63.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get__g2163_8a15 v1;
+        (v65.i256, v66.i1) = uaddo v63 v2;
+        br v66 block11 block16;
 
     block16:
-        call %set__g2163 v1 v66;
-        v72.i256 = mload v4 i256;
-        v74.@layout_19 = insert_value undef.@layout_19 0.i256 v0;
-        v76.@layout_19 = insert_value v74 1.i256 v1;
-        v78.@layout_19 = insert_value v76 2.i256 v72;
-        call %emit__g4c3d v78;
+        call %set__g2163 v1 v65;
+        v73.@layout_19 = insert_value undef.@layout_19 0.i256 v0;
+        v75.@layout_19 = insert_value v73 1.i256 v1;
+        v77.@layout_19 = insert_value v75 2.i256 v2;
+        call %emit__g4c3d v77;
         return;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_0f5c(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_27ad(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3a1f(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3a1f_0(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3ba3(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3ba3_0(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3bad(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_3bad_0(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_40a0(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_40a0_0(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_49c5(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_5ce9(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_6576(v0.objref<@layout_2>, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = mload v8 i256;
-        return v9;
+        v4.objref<i256> = obj.proj v0 0.i256;
+        v5.i256 = obj.load v4;
+        v7.i256 = add v5 v1;
+        v8.i256 = mload v7 i256;
+        return v8;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_69bf(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_6dae(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_780b(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_790f(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_790f_0(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_7946(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_7f19(v0.objref<@layout_2>, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = mload v8 i256;
-        return v9;
+        v4.objref<i256> = obj.proj v0 0.i256;
+        v5.i256 = obj.load v4;
+        v7.i256 = add v5 v1;
+        v8.i256 = mload v7 i256;
+        return v8;
 }
 
 func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_7f19_0(v0.objref<@layout_2>, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = mload v8 i256;
-        return v9;
+        v4.objref<i256> = obj.proj v0 0.i256;
+        v5.i256 = obj.load v4;
+        v7.i256 = add v5 v1;
+        v8.i256 = mload v7 i256;
+        return v8;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_8736(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_8736_0(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_88a1(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_9725(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_9757(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_9757_0(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_a6b2(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_a6b2_0(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_a8d6(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_a8d6_0(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b461(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b461_0(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b705(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b705_0(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b870(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b9ca(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_b9ca_0(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_bae8(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_bae8_0(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c259(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c2d4(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c32c(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c700(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_c700_0(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_ce64(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_d831(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_d831_0(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_e134(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_e134_0(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_faf2(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_fb71(v0.objref<@layout_2>, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = mload v8 i256;
-        return v9;
+        v4.objref<i256> = obj.proj v0 0.i256;
+        v5.i256 = obj.load v4;
+        v7.i256 = add v5 v1;
+        v8.i256 = mload v7 i256;
+        return v8;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_fdcb(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_fec2(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_fec2_0(v0.@layout_5, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_1cfc(v0.i256, v1.@layout_0) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v0 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.i256 = extract_value v1 0.i256;
-        v7.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_98d1 v3 v6;
-        return v7;
+        v5.i256 = extract_value v1 0.i256;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_98d1 v0 v5;
+        return v6;
 }
 
 func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_2c8a(v0.i256, v1.@layout_22) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v0 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.@layout_0 = extract_value v1 0.i256;
-        v7.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_1cfc v3 v6;
-        v8.i256 = mload v2 i256;
-        (v9.i256, v10.i1) = uaddo v8 v7;
-        br v10 block2 block3;
+        v5.@layout_0 = extract_value v1 0.i256;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_1cfc v0 v5;
+        (v7.i256, v8.i1) = uaddo v0 v6;
+        br v8 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -12574,142 +10537,99 @@ func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__wri
         evm_revert 0.i256 36.i256;
 
     block3:
-        v17.@layout_0 = extract_value v1 1.i256;
-        v18.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_1cfc v9 v17;
-        (v20.i256, v21.i1) = uaddo v7 v18;
-        br v21 block2 block4;
+        v15.@layout_0 = extract_value v1 1.i256;
+        v16.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_1cfc v7 v15;
+        (v18.i256, v19.i1) = uaddo v6 v16;
+        br v19 block2 block4;
 
     block4:
-        return v20;
+        return v18;
 }
 
 func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_3658(v0.i256, v1.@layout_0) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v0 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.i256 = extract_value v1 0.i256;
-        v7.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_e672 v3 v6;
-        return v7;
+        v5.i256 = extract_value v1 0.i256;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_e672 v0 v5;
+        return v6;
 }
 
 func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_526f(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        mstore v4 v5 i256;
+        mstore v0 v1 i256;
         return 32.i256;
 }
 
 func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_526f_0(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        mstore v4 v5 i256;
+        mstore v0 v1 i256;
         return 32.i256;
 }
 
 func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_526f_1(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        mstore v4 v5 i256;
+        mstore v0 v1 i256;
         return 32.i256;
 }
 
 func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_5a27(v0.i256, v1.@layout_0) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v0 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.i256 = extract_value v1 0.i256;
-        v7.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_f9d3 v3 v6;
-        return v7;
+        v5.i256 = extract_value v1 0.i256;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_f9d3 v0 v5;
+        return v6;
 }
 
 func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_686a(v0.i256, v1.@layout_0) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v0 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.i256 = extract_value v1 0.i256;
-        v7.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_cfe2 v3 v6;
-        return v7;
+        v5.i256 = extract_value v1 0.i256;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_cfe2 v0 v5;
+        return v6;
 }
 
 func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_98d1(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        mstore v4 v5 i256;
+        mstore v0 v1 i256;
         return 32.i256;
 }
 
 func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_b1ec(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        mstore v4 v5 i256;
+        mstore v0 v1 i256;
         return 32.i256;
 }
 
 func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_ba59(v0.i256, v1.@layout_22) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v0 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.@layout_0 = extract_value v1 0.i256;
-        v7.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_fabb v3 v6;
-        v8.i256 = mload v2 i256;
-        (v9.i256, v10.i1) = uaddo v8 v7;
-        br v10 block2 block3;
+        v5.@layout_0 = extract_value v1 0.i256;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_fabb v0 v5;
+        (v7.i256, v8.i1) = uaddo v0 v6;
+        br v8 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -12717,28 +10637,24 @@ func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__wri
         evm_revert 0.i256 36.i256;
 
     block3:
-        v17.@layout_0 = extract_value v1 1.i256;
-        v18.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_fabb v9 v17;
-        (v20.i256, v21.i1) = uaddo v7 v18;
-        br v21 block2 block4;
+        v15.@layout_0 = extract_value v1 1.i256;
+        v16.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_fabb v7 v15;
+        (v18.i256, v19.i1) = uaddo v6 v16;
+        br v19 block2 block4;
 
     block4:
-        return v20;
+        return v18;
 }
 
 func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_ba59_0(v0.i256, v1.@layout_22) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v0 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.@layout_0 = extract_value v1 0.i256;
-        v7.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_fabb_0 v3 v6;
-        v8.i256 = mload v2 i256;
-        (v9.i256, v10.i1) = uaddo v8 v7;
-        br v10 block2 block3;
+        v5.@layout_0 = extract_value v1 0.i256;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_fabb_0 v0 v5;
+        (v7.i256, v8.i1) = uaddo v0 v6;
+        br v8 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -12746,28 +10662,24 @@ func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__wri
         evm_revert 0.i256 36.i256;
 
     block3:
-        v17.@layout_0 = extract_value v1 1.i256;
-        v18.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_fabb_0 v9 v17;
-        (v20.i256, v21.i1) = uaddo v7 v18;
-        br v21 block2 block4;
+        v15.@layout_0 = extract_value v1 1.i256;
+        v16.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_fabb_0 v7 v15;
+        (v18.i256, v19.i1) = uaddo v6 v16;
+        br v19 block2 block4;
 
     block4:
-        return v20;
+        return v18;
 }
 
 func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_ba59_1(v0.i256, v1.@layout_22) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v0 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.@layout_0 = extract_value v1 0.i256;
-        v7.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_fabb_1 v3 v6;
-        v8.i256 = mload v2 i256;
-        (v9.i256, v10.i1) = uaddo v8 v7;
-        br v10 block2 block3;
+        v5.@layout_0 = extract_value v1 0.i256;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_fabb_1 v0 v5;
+        (v7.i256, v8.i1) = uaddo v0 v6;
+        br v8 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -12775,28 +10687,24 @@ func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__wri
         evm_revert 0.i256 36.i256;
 
     block3:
-        v17.@layout_0 = extract_value v1 1.i256;
-        v18.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_fabb_1 v9 v17;
-        (v20.i256, v21.i1) = uaddo v7 v18;
-        br v21 block2 block4;
+        v15.@layout_0 = extract_value v1 1.i256;
+        v16.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_fabb_1 v7 v15;
+        (v18.i256, v19.i1) = uaddo v6 v16;
+        br v19 block2 block4;
 
     block4:
-        return v20;
+        return v18;
 }
 
 func inline(always) private %write_key__g6d15(v0.i256, v1.@layout_16) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v0 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.i256 = extract_value v1 0.i256;
-        v7.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_b1ec v3 v6;
-        v8.i256 = mload v2 i256;
-        (v9.i256, v10.i1) = uaddo v8 v7;
-        br v10 block2 block3;
+        v5.i256 = extract_value v1 0.i256;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_b1ec v0 v5;
+        (v7.i256, v8.i1) = uaddo v0 v6;
+        br v8 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -12804,330 +10712,255 @@ func inline(always) private %write_key__g6d15(v0.i256, v1.@layout_16) -> i256 {
         evm_revert 0.i256 36.i256;
 
     block3:
-        v17.@layout_0 = extract_value v1 1.i256;
-        v18.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_5a27 v9 v17;
-        (v20.i256, v21.i1) = uaddo v7 v18;
-        br v21 block2 block4;
+        v15.@layout_0 = extract_value v1 1.i256;
+        v16.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_5a27 v7 v15;
+        (v18.i256, v19.i1) = uaddo v6 v16;
+        br v19 block2 block4;
 
     block4:
-        return v20;
+        return v18;
 }
 
 func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_cfe2(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        mstore v4 v5 i256;
+        mstore v0 v1 i256;
         return 32.i256;
 }
 
 func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_e672(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        mstore v4 v5 i256;
+        mstore v0 v1 i256;
         return 32.i256;
 }
 
 func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_f9d3(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        mstore v4 v5 i256;
+        mstore v0 v1 i256;
         return 32.i256;
 }
 
 func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_fabb(v0.i256, v1.@layout_0) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v0 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.i256 = extract_value v1 0.i256;
-        v7.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_526f v3 v6;
-        return v7;
+        v5.i256 = extract_value v1 0.i256;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_526f v0 v5;
+        return v6;
 }
 
 func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_fabb_0(v0.i256, v1.@layout_0) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v0 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.i256 = extract_value v1 0.i256;
-        v7.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_526f_0 v3 v6;
-        return v7;
+        v5.i256 = extract_value v1 0.i256;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_526f_0 v0 v5;
+        return v6;
 }
 
 func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_fabb_1(v0.i256, v1.@layout_0) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v0 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.i256 = extract_value v1 0.i256;
-        v7.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_526f_1 v3 v6;
-        return v7;
+        v5.i256 = extract_value v1 0.i256;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_526f_1 v0 v5;
+        return v6;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_0617(v0.objref<@layout_1>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 1.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        mstore v6 v7 i256;
-        v10.i256 = add v6 32.i256;
-        v11.objref<i256> = obj.proj v0 1.i256;
-        obj.store v11 v10;
+        v4.objref<i256> = obj.proj v0 1.i256;
+        v5.i256 = obj.load v4;
+        mstore v5 v1 i256;
+        v9.i256 = add v5 32.i256;
+        v10.objref<i256> = obj.proj v0 1.i256;
+        obj.store v10 v9;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_124f(v0.objref<@layout_1>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 1.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        mstore v6 v7 i256;
-        v10.i256 = add v6 32.i256;
-        v11.objref<i256> = obj.proj v0 1.i256;
-        obj.store v11 v10;
+        v4.objref<i256> = obj.proj v0 1.i256;
+        v5.i256 = obj.load v4;
+        mstore v5 v1 i256;
+        v9.i256 = add v5 32.i256;
+        v10.objref<i256> = obj.proj v0 1.i256;
+        obj.store v10 v9;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_1ad1(v0.objref<@layout_1>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 1.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        mstore v6 v7 i256;
-        v10.i256 = add v6 32.i256;
-        v11.objref<i256> = obj.proj v0 1.i256;
-        obj.store v11 v10;
+        v4.objref<i256> = obj.proj v0 1.i256;
+        v5.i256 = obj.load v4;
+        mstore v5 v1 i256;
+        v9.i256 = add v5 32.i256;
+        v10.objref<i256> = obj.proj v0 1.i256;
+        obj.store v10 v9;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_406d(v0.objref<@layout_1>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 1.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        mstore v6 v7 i256;
-        v10.i256 = add v6 32.i256;
-        v11.objref<i256> = obj.proj v0 1.i256;
-        obj.store v11 v10;
+        v4.objref<i256> = obj.proj v0 1.i256;
+        v5.i256 = obj.load v4;
+        mstore v5 v1 i256;
+        v9.i256 = add v5 32.i256;
+        v10.objref<i256> = obj.proj v0 1.i256;
+        obj.store v10 v9;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_7a95(v0.objref<@layout_1>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 1.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        mstore v6 v7 i256;
-        v10.i256 = add v6 32.i256;
-        v11.objref<i256> = obj.proj v0 1.i256;
-        obj.store v11 v10;
+        v4.objref<i256> = obj.proj v0 1.i256;
+        v5.i256 = obj.load v4;
+        mstore v5 v1 i256;
+        v9.i256 = add v5 32.i256;
+        v10.objref<i256> = obj.proj v0 1.i256;
+        obj.store v10 v9;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_7b53(v0.objref<@layout_1>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 1.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        mstore v6 v7 i256;
-        v10.i256 = add v6 32.i256;
-        v11.objref<i256> = obj.proj v0 1.i256;
-        obj.store v11 v10;
+        v4.objref<i256> = obj.proj v0 1.i256;
+        v5.i256 = obj.load v4;
+        mstore v5 v1 i256;
+        v9.i256 = add v5 32.i256;
+        v10.objref<i256> = obj.proj v0 1.i256;
+        obj.store v10 v9;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_8727(v0.objref<@layout_1>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 1.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        mstore v6 v7 i256;
-        v10.i256 = add v6 32.i256;
-        v11.objref<i256> = obj.proj v0 1.i256;
-        obj.store v11 v10;
+        v4.objref<i256> = obj.proj v0 1.i256;
+        v5.i256 = obj.load v4;
+        mstore v5 v1 i256;
+        v9.i256 = add v5 32.i256;
+        v10.objref<i256> = obj.proj v0 1.i256;
+        obj.store v10 v9;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_8eda(v0.objref<@layout_1>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 1.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        mstore v6 v7 i256;
-        v10.i256 = add v6 32.i256;
-        v11.objref<i256> = obj.proj v0 1.i256;
-        obj.store v11 v10;
+        v4.objref<i256> = obj.proj v0 1.i256;
+        v5.i256 = obj.load v4;
+        mstore v5 v1 i256;
+        v9.i256 = add v5 32.i256;
+        v10.objref<i256> = obj.proj v0 1.i256;
+        obj.store v10 v9;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_8f67(v0.objref<@layout_1>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 1.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        mstore v6 v7 i256;
-        v10.i256 = add v6 32.i256;
-        v11.objref<i256> = obj.proj v0 1.i256;
-        obj.store v11 v10;
+        v4.objref<i256> = obj.proj v0 1.i256;
+        v5.i256 = obj.load v4;
+        mstore v5 v1 i256;
+        v9.i256 = add v5 32.i256;
+        v10.objref<i256> = obj.proj v0 1.i256;
+        obj.store v10 v9;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_aa60(v0.objref<@layout_1>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 1.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        mstore v6 v7 i256;
-        v10.i256 = add v6 32.i256;
-        v11.objref<i256> = obj.proj v0 1.i256;
-        obj.store v11 v10;
+        v4.objref<i256> = obj.proj v0 1.i256;
+        v5.i256 = obj.load v4;
+        mstore v5 v1 i256;
+        v9.i256 = add v5 32.i256;
+        v10.objref<i256> = obj.proj v0 1.i256;
+        obj.store v10 v9;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_at_7ecd(v0.objref<@layout_1>, v1.i256, v2.i256) {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v3 i256;
-        v6.i256 = mload v4 i256;
-        mstore v5 v6 i256;
+        mstore v1 v2 i256;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_at_e460(v0.objref<@layout_1>, v1.i256, v2.i256) {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v3 i256;
-        v6.i256 = mload v4 i256;
-        mstore v5 v6 i256;
+        mstore v1 v2 i256;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_d813(v0.objref<@layout_1>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 1.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        mstore v6 v7 i256;
-        v10.i256 = add v6 32.i256;
-        v11.objref<i256> = obj.proj v0 1.i256;
-        obj.store v11 v10;
+        v4.objref<i256> = obj.proj v0 1.i256;
+        v5.i256 = obj.load v4;
+        mstore v5 v1 i256;
+        v9.i256 = add v5 32.i256;
+        v10.objref<i256> = obj.proj v0 1.i256;
+        obj.store v10 v9;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_eb98(v0.objref<@layout_1>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 1.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        mstore v6 v7 i256;
-        v10.i256 = add v6 32.i256;
-        v11.objref<i256> = obj.proj v0 1.i256;
-        obj.store v11 v10;
+        v4.objref<i256> = obj.proj v0 1.i256;
+        v5.i256 = obj.load v4;
+        mstore v5 v1 i256;
+        v9.i256 = add v5 32.i256;
+        v10.objref<i256> = obj.proj v0 1.i256;
+        obj.store v10 v9;
         return;
 }
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/erc20_low_level.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/erc20_low_level.snap
@@ -12,31 +12,22 @@ global private const @layout_0 $const_region_0 = {0};
 
 func private %abi_encode_string(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
         call %mstore 0.i256 32.i256;
-        v7.i256 = mload v3 i256;
-        call %mstore 32.i256 v7;
-        v10.i256 = mload v2 i256;
-        call %mstore 64.i256 v10;
+        call %mstore 32.i256 v1;
+        call %mstore 64.i256 v0;
         call %std__lib__evm__effects__impl_trait_Evm_0098__return_data_a822 0.i256 96.i256;
         unreachable;
 }
 
 func private %abi_encode_u256(v0.i256) {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v1 i256;
-        call %mstore 0.i256 v3;
+        call %mstore 0.i256 v0;
         call %std__lib__evm__effects__impl_trait_Evm_0098__return_data_a822 0.i256 32.i256;
         unreachable;
 }
@@ -65,28 +56,22 @@ func private %allowance__g35d6(v0.i256, v1.@layout_0, v2.@layout_0) -> i256 {
 
 func private %approve__g35d6(v0.i256, v1.@layout_0, v2.@layout_0, v3.i256) {
     block0:
-        v4.*i256 = alloca i256;
-        mstore v4 v3 i256;
         jump block1;
 
     block1:
-        v9.@layout_1 = insert_value undef.@layout_1 0.i256 v1;
-        v11.@layout_1 = insert_value v9 1.i256 v2;
-        v12.i256 = mload v4 i256;
-        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set__ga15b_f433 v11 v12;
+        v8.@layout_1 = insert_value undef.@layout_1 0.i256 v1;
+        v10.@layout_1 = insert_value v8 1.i256 v2;
+        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set__ga15b_f433 v10 v3;
         return;
 }
 
 func private %approve__gb6ca(v0.@layout_0, v1.i256, v2.i256) -> i256 {
     block0:
-        v3.*i256 = alloca i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v5.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_a1e8__caller_fcc7;
-        v7.i256 = mload v3 i256;
-        call %approve__g35d6 v2 v5 v0 v7;
+        v4.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_a1e8__caller_fcc7;
+        call %approve__g35d6 v2 v4 v0 v1;
         return 1.i256;
 }
 
@@ -128,14 +113,11 @@ func private %standalone_erc20_low_level__erc20_low_level__impl_Erc20_16d9__bala
 
 func private %calldataload(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = evm_calldata_load v2;
-        return v3;
+        v2.i256 = evm_calldata_load v0;
+        return v2;
 }
 
 func private %std__lib__evm__effects__impl_trait_Evm_a1e8__caller_1c07() -> @layout_0 {
@@ -180,19 +162,10 @@ func private %std__lib__evm__effects__impl_trait_Evm_a1e8__caller_fcc7() -> @lay
 
 func private %codecopy(v0.i256, v1.i256, v2.i256) {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        mstore v3 v0 i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
         jump block1;
 
     block1:
-        v6.i256 = mload v3 i256;
-        v7.i256 = mload v4 i256;
-        v8.i256 = mload v5 i256;
-        evm_code_copy v6 v7 v8;
+        evm_code_copy v0 v1 v2;
         return;
 }
 
@@ -230,90 +203,66 @@ func private %std__lib__evm__effects__impl_trait_Address_3ffb__eq_d2f0(v0.i256, 
 
 func private %core__lib__effect_ref__impl_trait_StorPtr_27da__from_raw__gb51e_82ea(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        return v2;
+        return v0;
 }
 
 func private %core__lib__effect_ref__impl_trait_StorPtr_27da__from_raw__gb51e_82ea_0(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        return v2;
+        return v0;
 }
 
 func private %std__lib__evm__word__impl_trait_u256_1f9e__from_word_09f5(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        return v2;
+        return v0;
 }
 
 func private %std__lib__evm__word__impl_trait_u256_1f9e__from_word_3cf5(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        return v2;
+        return v0;
 }
 
 func private %std__lib__evm__word__impl_trait_u256_1f9e__from_word_507e(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        return v2;
+        return v0;
 }
 
 func private %std__lib__evm__word__impl_trait_u256_1f9e__from_word_507e_0(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        return v2;
+        return v0;
 }
 
 func private %std__lib__evm__word__impl_trait_u256_1f9e__from_word_507e_1(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        return v2;
+        return v0;
 }
 
 func private %std__lib__evm__word__impl_trait_u256_1f9e__from_word_7015(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        return v2;
+        return v0;
 }
 
 func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__get__ga15b_679e(v0.@layout_1) -> i256 {
@@ -412,27 +361,22 @@ func private %manual_contract_runtime_root_Erc20Contract() {
 
 func private %mint__gd1d8(v0.@layout_0, v1.i256, v2.i256) -> i256 {
     block0:
-        v3.*i256 = alloca i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v6.i256 = mload v3 i256;
-        call %mint__g0502 v2 v0 v6;
+        call %mint__g0502 v2 v0 v1;
         return 1.i256;
 }
 
 func private %mint__g0502(v0.i256, v1.@layout_0, v2.i256) {
     block0:
-        v3.*i256 = alloca i256;
-        mstore v3 v2 i256;
         jump block1;
 
     block1:
-        v4.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_a1e8__caller_1c07_1;
-        v7.i256 = add v0 1.i256;
-        v8.i1 = call %core__lib__ops__trait_Eq__ne__g7528_bf6a v4 v7;
-        br v8 block2 block3;
+        v3.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_a1e8__caller_1c07_1;
+        v6.i256 = add v0 1.i256;
+        v7.i1 = call %core__lib__ops__trait_Eq__ne__g7528_bf6a v3 v6;
+        br v7 block2 block3;
 
     block2:
         call %std__lib__evm__effects__impl_trait_Evm_0098__revert_7c32 0.i256 0.i256;
@@ -442,10 +386,9 @@ func private %mint__g0502(v0.i256, v1.@layout_0, v2.i256) {
         jump block4;
 
     block4:
-        v12.i256 = call %standalone_erc20_low_level__erc20_low_level__impl_Erc20_16d9__balance_of__g35d6_6d6f v0 v1;
-        v13.i256 = mload v3 i256;
-        (v14.i256, v15.i1) = uaddo v12 v13;
-        br v15 block5 block6;
+        v11.i256 = call %standalone_erc20_low_level__erc20_low_level__impl_Erc20_16d9__balance_of__g35d6_6d6f v0 v1;
+        (v13.i256, v14.i1) = uaddo v11 v2;
+        br v14 block5 block6;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -453,29 +396,22 @@ func private %mint__g0502(v0.i256, v1.@layout_0, v2.i256) {
         evm_revert 0.i256 36.i256;
 
     block6:
-        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set__g2163_a4c9 v1 v14;
-        v23.i256 = evm_sload v0;
-        v24.i256 = mload v3 i256;
-        (v25.i256, v26.i1) = uaddo v23 v24;
-        br v26 block5 block7;
+        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set__g2163_a4c9 v1 v13;
+        v22.i256 = evm_sload v0;
+        (v24.i256, v25.i1) = uaddo v22 v2;
+        br v25 block5 block7;
 
     block7:
-        evm_sstore v0 v25;
+        evm_sstore v0 v24;
         return;
 }
 
 func private %mstore(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        mstore v4 v5 i256;
+        mstore v0 v1 i256;
         return;
 }
 
@@ -501,100 +437,58 @@ func private %core__lib__ops__trait_Eq__ne__g7528_bf6a(v0.@layout_0, v1.i256) ->
 
 func private %std__lib__evm__effects__impl_trait_Evm_0098__return_data_0402(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        evm_return v4 v5;
+        evm_return v0 v1;
 }
 
 func private %std__lib__evm__effects__impl_trait_Evm_0098__return_data_a822(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        evm_return v4 v5;
+        evm_return v0 v1;
 }
 
 func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_61f0(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        evm_revert v4 v5;
+        evm_revert v0 v1;
 }
 
 func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_7c32(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        evm_revert v4 v5;
+        evm_revert v0 v1;
 }
 
 func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_7c32_0(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        evm_revert v4 v5;
+        evm_revert v0 v1;
 }
 
 func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_7c32_1(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        evm_revert v4 v5;
+        evm_revert v0 v1;
 }
 
 func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_7c32_2(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        evm_revert v4 v5;
+        evm_revert v0 v1;
 }
 
 func private %runtime() {
@@ -794,198 +688,142 @@ func private %set_owner_once(v0.i256, v1.@layout_0) {
 
 func private %std__lib__evm__effects__trait_RawStorage__stor_ptr__g3730_6bd4(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = call %core__lib__effect_ref__impl_trait_StorPtr_27da__from_raw__gb51e_82ea v2;
-        return v3;
+        v2.i256 = call %core__lib__effect_ref__impl_trait_StorPtr_27da__from_raw__gb51e_82ea v0;
+        return v2;
 }
 
 func private %std__lib__evm__effects__trait_RawStorage__stor_ptr__g3730_6bd4_0(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = call %core__lib__effect_ref__impl_trait_StorPtr_27da__from_raw__gb51e_82ea_0 v2;
-        return v3;
+        v2.i256 = call %core__lib__effect_ref__impl_trait_StorPtr_27da__from_raw__gb51e_82ea_0 v0;
+        return v2;
 }
 
 func inline(always) private %std__lib__evm__storage_map__storagemap_get_word_with_salt__g7bf4_960f(v0.@layout_1, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v5.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_d0e6 v0 v3;
-        v6.i256 = evm_sload v5;
-        return v6;
+        v4.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_d0e6 v0 v1;
+        v5.i256 = evm_sload v4;
+        return v5;
 }
 
 func inline(always) private %std__lib__evm__storage_map__storagemap_get_word_with_salt__g67a8_bfbb(v0.@layout_0, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v5.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g67a8_e7af v0 v3;
-        v6.i256 = evm_sload v5;
-        return v6;
+        v4.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g67a8_e7af v0 v1;
+        v5.i256 = evm_sload v4;
+        return v5;
 }
 
 func inline(always) private %std__lib__evm__storage_map__storagemap_get_word_with_salt__g67a8_fadf(v0.@layout_0, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v5.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g67a8_25ce v0 v3;
-        v6.i256 = evm_sload v5;
-        return v6;
+        v4.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g67a8_25ce v0 v1;
+        v5.i256 = evm_sload v4;
+        return v5;
 }
 
 func inline(always) private %std__lib__evm__storage_map__storagemap_get_word_with_salt__g67a8_fadf_0(v0.@layout_0, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v5.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g67a8_25ce_0 v0 v3;
-        v6.i256 = evm_sload v5;
-        return v6;
+        v4.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g67a8_25ce_0 v0 v1;
+        v5.i256 = evm_sload v4;
+        return v5;
 }
 
 func inline(always) private %std__lib__evm__storage_map__storagemap_get_word_with_salt__g67a8_fadf_1(v0.@layout_0, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v5.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g67a8_25ce_1 v0 v3;
-        v6.i256 = evm_sload v5;
-        return v6;
+        v4.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g67a8_25ce_1 v0 v1;
+        v5.i256 = evm_sload v4;
+        return v5;
 }
 
 func inline(always) private %std__lib__evm__storage_map__storagemap_get_word_with_salt__g7bf4_fdb1(v0.@layout_1, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v5.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_d8a5 v0 v3;
-        v6.i256 = evm_sload v5;
-        return v6;
+        v4.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_d8a5 v0 v1;
+        v5.i256 = evm_sload v4;
+        return v5;
 }
 
 func inline(always) private %std__lib__evm__storage_map__storagemap_set_word_with_salt__g7bf4_3d2b(v0.@layout_1, v1.i256, v2.i256) {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v3 i256;
-        v7.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_d0e6 v0 v5;
-        v8.i256 = mload v4 i256;
-        evm_sstore v7 v8;
+        v5.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_d0e6 v0 v1;
+        evm_sstore v5 v2;
         return;
 }
 
 func inline(always) private %std__lib__evm__storage_map__storagemap_set_word_with_salt__g7bf4_c24d(v0.@layout_1, v1.i256, v2.i256) {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v3 i256;
-        v7.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_88de v0 v5;
-        v8.i256 = mload v4 i256;
-        evm_sstore v7 v8;
+        v5.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_88de v0 v1;
+        evm_sstore v5 v2;
         return;
 }
 
 func inline(always) private %std__lib__evm__storage_map__storagemap_set_word_with_salt__g67a8_dea8(v0.@layout_0, v1.i256, v2.i256) {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v3 i256;
-        v7.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g67a8_25ce v0 v5;
-        v8.i256 = mload v4 i256;
-        evm_sstore v7 v8;
+        v5.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g67a8_25ce v0 v1;
+        evm_sstore v5 v2;
         return;
 }
 
 func inline(always) private %std__lib__evm__storage_map__storagemap_set_word_with_salt__g67a8_dea8_0(v0.@layout_0, v1.i256, v2.i256) {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v3 i256;
-        v7.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g67a8_25ce_0 v0 v5;
-        v8.i256 = mload v4 i256;
-        evm_sstore v7 v8;
+        v5.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g67a8_25ce_0 v0 v1;
+        evm_sstore v5 v2;
         return;
 }
 
 func inline(always) private %std__lib__evm__storage_map__storagemap_set_word_with_salt__g67a8_dea8_1(v0.@layout_0, v1.i256, v2.i256) {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v3 i256;
-        v7.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g67a8_25ce_1 v0 v5;
-        v8.i256 = mload v4 i256;
-        evm_sstore v7 v8;
+        v5.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g67a8_25ce_1 v0 v1;
+        evm_sstore v5 v2;
         return;
 }
 
 func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g67a8_25ce(v0.@layout_0, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.*i8 = evm_malloc 0.i256;
-        v5.i256 = ptr_to_int v4 i256;
-        v7.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_b647 v5 v0;
-        (v8.i256, v9.i1) = uaddo v5 v7;
-        br v9 block2 block3;
+        v3.*i8 = evm_malloc 0.i256;
+        v4.i256 = ptr_to_int v3 i256;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_b647 v4 v0;
+        (v7.i256, v8.i1) = uaddo v4 v6;
+        br v8 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -993,28 +831,25 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot
         evm_revert 0.i256 36.i256;
 
     block3:
-        v14.i256 = mload v2 i256;
-        mstore v8 v14 i256;
-        (v18.i256, v19.i1) = uaddo v7 32.i256;
-        br v19 block2 block4;
+        mstore v7 v1 i256;
+        (v17.i256, v18.i1) = uaddo v6 32.i256;
+        br v18 block2 block4;
 
     block4:
-        v21.i256 = evm_keccak256 v5 v18;
-        return v21;
+        v20.i256 = evm_keccak256 v4 v17;
+        return v20;
 }
 
 func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g67a8_25ce_0(v0.@layout_0, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.*i8 = evm_malloc 0.i256;
-        v5.i256 = ptr_to_int v4 i256;
-        v7.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_b647_0 v5 v0;
-        (v8.i256, v9.i1) = uaddo v5 v7;
-        br v9 block2 block3;
+        v3.*i8 = evm_malloc 0.i256;
+        v4.i256 = ptr_to_int v3 i256;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_b647_0 v4 v0;
+        (v7.i256, v8.i1) = uaddo v4 v6;
+        br v8 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -1022,28 +857,25 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot
         evm_revert 0.i256 36.i256;
 
     block3:
-        v14.i256 = mload v2 i256;
-        mstore v8 v14 i256;
-        (v18.i256, v19.i1) = uaddo v7 32.i256;
-        br v19 block2 block4;
+        mstore v7 v1 i256;
+        (v17.i256, v18.i1) = uaddo v6 32.i256;
+        br v18 block2 block4;
 
     block4:
-        v21.i256 = evm_keccak256 v5 v18;
-        return v21;
+        v20.i256 = evm_keccak256 v4 v17;
+        return v20;
 }
 
 func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g67a8_25ce_1(v0.@layout_0, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.*i8 = evm_malloc 0.i256;
-        v5.i256 = ptr_to_int v4 i256;
-        v7.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_b647_1 v5 v0;
-        (v8.i256, v9.i1) = uaddo v5 v7;
-        br v9 block2 block3;
+        v3.*i8 = evm_malloc 0.i256;
+        v4.i256 = ptr_to_int v3 i256;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_b647_1 v4 v0;
+        (v7.i256, v8.i1) = uaddo v4 v6;
+        br v8 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -1051,28 +883,25 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot
         evm_revert 0.i256 36.i256;
 
     block3:
-        v14.i256 = mload v2 i256;
-        mstore v8 v14 i256;
-        (v18.i256, v19.i1) = uaddo v7 32.i256;
-        br v19 block2 block4;
+        mstore v7 v1 i256;
+        (v17.i256, v18.i1) = uaddo v6 32.i256;
+        br v18 block2 block4;
 
     block4:
-        v21.i256 = evm_keccak256 v5 v18;
-        return v21;
+        v20.i256 = evm_keccak256 v4 v17;
+        return v20;
 }
 
 func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_88de(v0.@layout_1, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.*i8 = evm_malloc 0.i256;
-        v5.i256 = ptr_to_int v4 i256;
-        v7.i256 = call %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_d08c v5 v0;
-        (v8.i256, v9.i1) = uaddo v5 v7;
-        br v9 block2 block3;
+        v3.*i8 = evm_malloc 0.i256;
+        v4.i256 = ptr_to_int v3 i256;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_d08c v4 v0;
+        (v7.i256, v8.i1) = uaddo v4 v6;
+        br v8 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -1080,28 +909,25 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot
         evm_revert 0.i256 36.i256;
 
     block3:
-        v14.i256 = mload v2 i256;
-        mstore v8 v14 i256;
-        (v18.i256, v19.i1) = uaddo v7 32.i256;
-        br v19 block2 block4;
+        mstore v7 v1 i256;
+        (v17.i256, v18.i1) = uaddo v6 32.i256;
+        br v18 block2 block4;
 
     block4:
-        v21.i256 = evm_keccak256 v5 v18;
-        return v21;
+        v20.i256 = evm_keccak256 v4 v17;
+        return v20;
 }
 
 func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_d0e6(v0.@layout_1, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.*i8 = evm_malloc 0.i256;
-        v5.i256 = ptr_to_int v4 i256;
-        v7.i256 = call %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_69bb v5 v0;
-        (v8.i256, v9.i1) = uaddo v5 v7;
-        br v9 block2 block3;
+        v3.*i8 = evm_malloc 0.i256;
+        v4.i256 = ptr_to_int v3 i256;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_69bb v4 v0;
+        (v7.i256, v8.i1) = uaddo v4 v6;
+        br v8 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -1109,28 +935,25 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot
         evm_revert 0.i256 36.i256;
 
     block3:
-        v14.i256 = mload v2 i256;
-        mstore v8 v14 i256;
-        (v18.i256, v19.i1) = uaddo v7 32.i256;
-        br v19 block2 block4;
+        mstore v7 v1 i256;
+        (v17.i256, v18.i1) = uaddo v6 32.i256;
+        br v18 block2 block4;
 
     block4:
-        v21.i256 = evm_keccak256 v5 v18;
-        return v21;
+        v20.i256 = evm_keccak256 v4 v17;
+        return v20;
 }
 
 func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g7bf4_d8a5(v0.@layout_1, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.*i8 = evm_malloc 0.i256;
-        v5.i256 = ptr_to_int v4 i256;
-        v7.i256 = call %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_d74c v5 v0;
-        (v8.i256, v9.i1) = uaddo v5 v7;
-        br v9 block2 block3;
+        v3.*i8 = evm_malloc 0.i256;
+        v4.i256 = ptr_to_int v3 i256;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_d74c v4 v0;
+        (v7.i256, v8.i1) = uaddo v4 v6;
+        br v8 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -1138,28 +961,25 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot
         evm_revert 0.i256 36.i256;
 
     block3:
-        v14.i256 = mload v2 i256;
-        mstore v8 v14 i256;
-        (v18.i256, v19.i1) = uaddo v7 32.i256;
-        br v19 block2 block4;
+        mstore v7 v1 i256;
+        (v17.i256, v18.i1) = uaddo v6 32.i256;
+        br v18 block2 block4;
 
     block4:
-        v21.i256 = evm_keccak256 v5 v18;
-        return v21;
+        v20.i256 = evm_keccak256 v4 v17;
+        return v20;
 }
 
 func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__g67a8_e7af(v0.@layout_0, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.*i8 = evm_malloc 0.i256;
-        v5.i256 = ptr_to_int v4 i256;
-        v7.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_72b5 v5 v0;
-        (v8.i256, v9.i1) = uaddo v5 v7;
-        br v9 block2 block3;
+        v3.*i8 = evm_malloc 0.i256;
+        v4.i256 = ptr_to_int v3 i256;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_72b5 v4 v0;
+        (v7.i256, v8.i1) = uaddo v4 v6;
+        br v8 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -1167,14 +987,13 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot
         evm_revert 0.i256 36.i256;
 
     block3:
-        v14.i256 = mload v2 i256;
-        mstore v8 v14 i256;
-        (v18.i256, v19.i1) = uaddo v7 32.i256;
-        br v19 block2 block4;
+        mstore v7 v1 i256;
+        (v17.i256, v18.i1) = uaddo v6 32.i256;
+        br v18 block2 block4;
 
     block4:
-        v21.i256 = evm_keccak256 v5 v18;
-        return v21;
+        v20.i256 = evm_keccak256 v4 v17;
+        return v20;
 }
 
 func private %std__lib__evm__word__impl_trait_u256_1f9e__to_word_0522(v0.i256) -> i256 {
@@ -1219,15 +1038,12 @@ func private %std__lib__evm__word__impl_trait_u256_1f9e__to_word_bf41_1(v0.i256)
 
 func private %standalone_erc20_low_level__erc20_low_level__impl_Erc20_16d9__transfer__g0f37_233d(v0.i256, v1.@layout_0, v2.@layout_0, v3.i256) {
     block0:
-        v4.*i256 = alloca i256;
-        mstore v4 v3 i256;
         jump block1;
 
     block1:
-        v7.i256 = call %standalone_erc20_low_level__erc20_low_level__impl_Erc20_16d9__balance_of__g35d6_6d6f_0 v0 v1;
-        v8.i256 = mload v4 i256;
-        v9.i1 = lt v7 v8;
-        br v9 block2 block3;
+        v6.i256 = call %standalone_erc20_low_level__erc20_low_level__impl_Erc20_16d9__balance_of__g35d6_6d6f_0 v0 v1;
+        v8.i1 = lt v6 v3;
+        br v8 block2 block3;
 
     block2:
         call %std__lib__evm__effects__impl_trait_Evm_0098__revert_7c32_0 0.i256 0.i256;
@@ -1237,10 +1053,9 @@ func private %standalone_erc20_low_level__erc20_low_level__impl_Erc20_16d9__tran
         jump block4;
 
     block4:
-        v13.i256 = call %standalone_erc20_low_level__erc20_low_level__impl_Erc20_16d9__balance_of__g35d6_6d6f_0 v0 v2;
-        v15.i256 = mload v4 i256;
-        (v17.i256, v18.i1) = usubo v7 v15;
-        br v18 block5 block6;
+        v12.i256 = call %standalone_erc20_low_level__erc20_low_level__impl_Erc20_16d9__balance_of__g35d6_6d6f_0 v0 v2;
+        (v16.i256, v17.i1) = usubo v6 v3;
+        br v17 block5 block6;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -1248,27 +1063,23 @@ func private %standalone_erc20_low_level__erc20_low_level__impl_Erc20_16d9__tran
         evm_revert 0.i256 36.i256;
 
     block6:
-        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set__g2163_a4c9_0 v1 v17;
-        v26.i256 = mload v4 i256;
-        (v28.i256, v29.i1) = uaddo v13 v26;
-        br v29 block5 block7;
+        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set__g2163_a4c9_0 v1 v16;
+        (v27.i256, v28.i1) = uaddo v12 v3;
+        br v28 block5 block7;
 
     block7:
-        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set__g2163_a4c9_0 v2 v28;
+        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set__g2163_a4c9_0 v2 v27;
         return;
 }
 
 func private %standalone_erc20_low_level__erc20_low_level__impl_Erc20_16d9__transfer__g0f37_233d_0(v0.i256, v1.@layout_0, v2.@layout_0, v3.i256) {
     block0:
-        v4.*i256 = alloca i256;
-        mstore v4 v3 i256;
         jump block1;
 
     block1:
-        v7.i256 = call %standalone_erc20_low_level__erc20_low_level__impl_Erc20_16d9__balance_of__g35d6_6d6f_1 v0 v1;
-        v8.i256 = mload v4 i256;
-        v9.i1 = lt v7 v8;
-        br v9 block2 block3;
+        v6.i256 = call %standalone_erc20_low_level__erc20_low_level__impl_Erc20_16d9__balance_of__g35d6_6d6f_1 v0 v1;
+        v8.i1 = lt v6 v3;
+        br v8 block2 block3;
 
     block2:
         call %std__lib__evm__effects__impl_trait_Evm_0098__revert_7c32_2 0.i256 0.i256;
@@ -1278,10 +1089,9 @@ func private %standalone_erc20_low_level__erc20_low_level__impl_Erc20_16d9__tran
         jump block4;
 
     block4:
-        v13.i256 = call %standalone_erc20_low_level__erc20_low_level__impl_Erc20_16d9__balance_of__g35d6_6d6f_1 v0 v2;
-        v15.i256 = mload v4 i256;
-        (v17.i256, v18.i1) = usubo v7 v15;
-        br v18 block5 block6;
+        v12.i256 = call %standalone_erc20_low_level__erc20_low_level__impl_Erc20_16d9__balance_of__g35d6_6d6f_1 v0 v2;
+        (v16.i256, v17.i1) = usubo v6 v3;
+        br v17 block5 block6;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -1289,41 +1099,34 @@ func private %standalone_erc20_low_level__erc20_low_level__impl_Erc20_16d9__tran
         evm_revert 0.i256 36.i256;
 
     block6:
-        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set__g2163_a4c9_1 v1 v17;
-        v26.i256 = mload v4 i256;
-        (v28.i256, v29.i1) = uaddo v13 v26;
-        br v29 block5 block7;
+        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set__g2163_a4c9_1 v1 v16;
+        (v27.i256, v28.i1) = uaddo v12 v3;
+        br v28 block5 block7;
 
     block7:
-        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set__g2163_a4c9_1 v2 v28;
+        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set__g2163_a4c9_1 v2 v27;
         return;
 }
 
 func private %transfer__gd1d8(v0.@layout_0, v1.i256, v2.i256) -> i256 {
     block0:
-        v3.*i256 = alloca i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v5.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_a1e8__caller_1c07;
-        v7.i256 = mload v3 i256;
-        call %standalone_erc20_low_level__erc20_low_level__impl_Erc20_16d9__transfer__g0f37_233d v2 v5 v0 v7;
+        v4.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_a1e8__caller_1c07;
+        call %standalone_erc20_low_level__erc20_low_level__impl_Erc20_16d9__transfer__g0f37_233d v2 v4 v0 v1;
         return 1.i256;
 }
 
 func private %transfer_from__g0502(v0.i256, v1.@layout_0, v2.@layout_0, v3.i256) {
     block0:
-        v4.*i256 = alloca i256;
-        mstore v4 v3 i256;
         jump block1;
 
     block1:
-        v5.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_a1e8__caller_1c07_1;
-        v8.i256 = call %allowance__g35d6 v0 v1 v5;
-        v9.i256 = mload v4 i256;
-        v10.i1 = lt v8 v9;
-        br v10 block2 block3;
+        v4.@layout_0 = call %std__lib__evm__effects__impl_trait_Evm_a1e8__caller_1c07_1;
+        v7.i256 = call %allowance__g35d6 v0 v1 v4;
+        v9.i1 = lt v7 v3;
+        br v9 block2 block3;
 
     block2:
         call %std__lib__evm__effects__impl_trait_Evm_0098__revert_7c32 0.i256 0.i256;
@@ -1333,13 +1136,11 @@ func private %transfer_from__g0502(v0.i256, v1.@layout_0, v2.@layout_0, v3.i256)
         jump block4;
 
     block4:
-        v14.i256 = mload v4 i256;
-        call %standalone_erc20_low_level__erc20_low_level__impl_Erc20_16d9__transfer__g0f37_233d_0 v0 v1 v2 v14;
-        v18.@layout_1 = insert_value undef.@layout_1 0.i256 v1;
-        v21.@layout_1 = insert_value v18 1.i256 v5;
-        v22.i256 = mload v4 i256;
-        (v24.i256, v25.i1) = usubo v8 v22;
-        br v25 block5 block6;
+        call %standalone_erc20_low_level__erc20_low_level__impl_Erc20_16d9__transfer__g0f37_233d_0 v0 v1 v2 v3;
+        v17.@layout_1 = insert_value undef.@layout_1 0.i256 v1;
+        v20.@layout_1 = insert_value v17 1.i256 v4;
+        (v22.i256, v23.i1) = usubo v7 v3;
+        br v23 block5 block6;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -1347,61 +1148,48 @@ func private %transfer_from__g0502(v0.i256, v1.@layout_0, v2.@layout_0, v3.i256)
         evm_revert 0.i256 36.i256;
 
     block6:
-        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set__ga15b_5b22 v21 v24;
+        call %std__lib__evm__storage_map__impl_StorageMap_9f54__set__ga15b_5b22 v20 v22;
         return;
 }
 
 func private %transfer_from__gd1d8(v0.@layout_0, v1.@layout_0, v2.i256, v3.i256) -> i256 {
     block0:
-        v4.*i256 = alloca i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v8.i256 = mload v4 i256;
-        call %transfer_from__g0502 v3 v0 v1 v8;
+        call %transfer_from__g0502 v3 v0 v1 v2;
         return 1.i256;
 }
 
 func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_0b7a(v0.i256, v1.@layout_0) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v0 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.i256 = extract_value v1 0.i256;
-        v7.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_a907 v3 v6;
-        return v7;
+        v5.i256 = extract_value v1 0.i256;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_a907 v0 v5;
+        return v6;
 }
 
 func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_1ccc(v0.i256, v1.@layout_0) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v0 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.i256 = extract_value v1 0.i256;
-        v7.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_a6f4 v3 v6;
-        return v7;
+        v5.i256 = extract_value v1 0.i256;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_a6f4 v0 v5;
+        return v6;
 }
 
 func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_69bb(v0.i256, v1.@layout_1) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v0 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.@layout_0 = extract_value v1 0.i256;
-        v7.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_c11e v3 v6;
-        v8.i256 = mload v2 i256;
-        (v9.i256, v10.i1) = uaddo v8 v7;
-        br v10 block2 block3;
+        v5.@layout_0 = extract_value v1 0.i256;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_c11e v0 v5;
+        (v7.i256, v8.i1) = uaddo v0 v6;
+        br v8 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -1409,168 +1197,119 @@ func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__wri
         evm_revert 0.i256 36.i256;
 
     block3:
-        v17.@layout_0 = extract_value v1 1.i256;
-        v18.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_c11e v9 v17;
-        (v20.i256, v21.i1) = uaddo v7 v18;
-        br v21 block2 block4;
+        v15.@layout_0 = extract_value v1 1.i256;
+        v16.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_c11e v7 v15;
+        (v18.i256, v19.i1) = uaddo v6 v16;
+        br v19 block2 block4;
 
     block4:
-        return v20;
+        return v18;
 }
 
 func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_72b5(v0.i256, v1.@layout_0) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v0 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.i256 = extract_value v1 0.i256;
-        v7.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_f2a4 v3 v6;
-        return v7;
+        v5.i256 = extract_value v1 0.i256;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_f2a4 v0 v5;
+        return v6;
 }
 
 func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_72e3(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        mstore v4 v5 i256;
+        mstore v0 v1 i256;
         return 32.i256;
 }
 
 func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_72e3_0(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        mstore v4 v5 i256;
+        mstore v0 v1 i256;
         return 32.i256;
 }
 
 func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_72e3_1(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        mstore v4 v5 i256;
+        mstore v0 v1 i256;
         return 32.i256;
 }
 
 func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_a6f4(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        mstore v4 v5 i256;
+        mstore v0 v1 i256;
         return 32.i256;
 }
 
 func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_a907(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        mstore v4 v5 i256;
+        mstore v0 v1 i256;
         return 32.i256;
 }
 
 func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_b647(v0.i256, v1.@layout_0) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v0 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.i256 = extract_value v1 0.i256;
-        v7.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_72e3 v3 v6;
-        return v7;
+        v5.i256 = extract_value v1 0.i256;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_72e3 v0 v5;
+        return v6;
 }
 
 func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_b647_0(v0.i256, v1.@layout_0) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v0 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.i256 = extract_value v1 0.i256;
-        v7.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_72e3_0 v3 v6;
-        return v7;
+        v5.i256 = extract_value v1 0.i256;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_72e3_0 v0 v5;
+        return v6;
 }
 
 func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_b647_1(v0.i256, v1.@layout_0) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v0 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.i256 = extract_value v1 0.i256;
-        v7.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_72e3_1 v3 v6;
-        return v7;
+        v5.i256 = extract_value v1 0.i256;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_72e3_1 v0 v5;
+        return v6;
 }
 
 func inline(always) private %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_c11e(v0.i256, v1.@layout_0) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v0 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.i256 = extract_value v1 0.i256;
-        v7.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_e8dd v3 v6;
-        return v7;
+        v5.i256 = extract_value v1 0.i256;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_e8dd v0 v5;
+        return v6;
 }
 
 func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_d08c(v0.i256, v1.@layout_1) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v0 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.@layout_0 = extract_value v1 0.i256;
-        v7.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_0b7a v3 v6;
-        v8.i256 = mload v2 i256;
-        (v9.i256, v10.i1) = uaddo v8 v7;
-        br v10 block2 block3;
+        v5.@layout_0 = extract_value v1 0.i256;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_0b7a v0 v5;
+        (v7.i256, v8.i1) = uaddo v0 v6;
+        br v8 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -1578,28 +1317,24 @@ func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__wri
         evm_revert 0.i256 36.i256;
 
     block3:
-        v17.@layout_0 = extract_value v1 1.i256;
-        v18.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_0b7a v9 v17;
-        (v20.i256, v21.i1) = uaddo v7 v18;
-        br v21 block2 block4;
+        v15.@layout_0 = extract_value v1 1.i256;
+        v16.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_0b7a v7 v15;
+        (v18.i256, v19.i1) = uaddo v6 v16;
+        br v19 block2 block4;
 
     block4:
-        return v20;
+        return v18;
 }
 
 func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__write_key__g7528_d74c(v0.i256, v1.@layout_1) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v0 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.@layout_0 = extract_value v1 0.i256;
-        v7.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_1ccc v3 v6;
-        v8.i256 = mload v2 i256;
-        (v9.i256, v10.i1) = uaddo v8 v7;
-        br v10 block2 block3;
+        v5.@layout_0 = extract_value v1 0.i256;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_1ccc v0 v5;
+        (v7.i256, v8.i1) = uaddo v0 v6;
+        br v8 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -1607,42 +1342,30 @@ func inline(always) private %std__lib__evm__storage_map__impl_trait____9761__wri
         evm_revert 0.i256 36.i256;
 
     block3:
-        v17.@layout_0 = extract_value v1 1.i256;
-        v18.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_1ccc v9 v17;
-        (v20.i256, v21.i1) = uaddo v7 v18;
-        br v21 block2 block4;
+        v15.@layout_0 = extract_value v1 1.i256;
+        v16.i256 = call %std__lib__evm__storage_map__impl_trait_Address_4d4e__write_key_1ccc v7 v15;
+        (v18.i256, v19.i1) = uaddo v6 v16;
+        br v19 block2 block4;
 
     block4:
-        return v20;
+        return v18;
 }
 
 func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_e8dd(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        mstore v4 v5 i256;
+        mstore v0 v1 i256;
         return 32.i256;
 }
 
 func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_f2a4(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        mstore v4 v5 i256;
+        mstore v0 v1 i256;
         return 32.i256;
 }
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/event_logging.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/event_logging.snap
@@ -15,14 +15,11 @@ global private const @layout_0 $const_region_1 = {2};
 
 func private %abi_payload_size(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = call %payload_size v2;
-        return v3;
+        v2.i256 = call %payload_size v0;
+        return v2;
 }
 
 func private %as_topic(v0.@layout_0) -> i256 {
@@ -36,16 +33,12 @@ func private %as_topic(v0.@layout_0) -> i256 {
 
 func inline(always) private %at(v0.i256) -> @layout_1 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = mload v1 i256;
-        v6.@layout_1 = insert_value undef.@layout_1 0.i256 v2;
-        v8.@layout_1 = insert_value v6 1.i256 v3;
-        return v8;
+        v4.@layout_1 = insert_value undef.@layout_1 0.i256 v0;
+        v6.@layout_1 = insert_value v4 1.i256 v0;
+        return v6;
 }
 
 func private %base(v0.objref<@layout_1>) -> i256 {
@@ -77,22 +70,19 @@ func inline(always) private %emit(v0.@layout_2) {
 
 func private %emit_transfer(v0.constref<@layout_0>, v1.constref<@layout_0>, v2.i256) {
     block0:
-        v3.*i256 = alloca i256;
-        mstore v3 v2 i256;
         jump block1;
 
     block1:
-        v6.i256 = mload v3 i256;
-        v7.objref<@layout_0> = obj.alloc @layout_0;
-        obj.init.const v7 v0;
-        v8.@layout_0 = obj.load v7;
-        v9.objref<@layout_0> = obj.alloc @layout_0;
-        obj.init.const v9 v1;
-        v10.@layout_0 = obj.load v9;
-        v13.@layout_2 = insert_value undef.@layout_2 0.i256 v8;
-        v15.@layout_2 = insert_value v13 1.i256 v10;
-        v17.@layout_2 = insert_value v15 2.i256 v6;
-        call %emit v17;
+        v6.objref<@layout_0> = obj.alloc @layout_0;
+        obj.init.const v6 v0;
+        v7.@layout_0 = obj.load v6;
+        v8.objref<@layout_0> = obj.alloc @layout_0;
+        obj.init.const v8 v1;
+        v9.@layout_0 = obj.load v8;
+        v12.@layout_2 = insert_value undef.@layout_2 0.i256 v7;
+        v14.@layout_2 = insert_value v12 1.i256 v9;
+        v16.@layout_2 = insert_value v14 2.i256 v2;
+        call %emit v16;
         return;
 }
 
@@ -137,37 +127,19 @@ func inline(always) private %encode_alloc(v0.i256) -> @layout_3 {
 
 func private %encoder_new(v0.i256) -> @layout_1 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.@layout_1 = call %new v2;
-        return v3;
+        v2.@layout_1 = call %new v0;
+        return v2;
 }
 
 func private %log3(v0.i256, v1.i256, v2.i256, v3.i256, v4.i256) {
     block0:
-        v5.*i256 = alloca i256;
-        v6.*i256 = alloca i256;
-        v7.*i256 = alloca i256;
-        v8.*i256 = alloca i256;
-        v9.*i256 = alloca i256;
-        mstore v5 v0 i256;
-        mstore v6 v1 i256;
-        mstore v7 v2 i256;
-        mstore v8 v3 i256;
-        mstore v9 v4 i256;
         jump block1;
 
     block1:
-        v10.i256 = mload v5 i256;
-        v11.i256 = mload v6 i256;
-        v12.i256 = mload v7 i256;
-        v13.i256 = mload v8 i256;
-        v14.i256 = mload v9 i256;
-        evm_log3 v10 v11 v12 v13 v14;
+        evm_log3 v0 v1 v2 v3 v4;
         return;
 }
 
@@ -193,34 +165,28 @@ func private %main_root() {
 
 func private %new(v0.i256) -> @layout_1 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v4.i1 = eq v2 0.i256;
-        br v4 block2 block3;
+        v3.i1 = eq v0 0.i256;
+        br v3 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v5.i256 = mload v1 i256;
-        v6.*i8 = evm_malloc v5;
-        v7.i256 = ptr_to_int v6 i256;
+        v5.*i8 = evm_malloc v0;
+        v6.i256 = ptr_to_int v5 i256;
         jump block4;
 
     block4:
-        v8.i256 = phi (0.i256 block2) (v7 block3);
-        v9.@layout_1 = call %at v8;
-        return v9;
+        v7.i256 = phi (0.i256 block2) (v6 block3);
+        v8.@layout_1 = call %at v7;
+        return v8;
 }
 
 func private %payload_size(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
@@ -229,18 +195,15 @@ func private %payload_size(v0.i256) -> i256 {
 
 func private %write_word(v0.objref<@layout_1>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 1.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        mstore v6 v7 i256;
-        v10.i256 = add v6 32.i256;
-        v11.objref<i256> = obj.proj v0 1.i256;
-        obj.store v11 v10;
+        v4.objref<i256> = obj.proj v0 1.i256;
+        v5.i256 = obj.load v4;
+        mstore v5 v1 i256;
+        v9.i256 = add v5 32.i256;
+        v10.objref<i256> = obj.proj v0 1.i256;
+        obj.store v10 v9;
         return;
 }
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/event_logging_via_log.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/event_logging_via_log.snap
@@ -15,14 +15,11 @@ global private const @layout_0 $const_region_1 = {2};
 
 func private %abi_payload_size(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = call %payload_size v2;
-        return v3;
+        v2.i256 = call %payload_size v0;
+        return v2;
 }
 
 func private %as_topic(v0.@layout_0) -> i256 {
@@ -36,16 +33,12 @@ func private %as_topic(v0.@layout_0) -> i256 {
 
 func inline(always) private %at(v0.i256) -> @layout_1 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = mload v1 i256;
-        v6.@layout_1 = insert_value undef.@layout_1 0.i256 v2;
-        v8.@layout_1 = insert_value v6 1.i256 v3;
-        return v8;
+        v4.@layout_1 = insert_value undef.@layout_1 0.i256 v0;
+        v6.@layout_1 = insert_value v4 1.i256 v0;
+        return v6;
 }
 
 func private %base(v0.objref<@layout_1>) -> i256 {
@@ -86,22 +79,19 @@ func inline(always) private %emit__gcd5c(v0.@layout_2) {
 
 func private %emit_transfer(v0.constref<@layout_0>, v1.constref<@layout_0>, v2.i256) {
     block0:
-        v3.*i256 = alloca i256;
-        mstore v3 v2 i256;
         jump block1;
 
     block1:
-        v6.i256 = mload v3 i256;
-        v7.objref<@layout_0> = obj.alloc @layout_0;
-        obj.init.const v7 v0;
-        v8.@layout_0 = obj.load v7;
-        v9.objref<@layout_0> = obj.alloc @layout_0;
-        obj.init.const v9 v1;
-        v10.@layout_0 = obj.load v9;
-        v13.@layout_2 = insert_value undef.@layout_2 0.i256 v8;
-        v15.@layout_2 = insert_value v13 1.i256 v10;
-        v17.@layout_2 = insert_value v15 2.i256 v6;
-        call %emit__g4f95 v17;
+        v6.objref<@layout_0> = obj.alloc @layout_0;
+        obj.init.const v6 v0;
+        v7.@layout_0 = obj.load v6;
+        v8.objref<@layout_0> = obj.alloc @layout_0;
+        obj.init.const v8 v1;
+        v9.@layout_0 = obj.load v8;
+        v12.@layout_2 = insert_value undef.@layout_2 0.i256 v7;
+        v14.@layout_2 = insert_value v12 1.i256 v9;
+        v16.@layout_2 = insert_value v14 2.i256 v2;
+        call %emit__g4f95 v16;
         return;
 }
 
@@ -146,37 +136,19 @@ func inline(always) private %encode_alloc(v0.i256) -> @layout_3 {
 
 func private %encoder_new(v0.i256) -> @layout_1 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.@layout_1 = call %new v2;
-        return v3;
+        v2.@layout_1 = call %new v0;
+        return v2;
 }
 
 func private %log3(v0.i256, v1.i256, v2.i256, v3.i256, v4.i256) {
     block0:
-        v5.*i256 = alloca i256;
-        v6.*i256 = alloca i256;
-        v7.*i256 = alloca i256;
-        v8.*i256 = alloca i256;
-        v9.*i256 = alloca i256;
-        mstore v5 v0 i256;
-        mstore v6 v1 i256;
-        mstore v7 v2 i256;
-        mstore v8 v3 i256;
-        mstore v9 v4 i256;
         jump block1;
 
     block1:
-        v10.i256 = mload v5 i256;
-        v11.i256 = mload v6 i256;
-        v12.i256 = mload v7 i256;
-        v13.i256 = mload v8 i256;
-        v14.i256 = mload v9 i256;
-        evm_log3 v10 v11 v12 v13 v14;
+        evm_log3 v0 v1 v2 v3 v4;
         return;
 }
 
@@ -202,34 +174,28 @@ func private %main_root() {
 
 func private %new(v0.i256) -> @layout_1 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v4.i1 = eq v2 0.i256;
-        br v4 block2 block3;
+        v3.i1 = eq v0 0.i256;
+        br v3 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v5.i256 = mload v1 i256;
-        v6.*i8 = evm_malloc v5;
-        v7.i256 = ptr_to_int v6 i256;
+        v5.*i8 = evm_malloc v0;
+        v6.i256 = ptr_to_int v5 i256;
         jump block4;
 
     block4:
-        v8.i256 = phi (0.i256 block2) (v7 block3);
-        v9.@layout_1 = call %at v8;
-        return v9;
+        v7.i256 = phi (0.i256 block2) (v6 block3);
+        v8.@layout_1 = call %at v7;
+        return v8;
 }
 
 func private %payload_size(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
@@ -238,18 +204,15 @@ func private %payload_size(v0.i256) -> i256 {
 
 func private %write_word(v0.objref<@layout_1>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 1.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        mstore v6 v7 i256;
-        v10.i256 = add v6 32.i256;
-        v11.objref<i256> = obj.proj v0 1.i256;
-        obj.store v11 v10;
+        v4.objref<i256> = obj.proj v0 1.i256;
+        v5.i256 = obj.load v4;
+        mstore v5 v1 i256;
+        v9.i256 = add v5 32.i256;
+        v10.objref<i256> = obj.proj v0 1.i256;
+        obj.store v10 v9;
         return;
 }
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/explicit_raw_boundaries.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/explicit_raw_boundaries.snap
@@ -38,24 +38,18 @@ func private %explicit_raw_boundaries() {
 
 func private %from_raw__g4a95(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        return v2;
+        return v0;
 }
 
 func private %from_raw__ge513(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        return v2;
+        return v0;
 }
 
 func private %main_root() {
@@ -69,55 +63,37 @@ func private %main_root() {
 
 func private %mem_ptr__g8840(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = call %from_raw__ge513 v2;
-        return v3;
+        v2.i256 = call %from_raw__ge513 v0;
+        return v2;
 }
 
 func private %mem_ptr__g9700(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = call %from_raw__g4a95 v2;
-        return v3;
+        v2.i256 = call %from_raw__g4a95 v0;
+        return v2;
 }
 
 func private %std__lib__evm__effects__impl_trait_Evm_d0d8__mstore_f26e(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        mstore v4 v5 i256;
+        mstore v0 v1 i256;
         return;
 }
 
 func private %std__lib__evm__effects__impl_trait_Evm_d0d8__mstore_f26e_0(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        mstore v4 v5 i256;
+        mstore v0 v1 i256;
         return;
 }
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/for_array.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/for_array.snap
@@ -9,28 +9,27 @@ global private const [i64; 25] $const_region_0 = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
 
 func private %for_array_sum() -> i64 {
     block0:
-        v0.*i64 = alloca i64;
         jump block1;
 
     block1:
+        v25.constref<[i64; 25]> = const.ref $const_region_0;
         v26.constref<[i64; 25]> = const.ref $const_region_0;
-        v27.constref<[i64; 25]> = const.ref $const_region_0;
-        v30.i256 = call %len v27;
+        v29.i256 = call %len v26;
         jump block2;
 
     block2:
-        v54.i64 = phi (0.i64 block1) (v45 block7);
-        v31.i256 = phi (0.i256 block1) (v48 block7);
-        v33.i1 = lt v31 v30;
-        br v33 block3 block4;
+        v51.i64 = phi (0.i64 block1) (v37 block7);
+        v30.i256 = phi (0.i256 block1) (v45 block7);
+        v32.i1 = lt v30 v29;
+        br v32 block3 block4;
 
     block3:
-        v36.i64 = call %get v27 v31;
-        (v38.i64, v39.i1) = uaddo v54 v36;
-        br v39 block5 block6;
+        v35.i64 = call %get v26 v30;
+        (v37.i64, v38.i1) = uaddo v51 v35;
+        br v38 block5 block6;
 
     block4:
-        return v54;
+        return v51;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -38,11 +37,8 @@ func private %for_array_sum() -> i64 {
         evm_revert 0.i256 36.i256;
 
     block6:
-        mstore v0 v38 i64;
-        v44.i256 = mload v0 i256;
-        v45.i64 = trunc v44 i64;
-        (v48.i256, v49.i1) = uaddo v31 1.i256;
-        br v49 block5 block7;
+        (v45.i256, v46.i1) = uaddo v30 1.i256;
+        br v46 block5 block7;
 
     block7:
         jump block2;
@@ -50,23 +46,20 @@ func private %for_array_sum() -> i64 {
 
 func private %get(v0.constref<[i64; 25]>, v1.i256) -> i64 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.i1 = lt v3 25.i256;
-        v7.i1 = is_zero v6;
-        br v7 block2 block3;
+        v5.i1 = lt v1 25.i256;
+        v6.i1 = is_zero v5;
+        br v6 block2 block3;
 
     block2:
         evm_revert 0.i256 0.i256;
 
     block3:
-        v9.constref<i64> = const.index v0 v3;
-        v10.i64 = const.load v9;
-        return v10;
+        v8.constref<i64> = const.index v0 v1;
+        v9.i64 = const.load v8;
+        return v9;
 }
 
 func private %len(v0.constref<[i64; 25]>) -> i256 {

--- a/crates/codegen/tests/fixtures/sonatina_ir/for_array_large.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/for_array_large.snap
@@ -9,28 +9,27 @@ global private const [i64; 10] $const_region_0 = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 
 func private %for_array_large_sum() -> i64 {
     block0:
-        v0.*i64 = alloca i64;
         jump block1;
 
     block1:
+        v10.constref<[i64; 10]> = const.ref $const_region_0;
         v11.constref<[i64; 10]> = const.ref $const_region_0;
-        v12.constref<[i64; 10]> = const.ref $const_region_0;
-        v15.i256 = call %len v12;
+        v14.i256 = call %len v11;
         jump block2;
 
     block2:
-        v39.i64 = phi (0.i64 block1) (v30 block7);
-        v16.i256 = phi (0.i256 block1) (v33 block7);
-        v18.i1 = lt v16 v15;
-        br v18 block3 block4;
+        v36.i64 = phi (0.i64 block1) (v22 block7);
+        v15.i256 = phi (0.i256 block1) (v30 block7);
+        v17.i1 = lt v15 v14;
+        br v17 block3 block4;
 
     block3:
-        v21.i64 = call %get v12 v16;
-        (v23.i64, v24.i1) = uaddo v39 v21;
-        br v24 block5 block6;
+        v20.i64 = call %get v11 v15;
+        (v22.i64, v23.i1) = uaddo v36 v20;
+        br v23 block5 block6;
 
     block4:
-        return v39;
+        return v36;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -38,11 +37,8 @@ func private %for_array_large_sum() -> i64 {
         evm_revert 0.i256 36.i256;
 
     block6:
-        mstore v0 v23 i64;
-        v29.i256 = mload v0 i256;
-        v30.i64 = trunc v29 i64;
-        (v33.i256, v34.i1) = uaddo v16 1.i256;
-        br v34 block5 block7;
+        (v30.i256, v31.i1) = uaddo v15 1.i256;
+        br v31 block5 block7;
 
     block7:
         jump block2;
@@ -50,23 +46,20 @@ func private %for_array_large_sum() -> i64 {
 
 func private %get(v0.constref<[i64; 10]>, v1.i256) -> i64 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.i1 = lt v3 10.i256;
-        v7.i1 = is_zero v6;
-        br v7 block2 block3;
+        v5.i1 = lt v1 10.i256;
+        v6.i1 = is_zero v5;
+        br v6 block2 block3;
 
     block2:
         evm_revert 0.i256 0.i256;
 
     block3:
-        v9.constref<i64> = const.index v0 v3;
-        v10.i64 = const.load v9;
-        return v10;
+        v8.constref<i64> = const.index v0 v1;
+        v9.i64 = const.load v8;
+        return v9;
 }
 
 func private %len(v0.constref<[i64; 10]>) -> i256 {

--- a/crates/codegen/tests/fixtures/sonatina_ir/for_range.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/for_range.snap
@@ -11,27 +11,26 @@ global private const @layout_0 $const_region_0 = {0, 10};
 
 func private %for_range_sum() -> i256 {
     block0:
-        v0.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.constref<@layout_0> = const.ref $const_region_0;
-        v4.i256 = call %len v3;
+        v2.constref<@layout_0> = const.ref $const_region_0;
+        v3.i256 = call %len v2;
         jump block2;
 
     block2:
-        v27.i256 = phi (0.i256 block1) (v18 block7);
-        v5.i256 = phi (0.i256 block1) (v21 block7);
-        v7.i1 = lt v5 v4;
-        br v7 block3 block4;
+        v25.i256 = phi (0.i256 block1) (v11 block7);
+        v4.i256 = phi (0.i256 block1) (v19 block7);
+        v6.i1 = lt v4 v3;
+        br v6 block3 block4;
 
     block3:
-        v10.i256 = call %get v3 v5;
-        (v12.i256, v13.i1) = uaddo v27 v10;
-        br v13 block5 block6;
+        v9.i256 = call %get v2 v4;
+        (v11.i256, v12.i1) = uaddo v25 v9;
+        br v12 block5 block6;
 
     block4:
-        return v27;
+        return v25;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -39,10 +38,8 @@ func private %for_range_sum() -> i256 {
         evm_revert 0.i256 36.i256;
 
     block6:
-        mstore v0 v12 i256;
-        v18.i256 = mload v0 i256;
-        (v21.i256, v22.i1) = uaddo v5 1.i256;
-        br v22 block5 block7;
+        (v19.i256, v20.i1) = uaddo v4 1.i256;
+        br v20 block5 block7;
 
     block7:
         jump block2;
@@ -50,16 +47,13 @@ func private %for_range_sum() -> i256 {
 
 func private %get(v0.constref<@layout_0>, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.constref<i256> = const.proj v0 0.i256;
-        v6.i256 = const.load v5;
-        v7.i256 = mload v2 i256;
-        (v8.i256, v9.i1) = uaddo v6 v7;
-        br v9 block2 block3;
+        v4.constref<i256> = const.proj v0 0.i256;
+        v5.i256 = const.load v4;
+        (v7.i256, v8.i1) = uaddo v5 v1;
+        br v8 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -67,7 +61,7 @@ func private %get(v0.constref<@layout_0>, v1.i256) -> i256 {
         evm_revert 0.i256 36.i256;
 
     block3:
-        return v8;
+        return v7;
 }
 
 func private %len(v0.constref<@layout_0>) -> i256 {

--- a/crates/codegen/tests/fixtures/sonatina_ir/full_contract.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/full_contract.snap
@@ -10,13 +10,10 @@ type @layout_1 = {i256, i256};
 
 func private %abi_encode(v0.i256) {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v1 i256;
-        call %mstore 0.i256 v3;
+        call %mstore 0.i256 v0;
         call %std__lib__evm__effects__impl_trait_Evm_0098__return_data_f771 0.i256 32.i256;
         unreachable;
 }
@@ -63,31 +60,19 @@ func private %impl_Point__area(v0.objref<@layout_1>) -> i256 {
 
 func private %calldataload(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = evm_calldata_load v2;
-        return v3;
+        v2.i256 = evm_calldata_load v0;
+        return v2;
 }
 
 func private %codecopy(v0.i256, v1.i256, v2.i256) {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        mstore v3 v0 i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
         jump block1;
 
     block1:
-        v6.i256 = mload v3 i256;
-        v7.i256 = mload v4 i256;
-        v8.i256 = mload v5 i256;
-        evm_code_copy v6 v7 v8;
+        evm_code_copy v0 v1 v2;
         return;
 }
 
@@ -206,59 +191,35 @@ func private %manual_contract_runtime_root_ShapeDispatcher() {
 
 func private %mstore(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        mstore v4 v5 i256;
+        mstore v0 v1 i256;
         return;
 }
 
 func private %std__lib__evm__effects__impl_trait_Evm_0098__return_data_b16a(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        evm_return v4 v5;
+        evm_return v0 v1;
 }
 
 func private %std__lib__evm__effects__impl_trait_Evm_0098__return_data_b16a_0(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        evm_return v4 v5;
+        evm_return v0 v1;
 }
 
 func private %std__lib__evm__effects__impl_trait_Evm_0098__return_data_f771(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        evm_return v4 v5;
+        evm_return v0 v1;
 }
 
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/function_call.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/function_call.snap
@@ -7,14 +7,11 @@ target = "evm-ethereum-osaka"
 
 func private %add_one(v0.i64) -> i64 {
     block0:
-        v1.*i64 = alloca i64;
-        mstore v1 v0 i64;
         jump block1;
 
     block1:
-        v2.i64 = mload v1 i64;
-        (v4.i64, v5.i1) = uaddo v2 1.i64;
-        br v5 block2 block3;
+        (v3.i64, v4.i1) = uaddo v0 1.i64;
+        br v4 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -22,7 +19,7 @@ func private %add_one(v0.i64) -> i64 {
         evm_revert 0.i256 36.i256;
 
     block3:
-        return v4;
+        return v3;
 }
 
 func private %call_add_one() -> i64 {

--- a/crates/codegen/tests/fixtures/sonatina_ir/high_level_contract.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/high_level_contract.snap
@@ -19,18 +19,12 @@ global private const @layout_4 $const_region_0 = {0};
 
 func private %__EchoContract_init(v0.i256, v1.i256, v2.i256) {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v0 i256;
-        mstore v4 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v3 i256;
-        evm_sstore v2 v5;
-        v7.i256 = mload v4 i256;
-        v9.i256 = add v2 1.i256;
-        evm_sstore v9 v7;
+        evm_sstore v2 v0;
+        v7.i256 = add v2 1.i256;
+        evm_sstore v7 v1;
         return;
 }
 
@@ -61,24 +55,21 @@ func private %__EchoContract_recv_0_2(v0.i256) -> i256 {
 
 func private %abi_field_size(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_9950_0 v2;
+        v2.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_9950_0 v0;
         br 0.i1 block2 block3;
 
     block2:
-        (v7.i256, v8.i1) = uaddo 32.i256 v3;
-        br v8 block5 block6;
+        (v6.i256, v7.i1) = uaddo 32.i256 v2;
+        br v7 block5 block6;
 
     block3:
         jump block4;
 
     block4:
-        return v3;
+        return v2;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -86,19 +77,16 @@ func private %abi_field_size(v0.i256) -> i256 {
         evm_revert 0.i256 36.i256;
 
     block6:
-        return v7;
+        return v6;
 }
 
 func private %abi_single_root_size(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = call %abi_field_size v2;
-        return v3;
+        v2.i256 = call %abi_field_size v0;
+        return v2;
 }
 
 func private %std__lib__evm__effects__impl_trait_Evm_c913__abort_2725() {
@@ -130,16 +118,12 @@ func private %std__lib__evm__effects__impl_trait_Evm_c913__abort_ee4e() {
 
 func inline(always) private %at(v0.i256) -> @layout_0 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = mload v1 i256;
-        v6.@layout_0 = insert_value undef.@layout_0 0.i256 v2;
-        v8.@layout_0 = insert_value v6 1.i256 v3;
-        return v8;
+        v4.@layout_0 = insert_value undef.@layout_0 0.i256 v0;
+        v6.@layout_0 = insert_value v4 1.i256 v0;
+        return v6;
 }
 
 func private %base__g463e(v0.objref<@layout_3>) -> i256 {
@@ -164,19 +148,11 @@ func private %impl_trait_SolEncoder__base(v0.objref<@layout_0>) -> i256 {
 
 func inline(always) private %checked_frame_end(v0.i256, v1.i256, v2.i256) -> i256 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        mstore v3 v0 i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
         jump block1;
 
     block1:
-        v6.i256 = mload v3 i256;
-        v7.i256 = mload v4 i256;
-        (v8.i256, v9.i1) = uaddo v6 v7;
-        br v9 block6 block7;
+        (v5.i256, v6.i1) = uaddo v0 v1;
+        br v6 block6 block7;
 
     block2:
         call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_f5d2;
@@ -186,12 +162,11 @@ func inline(always) private %checked_frame_end(v0.i256, v1.i256, v2.i256) -> i25
         jump block4;
 
     block4:
-        return v8;
+        return v5;
 
     block5:
-        v19.i256 = mload v5 i256;
-        v20.i1 = gt v8 v19;
-        br v20 block2 block3;
+        v17.i1 = gt v5 v2;
+        br v17 block2 block3;
 
     block6:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -199,24 +174,17 @@ func inline(always) private %checked_frame_end(v0.i256, v1.i256, v2.i256) -> i25
         evm_revert 0.i256 36.i256;
 
     block7:
-        v15.i256 = mload v3 i256;
-        v16.i1 = lt v8 v15;
-        br v16 block2 block5;
+        v13.i1 = lt v5 v0;
+        br v13 block2 block5;
 }
 
 func inline(always) private %checked_tail(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        (v6.i256, v7.i1) = uaddo v4 v5;
-        br v7 block5 block6;
+        (v4.i256, v5.i1) = uaddo v0 v1;
+        br v5 block5 block6;
 
     block2:
         call %std__lib__abi__sol__impl_trait_Sol_1f5f__decode_error_eb34;
@@ -226,7 +194,7 @@ func inline(always) private %checked_tail(v0.i256, v1.i256) -> i256 {
         jump block4;
 
     block4:
-        return v6;
+        return v4;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -234,9 +202,8 @@ func inline(always) private %checked_tail(v0.i256, v1.i256) -> i256 {
         evm_revert 0.i256 36.i256;
 
     block6:
-        v13.i256 = mload v2 i256;
-        v14.i1 = lt v6 v13;
-        br v14 block2 block3;
+        v12.i1 = lt v4 v0;
+        br v12 block2 block3;
 }
 
 func inline(always) private %contract_init_abi_EchoContract() {
@@ -472,29 +439,22 @@ func inline(always) private %decode_field(v0.objref<@layout_3>) -> i256 {
 
 func inline(always) private %decode_field_from(v0.@layout_4, v1.i256, v2.i256) -> i256 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v7.i256 = mload v4 i256;
-        v8.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_1f7f v0 v7;
-        v9.i256 = mload v3 i256;
-        (v10.i256, v11.i1) = uaddo v9 v8;
-        br v11 block5 block6;
+        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_1f7f v0 v2;
+        (v8.i256, v9.i1) = uaddo v1 v6;
+        br v9 block5 block6;
 
     block3:
         jump block4;
 
     block4:
-        v20.i256 = mload v4 i256;
-        v21.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_4818_0 v0 v20;
-        return v21;
+        v19.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_4818_0 v0 v2;
+        return v19;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -502,60 +462,44 @@ func inline(always) private %decode_field_from(v0.@layout_4, v1.i256, v2.i256) -
         evm_revert 0.i256 36.i256;
 
     block6:
-        v18.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_4818_0 v0 v10;
-        return v18;
+        v16.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_4818_0 v0 v8;
+        return v16;
 }
 
 func inline(always) private %decode_field_from_prechecked_head(v0.@layout_4, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        v6.*i256 = alloca i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
-        mstore v6 v3 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = mload v5 i256;
-        v10.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_1f7f v0 v9;
-        v11.i256 = mload v4 i256;
-        v12.i256 = call %checked_tail v11 v10;
-        v13.i256 = mload v6 i256;
-        v14.i256 = call %decode_from_bounded v0 v12 v13;
-        return v14;
+        v7.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_1f7f v0 v2;
+        v9.i256 = call %checked_tail v1 v7;
+        v11.i256 = call %decode_from_bounded v0 v9 v3;
+        return v11;
 
     block3:
         jump block4;
 
     block4:
-        v16.i256 = mload v5 i256;
-        v17.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_4818_0 v0 v16;
-        return v17;
+        v14.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_4818_0 v0 v2;
+        return v14;
 }
 
 func inline(always) private %impl_trait_Echo__decode_from__gd20d(v0.@layout_4, v1.i256) -> @layout_5 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_6a97 v0;
-        v5.i256 = mload v2 i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = call %decode_msg_field_from v0 v5 v6 v4;
-        v10.@layout_5 = insert_value undef.@layout_5 0.i256 v7;
-        return v10;
+        v3.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_6a97 v0;
+        v5.i256 = call %decode_msg_field_from v0 v1 v1 v3;
+        v8.@layout_5 = insert_value undef.@layout_5 0.i256 v5;
+        return v8;
 }
 
 func inline(always) private %impl_trait_Answer__decode_from__gd20d(v0.@layout_4, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
@@ -564,8 +508,6 @@ func inline(always) private %impl_trait_Answer__decode_from__gd20d(v0.@layout_4,
 
 func inline(always) private %impl_trait_GetX__decode_from__gd20d(v0.@layout_4, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
@@ -574,119 +516,76 @@ func inline(always) private %impl_trait_GetX__decode_from__gd20d(v0.@layout_4, v
 
 func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_4818(v0.@layout_4, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_81b2 v0 v4;
-        return v5;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_81b2 v0 v1;
+        return v4;
 }
 
 func inline(always) private %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_4818_0(v0.@layout_4, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_81b2_0 v0 v4;
-        return v5;
+        v4.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_81b2_0 v0 v1;
+        return v4;
 }
 
 func private %decode_from_bounded(v0.@layout_4, v1.i256, v2.i256) -> i256 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v3 i256;
-        v7.i256 = mload v4 i256;
-        v8.i256 = call %checked_frame_end v5 32.i256 v7;
-        v10.i256 = mload v3 i256;
-        v11.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_4818 v0 v10;
-        return v11;
+        v6.i256 = call %checked_frame_end v1 32.i256 v2;
+        v8.i256 = call %core__lib__abi__impl_trait_u256_85b6__decode_from__g72ab_4818 v0 v1;
+        return v8;
 }
 
 func inline(always) private %decode_from_prechecked_head__g2d0f(v0.@layout_4, v1.i256, v2.i256) {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v4 i256;
-        v7.i256 = mload v3 i256;
-        call %impl_trait_GetX__decode_from__gd20d v0 v7;
+        call %impl_trait_GetX__decode_from__gd20d v0 v1;
         return;
 }
 
 func inline(always) private %decode_from_prechecked_head__g2f3f(v0.@layout_4, v1.i256, v2.i256) {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v4 i256;
-        v7.i256 = mload v3 i256;
-        call %impl_trait_Answer__decode_from__gd20d v0 v7;
+        call %impl_trait_Answer__decode_from__gd20d v0 v1;
         return;
 }
 
 func inline(always) private %decode_from_prechecked_head__g6fcf(v0.@layout_4, v1.i256, v2.i256) -> @layout_5 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v4 i256;
-        v7.i256 = mload v3 i256;
-        v8.@layout_5 = call %impl_trait_Echo__decode_from__gd20d v0 v7;
-        return v8;
+        v6.@layout_5 = call %impl_trait_Echo__decode_from__gd20d v0 v1;
+        return v6;
 }
 
 func inline(always) private %decode_msg_field_from(v0.@layout_4, v1.i256, v2.i256, v3.i256) -> i256 {
     block0:
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        v6.*i256 = alloca i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
-        mstore v6 v3 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v9.i256 = mload v4 i256;
-        v10.i256 = mload v5 i256;
-        v11.i256 = mload v6 i256;
-        v12.i256 = call %decode_field_from_prechecked_head v0 v9 v10 v11;
-        return v12;
+        v9.i256 = call %decode_field_from_prechecked_head v0 v1 v2 v3;
+        return v9;
 
     block3:
         jump block4;
 
     block4:
-        v13.i256 = mload v6 i256;
-        v15.i256 = mload v4 i256;
-        v16.i256 = mload v5 i256;
-        v17.i256 = call %decode_field_from v0 v15 v16;
-        return v17;
+        v14.i256 = call %decode_field_from v0 v1 v2;
+        return v14;
 }
 
 func inline(always) private %decode_payload__g407e(v0.objref<@layout_3>) -> i256 {
@@ -714,14 +613,12 @@ func inline(always) private %decode_runtime_args__g9e33(v0.objref<@layout_8>) ->
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v4.@layout_4 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_024f;
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_7c2f v4;
-        mstore v1 v6 i256;
-        mstore v2 4.i256 i256;
+        v3.@layout_4 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_024f;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_7c2f v3;
+        mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
 
     block2:
@@ -732,30 +629,26 @@ func inline(always) private %decode_runtime_args__g9e33(v0.objref<@layout_8>) ->
         jump block4;
 
     block4:
-        v12.i256 = mload v1 i256;
-        v13.@layout_5 = call %decode_from_prechecked_head__g6fcf v4 4.i256 v12;
-        return v13;
+        v12.@layout_5 = call %decode_from_prechecked_head__g6fcf v3 4.i256 v5;
+        return v12;
 
     block5:
-        v14.i256 = mload v1 i256;
-        mstore v3 v14 i256;
-        v16.i256 = mload v3 i256;
-        v17.i1 = gt 36.i256 v16;
-        br v17 block2 block3;
+        mstore v2 v5 i256;
+        v15.i256 = mload v2 i256;
+        v16.i1 = gt 36.i256 v15;
+        br v16 block2 block3;
 }
 
 func inline(always) private %decode_runtime_args__gf173(v0.objref<@layout_8>) {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v4.@layout_4 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_58ca;
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_34dc v4;
-        mstore v1 v6 i256;
-        mstore v2 4.i256 i256;
+        v3.@layout_4 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_58ca;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_34dc v3;
+        mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
 
     block2:
@@ -766,30 +659,26 @@ func inline(always) private %decode_runtime_args__gf173(v0.objref<@layout_8>) {
         jump block4;
 
     block4:
-        v11.i256 = mload v1 i256;
-        call %decode_from_prechecked_head__g2d0f v4 4.i256 v11;
+        call %decode_from_prechecked_head__g2d0f v3 4.i256 v5;
         return;
 
     block5:
-        v13.i256 = mload v1 i256;
-        mstore v3 v13 i256;
-        v15.i256 = mload v3 i256;
-        v16.i1 = gt 4.i256 v15;
-        br v16 block2 block3;
+        mstore v2 v5 i256;
+        v14.i256 = mload v2 i256;
+        v15.i1 = gt 4.i256 v14;
+        br v15 block2 block3;
 }
 
 func inline(always) private %decode_runtime_args__g235a(v0.objref<@layout_8>) {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v4.@layout_4 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_414c;
-        v6.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_1779 v4;
-        mstore v1 v6 i256;
-        mstore v2 4.i256 i256;
+        v3.@layout_4 = call %std__lib__evm__effects__impl_trait_Evm_c913__input_414c;
+        v5.i256 = call %std__lib__evm__calldata__impl_trait_CallData_087c__len_1779 v3;
+        mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
 
     block2:
@@ -800,16 +689,14 @@ func inline(always) private %decode_runtime_args__g235a(v0.objref<@layout_8>) {
         jump block4;
 
     block4:
-        v11.i256 = mload v1 i256;
-        call %decode_from_prechecked_head__g2f3f v4 4.i256 v11;
+        call %decode_from_prechecked_head__g2f3f v3 4.i256 v5;
         return;
 
     block5:
-        v13.i256 = mload v1 i256;
-        mstore v3 v13 i256;
-        v15.i256 = mload v3 i256;
-        v16.i1 = gt 4.i256 v15;
-        br v16 block2 block3;
+        mstore v2 v5 i256;
+        v14.i256 = mload v2 i256;
+        v15.i1 = gt 4.i256 v14;
+        br v15 block2 block3;
 }
 
 func private %decoder_new(v0.@layout_1) -> @layout_3 {
@@ -914,26 +801,20 @@ func private %encode_single_root_alloc(v0.i256) -> @layout_6 {
 
 func private %encode_to_ptr(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        call %store_word v3 v0;
+        call %store_word v1 v0;
         return;
 }
 
 func private %encoder_new(v0.i256) -> @layout_0 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.@layout_0 = call %impl_SolEncoder__new v2;
-        return v3;
+        v2.@layout_0 = call %impl_SolEncoder__new v0;
+        return v2;
 }
 
 func private %std__lib__evm__effects__impl_trait_Evm_c913__input_024f() -> @layout_4 {
@@ -966,31 +847,27 @@ func private %std__lib__evm__effects__impl_trait_Evm_c913__input_58ca() -> @layo
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_1779(v0.@layout_4) -> i256 {
     block0:
         v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.i256 = extract_value v0 0.i256;
-        v7.i256 = mload v1 i256;
-        mstore v2 v7 i256;
-        v8.i256 = mload v2 i256;
-        v9.i1 = gt v6 v8;
-        br v9 block2 block3;
+        v2.i256 = evm_calldata_size;
+        v5.i256 = extract_value v0 0.i256;
+        mstore v1 v2 i256;
+        v6.i256 = mload v1 i256;
+        v7.i1 = gt v5 v6;
+        br v7 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v11.i256 = extract_value v0 0.i256;
-        v12.i256 = mload v1 i256;
-        (v13.i256, v14.i1) = usubo v12 v11;
-        br v14 block5 block6;
+        v9.i256 = extract_value v0 0.i256;
+        (v11.i256, v12.i1) = usubo v2 v9;
+        br v12 block5 block6;
 
     block4:
-        v19.i256 = phi (0.i256 block2) (v13 block6);
-        return v19;
+        v17.i256 = phi (0.i256 block2) (v11 block6);
+        return v17;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -1004,31 +881,27 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_34dc(v0.@layout_4) -> i256 {
     block0:
         v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.i256 = extract_value v0 0.i256;
-        v7.i256 = mload v1 i256;
-        mstore v2 v7 i256;
-        v8.i256 = mload v2 i256;
-        v9.i1 = gt v6 v8;
-        br v9 block2 block3;
+        v2.i256 = evm_calldata_size;
+        v5.i256 = extract_value v0 0.i256;
+        mstore v1 v2 i256;
+        v6.i256 = mload v1 i256;
+        v7.i1 = gt v5 v6;
+        br v7 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v11.i256 = extract_value v0 0.i256;
-        v12.i256 = mload v1 i256;
-        (v13.i256, v14.i1) = usubo v12 v11;
-        br v14 block5 block6;
+        v9.i256 = extract_value v0 0.i256;
+        (v11.i256, v12.i1) = usubo v2 v9;
+        br v12 block5 block6;
 
     block4:
-        v19.i256 = phi (0.i256 block2) (v13 block6);
-        return v19;
+        v17.i256 = phi (0.i256 block2) (v11 block6);
+        return v17;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -1042,31 +915,27 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_6a97(v0.@layout_4) -> i256 {
     block0:
         v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.i256 = extract_value v0 0.i256;
-        v7.i256 = mload v1 i256;
-        mstore v2 v7 i256;
-        v8.i256 = mload v2 i256;
-        v9.i1 = gt v6 v8;
-        br v9 block2 block3;
+        v2.i256 = evm_calldata_size;
+        v5.i256 = extract_value v0 0.i256;
+        mstore v1 v2 i256;
+        v6.i256 = mload v1 i256;
+        v7.i1 = gt v5 v6;
+        br v7 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v11.i256 = extract_value v0 0.i256;
-        v12.i256 = mload v1 i256;
-        (v13.i256, v14.i1) = usubo v12 v11;
-        br v14 block5 block6;
+        v9.i256 = extract_value v0 0.i256;
+        (v11.i256, v12.i1) = usubo v2 v9;
+        br v12 block5 block6;
 
     block4:
-        v19.i256 = phi (0.i256 block2) (v13 block6);
-        return v19;
+        v17.i256 = phi (0.i256 block2) (v11 block6);
+        return v17;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -1080,31 +949,27 @@ func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__len_7c2f(v0.@layout_4) -> i256 {
     block0:
         v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.i256 = extract_value v0 0.i256;
-        v7.i256 = mload v1 i256;
-        mstore v2 v7 i256;
-        v8.i256 = mload v2 i256;
-        v9.i1 = gt v6 v8;
-        br v9 block2 block3;
+        v2.i256 = evm_calldata_size;
+        v5.i256 = extract_value v0 0.i256;
+        mstore v1 v2 i256;
+        v6.i256 = mload v1 i256;
+        v7.i1 = gt v5 v6;
+        br v7 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v11.i256 = extract_value v0 0.i256;
-        v12.i256 = mload v1 i256;
-        (v13.i256, v14.i1) = usubo v12 v11;
-        br v14 block5 block6;
+        v9.i256 = extract_value v0 0.i256;
+        (v11.i256, v12.i1) = usubo v2 v9;
+        br v12 block5 block6;
 
     block4:
-        v19.i256 = phi (0.i256 block2) (v13 block6);
-        return v19;
+        v17.i256 = phi (0.i256 block2) (v11 block6);
+        return v17;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -1137,28 +1002,24 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_f8db
 
 func private %impl_SolEncoder__new(v0.i256) -> @layout_0 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v4.i1 = eq v2 0.i256;
-        br v4 block2 block3;
+        v3.i1 = eq v0 0.i256;
+        br v3 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v5.i256 = mload v1 i256;
-        v6.*i8 = evm_malloc v5;
-        v7.i256 = ptr_to_int v6 i256;
+        v5.*i8 = evm_malloc v0;
+        v6.i256 = ptr_to_int v5 i256;
         jump block4;
 
     block4:
-        v8.i256 = phi (0.i256 block2) (v7 block3);
-        v9.@layout_0 = call %at v8;
-        return v9;
+        v7.i256 = phi (0.i256 block2) (v6 block3);
+        v8.@layout_0 = call %at v7;
+        return v8;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_CallData_8f43__new_45d4() -> @layout_4 {
@@ -1220,8 +1081,6 @@ func inline(always) private %impl_SolDecoder__new__g463e(v0.@layout_1) -> @layou
 
 func private %core__lib__abi__trait_AbiSize__payload_size__ge513_9950(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
@@ -1230,8 +1089,6 @@ func private %core__lib__abi__trait_AbiSize__payload_size__ge513_9950(v0.i256) -
 
 func private %core__lib__abi__trait_AbiSize__payload_size__ge513_9950_0(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
@@ -1262,22 +1119,20 @@ func private %impl_trait_SolEncoder__pos(v0.objref<@layout_0>) -> i256 {
 func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_66f1(v0.objref<@layout_3>) -> i256 {
     block0:
         v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v5.objref<@layout_2> = obj.proj v0 0.i256;
-        v6.objref<@layout_1> = obj.proj v5 0.i256;
-        v7.@layout_1 = obj.load v6;
-        v8.objref<@layout_2> = obj.proj v0 0.i256;
-        v9.objref<@layout_1> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_f8db v9;
-        mstore v1 v10 i256;
-        v11.objref<@layout_2> = obj.proj v0 0.i256;
-        v13.objref<i256> = obj.proj v11 1.i256;
-        v14.i256 = obj.load v13;
-        (v16.i256, v17.i1) = uaddo v14 32.i256;
-        br v17 block6 block7;
+        v4.objref<@layout_2> = obj.proj v0 0.i256;
+        v5.objref<@layout_1> = obj.proj v4 0.i256;
+        v6.@layout_1 = obj.load v5;
+        v7.objref<@layout_2> = obj.proj v0 0.i256;
+        v8.objref<@layout_1> = obj.proj v7 0.i256;
+        v9.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_f8db v8;
+        v10.objref<@layout_2> = obj.proj v0 0.i256;
+        v12.objref<i256> = obj.proj v10 1.i256;
+        v13.i256 = obj.load v12;
+        (v15.i256, v16.i1) = uaddo v13 32.i256;
+        br v16 block6 block7;
 
     block2:
         evm_revert 0.i256 0.i256;
@@ -1286,26 +1141,25 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         jump block4;
 
     block4:
-        v28.objref<@layout_2> = obj.proj v0 0.i256;
-        v29.objref<@layout_1> = obj.proj v28 0.i256;
-        v30.@layout_1 = obj.load v29;
-        v31.objref<@layout_2> = obj.proj v0 0.i256;
-        v32.objref<i256> = obj.proj v31 1.i256;
-        v33.i256 = obj.load v32;
-        v34.objref<@layout_2> = obj.proj v0 0.i256;
-        v35.objref<@layout_1> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_7f06 v35 v33;
-        v38.objref<@layout_2> = obj.proj v0 0.i256;
-        v39.objref<i256> = obj.proj v38 1.i256;
-        obj.store v39 v16;
-        return v36;
+        v27.objref<@layout_2> = obj.proj v0 0.i256;
+        v28.objref<@layout_1> = obj.proj v27 0.i256;
+        v29.@layout_1 = obj.load v28;
+        v30.objref<@layout_2> = obj.proj v0 0.i256;
+        v31.objref<i256> = obj.proj v30 1.i256;
+        v32.i256 = obj.load v31;
+        v33.objref<@layout_2> = obj.proj v0 0.i256;
+        v34.objref<@layout_1> = obj.proj v33 0.i256;
+        v35.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_7f06 v34 v32;
+        v37.objref<@layout_2> = obj.proj v0 0.i256;
+        v38.objref<i256> = obj.proj v37 1.i256;
+        obj.store v38 v15;
+        return v35;
 
     block5:
-        v40.i256 = mload v1 i256;
-        mstore v2 v40 i256;
-        v42.i256 = mload v2 i256;
-        v43.i1 = gt v16 v42;
-        br v43 block2 block3;
+        mstore v1 v9 i256;
+        v41.i256 = mload v1 i256;
+        v42.i1 = gt v15 v41;
+        br v42 block2 block3;
 
     block6:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -1313,32 +1167,30 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         evm_revert 0.i256 36.i256;
 
     block7:
-        v23.objref<@layout_2> = obj.proj v0 0.i256;
-        v24.objref<i256> = obj.proj v23 1.i256;
-        v25.i256 = obj.load v24;
-        v26.i1 = lt v16 v25;
-        br v26 block2 block5;
+        v22.objref<@layout_2> = obj.proj v0 0.i256;
+        v23.objref<i256> = obj.proj v22 1.i256;
+        v24.i256 = obj.load v23;
+        v25.i1 = lt v15 v24;
+        br v25 block2 block5;
 }
 
 func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_d95a(v0.objref<@layout_3>) -> i256 {
     block0:
         v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v5.objref<@layout_2> = obj.proj v0 0.i256;
-        v6.objref<@layout_1> = obj.proj v5 0.i256;
-        v7.@layout_1 = obj.load v6;
-        v8.objref<@layout_2> = obj.proj v0 0.i256;
-        v9.objref<@layout_1> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_8748 v9;
-        mstore v1 v10 i256;
-        v11.objref<@layout_2> = obj.proj v0 0.i256;
-        v13.objref<i256> = obj.proj v11 1.i256;
-        v14.i256 = obj.load v13;
-        (v16.i256, v17.i1) = uaddo v14 32.i256;
-        br v17 block6 block7;
+        v4.objref<@layout_2> = obj.proj v0 0.i256;
+        v5.objref<@layout_1> = obj.proj v4 0.i256;
+        v6.@layout_1 = obj.load v5;
+        v7.objref<@layout_2> = obj.proj v0 0.i256;
+        v8.objref<@layout_1> = obj.proj v7 0.i256;
+        v9.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_8748 v8;
+        v10.objref<@layout_2> = obj.proj v0 0.i256;
+        v12.objref<i256> = obj.proj v10 1.i256;
+        v13.i256 = obj.load v12;
+        (v15.i256, v16.i1) = uaddo v13 32.i256;
+        br v16 block6 block7;
 
     block2:
         evm_revert 0.i256 0.i256;
@@ -1347,26 +1199,25 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         jump block4;
 
     block4:
-        v28.objref<@layout_2> = obj.proj v0 0.i256;
-        v29.objref<@layout_1> = obj.proj v28 0.i256;
-        v30.@layout_1 = obj.load v29;
-        v31.objref<@layout_2> = obj.proj v0 0.i256;
-        v32.objref<i256> = obj.proj v31 1.i256;
-        v33.i256 = obj.load v32;
-        v34.objref<@layout_2> = obj.proj v0 0.i256;
-        v35.objref<@layout_1> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_38bd v35 v33;
-        v38.objref<@layout_2> = obj.proj v0 0.i256;
-        v39.objref<i256> = obj.proj v38 1.i256;
-        obj.store v39 v16;
-        return v36;
+        v27.objref<@layout_2> = obj.proj v0 0.i256;
+        v28.objref<@layout_1> = obj.proj v27 0.i256;
+        v29.@layout_1 = obj.load v28;
+        v30.objref<@layout_2> = obj.proj v0 0.i256;
+        v31.objref<i256> = obj.proj v30 1.i256;
+        v32.i256 = obj.load v31;
+        v33.objref<@layout_2> = obj.proj v0 0.i256;
+        v34.objref<@layout_1> = obj.proj v33 0.i256;
+        v35.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_38bd v34 v32;
+        v37.objref<@layout_2> = obj.proj v0 0.i256;
+        v38.objref<i256> = obj.proj v37 1.i256;
+        obj.store v38 v15;
+        return v35;
 
     block5:
-        v40.i256 = mload v1 i256;
-        mstore v2 v40 i256;
-        v42.i256 = mload v2 i256;
-        v43.i1 = gt v16 v42;
-        br v43 block2 block3;
+        mstore v1 v9 i256;
+        v41.i256 = mload v1 i256;
+        v42.i1 = gt v15 v41;
+        br v42 block2 block3;
 
     block6:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -1374,226 +1225,169 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         evm_revert 0.i256 36.i256;
 
     block7:
-        v23.objref<@layout_2> = obj.proj v0 0.i256;
-        v24.objref<i256> = obj.proj v23 1.i256;
-        v25.i256 = obj.load v24;
-        v26.i1 = lt v16 v25;
-        br v26 block2 block5;
+        v22.objref<@layout_2> = obj.proj v0 0.i256;
+        v23.objref<i256> = obj.proj v22 1.i256;
+        v24.i256 = obj.load v23;
+        v25.i1 = lt v15 v24;
+        br v25 block2 block5;
 }
 
 func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_6da5(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        evm_revert v4 v5;
+        evm_revert v0 v1;
 }
 
 func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_a97d(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        evm_revert v4 v5;
+        evm_revert v0 v1;
 }
 
 func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_f892(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        evm_revert v4 v5;
+        evm_revert v0 v1;
 }
 
 func private %impl_trait_SolEncoder__set_base(v0.objref<@layout_0>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        obj.store v6 v3;
+        v5.objref<i256> = obj.proj v0 0.i256;
+        obj.store v5 v1;
         return;
 }
 
 func private %set_base__g463e(v0.objref<@layout_3>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 1.i256;
-        obj.store v6 v3;
+        v5.objref<i256> = obj.proj v0 1.i256;
+        obj.store v5 v1;
         return;
 }
 
 func private %set_pos__g463e(v0.objref<@layout_3>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<@layout_2> = obj.proj v0 0.i256;
-        v8.objref<i256> = obj.proj v6 1.i256;
-        obj.store v8 v3;
+        v5.objref<@layout_2> = obj.proj v0 0.i256;
+        v7.objref<i256> = obj.proj v5 1.i256;
+        obj.store v7 v1;
         return;
 }
 
 func private %impl_trait_SolEncoder__set_pos(v0.objref<@layout_0>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 1.i256;
-        obj.store v6 v3;
+        v5.objref<i256> = obj.proj v0 1.i256;
+        obj.store v5 v1;
         return;
 }
 
 func private %store_word(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        mstore v4 v5 i256;
+        mstore v0 v1 i256;
         return;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_1f7f(v0.@layout_4, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_38bd(v0.objref<@layout_1>, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = mload v8 i256;
-        return v9;
+        v4.objref<i256> = obj.proj v0 0.i256;
+        v5.i256 = obj.load v4;
+        v7.i256 = add v5 v1;
+        v8.i256 = mload v7 i256;
+        return v8;
 }
 
 func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_7f06(v0.objref<@layout_1>, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = mload v8 i256;
-        return v9;
+        v4.objref<i256> = obj.proj v0 0.i256;
+        v5.i256 = obj.load v4;
+        v7.i256 = add v5 v1;
+        v8.i256 = mload v7 i256;
+        return v8;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_81b2(v0.@layout_4, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func inline(always) private %std__lib__evm__calldata__impl_trait_CallData_087c__word_at_81b2_0(v0.@layout_4, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        v7.i256 = add v5 v6;
-        v8.i256 = evm_calldata_load v7;
-        return v8;
+        v4.i256 = extract_value v0 0.i256;
+        v6.i256 = add v4 v1;
+        v7.i256 = evm_calldata_load v6;
+        return v7;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_6213(v0.objref<@layout_0>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 1.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        mstore v6 v7 i256;
-        v10.i256 = add v6 32.i256;
-        v11.objref<i256> = obj.proj v0 1.i256;
-        obj.store v11 v10;
+        v4.objref<i256> = obj.proj v0 1.i256;
+        v5.i256 = obj.load v4;
+        mstore v5 v1 i256;
+        v9.i256 = add v5 32.i256;
+        v10.objref<i256> = obj.proj v0 1.i256;
+        obj.store v10 v9;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_d116(v0.objref<@layout_0>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 1.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        mstore v6 v7 i256;
-        v10.i256 = add v6 32.i256;
-        v11.objref<i256> = obj.proj v0 1.i256;
-        obj.store v11 v10;
+        v4.objref<i256> = obj.proj v0 1.i256;
+        v5.i256 = obj.load v4;
+        mstore v5 v1 i256;
+        v9.i256 = add v5 32.i256;
+        v10.objref<i256> = obj.proj v0 1.i256;
+        obj.store v10 v9;
         return;
 }
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/if_else.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/if_else.snap
@@ -7,14 +7,11 @@ target = "evm-ethereum-osaka"
 
 func private %helper(v0.i64) -> i64 {
     block0:
-        v1.*i64 = alloca i64;
-        mstore v1 v0 i64;
         jump block1;
 
     block1:
-        v2.i64 = mload v1 i64;
-        (v4.i64, v5.i1) = uaddo v2 1.i64;
-        br v5 block2 block3;
+        (v3.i64, v4.i1) = uaddo v0 1.i64;
+        br v4 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -22,30 +19,27 @@ func private %helper(v0.i64) -> i64 {
         evm_revert 0.i256 36.i256;
 
     block3:
-        return v4;
+        return v3;
 }
 
 func private %if_else(v0.i1) -> i64 {
     block0:
-        v1.*i1 = alloca i1;
-        mstore v1 v0 i1;
         jump block1;
 
     block1:
-        v2.i1 = mload v1 i1;
-        br v2 block2 block3;
+        br v0 block2 block3;
 
     block2:
-        v4.i64 = call %helper 1.i64;
+        v3.i64 = call %helper 1.i64;
         jump block4;
 
     block3:
-        v6.i64 = call %helper 2.i64;
+        v5.i64 = call %helper 2.i64;
         jump block4;
 
     block4:
-        v7.i64 = phi (v4 block2) (v6 block3);
-        return v7;
+        v6.i64 = phi (v3 block2) (v5 block3);
+        return v6;
 }
 
 func private %main() -> i64 {

--- a/crates/codegen/tests/fixtures/sonatina_ir/init_args_with_child_dep.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/init_args_with_child_dep.snap
@@ -15,10 +15,6 @@ type @layout_6 = {i256};
 
 func private %__Child_init(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
@@ -27,16 +23,12 @@ func private %__Child_init(v0.i256, v1.i256) {
 
 func private %__Parent_init(v0.i256) {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v1 i256;
-        v4.i256 = mload v1 i256;
-        v6.@layout_0 = insert_value undef.@layout_0 0.i256 v3;
-        v8.@layout_0 = insert_value v6 1.i256 v4;
-        v9.@layout_5 = call %create 0.i256 v8;
+        v4.@layout_0 = insert_value undef.@layout_0 0.i256 v0;
+        v6.@layout_0 = insert_value v4 1.i256 v0;
+        v7.@layout_5 = call %create 0.i256 v6;
         return;
 }
 
@@ -51,16 +43,12 @@ func private %abi_payload_size(v0.@layout_0) -> i256 {
 
 func inline(always) private %at(v0.i256) -> @layout_1 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = mload v1 i256;
-        v6.@layout_1 = insert_value undef.@layout_1 0.i256 v2;
-        v8.@layout_1 = insert_value v6 1.i256 v3;
-        return v8;
+        v4.@layout_1 = insert_value undef.@layout_1 0.i256 v0;
+        v6.@layout_1 = insert_value v4 1.i256 v0;
+        return v6;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__base__g463e_1672(v0.objref<@layout_4>) -> i256 {
@@ -299,29 +287,21 @@ func private %contract_runtime_root_Parent() {
 func private %copy_words(v0.i256, v1.i256, v2.i256) {
     block0:
         v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        v6.*i256 = alloca i256;
-        mstore v3 v0 i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
         jump block1;
 
     block1:
-        mstore v6 0.i256 i256;
+        mstore v3 0.i256 i256;
         jump block2;
 
     block2:
-        v8.i256 = mload v6 i256;
-        v9.i256 = mload v5 i256;
-        v10.i1 = lt v8 v9;
-        br v10 block3 block4;
+        v5.i256 = mload v3 i256;
+        v7.i1 = lt v5 v2;
+        br v7 block3 block4;
 
     block3:
-        v11.i256 = mload v3 i256;
-        v12.i256 = mload v6 i256;
-        (v13.i256, v14.i1) = uaddo v11 v12;
-        br v14 block5 block6;
+        v9.i256 = mload v3 i256;
+        (v10.i256, v11.i1) = uaddo v0 v9;
+        br v11 block5 block6;
 
     block4:
         return;
@@ -332,70 +312,66 @@ func private %copy_words(v0.i256, v1.i256, v2.i256) {
         evm_revert 0.i256 36.i256;
 
     block6:
-        v19.i256 = mload v4 i256;
-        v20.i256 = mload v6 i256;
-        (v21.i256, v22.i1) = uaddo v19 v20;
-        br v22 block5 block7;
+        v17.i256 = mload v3 i256;
+        (v18.i256, v19.i1) = uaddo v1 v17;
+        br v19 block5 block7;
 
     block7:
-        v23.i256 = mload v21 i256;
-        mstore v13 v23 i256;
-        v26.i256 = ptr_to_int v6 i256;
-        v28.i256 = mload v26 i256;
-        (v29.i256, v30.i1) = uaddo v28 32.i256;
-        br v30 block5 block8;
+        v20.i256 = mload v18 i256;
+        mstore v10 v20 i256;
+        v23.i256 = ptr_to_int v3 i256;
+        v25.i256 = mload v23 i256;
+        (v26.i256, v27.i1) = uaddo v25 32.i256;
+        br v27 block5 block8;
 
     block8:
-        mstore v26 v29 i256;
+        mstore v23 v26 i256;
         jump block2;
 }
 
 func private %create(v0.i256, v1.@layout_0) -> @layout_5 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v0 i256;
         jump block1;
 
     block1:
-        v3.i256 = sym_size &Child_init;
-        v4.i256 = sym_addr &Child_init;
+        v2.i256 = sym_size &Child_init;
+        v3.i256 = sym_addr &Child_init;
         br 1.i1 block5 block3;
 
     block2:
-        v8.*i8 = evm_malloc v3;
-        v9.i256 = ptr_to_int v8 i256;
-        evm_code_copy v9 v4 v3;
-        v12.i256 = mload v2 i256;
-        v13.@layout_5 = call %create_raw v12 v9 v3;
+        v7.*i8 = evm_malloc v2;
+        v8.i256 = ptr_to_int v7 i256;
+        evm_code_copy v8 v3 v2;
+        v12.@layout_5 = call %create_raw v0 v8 v2;
         jump block4;
 
     block3:
-        v15.@layout_0 = call %encode_abi_payload v1;
-        v17.i256 = extract_value v15 1.i256;
-        (v19.i256, v20.i1) = uaddo v3 v17;
-        br v20 block9 block10;
+        v14.@layout_0 = call %encode_abi_payload v1;
+        v16.i256 = extract_value v14 1.i256;
+        (v18.i256, v19.i1) = uaddo v2 v16;
+        br v19 block9 block10;
 
     block4:
-        v44.@layout_5 = phi (v13 block2) (v43 block12);
-        v45.i256 = extract_value v44 0.i256;
-        v46.i1 = eq v45 0.i256;
-        br v46 block6 block7;
+        v43.@layout_5 = phi (v12 block2) (v42 block12);
+        v44.i256 = extract_value v43 0.i256;
+        v45.i1 = eq v44 0.i256;
+        br v45 block6 block7;
 
     block5:
         br 0.i1 block2 block3;
 
     block6:
-        v48.i256 = evm_return_data_size;
-        v49.*i8 = evm_malloc v48;
-        v50.i256 = ptr_to_int v49 i256;
-        evm_return_data_copy v50 0.i256 v48;
-        evm_revert v50 v48;
+        v47.i256 = evm_return_data_size;
+        v48.*i8 = evm_malloc v47;
+        v49.i256 = ptr_to_int v48 i256;
+        evm_return_data_copy v49 0.i256 v47;
+        evm_revert v49 v47;
 
     block7:
         jump block8;
 
     block8:
-        return v44;
+        return v43;
 
     block9:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -403,43 +379,33 @@ func private %create(v0.i256, v1.@layout_0) -> @layout_5 {
         evm_revert 0.i256 36.i256;
 
     block10:
-        v26.*i8 = evm_malloc v19;
-        v27.i256 = ptr_to_int v26 i256;
-        evm_code_copy v27 v4 v3;
-        (v31.i256, v32.i1) = uaddo v27 v3;
-        br v32 block9 block11;
+        v25.*i8 = evm_malloc v18;
+        v26.i256 = ptr_to_int v25 i256;
+        evm_code_copy v26 v3 v2;
+        (v30.i256, v31.i1) = uaddo v26 v2;
+        br v31 block9 block11;
 
     block11:
-        v34.i256 = extract_value v15 0.i256;
-        v35.i256 = extract_value v15 1.i256;
-        call %copy_words v31 v34 v35;
-        v37.i256 = extract_value v15 1.i256;
-        (v39.i256, v40.i1) = uaddo v3 v37;
-        br v40 block9 block12;
+        v33.i256 = extract_value v14 0.i256;
+        v34.i256 = extract_value v14 1.i256;
+        call %copy_words v30 v33 v34;
+        v36.i256 = extract_value v14 1.i256;
+        (v38.i256, v39.i1) = uaddo v2 v36;
+        br v39 block9 block12;
 
     block12:
-        v41.i256 = mload v2 i256;
-        v43.@layout_5 = call %create_raw v41 v27 v39;
+        v42.@layout_5 = call %create_raw v0 v26 v38;
         jump block4;
 }
 
 func private %create_raw(v0.i256, v1.i256, v2.i256) -> @layout_5 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        mstore v3 v0 i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
         jump block1;
 
     block1:
-        v6.i256 = mload v3 i256;
-        v7.i256 = mload v4 i256;
-        v8.i256 = mload v5 i256;
-        v9.i256 = evm_create v6 v7 v8;
-        v12.@layout_5 = insert_value undef.@layout_5 0.i256 v9;
-        return v12;
+        v6.i256 = evm_create v0 v1 v2;
+        v9.@layout_5 = insert_value undef.@layout_5 0.i256 v6;
+        return v9;
 }
 
 func inline(always) private %core__lib__abi__decode_field__g3854_271d(v0.objref<@layout_4>) -> i256 {
@@ -574,17 +540,14 @@ func private %std__lib__abi__sol__impl_trait_Sol_1f5f__decoder_new__g463e_6eaf_0
 
 func private %dynamic_payload_size(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v3.i256 = mload v1 i256;
-        v4.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_99cc v3;
-        return v4;
+        v3.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_99cc v0;
+        return v3;
 
     block3:
         jump block4;
@@ -655,32 +618,25 @@ func inline(always) private %encode_alloc(v0.@layout_0) -> @layout_0 {
 
 func inline(always) private %encode_field_at(v0.i256, v1.objref<@layout_1>, v2.i256, v3.i256, v4.i256) {
     block0:
-        v5.*i256 = alloca i256;
-        v6.*i256 = alloca i256;
-        mstore v5 v2 i256;
-        mstore v6 v3 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v10.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_b316 v0;
-        v11.i256 = mload v6 i256;
-        v12.i256 = mload v5 i256;
-        v13.i256 = mload v4 i256;
-        v14.i256 = sub v13 v12;
-        call %write_word_at v1 v11 v14;
+        v8.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_b316 v0;
+        v11.i256 = mload v4 i256;
+        v12.i256 = sub v11 v2;
+        call %write_word_at v1 v3 v12;
+        v15.i256 = mload v4 i256;
+        call %impl_trait_SolEncoder__set_base v1 v15;
         v17.i256 = mload v4 i256;
-        call %impl_trait_SolEncoder__set_base v1 v17;
-        v19.i256 = mload v4 i256;
-        call %impl_trait_SolEncoder__set_pos v1 v19;
+        call %impl_trait_SolEncoder__set_pos v1 v17;
         call %encode__g426c v0 v1;
-        v22.i256 = mload v5 i256;
-        call %impl_trait_SolEncoder__set_base v1 v22;
-        v24.i256 = mload v4 i256;
-        v25.i256 = add v24 v10;
-        mstore v4 v25 i256;
+        call %impl_trait_SolEncoder__set_base v1 v2;
+        v21.i256 = mload v4 i256;
+        v22.i256 = add v21 v8;
+        mstore v4 v22 i256;
         return;
 
     block3:
@@ -690,42 +646,34 @@ func inline(always) private %encode_field_at(v0.i256, v1.objref<@layout_1>, v2.i
         br 1.i1 block5 block6;
 
     block5:
-        v27.i256 = mload v6 i256;
-        call %encode_to_ptr v0 v27;
+        call %encode_to_ptr v0 v3;
         return;
 
     block6:
         jump block7;
 
     block7:
-        v30.i256 = mload v6 i256;
-        call %impl_trait_SolEncoder__set_pos v1 v30;
+        call %impl_trait_SolEncoder__set_pos v1 v3;
         call %encode__g426c v0 v1;
         return;
 }
 
 func private %encode_to_ptr(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        call %store_word v3 v0;
+        call %store_word v1 v0;
         return;
 }
 
 func private %encoder_new(v0.i256) -> @layout_1 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.@layout_1 = call %impl_SolEncoder__new v2;
-        return v3;
+        v2.@layout_1 = call %impl_SolEncoder__new v0;
+        return v2;
 }
 
 func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_0d16(v0.objref<@layout_2>) -> i256 {
@@ -770,28 +718,24 @@ func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_d700
 
 func private %impl_SolEncoder__new(v0.i256) -> @layout_1 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v4.i1 = eq v2 0.i256;
-        br v4 block2 block3;
+        v3.i1 = eq v0 0.i256;
+        br v3 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v5.i256 = mload v1 i256;
-        v6.*i8 = evm_malloc v5;
-        v7.i256 = ptr_to_int v6 i256;
+        v5.*i8 = evm_malloc v0;
+        v6.i256 = ptr_to_int v5 i256;
         jump block4;
 
     block4:
-        v8.i256 = phi (0.i256 block2) (v7 block3);
-        v9.@layout_1 = call %at v8;
-        return v9;
+        v7.i256 = phi (0.i256 block2) (v6 block3);
+        v8.@layout_1 = call %at v7;
+        return v8;
 }
 
 func inline(always) private %std__lib__abi__sol__impl_SolDecoder_113c__new__g463e_7b57(v0.@layout_2) -> @layout_4 {
@@ -838,8 +782,6 @@ func inline(always) private %core__lib__abi__impl_Cursor_1a04__new__g463e_aa29_0
 
 func private %core__lib__abi__trait_AbiSize__payload_size__ge513_99cc(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
@@ -848,8 +790,6 @@ func private %core__lib__abi__trait_AbiSize__payload_size__ge513_99cc(v0.i256) -
 
 func private %core__lib__abi__trait_AbiSize__payload_size__ge513_b316(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
@@ -895,22 +835,20 @@ func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__pos__g463e_5a37(v0
 func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_4a6a(v0.objref<@layout_4>) -> i256 {
     block0:
         v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v5.objref<@layout_3> = obj.proj v0 0.i256;
-        v6.objref<@layout_2> = obj.proj v5 0.i256;
-        v7.@layout_2 = obj.load v6;
-        v8.objref<@layout_3> = obj.proj v0 0.i256;
-        v9.objref<@layout_2> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_d700 v9;
-        mstore v1 v10 i256;
-        v11.objref<@layout_3> = obj.proj v0 0.i256;
-        v13.objref<i256> = obj.proj v11 1.i256;
-        v14.i256 = obj.load v13;
-        (v16.i256, v17.i1) = uaddo v14 32.i256;
-        br v17 block6 block7;
+        v4.objref<@layout_3> = obj.proj v0 0.i256;
+        v5.objref<@layout_2> = obj.proj v4 0.i256;
+        v6.@layout_2 = obj.load v5;
+        v7.objref<@layout_3> = obj.proj v0 0.i256;
+        v8.objref<@layout_2> = obj.proj v7 0.i256;
+        v9.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_d700 v8;
+        v10.objref<@layout_3> = obj.proj v0 0.i256;
+        v12.objref<i256> = obj.proj v10 1.i256;
+        v13.i256 = obj.load v12;
+        (v15.i256, v16.i1) = uaddo v13 32.i256;
+        br v16 block6 block7;
 
     block2:
         evm_revert 0.i256 0.i256;
@@ -919,26 +857,25 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         jump block4;
 
     block4:
-        v28.objref<@layout_3> = obj.proj v0 0.i256;
-        v29.objref<@layout_2> = obj.proj v28 0.i256;
-        v30.@layout_2 = obj.load v29;
-        v31.objref<@layout_3> = obj.proj v0 0.i256;
-        v32.objref<i256> = obj.proj v31 1.i256;
-        v33.i256 = obj.load v32;
-        v34.objref<@layout_3> = obj.proj v0 0.i256;
-        v35.objref<@layout_2> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_7a87 v35 v33;
-        v38.objref<@layout_3> = obj.proj v0 0.i256;
-        v39.objref<i256> = obj.proj v38 1.i256;
-        obj.store v39 v16;
-        return v36;
+        v27.objref<@layout_3> = obj.proj v0 0.i256;
+        v28.objref<@layout_2> = obj.proj v27 0.i256;
+        v29.@layout_2 = obj.load v28;
+        v30.objref<@layout_3> = obj.proj v0 0.i256;
+        v31.objref<i256> = obj.proj v30 1.i256;
+        v32.i256 = obj.load v31;
+        v33.objref<@layout_3> = obj.proj v0 0.i256;
+        v34.objref<@layout_2> = obj.proj v33 0.i256;
+        v35.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_7a87 v34 v32;
+        v37.objref<@layout_3> = obj.proj v0 0.i256;
+        v38.objref<i256> = obj.proj v37 1.i256;
+        obj.store v38 v15;
+        return v35;
 
     block5:
-        v40.i256 = mload v1 i256;
-        mstore v2 v40 i256;
-        v42.i256 = mload v2 i256;
-        v43.i1 = gt v16 v42;
-        br v43 block2 block3;
+        mstore v1 v9 i256;
+        v41.i256 = mload v1 i256;
+        v42.i1 = gt v15 v41;
+        br v42 block2 block3;
 
     block6:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -946,32 +883,30 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         evm_revert 0.i256 36.i256;
 
     block7:
-        v23.objref<@layout_3> = obj.proj v0 0.i256;
-        v24.objref<i256> = obj.proj v23 1.i256;
-        v25.i256 = obj.load v24;
-        v26.i1 = lt v16 v25;
-        br v26 block2 block5;
+        v22.objref<@layout_3> = obj.proj v0 0.i256;
+        v23.objref<i256> = obj.proj v22 1.i256;
+        v24.i256 = obj.load v23;
+        v25.i1 = lt v15 v24;
+        br v25 block2 block5;
 }
 
 func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_6997(v0.objref<@layout_4>) -> i256 {
     block0:
         v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v5.objref<@layout_3> = obj.proj v0 0.i256;
-        v6.objref<@layout_2> = obj.proj v5 0.i256;
-        v7.@layout_2 = obj.load v6;
-        v8.objref<@layout_3> = obj.proj v0 0.i256;
-        v9.objref<@layout_2> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_0d16 v9;
-        mstore v1 v10 i256;
-        v11.objref<@layout_3> = obj.proj v0 0.i256;
-        v13.objref<i256> = obj.proj v11 1.i256;
-        v14.i256 = obj.load v13;
-        (v16.i256, v17.i1) = uaddo v14 32.i256;
-        br v17 block6 block7;
+        v4.objref<@layout_3> = obj.proj v0 0.i256;
+        v5.objref<@layout_2> = obj.proj v4 0.i256;
+        v6.@layout_2 = obj.load v5;
+        v7.objref<@layout_3> = obj.proj v0 0.i256;
+        v8.objref<@layout_2> = obj.proj v7 0.i256;
+        v9.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_0d16 v8;
+        v10.objref<@layout_3> = obj.proj v0 0.i256;
+        v12.objref<i256> = obj.proj v10 1.i256;
+        v13.i256 = obj.load v12;
+        (v15.i256, v16.i1) = uaddo v13 32.i256;
+        br v16 block6 block7;
 
     block2:
         evm_revert 0.i256 0.i256;
@@ -980,26 +915,25 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         jump block4;
 
     block4:
-        v28.objref<@layout_3> = obj.proj v0 0.i256;
-        v29.objref<@layout_2> = obj.proj v28 0.i256;
-        v30.@layout_2 = obj.load v29;
-        v31.objref<@layout_3> = obj.proj v0 0.i256;
-        v32.objref<i256> = obj.proj v31 1.i256;
-        v33.i256 = obj.load v32;
-        v34.objref<@layout_3> = obj.proj v0 0.i256;
-        v35.objref<@layout_2> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_f08f v35 v33;
-        v38.objref<@layout_3> = obj.proj v0 0.i256;
-        v39.objref<i256> = obj.proj v38 1.i256;
-        obj.store v39 v16;
-        return v36;
+        v27.objref<@layout_3> = obj.proj v0 0.i256;
+        v28.objref<@layout_2> = obj.proj v27 0.i256;
+        v29.@layout_2 = obj.load v28;
+        v30.objref<@layout_3> = obj.proj v0 0.i256;
+        v31.objref<i256> = obj.proj v30 1.i256;
+        v32.i256 = obj.load v31;
+        v33.objref<@layout_3> = obj.proj v0 0.i256;
+        v34.objref<@layout_2> = obj.proj v33 0.i256;
+        v35.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_f08f v34 v32;
+        v37.objref<@layout_3> = obj.proj v0 0.i256;
+        v38.objref<i256> = obj.proj v37 1.i256;
+        obj.store v38 v15;
+        return v35;
 
     block5:
-        v40.i256 = mload v1 i256;
-        mstore v2 v40 i256;
-        v42.i256 = mload v2 i256;
-        v43.i1 = gt v16 v42;
-        br v43 block2 block3;
+        mstore v1 v9 i256;
+        v41.i256 = mload v1 i256;
+        v42.i1 = gt v15 v41;
+        br v42 block2 block3;
 
     block6:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -1007,32 +941,30 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         evm_revert 0.i256 36.i256;
 
     block7:
-        v23.objref<@layout_3> = obj.proj v0 0.i256;
-        v24.objref<i256> = obj.proj v23 1.i256;
-        v25.i256 = obj.load v24;
-        v26.i1 = lt v16 v25;
-        br v26 block2 block5;
+        v22.objref<@layout_3> = obj.proj v0 0.i256;
+        v23.objref<i256> = obj.proj v22 1.i256;
+        v24.i256 = obj.load v23;
+        v25.i1 = lt v15 v24;
+        br v25 block2 block5;
 }
 
 func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_b4b0(v0.objref<@layout_4>) -> i256 {
     block0:
         v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v5.objref<@layout_3> = obj.proj v0 0.i256;
-        v6.objref<@layout_2> = obj.proj v5 0.i256;
-        v7.@layout_2 = obj.load v6;
-        v8.objref<@layout_3> = obj.proj v0 0.i256;
-        v9.objref<@layout_2> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_4f49 v9;
-        mstore v1 v10 i256;
-        v11.objref<@layout_3> = obj.proj v0 0.i256;
-        v13.objref<i256> = obj.proj v11 1.i256;
-        v14.i256 = obj.load v13;
-        (v16.i256, v17.i1) = uaddo v14 32.i256;
-        br v17 block6 block7;
+        v4.objref<@layout_3> = obj.proj v0 0.i256;
+        v5.objref<@layout_2> = obj.proj v4 0.i256;
+        v6.@layout_2 = obj.load v5;
+        v7.objref<@layout_3> = obj.proj v0 0.i256;
+        v8.objref<@layout_2> = obj.proj v7 0.i256;
+        v9.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_4f49 v8;
+        v10.objref<@layout_3> = obj.proj v0 0.i256;
+        v12.objref<i256> = obj.proj v10 1.i256;
+        v13.i256 = obj.load v12;
+        (v15.i256, v16.i1) = uaddo v13 32.i256;
+        br v16 block6 block7;
 
     block2:
         evm_revert 0.i256 0.i256;
@@ -1041,26 +973,25 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         jump block4;
 
     block4:
-        v28.objref<@layout_3> = obj.proj v0 0.i256;
-        v29.objref<@layout_2> = obj.proj v28 0.i256;
-        v30.@layout_2 = obj.load v29;
-        v31.objref<@layout_3> = obj.proj v0 0.i256;
-        v32.objref<i256> = obj.proj v31 1.i256;
-        v33.i256 = obj.load v32;
-        v34.objref<@layout_3> = obj.proj v0 0.i256;
-        v35.objref<@layout_2> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_9236 v35 v33;
-        v38.objref<@layout_3> = obj.proj v0 0.i256;
-        v39.objref<i256> = obj.proj v38 1.i256;
-        obj.store v39 v16;
-        return v36;
+        v27.objref<@layout_3> = obj.proj v0 0.i256;
+        v28.objref<@layout_2> = obj.proj v27 0.i256;
+        v29.@layout_2 = obj.load v28;
+        v30.objref<@layout_3> = obj.proj v0 0.i256;
+        v31.objref<i256> = obj.proj v30 1.i256;
+        v32.i256 = obj.load v31;
+        v33.objref<@layout_3> = obj.proj v0 0.i256;
+        v34.objref<@layout_2> = obj.proj v33 0.i256;
+        v35.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_9236 v34 v32;
+        v37.objref<@layout_3> = obj.proj v0 0.i256;
+        v38.objref<i256> = obj.proj v37 1.i256;
+        obj.store v38 v15;
+        return v35;
 
     block5:
-        v40.i256 = mload v1 i256;
-        mstore v2 v40 i256;
-        v42.i256 = mload v2 i256;
-        v43.i1 = gt v16 v42;
-        br v43 block2 block3;
+        mstore v1 v9 i256;
+        v41.i256 = mload v1 i256;
+        v42.i1 = gt v15 v41;
+        br v42 block2 block3;
 
     block6:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -1068,32 +999,30 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         evm_revert 0.i256 36.i256;
 
     block7:
-        v23.objref<@layout_3> = obj.proj v0 0.i256;
-        v24.objref<i256> = obj.proj v23 1.i256;
-        v25.i256 = obj.load v24;
-        v26.i1 = lt v16 v25;
-        br v26 block2 block5;
+        v22.objref<@layout_3> = obj.proj v0 0.i256;
+        v23.objref<i256> = obj.proj v22 1.i256;
+        v24.i256 = obj.load v23;
+        v25.i1 = lt v15 v24;
+        br v25 block2 block5;
 }
 
 func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__read_word__g463e_c4ab(v0.objref<@layout_4>) -> i256 {
     block0:
         v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v5.objref<@layout_3> = obj.proj v0 0.i256;
-        v6.objref<@layout_2> = obj.proj v5 0.i256;
-        v7.@layout_2 = obj.load v6;
-        v8.objref<@layout_3> = obj.proj v0 0.i256;
-        v9.objref<@layout_2> = obj.proj v8 0.i256;
-        v10.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_2f12 v9;
-        mstore v1 v10 i256;
-        v11.objref<@layout_3> = obj.proj v0 0.i256;
-        v13.objref<i256> = obj.proj v11 1.i256;
-        v14.i256 = obj.load v13;
-        (v16.i256, v17.i1) = uaddo v14 32.i256;
-        br v17 block6 block7;
+        v4.objref<@layout_3> = obj.proj v0 0.i256;
+        v5.objref<@layout_2> = obj.proj v4 0.i256;
+        v6.@layout_2 = obj.load v5;
+        v7.objref<@layout_3> = obj.proj v0 0.i256;
+        v8.objref<@layout_2> = obj.proj v7 0.i256;
+        v9.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__len_2f12 v8;
+        v10.objref<@layout_3> = obj.proj v0 0.i256;
+        v12.objref<i256> = obj.proj v10 1.i256;
+        v13.i256 = obj.load v12;
+        (v15.i256, v16.i1) = uaddo v13 32.i256;
+        br v16 block6 block7;
 
     block2:
         evm_revert 0.i256 0.i256;
@@ -1102,26 +1031,25 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         jump block4;
 
     block4:
-        v28.objref<@layout_3> = obj.proj v0 0.i256;
-        v29.objref<@layout_2> = obj.proj v28 0.i256;
-        v30.@layout_2 = obj.load v29;
-        v31.objref<@layout_3> = obj.proj v0 0.i256;
-        v32.objref<i256> = obj.proj v31 1.i256;
-        v33.i256 = obj.load v32;
-        v34.objref<@layout_3> = obj.proj v0 0.i256;
-        v35.objref<@layout_2> = obj.proj v34 0.i256;
-        v36.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_78ee v35 v33;
-        v38.objref<@layout_3> = obj.proj v0 0.i256;
-        v39.objref<i256> = obj.proj v38 1.i256;
-        obj.store v39 v16;
-        return v36;
+        v27.objref<@layout_3> = obj.proj v0 0.i256;
+        v28.objref<@layout_2> = obj.proj v27 0.i256;
+        v29.@layout_2 = obj.load v28;
+        v30.objref<@layout_3> = obj.proj v0 0.i256;
+        v31.objref<i256> = obj.proj v30 1.i256;
+        v32.i256 = obj.load v31;
+        v33.objref<@layout_3> = obj.proj v0 0.i256;
+        v34.objref<@layout_2> = obj.proj v33 0.i256;
+        v35.i256 = call %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_78ee v34 v32;
+        v37.objref<@layout_3> = obj.proj v0 0.i256;
+        v38.objref<i256> = obj.proj v37 1.i256;
+        obj.store v38 v15;
+        return v35;
 
     block5:
-        v40.i256 = mload v1 i256;
-        mstore v2 v40 i256;
-        v42.i256 = mload v2 i256;
-        v43.i1 = gt v16 v42;
-        br v43 block2 block3;
+        mstore v1 v9 i256;
+        v41.i256 = mload v1 i256;
+        v42.i1 = gt v15 v41;
+        br v42 block2 block3;
 
     block6:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -1129,197 +1057,152 @@ func inline(always) private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__rea
         evm_revert 0.i256 36.i256;
 
     block7:
-        v23.objref<@layout_3> = obj.proj v0 0.i256;
-        v24.objref<i256> = obj.proj v23 1.i256;
-        v25.i256 = obj.load v24;
-        v26.i1 = lt v16 v25;
-        br v26 block2 block5;
+        v22.objref<@layout_3> = obj.proj v0 0.i256;
+        v23.objref<i256> = obj.proj v22 1.i256;
+        v24.i256 = obj.load v23;
+        v25.i1 = lt v15 v24;
+        br v25 block2 block5;
 }
 
 func private %impl_trait_SolEncoder__set_base(v0.objref<@layout_1>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        obj.store v6 v3;
+        v5.objref<i256> = obj.proj v0 0.i256;
+        obj.store v5 v1;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_bba9(v0.objref<@layout_4>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 1.i256;
-        obj.store v6 v3;
+        v5.objref<i256> = obj.proj v0 1.i256;
+        obj.store v5 v1;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_base__g463e_e112(v0.objref<@layout_4>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 1.i256;
-        obj.store v6 v3;
+        v5.objref<i256> = obj.proj v0 1.i256;
+        obj.store v5 v1;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_0c70(v0.objref<@layout_4>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<@layout_3> = obj.proj v0 0.i256;
-        v8.objref<i256> = obj.proj v6 1.i256;
-        obj.store v8 v3;
+        v5.objref<@layout_3> = obj.proj v0 0.i256;
+        v7.objref<i256> = obj.proj v5 1.i256;
+        obj.store v7 v1;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolDecoder_68ab__set_pos__g463e_5886(v0.objref<@layout_4>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<@layout_3> = obj.proj v0 0.i256;
-        v8.objref<i256> = obj.proj v6 1.i256;
-        obj.store v8 v3;
+        v5.objref<@layout_3> = obj.proj v0 0.i256;
+        v7.objref<i256> = obj.proj v5 1.i256;
+        obj.store v7 v1;
         return;
 }
 
 func private %impl_trait_SolEncoder__set_pos(v0.objref<@layout_1>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 1.i256;
-        obj.store v6 v3;
+        v5.objref<i256> = obj.proj v0 1.i256;
+        obj.store v5 v1;
         return;
 }
 
 func private %store_word(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        mstore v4 v5 i256;
+        mstore v0 v1 i256;
         return;
 }
 
 func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_78ee(v0.objref<@layout_2>, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = mload v8 i256;
-        return v9;
+        v4.objref<i256> = obj.proj v0 0.i256;
+        v5.i256 = obj.load v4;
+        v7.i256 = add v5 v1;
+        v8.i256 = mload v7 i256;
+        return v8;
 }
 
 func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_7a87(v0.objref<@layout_2>, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = mload v8 i256;
-        return v9;
+        v4.objref<i256> = obj.proj v0 0.i256;
+        v5.i256 = obj.load v4;
+        v7.i256 = add v5 v1;
+        v8.i256 = mload v7 i256;
+        return v8;
 }
 
 func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_9236(v0.objref<@layout_2>, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = mload v8 i256;
-        return v9;
+        v4.objref<i256> = obj.proj v0 0.i256;
+        v5.i256 = obj.load v4;
+        v7.i256 = add v5 v1;
+        v8.i256 = mload v7 i256;
+        return v8;
 }
 
 func private %std__lib__evm__memory_input__impl_trait_MemoryBytes_c1cd__word_at_f08f(v0.objref<@layout_2>, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 0.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = add v6 v7;
-        v9.i256 = mload v8 i256;
-        return v9;
+        v4.objref<i256> = obj.proj v0 0.i256;
+        v5.i256 = obj.load v4;
+        v7.i256 = add v5 v1;
+        v8.i256 = mload v7 i256;
+        return v8;
 }
 
 func private %write_word(v0.objref<@layout_1>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 1.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        mstore v6 v7 i256;
-        v10.i256 = add v6 32.i256;
-        v11.objref<i256> = obj.proj v0 1.i256;
-        obj.store v11 v10;
+        v4.objref<i256> = obj.proj v0 1.i256;
+        v5.i256 = obj.load v4;
+        mstore v5 v1 i256;
+        v9.i256 = add v5 32.i256;
+        v10.objref<i256> = obj.proj v0 1.i256;
+        obj.store v10 v9;
         return;
 }
 
 func private %write_word_at(v0.objref<@layout_1>, v1.i256, v2.i256) {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v3 i256;
-        v6.i256 = mload v4 i256;
-        mstore v5 v6 i256;
+        mstore v1 v2 i256;
         return;
 }
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/internal_helper_shadowing.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/internal_helper_shadowing.snap
@@ -10,17 +10,11 @@ type @layout_1 = {@layout_0, @layout_0};
 
 func private %call_internal_helpers(v0.i64, v1.i64) -> @layout_0 {
     block0:
-        v2.*i64 = alloca i64;
-        v3.*i64 = alloca i64;
-        mstore v2 v0 i64;
-        mstore v3 v1 i64;
         jump block1;
 
     block1:
-        v4.i64 = mload v2 i64;
-        v5.i64 = mload v3 i64;
-        (v6.i64, v7.i1) = uaddo v4 v5;
-        br v7 block2 block3;
+        (v4.i64, v5.i1) = uaddo v0 v1;
+        br v5 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -28,40 +22,26 @@ func private %call_internal_helpers(v0.i64, v1.i64) -> @layout_0 {
         evm_revert 0.i256 36.i256;
 
     block3:
-        v13.i64 = mload v2 i64;
-        v14.i64 = mload v3 i64;
-        v15.i64 = call %saturating_add v13 v14;
-        v17.@layout_0 = insert_value undef.@layout_0 0.i256 v6;
-        v19.@layout_0 = insert_value v17 1.i256 v15;
-        return v19;
+        v13.i64 = call %saturating_add v0 v1;
+        v15.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
+        v17.@layout_0 = insert_value v15 1.i256 v13;
+        return v17;
 }
 
 func private %call_user_helpers(v0.i64, v1.i64) -> @layout_0 {
     block0:
-        v2.*i64 = alloca i64;
-        v3.*i64 = alloca i64;
-        mstore v2 v0 i64;
-        mstore v3 v1 i64;
         jump block1;
 
     block1:
-        v4.i64 = mload v2 i64;
-        v5.i64 = mload v3 i64;
-        v6.i64 = call %checked_add_u64 v4 v5;
-        v7.i64 = mload v2 i64;
-        v8.i64 = mload v3 i64;
-        v9.i64 = call %saturating_add_u64 v7 v8;
-        v12.@layout_0 = insert_value undef.@layout_0 0.i256 v6;
-        v14.@layout_0 = insert_value v12 1.i256 v9;
-        return v14;
+        v4.i64 = call %checked_add_u64 v0 v1;
+        v5.i64 = call %saturating_add_u64 v0 v1;
+        v8.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
+        v10.@layout_0 = insert_value v8 1.i256 v5;
+        return v10;
 }
 
 func private %checked_add_u64(v0.i64, v1.i64) -> i64 {
     block0:
-        v2.*i64 = alloca i64;
-        v3.*i64 = alloca i64;
-        mstore v2 v0 i64;
-        mstore v3 v1 i64;
         jump block1;
 
     block1:
@@ -91,25 +71,15 @@ func private %main_root() {
 
 func private %saturating_add(v0.i64, v1.i64) -> i64 {
     block0:
-        v2.*i64 = alloca i64;
-        v3.*i64 = alloca i64;
-        mstore v2 v0 i64;
-        mstore v3 v1 i64;
         jump block1;
 
     block1:
-        v4.i64 = mload v2 i64;
-        v5.i64 = mload v3 i64;
-        v6.i64 = uaddsat v4 v5;
-        return v6;
+        v4.i64 = uaddsat v0 v1;
+        return v4;
 }
 
 func private %saturating_add_u64(v0.i64, v1.i64) -> i64 {
     block0:
-        v2.*i64 = alloca i64;
-        v3.*i64 = alloca i64;
-        mstore v2 v0 i64;
-        mstore v3 v1 i64;
         jump block1;
 
     block1:

--- a/crates/codegen/tests/fixtures/sonatina_ir/intrinsic_ops.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/intrinsic_ops.snap
@@ -7,50 +7,38 @@ target = "evm-ethereum-osaka"
 
 func private %calldataload(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = evm_calldata_load v2;
-        return v3;
+        v2.i256 = evm_calldata_load v0;
+        return v2;
 }
 
 func private %load_calldata(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = call %calldataload v2;
-        return v3;
+        v2.i256 = call %calldataload v0;
+        return v2;
 }
 
 func private %load_slot(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = call %sload v2;
-        return v3;
+        v2.i256 = call %sload v0;
+        return v2;
 }
 
 func private %load_word(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = call %mload v2;
-        return v3;
+        v2.i256 = call %mload v0;
+        return v2;
 }
 
 func private %main() -> i256 {
@@ -91,115 +79,73 @@ func private %main_root() {
 
 func private %mload(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = mload v2 i256;
-        return v3;
+        v2.i256 = mload v0 i256;
+        return v2;
 }
 
 func private %mstore(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        mstore v4 v5 i256;
+        mstore v0 v1 i256;
         return;
 }
 
 func private %mstore8(v0.i256, v1.i8) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i8 = alloca i8;
-        mstore v2 v0 i256;
-        mstore v3 v1 i8;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i8 = mload v3 i8;
-        evm_mstore8 v4 v5;
+        evm_mstore8 v0 v1;
         return;
 }
 
 func private %sload(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = evm_sload v2;
-        return v3;
+        v2.i256 = evm_sload v0;
+        return v2;
 }
 
 func private %sstore(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        evm_sstore v4 v5;
+        evm_sstore v0 v1;
         return;
 }
 
 func private %store_byte(v0.i256, v1.i8) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i8 = alloca i8;
-        mstore v2 v0 i256;
-        mstore v3 v1 i8;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i8 = mload v3 i8;
-        call %mstore8 v4 v5;
+        call %mstore8 v0 v1;
         return;
 }
 
 func private %store_slot(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        call %sstore v4 v5;
+        call %sstore v0 v1;
         return;
 }
 
 func private %store_word(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        call %mstore v4 v5;
+        call %mstore v0 v1;
         return;
 }
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/keccak_intrinsic.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/keccak_intrinsic.snap
@@ -7,32 +7,20 @@ target = "evm-ethereum-osaka"
 
 func private %hash(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        v6.i256 = call %keccak256 v4 v5;
-        return v6;
+        v4.i256 = call %keccak256 v0 v1;
+        return v4;
 }
 
 func private %keccak256(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        v6.i256 = evm_keccak256 v4 v5;
-        return v6;
+        v4.i256 = evm_keccak256 v0 v1;
+        return v4;
 }
 
 func private %main() -> i256 {

--- a/crates/codegen/tests/fixtures/sonatina_ir/logical_ops.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/logical_ops.snap
@@ -9,15 +9,12 @@ type @layout_0 = {i1, i1};
 
 func private %logical_and(v0.i8) -> i1 {
     block0:
-        v1.*i8 = alloca i8;
-        mstore v1 v0 i8;
         jump block1;
 
     block1:
-        v2.i8 = mload v1 i8;
-        v4.i1 = eq v2 -1.i8;
-        v5.i1 = is_zero v4;
-        br v5 block5 block3;
+        v3.i1 = eq v0 -1.i8;
+        v4.i1 = is_zero v3;
+        br v4 block5 block3;
 
     block2:
         jump block4;
@@ -26,13 +23,12 @@ func private %logical_and(v0.i8) -> i1 {
         jump block4;
 
     block4:
-        v8.i1 = phi (1.i1 block2) (0.i1 block3);
-        return v8;
+        v7.i1 = phi (1.i1 block2) (0.i1 block3);
+        return v7;
 
     block5:
-        v9.i8 = mload v1 i8;
-        (v11.i8, v12.i1) = uaddo v9 1.i8;
-        br v12 block6 block7;
+        (v10.i8, v11.i1) = uaddo v0 1.i8;
+        br v11 block6 block7;
 
     block6:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -40,8 +36,8 @@ func private %logical_and(v0.i8) -> i1 {
         evm_revert 0.i256 36.i256;
 
     block7:
-        v19.i1 = gt v11 0.i8;
-        br v19 block2 block3;
+        v18.i1 = gt v10 0.i8;
+        br v18 block2 block3;
 }
 
 func private %logical_ops() -> @layout_0 {
@@ -58,14 +54,11 @@ func private %logical_ops() -> @layout_0 {
 
 func private %logical_or(v0.i8) -> i1 {
     block0:
-        v1.*i8 = alloca i8;
-        mstore v1 v0 i8;
         jump block1;
 
     block1:
-        v2.i8 = mload v1 i8;
-        v4.i1 = eq v2 -1.i8;
-        br v4 block2 block5;
+        v3.i1 = eq v0 -1.i8;
+        br v3 block2 block5;
 
     block2:
         jump block4;
@@ -74,13 +67,12 @@ func private %logical_or(v0.i8) -> i1 {
         jump block4;
 
     block4:
-        v7.i1 = phi (1.i1 block2) (0.i1 block3);
-        return v7;
+        v6.i1 = phi (1.i1 block2) (0.i1 block3);
+        return v6;
 
     block5:
-        v8.i8 = mload v1 i8;
-        (v10.i8, v11.i1) = uaddo v8 1.i8;
-        br v11 block6 block7;
+        (v9.i8, v10.i1) = uaddo v0 1.i8;
+        br v10 block6 block7;
 
     block6:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -88,8 +80,8 @@ func private %logical_or(v0.i8) -> i1 {
         evm_revert 0.i256 36.i256;
 
     block7:
-        v18.i1 = gt v10 0.i8;
-        br v18 block2 block3;
+        v17.i1 = gt v9 0.i8;
+        br v17 block2 block3;
 }
 
 func private %main_root() {

--- a/crates/codegen/tests/fixtures/sonatina_ir/match_enum_with_data.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/match_enum_with_data.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/codegen/tests/sonatina_ir.rs
-assertion_line: 455
 expression: output
 input_file: crates/codegen/tests/fixtures/match_enum_with_data.fe
 ---
@@ -32,14 +31,11 @@ func private %main_root() {
 
 func private %make_some(v0.i64) -> @layout_0 {
     block0:
-        v1.*i64 = alloca i64;
-        mstore v1 v0 i64;
         jump block1;
 
     block1:
-        v2.i64 = mload v1 i64;
-        v3.@layout_0 = enum.make @layout_0 #Some v2;
-        return v3;
+        v2.@layout_0 = enum.make @layout_0 #Some v0;
+        return v2;
 }
 
 func private %match_option(v0.@layout_0) -> i64 {

--- a/crates/codegen/tests/fixtures/sonatina_ir/match_fn_call.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/match_fn_call.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/codegen/tests/sonatina_ir.rs
-assertion_line: 403
 expression: output
 input_file: crates/codegen/tests/fixtures/match_fn_call.fe
 ---
@@ -8,38 +7,29 @@ target = "evm-ethereum-osaka"
 
 func private %std__lib__evm__effects__impl_trait_Evm_0098__calldataload_7969(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = evm_calldata_load v2;
-        return v3;
+        v2.i256 = evm_calldata_load v0;
+        return v2;
 }
 
 func private %std__lib__evm__effects__impl_trait_Evm_0098__calldataload_7969_0(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = evm_calldata_load v2;
-        return v3;
+        v2.i256 = evm_calldata_load v0;
+        return v2;
 }
 
 func private %std__lib__evm__effects__impl_trait_Evm_0098__calldataload_7969_1(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = evm_calldata_load v2;
-        return v3;
+        v2.i256 = evm_calldata_load v0;
+        return v2;
 }
 
 func private %standalone_match_fn_call__match_fn_call__example__gcd5c_4226() -> i256 {

--- a/crates/codegen/tests/fixtures/sonatina_ir/match_literal.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/match_literal.snap
@@ -37,18 +37,15 @@ func private %main_root() {
 
 func private %match_bool(v0.i1) -> i64 {
     block0:
-        v1.*i1 = alloca i1;
-        mstore v1 v0 i1;
         jump block1;
 
     block1:
-        v2.i1 = mload v1 i1;
-        v4.i1 = eq v2 1.i1;
-        br v4 block3 block5;
+        v3.i1 = eq v0 1.i1;
+        br v3 block3 block5;
 
     block2:
-        v5.i64 = phi (1.i64 block3) (2.i64 block4);
-        return v5;
+        v4.i64 = phi (1.i64 block3) (2.i64 block4);
+        return v4;
 
     block3:
         jump block2;
@@ -62,18 +59,15 @@ func private %match_bool(v0.i1) -> i64 {
 
 func private %match_i128(v0.i128) -> i128 {
     block0:
-        v1.*i128 = alloca i128;
-        mstore v1 v0 i128;
         jump block1;
 
     block1:
-        v2.i128 = mload v1 i128;
-        v4.i1 = eq v2 0.i128;
-        br v4 block3 block6;
+        v3.i1 = eq v0 0.i128;
+        br v3 block3 block6;
 
     block2:
-        v5.i128 = phi (1.i128 block3) (2.i128 block4) (3.i128 block5);
-        return v5;
+        v4.i128 = phi (1.i128 block3) (2.i128 block4) (3.i128 block5);
+        return v4;
 
     block3:
         jump block2;
@@ -85,8 +79,8 @@ func private %match_i128(v0.i128) -> i128 {
         jump block2;
 
     block6:
-        v11.i1 = eq v2 170141183460469231731687303715884105727.i128;
-        br v11 block4 block7;
+        v10.i1 = eq v0 170141183460469231731687303715884105727.i128;
+        br v10 block4 block7;
 
     block7:
         jump block5;
@@ -94,18 +88,15 @@ func private %match_i128(v0.i128) -> i128 {
 
 func private %match_i16(v0.i16) -> i16 {
     block0:
-        v1.*i16 = alloca i16;
-        mstore v1 v0 i16;
         jump block1;
 
     block1:
-        v2.i16 = mload v1 i16;
-        v4.i1 = eq v2 0.i16;
-        br v4 block3 block6;
+        v3.i1 = eq v0 0.i16;
+        br v3 block3 block6;
 
     block2:
-        v5.i16 = phi (1.i16 block3) (2.i16 block4) (3.i16 block5);
-        return v5;
+        v4.i16 = phi (1.i16 block3) (2.i16 block4) (3.i16 block5);
+        return v4;
 
     block3:
         jump block2;
@@ -117,8 +108,8 @@ func private %match_i16(v0.i16) -> i16 {
         jump block2;
 
     block6:
-        v11.i1 = eq v2 32000.i16;
-        br v11 block4 block7;
+        v10.i1 = eq v0 32000.i16;
+        br v10 block4 block7;
 
     block7:
         jump block5;
@@ -126,18 +117,15 @@ func private %match_i16(v0.i16) -> i16 {
 
 func private %match_i256(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v4.i1 = eq v2 0.i256;
-        br v4 block3 block6;
+        v3.i1 = eq v0 0.i256;
+        br v3 block3 block6;
 
     block2:
-        v5.i256 = phi (1.i256 block3) (2.i256 block4) (3.i256 block5);
-        return v5;
+        v4.i256 = phi (1.i256 block3) (2.i256 block4) (3.i256 block5);
+        return v4;
 
     block3:
         jump block2;
@@ -149,8 +137,8 @@ func private %match_i256(v0.i256) -> i256 {
         jump block2;
 
     block6:
-        v11.i1 = eq v2 -1.i256;
-        br v11 block4 block7;
+        v10.i1 = eq v0 -1.i256;
+        br v10 block4 block7;
 
     block7:
         jump block5;
@@ -158,18 +146,15 @@ func private %match_i256(v0.i256) -> i256 {
 
 func private %match_i32(v0.i32) -> i32 {
     block0:
-        v1.*i32 = alloca i32;
-        mstore v1 v0 i32;
         jump block1;
 
     block1:
-        v2.i32 = mload v1 i32;
-        v4.i1 = eq v2 0.i32;
-        br v4 block3 block6;
+        v3.i1 = eq v0 0.i32;
+        br v3 block3 block6;
 
     block2:
-        v5.i32 = phi (1.i32 block3) (2.i32 block4) (3.i32 block5);
-        return v5;
+        v4.i32 = phi (1.i32 block3) (2.i32 block4) (3.i32 block5);
+        return v4;
 
     block3:
         jump block2;
@@ -181,8 +166,8 @@ func private %match_i32(v0.i32) -> i32 {
         jump block2;
 
     block6:
-        v11.i1 = eq v2 2000000000.i32;
-        br v11 block4 block7;
+        v10.i1 = eq v0 2000000000.i32;
+        br v10 block4 block7;
 
     block7:
         jump block5;
@@ -190,18 +175,15 @@ func private %match_i32(v0.i32) -> i32 {
 
 func private %match_i64(v0.i64) -> i64 {
     block0:
-        v1.*i64 = alloca i64;
-        mstore v1 v0 i64;
         jump block1;
 
     block1:
-        v2.i64 = mload v1 i64;
-        v4.i1 = eq v2 0.i64;
-        br v4 block3 block6;
+        v3.i1 = eq v0 0.i64;
+        br v3 block3 block6;
 
     block2:
-        v5.i64 = phi (1.i64 block3) (2.i64 block4) (3.i64 block5);
-        return v5;
+        v4.i64 = phi (1.i64 block3) (2.i64 block4) (3.i64 block5);
+        return v4;
 
     block3:
         jump block2;
@@ -213,8 +195,8 @@ func private %match_i64(v0.i64) -> i64 {
         jump block2;
 
     block6:
-        v11.i1 = eq v2 9223372036854775807.i64;
-        br v11 block4 block7;
+        v10.i1 = eq v0 9223372036854775807.i64;
+        br v10 block4 block7;
 
     block7:
         jump block5;
@@ -222,18 +204,15 @@ func private %match_i64(v0.i64) -> i64 {
 
 func private %match_i8(v0.i8) -> i8 {
     block0:
-        v1.*i8 = alloca i8;
-        mstore v1 v0 i8;
         jump block1;
 
     block1:
-        v2.i8 = mload v1 i8;
-        v4.i1 = eq v2 0.i8;
-        br v4 block3 block6;
+        v3.i1 = eq v0 0.i8;
+        br v3 block3 block6;
 
     block2:
-        v5.i8 = phi (1.i8 block3) (2.i8 block4) (3.i8 block5);
-        return v5;
+        v4.i8 = phi (1.i8 block3) (2.i8 block4) (3.i8 block5);
+        return v4;
 
     block3:
         jump block2;
@@ -245,8 +224,8 @@ func private %match_i8(v0.i8) -> i8 {
         jump block2;
 
     block6:
-        v11.i1 = eq v2 99.i8;
-        br v11 block4 block7;
+        v10.i1 = eq v0 99.i8;
+        br v10 block4 block7;
 
     block7:
         jump block5;
@@ -254,18 +233,15 @@ func private %match_i8(v0.i8) -> i8 {
 
 func private %match_u128(v0.i128) -> i128 {
     block0:
-        v1.*i128 = alloca i128;
-        mstore v1 v0 i128;
         jump block1;
 
     block1:
-        v2.i128 = mload v1 i128;
-        v4.i1 = eq v2 0.i128;
-        br v4 block3 block6;
+        v3.i1 = eq v0 0.i128;
+        br v3 block3 block6;
 
     block2:
-        v5.i128 = phi (1.i128 block3) (2.i128 block4) (3.i128 block5);
-        return v5;
+        v4.i128 = phi (1.i128 block3) (2.i128 block4) (3.i128 block5);
+        return v4;
 
     block3:
         jump block2;
@@ -277,8 +253,8 @@ func private %match_u128(v0.i128) -> i128 {
         jump block2;
 
     block6:
-        v11.i1 = eq v2 -1.i128;
-        br v11 block4 block7;
+        v10.i1 = eq v0 -1.i128;
+        br v10 block4 block7;
 
     block7:
         jump block5;
@@ -286,18 +262,15 @@ func private %match_u128(v0.i128) -> i128 {
 
 func private %match_u16(v0.i16) -> i16 {
     block0:
-        v1.*i16 = alloca i16;
-        mstore v1 v0 i16;
         jump block1;
 
     block1:
-        v2.i16 = mload v1 i16;
-        v4.i1 = eq v2 4660.i16;
-        br v4 block3 block6;
+        v3.i1 = eq v0 4660.i16;
+        br v3 block3 block6;
 
     block2:
-        v5.i16 = phi (1.i16 block3) (2.i16 block4) (3.i16 block5);
-        return v5;
+        v4.i16 = phi (1.i16 block3) (2.i16 block4) (3.i16 block5);
+        return v4;
 
     block3:
         jump block2;
@@ -309,8 +282,8 @@ func private %match_u16(v0.i16) -> i16 {
         jump block2;
 
     block6:
-        v11.i1 = eq v2 -21555.i16;
-        br v11 block4 block7;
+        v10.i1 = eq v0 -21555.i16;
+        br v10 block4 block7;
 
     block7:
         jump block5;
@@ -318,18 +291,15 @@ func private %match_u16(v0.i16) -> i16 {
 
 func private %match_u256(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v4.i1 = eq v2 0.i256;
-        br v4 block3 block6;
+        v3.i1 = eq v0 0.i256;
+        br v3 block3 block6;
 
     block2:
-        v5.i256 = phi (1.i256 block3) (2.i256 block4) (3.i256 block5);
-        return v5;
+        v4.i256 = phi (1.i256 block3) (2.i256 block4) (3.i256 block5);
+        return v4;
 
     block3:
         jump block2;
@@ -341,8 +311,8 @@ func private %match_u256(v0.i256) -> i256 {
         jump block2;
 
     block6:
-        v11.i1 = eq v2 -1.i256;
-        br v11 block4 block7;
+        v10.i1 = eq v0 -1.i256;
+        br v10 block4 block7;
 
     block7:
         jump block5;
@@ -350,18 +320,15 @@ func private %match_u256(v0.i256) -> i256 {
 
 func private %match_u32(v0.i32) -> i32 {
     block0:
-        v1.*i32 = alloca i32;
-        mstore v1 v0 i32;
         jump block1;
 
     block1:
-        v2.i32 = mload v1 i32;
-        v4.i1 = eq v2 -559038737.i32;
-        br v4 block3 block6;
+        v3.i1 = eq v0 -559038737.i32;
+        br v3 block3 block6;
 
     block2:
-        v5.i32 = phi (1.i32 block3) (2.i32 block4) (3.i32 block5);
-        return v5;
+        v4.i32 = phi (1.i32 block3) (2.i32 block4) (3.i32 block5);
+        return v4;
 
     block3:
         jump block2;
@@ -373,8 +340,8 @@ func private %match_u32(v0.i32) -> i32 {
         jump block2;
 
     block6:
-        v11.i1 = eq v2 -889275714.i32;
-        br v11 block4 block7;
+        v10.i1 = eq v0 -889275714.i32;
+        br v10 block4 block7;
 
     block7:
         jump block5;
@@ -382,18 +349,15 @@ func private %match_u32(v0.i32) -> i32 {
 
 func private %match_u64(v0.i64) -> i64 {
     block0:
-        v1.*i64 = alloca i64;
-        mstore v1 v0 i64;
         jump block1;
 
     block1:
-        v2.i64 = mload v1 i64;
-        v4.i1 = eq v2 0.i64;
-        br v4 block3 block6;
+        v3.i1 = eq v0 0.i64;
+        br v3 block3 block6;
 
     block2:
-        v5.i64 = phi (1.i64 block3) (2.i64 block4) (3.i64 block5);
-        return v5;
+        v4.i64 = phi (1.i64 block3) (2.i64 block4) (3.i64 block5);
+        return v4;
 
     block3:
         jump block2;
@@ -405,8 +369,8 @@ func private %match_u64(v0.i64) -> i64 {
         jump block2;
 
     block6:
-        v11.i1 = eq v2 -1.i64;
-        br v11 block4 block7;
+        v10.i1 = eq v0 -1.i64;
+        br v10 block4 block7;
 
     block7:
         jump block5;
@@ -414,18 +378,15 @@ func private %match_u64(v0.i64) -> i64 {
 
 func private %match_u8(v0.i8) -> i8 {
     block0:
-        v1.*i8 = alloca i8;
-        mstore v1 v0 i8;
         jump block1;
 
     block1:
-        v2.i8 = mload v1 i8;
-        v4.i1 = eq v2 0.i8;
-        br v4 block3 block6;
+        v3.i1 = eq v0 0.i8;
+        br v3 block3 block6;
 
     block2:
-        v5.i8 = phi (1.i8 block3) (2.i8 block4) (3.i8 block5);
-        return v5;
+        v4.i8 = phi (1.i8 block3) (2.i8 block4) (3.i8 block5);
+        return v4;
 
     block3:
         jump block2;
@@ -437,8 +398,8 @@ func private %match_u8(v0.i8) -> i8 {
         jump block2;
 
     block6:
-        v11.i1 = eq v2 -1.i8;
-        br v11 block4 block7;
+        v10.i1 = eq v0 -1.i8;
+        br v10 block4 block7;
 
     block7:
         jump block5;

--- a/crates/codegen/tests/fixtures/sonatina_ir/match_return.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/match_return.snap
@@ -48,16 +48,10 @@ func private %main_root() {
 
 func private %return_data(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        evm_return v4 v5;
+        evm_return v0 v1;
 }
 
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/match_wildcard.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/match_wildcard.snap
@@ -80,18 +80,15 @@ func private %multiple_before_wildcard(v0.@layout_1) -> i8 {
 
 func private %wildcard_not_last(v0.i8) -> i8 {
     block0:
-        v1.*i8 = alloca i8;
-        mstore v1 v0 i8;
         jump block1;
 
     block1:
-        v2.i8 = mload v1 i8;
-        v4.i1 = eq v2 0.i8;
-        br v4 block3 block5;
+        v3.i1 = eq v0 0.i8;
+        br v3 block3 block5;
 
     block2:
-        v5.i8 = phi (10.i8 block3) (99.i8 block4);
-        return v5;
+        v4.i8 = phi (10.i8 block3) (99.i8 block4);
+        return v4;
 
     block3:
         jump block2;

--- a/crates/codegen/tests/fixtures/sonatina_ir/name_collisions.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/name_collisions.snap
@@ -19,8 +19,6 @@ global private const @layout_4 $const_region_4 = {100};
 
 func private %standalone_name_collisions__name_collisions____u32_as_u256_56b3(v0.i32) -> i256 {
     block0:
-        v1.*i32 = alloca i32;
-        mstore v1 v0 i32;
         jump block1;
 
     block1:
@@ -29,8 +27,6 @@ func private %standalone_name_collisions__name_collisions____u32_as_u256_56b3(v0
 
 func private %standalone_name_collisions__name_collisions____u32_as_u256_56b3_0(v0.i32) -> i256 {
     block0:
-        v1.*i32 = alloca i32;
-        mstore v1 v0 i32;
         jump block1;
 
     block1:
@@ -168,14 +164,11 @@ func private %main_root() {
 
 func private %standalone_name_collisions__name_collisions__param_local_collision_a1c4(v0.i32) -> i32 {
     block0:
-        v1.*i32 = alloca i32;
-        mstore v1 v0 i32;
         jump block1;
 
     block1:
-        v2.i32 = mload v1 i32;
-        (v4.i32, v5.i1) = uaddo v2 1.i32;
-        br v5 block2 block3;
+        (v3.i32, v4.i1) = uaddo v0 1.i32;
+        br v4 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -183,23 +176,20 @@ func private %standalone_name_collisions__name_collisions__param_local_collision
         evm_revert 0.i256 36.i256;
 
     block3:
-        (v12.i32, v13.i1) = uaddo v4 2.i32;
-        br v13 block2 block4;
+        (v11.i32, v12.i1) = uaddo v3 2.i32;
+        br v12 block2 block4;
 
     block4:
-        return v12;
+        return v11;
 }
 
 func private %standalone_name_collisions__name_collisions__param_local_collision_a1c4_0(v0.i32) -> i32 {
     block0:
-        v1.*i32 = alloca i32;
-        mstore v1 v0 i32;
         jump block1;
 
     block1:
-        v2.i32 = mload v1 i32;
-        (v4.i32, v5.i1) = uaddo v2 1.i32;
-        br v5 block2 block3;
+        (v3.i32, v4.i1) = uaddo v0 1.i32;
+        br v4 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -207,11 +197,11 @@ func private %standalone_name_collisions__name_collisions__param_local_collision
         evm_revert 0.i256 36.i256;
 
     block3:
-        (v12.i32, v13.i1) = uaddo v4 2.i32;
-        br v13 block2 block4;
+        (v11.i32, v12.i1) = uaddo v3 2.i32;
+        br v12 block2 block4;
 
     block4:
-        return v12;
+        return v11;
 }
 
 func private %standalone_name_collisions__name_collisions__impl_a__impl_Widget_8971__process_7ed1(v0.constref<@layout_2>) -> i32 {
@@ -292,14 +282,11 @@ func private %standalone_name_collisions__name_collisions__impl_b__impl_Widget_b
 
 func private %standalone_name_collisions__name_collisions__ret_param_collision_c303(v0.i32) -> i32 {
     block0:
-        v1.*i32 = alloca i32;
-        mstore v1 v0 i32;
         jump block1;
 
     block1:
-        v2.i32 = mload v1 i32;
-        (v4.i32, v5.i1) = uaddo v2 1.i32;
-        br v5 block2 block3;
+        (v3.i32, v4.i1) = uaddo v0 1.i32;
+        br v4 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -307,19 +294,16 @@ func private %standalone_name_collisions__name_collisions__ret_param_collision_c
         evm_revert 0.i256 36.i256;
 
     block3:
-        return v4;
+        return v3;
 }
 
 func private %standalone_name_collisions__name_collisions__ret_param_collision_c303_0(v0.i32) -> i32 {
     block0:
-        v1.*i32 = alloca i32;
-        mstore v1 v0 i32;
         jump block1;
 
     block1:
-        v2.i32 = mload v1 i32;
-        (v4.i32, v5.i1) = uaddo v2 1.i32;
-        br v5 block2 block3;
+        (v3.i32, v4.i1) = uaddo v0 1.i32;
+        br v4 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -327,7 +311,7 @@ func private %standalone_name_collisions__name_collisions__ret_param_collision_c
         evm_revert 0.i256 36.i256;
 
     block3:
-        return v4;
+        return v3;
 }
 
 func private %standalone_name_collisions__name_collisions__impl_trait_MultiTraitImpl_5bd8__same_method_133c(v0.constref<@layout_4>) -> i32 {

--- a/crates/codegen/tests/fixtures/sonatina_ir/nested_struct.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/nested_struct.snap
@@ -13,56 +13,38 @@ global private const @layout_1 $const_region_1 = {{0}};
 
 func private %abi_encode(v0.i256) {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v1 i256;
-        call %mstore 0.i256 v3;
+        call %mstore 0.i256 v0;
         call %std__lib__evm__effects__impl_trait_Evm_0098__return_data_8d10 0.i256 32.i256;
         unreachable;
 }
 
 func private %calldataload(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = evm_calldata_load v2;
-        return v3;
+        v2.i256 = evm_calldata_load v0;
+        return v2;
 }
 
 func private %codecopy(v0.i256, v1.i256, v2.i256) {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        mstore v3 v0 i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
         jump block1;
 
     block1:
-        v6.i256 = mload v3 i256;
-        v7.i256 = mload v4 i256;
-        v8.i256 = mload v5 i256;
-        evm_code_copy v6 v7 v8;
+        evm_code_copy v0 v1 v2;
         return;
 }
 
 func private %from_raw(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        return v2;
+        return v0;
 }
 
 func private %init() {
@@ -99,41 +81,32 @@ func private %manual_contract_runtime_root_NestedStruct() {
 
 func private %mem_read(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v3.constref<@layout_0> = const.ref $const_region_0;
-        v4.constref<@layout_1> = const.ref $const_region_1;
-        v6.@layout_0 = insert_value undef.@layout_0 0.i256 0.i256;
-        v7.objref<@layout_1> = obj.alloc @layout_1;
-        v8.objref<@layout_0> = obj.proj v7 0.i256;
-        v9.objref<i256> = obj.proj v8 0.i256;
-        v10.i256 = extract_value v6 0.i256;
-        obj.store v9 v10;
-        v11.i256 = mload v1 i256;
-        v12.objref<@layout_0> = obj.proj v7 0.i256;
-        v13.objref<i256> = obj.proj v12 0.i256;
-        obj.store v13 v11;
-        v14.objref<@layout_0> = obj.proj v7 0.i256;
-        v15.objref<i256> = obj.proj v14 0.i256;
-        v16.i256 = obj.load v15;
-        return v16;
+        v2.constref<@layout_0> = const.ref $const_region_0;
+        v3.constref<@layout_1> = const.ref $const_region_1;
+        v5.@layout_0 = insert_value undef.@layout_0 0.i256 0.i256;
+        v6.objref<@layout_1> = obj.alloc @layout_1;
+        v7.objref<@layout_0> = obj.proj v6 0.i256;
+        v8.objref<i256> = obj.proj v7 0.i256;
+        v9.i256 = extract_value v5 0.i256;
+        obj.store v8 v9;
+        v11.objref<@layout_0> = obj.proj v6 0.i256;
+        v12.objref<i256> = obj.proj v11 0.i256;
+        obj.store v12 v0;
+        v13.objref<@layout_0> = obj.proj v6 0.i256;
+        v14.objref<i256> = obj.proj v13 0.i256;
+        v15.i256 = obj.load v14;
+        return v15;
 }
 
 func private %mstore(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        mstore v4 v5 i256;
+        mstore v0 v1 i256;
         return;
 }
 
@@ -148,44 +121,26 @@ func private %read_inner(v0.i256) -> i256 {
 
 func private %std__lib__evm__effects__impl_trait_Evm_0098__return_data_7adf(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        evm_return v4 v5;
+        evm_return v0 v1;
 }
 
 func private %std__lib__evm__effects__impl_trait_Evm_0098__return_data_7adf_0(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        evm_return v4 v5;
+        evm_return v0 v1;
 }
 
 func private %std__lib__evm__effects__impl_trait_Evm_0098__return_data_8d10(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        evm_return v4 v5;
+        evm_return v0 v1;
 }
 
 func private %runtime() {
@@ -234,25 +189,19 @@ func private %runtime() {
 
 func private %stor_ptr(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = call %from_raw v2;
-        return v3;
+        v2.i256 = call %from_raw v0;
+        return v2;
 }
 
 func private %write_inner(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v0 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        evm_sstore v1 v3;
+        evm_sstore v1 v0;
         return;
 }
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/newtype_field_mut_method_call.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/newtype_field_mut_method_call.snap
@@ -50,38 +50,35 @@ func private %main_root() {
 
 func private %newtype_field_mut_method_call(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v1 i256;
-        v5.@layout_0 = insert_value undef.@layout_0 0.i256 v3;
-        v7.@layout_0 = insert_value v5 1.i256 0.i256;
-        v9.@layout_1 = insert_value undef.@layout_1 0.i256 v7;
-        v11.@layout_2 = insert_value undef.@layout_2 0.i256 0.i256;
-        v12.@layout_2 = insert_value v11 1.i256 v9;
-        v13.objref<@layout_2> = obj.alloc @layout_2;
-        v14.objref<i256> = obj.proj v13 0.i256;
-        v15.i256 = extract_value v12 0.i256;
-        obj.store v14 v15;
-        v16.objref<@layout_1> = obj.proj v13 1.i256;
-        v17.@layout_1 = extract_value v12 1.i256;
-        v18.objref<@layout_0> = obj.proj v16 0.i256;
-        v19.@layout_0 = extract_value v17 0.i256;
-        v20.objref<i256> = obj.proj v18 0.i256;
-        v21.i256 = extract_value v19 0.i256;
-        obj.store v20 v21;
-        v22.objref<i256> = obj.proj v18 1.i256;
-        v23.i256 = extract_value v19 1.i256;
-        obj.store v22 v23;
-        v24.objref<@layout_1> = obj.proj v13 1.i256;
-        call %bump v24;
-        v26.objref<@layout_1> = obj.proj v13 1.i256;
-        v27.objref<@layout_0> = obj.proj v26 0.i256;
-        v28.objref<i256> = obj.proj v27 0.i256;
-        v29.i256 = obj.load v28;
-        return v29;
+        v4.@layout_0 = insert_value undef.@layout_0 0.i256 v0;
+        v6.@layout_0 = insert_value v4 1.i256 0.i256;
+        v8.@layout_1 = insert_value undef.@layout_1 0.i256 v6;
+        v10.@layout_2 = insert_value undef.@layout_2 0.i256 0.i256;
+        v11.@layout_2 = insert_value v10 1.i256 v8;
+        v12.objref<@layout_2> = obj.alloc @layout_2;
+        v13.objref<i256> = obj.proj v12 0.i256;
+        v14.i256 = extract_value v11 0.i256;
+        obj.store v13 v14;
+        v15.objref<@layout_1> = obj.proj v12 1.i256;
+        v16.@layout_1 = extract_value v11 1.i256;
+        v17.objref<@layout_0> = obj.proj v15 0.i256;
+        v18.@layout_0 = extract_value v16 0.i256;
+        v19.objref<i256> = obj.proj v17 0.i256;
+        v20.i256 = extract_value v18 0.i256;
+        obj.store v19 v20;
+        v21.objref<i256> = obj.proj v17 1.i256;
+        v22.i256 = extract_value v18 1.i256;
+        obj.store v21 v22;
+        v23.objref<@layout_1> = obj.proj v12 1.i256;
+        call %bump v23;
+        v25.objref<@layout_1> = obj.proj v12 1.i256;
+        v26.objref<@layout_0> = obj.proj v25 0.i256;
+        v27.objref<i256> = obj.proj v26 0.i256;
+        v28.i256 = obj.load v27;
+        return v28;
 }
 
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/newtype_storage_byplace_effect_arg.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/newtype_storage_byplace_effect_arg.snap
@@ -44,24 +44,21 @@ func private %__NewtypeByPlaceEffectArg_recv_0_0(v0.i256, v1.i256) -> i256 {
 
 func private %abi_field_size(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_a5ce_0 v2;
+        v2.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_a5ce_0 v0;
         br 0.i1 block2 block3;
 
     block2:
-        (v7.i256, v8.i1) = uaddo 32.i256 v3;
-        br v8 block5 block6;
+        (v6.i256, v7.i1) = uaddo 32.i256 v2;
+        br v7 block5 block6;
 
     block3:
         jump block4;
 
     block4:
-        return v3;
+        return v2;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -69,19 +66,16 @@ func private %abi_field_size(v0.i256) -> i256 {
         evm_revert 0.i256 36.i256;
 
     block6:
-        return v7;
+        return v6;
 }
 
 func private %abi_single_root_size(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = call %abi_field_size v2;
-        return v3;
+        v2.i256 = call %abi_field_size v0;
+        return v2;
 }
 
 func private %abort() {
@@ -95,16 +89,12 @@ func private %abort() {
 
 func inline(always) private %at(v0.i256) -> @layout_0 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = mload v1 i256;
-        v6.@layout_0 = insert_value undef.@layout_0 0.i256 v2;
-        v8.@layout_0 = insert_value v6 1.i256 v3;
-        return v8;
+        v4.@layout_0 = insert_value undef.@layout_0 0.i256 v0;
+        v6.@layout_0 = insert_value v4 1.i256 v0;
+        return v6;
 }
 
 func private %base(v0.objref<@layout_0>) -> i256 {
@@ -214,8 +204,6 @@ func private %contract_runtime_root_NewtypeByPlaceEffectArg() {
 
 func inline(always) private %decode_from(v0.@layout_1, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
@@ -224,16 +212,10 @@ func inline(always) private %decode_from(v0.@layout_1, v1.i256) {
 
 func inline(always) private %decode_from_prechecked_head(v0.@layout_1, v1.i256, v2.i256) {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v4 i256;
-        v7.i256 = mload v3 i256;
-        call %decode_from v0 v7;
+        call %decode_from v0 v1;
         return;
 }
 
@@ -241,14 +223,12 @@ func inline(always) private %decode_runtime_args(v0.objref<@layout_3>) {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v4.@layout_1 = call %input;
-        v6.i256 = call %len v4;
-        mstore v1 v6 i256;
-        mstore v2 4.i256 i256;
+        v3.@layout_1 = call %input;
+        v5.i256 = call %len v3;
+        mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
 
     block2:
@@ -259,16 +239,14 @@ func inline(always) private %decode_runtime_args(v0.objref<@layout_3>) {
         jump block4;
 
     block4:
-        v11.i256 = mload v1 i256;
-        call %decode_from_prechecked_head v4 4.i256 v11;
+        call %decode_from_prechecked_head v3 4.i256 v5;
         return;
 
     block5:
-        v13.i256 = mload v1 i256;
-        mstore v3 v13 i256;
-        v15.i256 = mload v3 i256;
-        v16.i1 = gt 4.i256 v15;
-        br v16 block2 block3;
+        mstore v2 v5 i256;
+        v14.i256 = mload v2 i256;
+        v15.i1 = gt 4.i256 v14;
+        br v15 block2 block3;
 }
 
 func private %encode(v0.i256, v1.objref<@layout_0>) {
@@ -364,26 +342,20 @@ func private %encode_single_root_alloc(v0.i256) -> @layout_4 {
 
 func private %encode_to_ptr(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        call %store_word v3 v0;
+        call %store_word v1 v0;
         return;
 }
 
 func private %encoder_new(v0.i256) -> @layout_0 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.@layout_0 = call %impl_SolEncoder__new v2;
-        return v3;
+        v2.@layout_0 = call %impl_SolEncoder__new v0;
+        return v2;
 }
 
 func private %input() -> @layout_1 {
@@ -398,31 +370,27 @@ func private %input() -> @layout_1 {
 func inline(always) private %len(v0.@layout_1) -> i256 {
     block0:
         v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.i256 = extract_value v0 0.i256;
-        v7.i256 = mload v1 i256;
-        mstore v2 v7 i256;
-        v8.i256 = mload v2 i256;
-        v9.i1 = gt v6 v8;
-        br v9 block2 block3;
+        v2.i256 = evm_calldata_size;
+        v5.i256 = extract_value v0 0.i256;
+        mstore v1 v2 i256;
+        v6.i256 = mload v1 i256;
+        v7.i1 = gt v5 v6;
+        br v7 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v11.i256 = extract_value v0 0.i256;
-        v12.i256 = mload v1 i256;
-        (v13.i256, v14.i1) = usubo v12 v11;
-        br v14 block5 block6;
+        v9.i256 = extract_value v0 0.i256;
+        (v11.i256, v12.i1) = usubo v2 v9;
+        br v12 block5 block6;
 
     block4:
-        v19.i256 = phi (0.i256 block2) (v13 block6);
-        return v19;
+        v17.i256 = phi (0.i256 block2) (v11 block6);
+        return v17;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -435,28 +403,24 @@ func inline(always) private %len(v0.@layout_1) -> i256 {
 
 func private %impl_SolEncoder__new(v0.i256) -> @layout_0 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v4.i1 = eq v2 0.i256;
-        br v4 block2 block3;
+        v3.i1 = eq v0 0.i256;
+        br v3 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v5.i256 = mload v1 i256;
-        v6.*i8 = evm_malloc v5;
-        v7.i256 = ptr_to_int v6 i256;
+        v5.*i8 = evm_malloc v0;
+        v6.i256 = ptr_to_int v5 i256;
         jump block4;
 
     block4:
-        v8.i256 = phi (0.i256 block2) (v7 block3);
-        v9.@layout_0 = call %at v8;
-        return v9;
+        v7.i256 = phi (0.i256 block2) (v6 block3);
+        v8.@layout_0 = call %at v7;
+        return v8;
 }
 
 func inline(always) private %impl_CallData__new() -> @layout_1 {
@@ -473,8 +437,6 @@ func inline(always) private %impl_CallData__new() -> @layout_1 {
 
 func private %core__lib__abi__trait_AbiSize__payload_size__ge513_a5ce(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
@@ -483,8 +445,6 @@ func private %core__lib__abi__trait_AbiSize__payload_size__ge513_a5ce(v0.i256) -
 
 func private %core__lib__abi__trait_AbiSize__payload_size__ge513_a5ce_0(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
@@ -503,90 +463,66 @@ func private %pos(v0.objref<@layout_0>) -> i256 {
 
 func private %revert(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        evm_revert v4 v5;
+        evm_revert v0 v1;
 }
 
 func private %set_base(v0.objref<@layout_0>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        obj.store v6 v3;
+        v5.objref<i256> = obj.proj v0 0.i256;
+        obj.store v5 v1;
         return;
 }
 
 func private %set_pos(v0.objref<@layout_0>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 1.i256;
-        obj.store v6 v3;
+        v5.objref<i256> = obj.proj v0 1.i256;
+        obj.store v5 v1;
         return;
 }
 
 func private %store_word(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        mstore v4 v5 i256;
+        mstore v0 v1 i256;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_8b2d(v0.objref<@layout_0>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 1.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        mstore v6 v7 i256;
-        v10.i256 = add v6 32.i256;
-        v11.objref<i256> = obj.proj v0 1.i256;
-        obj.store v11 v10;
+        v4.objref<i256> = obj.proj v0 1.i256;
+        v5.i256 = obj.load v4;
+        mstore v5 v1 i256;
+        v9.i256 = add v5 32.i256;
+        v10.objref<i256> = obj.proj v0 1.i256;
+        obj.store v10 v9;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_a98a(v0.objref<@layout_0>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 1.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        mstore v6 v7 i256;
-        v10.i256 = add v6 32.i256;
-        v11.objref<i256> = obj.proj v0 1.i256;
-        obj.store v11 v10;
+        v4.objref<i256> = obj.proj v0 1.i256;
+        v5.i256 = obj.load v4;
+        mstore v5 v1 i256;
+        v9.i256 = add v5 32.i256;
+        v10.objref<i256> = obj.proj v0 1.i256;
+        obj.store v10 v9;
         return;
 }
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/newtype_storage_field_mut_method_call.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/newtype_storage_field_mut_method_call.snap
@@ -33,24 +33,21 @@ func private %__NewtypeStorageFieldMutMethodCall_recv_0_0(v0.i256) -> i256 {
 
 func private %abi_field_size(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_4e75_0 v2;
+        v2.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_4e75_0 v0;
         br 0.i1 block2 block3;
 
     block2:
-        (v7.i256, v8.i1) = uaddo 32.i256 v3;
-        br v8 block5 block6;
+        (v6.i256, v7.i1) = uaddo 32.i256 v2;
+        br v7 block5 block6;
 
     block3:
         jump block4;
 
     block4:
-        return v3;
+        return v2;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -58,19 +55,16 @@ func private %abi_field_size(v0.i256) -> i256 {
         evm_revert 0.i256 36.i256;
 
     block6:
-        return v7;
+        return v6;
 }
 
 func private %abi_single_root_size(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = call %abi_field_size v2;
-        return v3;
+        v2.i256 = call %abi_field_size v0;
+        return v2;
 }
 
 func private %abort() {
@@ -84,16 +78,12 @@ func private %abort() {
 
 func inline(always) private %at(v0.i256) -> @layout_0 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = mload v1 i256;
-        v6.@layout_0 = insert_value undef.@layout_0 0.i256 v2;
-        v8.@layout_0 = insert_value v6 1.i256 v3;
-        return v8;
+        v4.@layout_0 = insert_value undef.@layout_0 0.i256 v0;
+        v6.@layout_0 = insert_value v4 1.i256 v0;
+        return v6;
 }
 
 func private %base(v0.objref<@layout_0>) -> i256 {
@@ -203,8 +193,6 @@ func private %contract_runtime_root_NewtypeStorageFieldMutMethodCall() {
 
 func inline(always) private %decode_from(v0.@layout_1, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
@@ -213,16 +201,10 @@ func inline(always) private %decode_from(v0.@layout_1, v1.i256) {
 
 func inline(always) private %decode_from_prechecked_head(v0.@layout_1, v1.i256, v2.i256) {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v4 i256;
-        v7.i256 = mload v3 i256;
-        call %decode_from v0 v7;
+        call %decode_from v0 v1;
         return;
 }
 
@@ -230,14 +212,12 @@ func inline(always) private %decode_runtime_args(v0.objref<@layout_3>) {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v4.@layout_1 = call %input;
-        v6.i256 = call %len v4;
-        mstore v1 v6 i256;
-        mstore v2 4.i256 i256;
+        v3.@layout_1 = call %input;
+        v5.i256 = call %len v3;
+        mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
 
     block2:
@@ -248,16 +228,14 @@ func inline(always) private %decode_runtime_args(v0.objref<@layout_3>) {
         jump block4;
 
     block4:
-        v11.i256 = mload v1 i256;
-        call %decode_from_prechecked_head v4 4.i256 v11;
+        call %decode_from_prechecked_head v3 4.i256 v5;
         return;
 
     block5:
-        v13.i256 = mload v1 i256;
-        mstore v3 v13 i256;
-        v15.i256 = mload v3 i256;
-        v16.i1 = gt 4.i256 v15;
-        br v16 block2 block3;
+        mstore v2 v5 i256;
+        v14.i256 = mload v2 i256;
+        v15.i1 = gt 4.i256 v14;
+        br v15 block2 block3;
 }
 
 func private %encode(v0.i256, v1.objref<@layout_0>) {
@@ -353,26 +331,20 @@ func private %encode_single_root_alloc(v0.i256) -> @layout_4 {
 
 func private %encode_to_ptr(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        call %store_word v3 v0;
+        call %store_word v1 v0;
         return;
 }
 
 func private %encoder_new(v0.i256) -> @layout_0 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.@layout_0 = call %impl_SolEncoder__new v2;
-        return v3;
+        v2.@layout_0 = call %impl_SolEncoder__new v0;
+        return v2;
 }
 
 func private %input() -> @layout_1 {
@@ -387,31 +359,27 @@ func private %input() -> @layout_1 {
 func inline(always) private %len(v0.@layout_1) -> i256 {
     block0:
         v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.i256 = extract_value v0 0.i256;
-        v7.i256 = mload v1 i256;
-        mstore v2 v7 i256;
-        v8.i256 = mload v2 i256;
-        v9.i1 = gt v6 v8;
-        br v9 block2 block3;
+        v2.i256 = evm_calldata_size;
+        v5.i256 = extract_value v0 0.i256;
+        mstore v1 v2 i256;
+        v6.i256 = mload v1 i256;
+        v7.i1 = gt v5 v6;
+        br v7 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v11.i256 = extract_value v0 0.i256;
-        v12.i256 = mload v1 i256;
-        (v13.i256, v14.i1) = usubo v12 v11;
-        br v14 block5 block6;
+        v9.i256 = extract_value v0 0.i256;
+        (v11.i256, v12.i1) = usubo v2 v9;
+        br v12 block5 block6;
 
     block4:
-        v19.i256 = phi (0.i256 block2) (v13 block6);
-        return v19;
+        v17.i256 = phi (0.i256 block2) (v11 block6);
+        return v17;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -436,34 +404,28 @@ func inline(always) private %impl_CallData__new() -> @layout_1 {
 
 func private %impl_SolEncoder__new(v0.i256) -> @layout_0 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v4.i1 = eq v2 0.i256;
-        br v4 block2 block3;
+        v3.i1 = eq v0 0.i256;
+        br v3 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v5.i256 = mload v1 i256;
-        v6.*i8 = evm_malloc v5;
-        v7.i256 = ptr_to_int v6 i256;
+        v5.*i8 = evm_malloc v0;
+        v6.i256 = ptr_to_int v5 i256;
         jump block4;
 
     block4:
-        v8.i256 = phi (0.i256 block2) (v7 block3);
-        v9.@layout_0 = call %at v8;
-        return v9;
+        v7.i256 = phi (0.i256 block2) (v6 block3);
+        v8.@layout_0 = call %at v7;
+        return v8;
 }
 
 func private %core__lib__abi__trait_AbiSize__payload_size__ge513_4e75(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
@@ -472,8 +434,6 @@ func private %core__lib__abi__trait_AbiSize__payload_size__ge513_4e75(v0.i256) -
 
 func private %core__lib__abi__trait_AbiSize__payload_size__ge513_4e75_0(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
@@ -492,90 +452,66 @@ func private %pos(v0.objref<@layout_0>) -> i256 {
 
 func private %revert(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        evm_revert v4 v5;
+        evm_revert v0 v1;
 }
 
 func private %set_base(v0.objref<@layout_0>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        obj.store v6 v3;
+        v5.objref<i256> = obj.proj v0 0.i256;
+        obj.store v5 v1;
         return;
 }
 
 func private %set_pos(v0.objref<@layout_0>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 1.i256;
-        obj.store v6 v3;
+        v5.objref<i256> = obj.proj v0 1.i256;
+        obj.store v5 v1;
         return;
 }
 
 func private %store_word(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        mstore v4 v5 i256;
+        mstore v0 v1 i256;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_90ae(v0.objref<@layout_0>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 1.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        mstore v6 v7 i256;
-        v10.i256 = add v6 32.i256;
-        v11.objref<i256> = obj.proj v0 1.i256;
-        obj.store v11 v10;
+        v4.objref<i256> = obj.proj v0 1.i256;
+        v5.i256 = obj.load v4;
+        mstore v5 v1 i256;
+        v9.i256 = add v5 32.i256;
+        v10.objref<i256> = obj.proj v0 1.i256;
+        obj.store v10 v9;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_9251(v0.objref<@layout_0>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 1.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        mstore v6 v7 i256;
-        v10.i256 = add v6 32.i256;
-        v11.objref<i256> = obj.proj v0 1.i256;
-        obj.store v11 v10;
+        v4.objref<i256> = obj.proj v0 1.i256;
+        v5.i256 = obj.load v4;
+        mstore v5 v1 i256;
+        v9.i256 = add v5 32.i256;
+        v10.objref<i256> = obj.proj v0 1.i256;
+        obj.store v10 v9;
         return;
 }
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/newtype_u8_word_conversion.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/newtype_u8_word_conversion.snap
@@ -28,28 +28,25 @@ func private %main_root() {
 
 func private %newtype_u8_roundtrip(v0.i8) -> i8 {
     block0:
-        v1.*i8 = alloca i8;
-        mstore v1 v0 i8;
         jump block1;
 
     block1:
-        v2.i8 = mload v1 i8;
-        v5.@layout_0 = insert_value undef.@layout_0 0.i256 v2;
-        v7.@layout_1 = insert_value undef.@layout_1 0.i256 v5;
-        v9.@layout_1 = insert_value v7 1.i256 0.i256;
-        v10.objref<@layout_1> = obj.alloc @layout_1;
-        v11.objref<@layout_0> = obj.proj v10 0.i256;
-        v12.@layout_0 = extract_value v9 0.i256;
-        v13.objref<i8> = obj.proj v11 0.i256;
-        v14.i8 = extract_value v12 0.i256;
-        obj.store v13 v14;
-        v15.objref<i256> = obj.proj v10 1.i256;
-        v16.i256 = extract_value v9 1.i256;
-        obj.store v15 v16;
-        v17.objref<@layout_0> = obj.proj v10 0.i256;
-        v18.objref<i8> = obj.proj v17 0.i256;
-        v19.i8 = obj.load v18;
-        return v19;
+        v4.@layout_0 = insert_value undef.@layout_0 0.i256 v0;
+        v6.@layout_1 = insert_value undef.@layout_1 0.i256 v4;
+        v8.@layout_1 = insert_value v6 1.i256 0.i256;
+        v9.objref<@layout_1> = obj.alloc @layout_1;
+        v10.objref<@layout_0> = obj.proj v9 0.i256;
+        v11.@layout_0 = extract_value v8 0.i256;
+        v12.objref<i8> = obj.proj v10 0.i256;
+        v13.i8 = extract_value v11 0.i256;
+        obj.store v12 v13;
+        v14.objref<i256> = obj.proj v9 1.i256;
+        v15.i256 = extract_value v8 1.i256;
+        obj.store v14 v15;
+        v16.objref<@layout_0> = obj.proj v9 0.i256;
+        v17.objref<i8> = obj.proj v16 0.i256;
+        v18.i8 = obj.load v17;
+        return v18;
 }
 
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/newtype_word_mut_method_call.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/newtype_word_mut_method_call.snap
@@ -52,16 +52,13 @@ func private %main_root() {
 
 func private %newtype_word_mut_method_call(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v5.@layout_0 = insert_value undef.@layout_0 0.i256 v2;
-        v6.@layout_0 = call %bump v5;
-        v7.i256 = extract_value v6 0.i256;
-        return v7;
+        v4.@layout_0 = insert_value undef.@layout_0 0.i256 v0;
+        v5.@layout_0 = call %bump v4;
+        v6.i256 = extract_value v5 0.i256;
+        return v6;
 }
 
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/pointer_field_aggregate.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/pointer_field_aggregate.snap
@@ -47,13 +47,10 @@ func private %standalone_pointer_field_aggregate__pointer_field_aggregate__bump_
 
 func private %from_raw(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        return v2;
+        return v0;
 }
 
 func private %main_root() {
@@ -67,14 +64,11 @@ func private %main_root() {
 
 func private %mem_ptr(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = call %from_raw v2;
-        return v3;
+        v2.i256 = call %from_raw v0;
+        return v2;
 }
 
 func private %pointer_field_aggregate() {

--- a/crates/codegen/tests/fixtures/sonatina_ir/range_bounds.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/range_bounds.snap
@@ -7,14 +7,11 @@ target = "evm-ethereum-osaka"
 
 func private %get(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v1 i256;
-        (v4.i256, v5.i1) = uaddo 0.i256 v3;
-        br v5 block2 block3;
+        (v3.i256, v4.i1) = uaddo 0.i256 v0;
+        br v4 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -22,7 +19,7 @@ func private %get(v0.i256) -> i256 {
         evm_revert 0.i256 36.i256;
 
     block3:
-        return v4;
+        return v3;
 }
 
 func private %len() -> i256 {
@@ -54,26 +51,25 @@ func private %main_root() {
 
 func private %sum_const() -> i256 {
     block0:
-        v0.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.i256 = call %len;
+        v2.i256 = call %len;
         jump block2;
 
     block2:
-        v22.i256 = phi (0.i256 block1) (v15 block7);
-        v4.i256 = phi (0.i256 block1) (v18 block7);
-        v6.i1 = lt v4 v3;
-        br v6 block3 block4;
+        v20.i256 = phi (0.i256 block1) (v9 block7);
+        v3.i256 = phi (0.i256 block1) (v16 block7);
+        v5.i1 = lt v3 v2;
+        br v5 block3 block4;
 
     block3:
-        v8.i256 = call %get v4;
-        (v10.i256, v11.i1) = uaddo v22 v8;
-        br v11 block5 block6;
+        v7.i256 = call %get v3;
+        (v9.i256, v10.i1) = uaddo v20 v7;
+        br v10 block5 block6;
 
     block4:
-        return v22;
+        return v20;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -81,10 +77,8 @@ func private %sum_const() -> i256 {
         evm_revert 0.i256 36.i256;
 
     block6:
-        mstore v0 v10 i256;
-        v15.i256 = mload v0 i256;
-        (v18.i256, v19.i1) = uaddo v4 1.i256;
-        br v19 block5 block7;
+        (v16.i256, v17.i1) = uaddo v3 1.i256;
+        br v17 block5 block7;
 
     block7:
         jump block2;

--- a/crates/codegen/tests/fixtures/sonatina_ir/raw_log_emit.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/raw_log_emit.snap
@@ -7,27 +7,18 @@ target = "evm-ethereum-osaka"
 
 func private %from_raw(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        return v2;
+        return v0;
 }
 
 func private %log0(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        evm_log0 v4 v5;
+        evm_log0 v0 v1;
         return;
 }
 
@@ -51,14 +42,11 @@ func private %main_root() {
 
 func private %mem_ptr(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = call %from_raw v2;
-        return v3;
+        v2.i256 = call %from_raw v0;
+        return v2;
 }
 
 func private %raw(v0.i256) -> i256 {

--- a/crates/codegen/tests/fixtures/sonatina_ir/ret.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/ret.snap
@@ -25,15 +25,10 @@ func private %main_root() {
 
 func private %retfoo(v0.i1, v1.i64) -> i64 {
     block0:
-        v2.*i1 = alloca i1;
-        v3.*i64 = alloca i64;
-        mstore v2 v0 i1;
-        mstore v3 v1 i64;
         jump block1;
 
     block1:
-        v4.i1 = mload v2 i1;
-        br v4 block2 block3;
+        br v0 block2 block3;
 
     block2:
         return 0.i64;
@@ -42,9 +37,8 @@ func private %retfoo(v0.i1, v1.i64) -> i64 {
         jump block4;
 
     block4:
-        v6.i64 = mload v3 i64;
-        v8.i1 = lt v6 5.i64;
-        br v8 block5 block6;
+        v6.i1 = lt v1 5.i64;
+        br v6 block5 block6;
 
     block5:
         return 1.i64;
@@ -53,9 +47,8 @@ func private %retfoo(v0.i1, v1.i64) -> i64 {
         jump block7;
 
     block7:
-        v10.i64 = mload v3 i64;
-        (v11.i64, v12.i1) = usubo v10 1.i64;
-        br v12 block11 block12;
+        (v9.i64, v10.i1) = usubo v1 1.i64;
+        br v10 block11 block12;
 
     block8:
         return 2.i64;
@@ -64,8 +57,8 @@ func private %retfoo(v0.i1, v1.i64) -> i64 {
         jump block10;
 
     block10:
-        (v22.i64, v23.i1) = uaddo v11 1.i64;
-        br v23 block11 block13;
+        (v20.i64, v21.i1) = uaddo v9 1.i64;
+        br v21 block11 block13;
 
     block11:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -73,11 +66,11 @@ func private %retfoo(v0.i1, v1.i64) -> i64 {
         evm_revert 0.i256 36.i256;
 
     block12:
-        v19.i1 = eq v11 42.i64;
-        br v19 block8 block9;
+        v17.i1 = eq v9 42.i64;
+        br v17 block8 block9;
 
     block13:
-        return v22;
+        return v20;
 }
 
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/revert.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/revert.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/codegen/tests/sonatina_ir.rs
-assertion_line: 403
 expression: output
 input_file: crates/codegen/tests/fixtures/revert.fe
 ---
@@ -46,60 +45,36 @@ func private %main_root() {
 
 func private %std__lib__evm__effects__impl_trait_Evm_d0d8__mstore_f3cd(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        mstore v4 v5 i256;
+        mstore v0 v1 i256;
         return;
 }
 
 func private %std__lib__evm__effects__impl_trait_Evm_d0d8__mstore_f3cd_0(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        mstore v4 v5 i256;
+        mstore v0 v1 i256;
         return;
 }
 
 func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_8f03(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        evm_revert v4 v5;
+        evm_revert v0 v1;
 }
 
 func private %std__lib__evm__effects__impl_trait_Evm_0098__revert_8f03_0(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        evm_revert v4 v5;
+        evm_revert v0 v1;
 }
 
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/storage.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/storage.snap
@@ -12,39 +12,33 @@ type @layout_0 = enum {
 
 func private %abi_encode(v0.i256) {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v1 i256;
-        call %mstore 0.i256 v3;
+        call %mstore 0.i256 v0;
         call %std__lib__evm__effects__impl_trait_Evm_0098__return_data_2541 0.i256 32.i256;
         unreachable;
 }
 
 func private %balance_of_raw(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v0 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v5.i1 = eq v3 0.i256;
-        br v5 block3 block5;
+        v4.i1 = eq v0 0.i256;
+        br v4 block3 block5;
 
     block2:
-        v6.i256 = phi (v8 block3) (v12 block4);
-        return v6;
+        v5.i256 = phi (v7 block3) (v11 block4);
+        return v5;
 
     block3:
-        v8.i256 = evm_sload v1;
+        v7.i256 = evm_sload v1;
         jump block2;
 
     block4:
-        v11.i256 = add v1 1.i256;
-        v12.i256 = evm_sload v11;
+        v10.i256 = add v1 1.i256;
+        v11.i256 = evm_sload v10;
         jump block2;
 
     block5:
@@ -53,45 +47,30 @@ func private %balance_of_raw(v0.i256, v1.i256) -> i256 {
 
 func private %calldataload(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = evm_calldata_load v2;
-        return v3;
+        v2.i256 = evm_calldata_load v0;
+        return v2;
 }
 
 func private %codecopy(v0.i256, v1.i256, v2.i256) {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        mstore v3 v0 i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
         jump block1;
 
     block1:
-        v6.i256 = mload v3 i256;
-        v7.i256 = mload v4 i256;
-        v8.i256 = mload v5 i256;
-        evm_code_copy v6 v7 v8;
+        evm_code_copy v0 v1 v2;
         return;
 }
 
 func private %credit_alice(v0.i256, v1.i256, v2.i256) -> i256 {
     block0:
-        v3.*i256 = alloca i256;
-        mstore v3 v0 i256;
         jump block1;
 
     block1:
-        v5.i256 = evm_sload v1;
-        v6.i256 = mload v3 i256;
-        (v7.i256, v8.i1) = uaddo v5 v6;
-        br v8 block2 block3;
+        v4.i256 = evm_sload v1;
+        (v6.i256, v7.i1) = uaddo v4 v0;
+        br v7 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -99,30 +78,26 @@ func private %credit_alice(v0.i256, v1.i256, v2.i256) -> i256 {
         evm_revert 0.i256 36.i256;
 
     block3:
-        evm_sstore v1 v7;
-        v16.i256 = evm_sload v2;
-        v17.i256 = mload v3 i256;
-        (v18.i256, v19.i1) = uaddo v16 v17;
-        br v19 block2 block4;
+        evm_sstore v1 v6;
+        v15.i256 = evm_sload v2;
+        (v17.i256, v18.i1) = uaddo v15 v0;
+        br v18 block2 block4;
 
     block4:
-        evm_sstore v2 v18;
-        v22.i256 = evm_sload v1;
-        return v22;
+        evm_sstore v2 v17;
+        v21.i256 = evm_sload v1;
+        return v21;
 }
 
 func private %credit_bob(v0.i256, v1.i256, v2.i256) -> i256 {
     block0:
-        v3.*i256 = alloca i256;
-        mstore v3 v0 i256;
         jump block1;
 
     block1:
-        v6.i256 = add v1 1.i256;
-        v7.i256 = evm_sload v6;
-        v8.i256 = mload v3 i256;
-        (v9.i256, v10.i1) = uaddo v7 v8;
-        br v10 block2 block3;
+        v5.i256 = add v1 1.i256;
+        v6.i256 = evm_sload v5;
+        (v8.i256, v9.i1) = uaddo v6 v0;
+        br v9 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -130,40 +105,33 @@ func private %credit_bob(v0.i256, v1.i256, v2.i256) -> i256 {
         evm_revert 0.i256 36.i256;
 
     block3:
-        v17.i256 = add v1 1.i256;
-        evm_sstore v17 v9;
-        v19.i256 = evm_sload v2;
-        v20.i256 = mload v3 i256;
-        (v21.i256, v22.i1) = uaddo v19 v20;
-        br v22 block2 block4;
+        v16.i256 = add v1 1.i256;
+        evm_sstore v16 v8;
+        v18.i256 = evm_sload v2;
+        (v20.i256, v21.i1) = uaddo v18 v0;
+        br v21 block2 block4;
 
     block4:
-        evm_sstore v2 v21;
-        v25.i256 = add v1 1.i256;
-        v26.i256 = evm_sload v25;
-        return v26;
+        evm_sstore v2 v20;
+        v24.i256 = add v1 1.i256;
+        v25.i256 = evm_sload v24;
+        return v25;
 }
 
 func private %from_raw__g9438(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        return v2;
+        return v0;
 }
 
 func private %from_raw__gf198(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        return v2;
+        return v0;
 }
 
 func private %init() {
@@ -200,59 +168,35 @@ func private %manual_contract_runtime_root_Coin() {
 
 func private %mstore(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        mstore v4 v5 i256;
+        mstore v0 v1 i256;
         return;
 }
 
 func private %std__lib__evm__effects__impl_trait_Evm_0098__return_data_2541(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        evm_return v4 v5;
+        evm_return v0 v1;
 }
 
 func private %std__lib__evm__effects__impl_trait_Evm_0098__return_data_e8fc(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        evm_return v4 v5;
+        evm_return v0 v1;
 }
 
 func private %std__lib__evm__effects__impl_trait_Evm_0098__return_data_e8fc_0(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        evm_return v4 v5;
+        evm_return v0 v1;
 }
 
 func private %runtime() {
@@ -345,26 +289,20 @@ func private %runtime() {
 
 func private %stor_ptr__g2c78(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = call %from_raw__g9438 v2;
-        return v3;
+        v2.i256 = call %from_raw__g9438 v0;
+        return v2;
 }
 
 func private %stor_ptr__gd216(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = call %from_raw__gf198 v2;
-        return v3;
+        v2.i256 = call %from_raw__gf198 v0;
+        return v2;
 }
 
 func private %total_supply(v0.i256) -> i256 {
@@ -378,28 +316,24 @@ func private %total_supply(v0.i256) -> i256 {
 
 func private %transfer_from_alice(v0.i256, v1.i256) -> @layout_0 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v0 i256;
         jump block1;
 
     block1:
-        v4.i256 = evm_sload v1;
-        v5.i256 = mload v2 i256;
-        v6.i1 = lt v4 v5;
-        br v6 block2 block3;
+        v3.i256 = evm_sload v1;
+        v5.i1 = lt v3 v0;
+        br v5 block2 block3;
 
     block2:
-        v7.@layout_0 = enum.make @layout_0 #Insufficient;
-        return v7;
+        v6.@layout_0 = enum.make @layout_0 #Insufficient;
+        return v6;
 
     block3:
         jump block4;
 
     block4:
-        v9.i256 = evm_sload v1;
-        v10.i256 = mload v2 i256;
-        (v11.i256, v12.i1) = usubo v9 v10;
-        br v12 block5 block6;
+        v8.i256 = evm_sload v1;
+        (v10.i256, v11.i1) = usubo v8 v0;
+        br v11 block5 block6;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -407,46 +341,41 @@ func private %transfer_from_alice(v0.i256, v1.i256) -> @layout_0 {
         evm_revert 0.i256 36.i256;
 
     block6:
-        evm_sstore v1 v11;
-        v20.i256 = add v1 1.i256;
-        v21.i256 = evm_sload v20;
-        v22.i256 = mload v2 i256;
-        (v23.i256, v24.i1) = uaddo v21 v22;
-        br v24 block5 block7;
+        evm_sstore v1 v10;
+        v19.i256 = add v1 1.i256;
+        v20.i256 = evm_sload v19;
+        (v22.i256, v23.i1) = uaddo v20 v0;
+        br v23 block5 block7;
 
     block7:
-        v26.i256 = add v1 1.i256;
-        evm_sstore v26 v23;
-        v27.@layout_0 = enum.make @layout_0 #Ok;
-        return v27;
+        v25.i256 = add v1 1.i256;
+        evm_sstore v25 v22;
+        v26.@layout_0 = enum.make @layout_0 #Ok;
+        return v26;
 }
 
 func private %transfer_from_bob(v0.i256, v1.i256) -> @layout_0 {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v0 i256;
         jump block1;
 
     block1:
-        v5.i256 = add v1 1.i256;
-        v6.i256 = evm_sload v5;
-        v7.i256 = mload v2 i256;
-        v8.i1 = lt v6 v7;
-        br v8 block2 block3;
+        v4.i256 = add v1 1.i256;
+        v5.i256 = evm_sload v4;
+        v7.i1 = lt v5 v0;
+        br v7 block2 block3;
 
     block2:
-        v9.@layout_0 = enum.make @layout_0 #Insufficient;
-        return v9;
+        v8.@layout_0 = enum.make @layout_0 #Insufficient;
+        return v8;
 
     block3:
         jump block4;
 
     block4:
-        v11.i256 = add v1 1.i256;
-        v12.i256 = evm_sload v11;
-        v13.i256 = mload v2 i256;
-        (v14.i256, v15.i1) = usubo v12 v13;
-        br v15 block5 block6;
+        v10.i256 = add v1 1.i256;
+        v11.i256 = evm_sload v10;
+        (v13.i256, v14.i1) = usubo v11 v0;
+        br v14 block5 block6;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -454,17 +383,16 @@ func private %transfer_from_bob(v0.i256, v1.i256) -> @layout_0 {
         evm_revert 0.i256 36.i256;
 
     block6:
-        v22.i256 = add v1 1.i256;
-        evm_sstore v22 v14;
-        v23.i256 = evm_sload v1;
-        v24.i256 = mload v2 i256;
-        (v25.i256, v26.i1) = uaddo v23 v24;
-        br v26 block5 block7;
+        v21.i256 = add v1 1.i256;
+        evm_sstore v21 v13;
+        v22.i256 = evm_sload v1;
+        (v24.i256, v25.i1) = uaddo v22 v0;
+        br v25 block5 block7;
 
     block7:
-        evm_sstore v1 v25;
-        v28.@layout_0 = enum.make @layout_0 #Ok;
-        return v28;
+        evm_sstore v1 v24;
+        v27.@layout_0 = enum.make @layout_0 #Ok;
+        return v27;
 }
 
 func private %transfer_result_code(v0.@layout_0) -> i256 {

--- a/crates/codegen/tests/fixtures/sonatina_ir/storage_map.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/storage_map.snap
@@ -7,38 +7,29 @@ target = "evm-ethereum-osaka"
 
 func private %from_word(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        return v2;
+        return v0;
 }
 
 func inline(always) private %get(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v1 i256;
-        v4.i256 = call %storagemap_get_word_with_salt v3 0.i256;
-        v5.i256 = call %from_word v4;
-        return v5;
+        v3.i256 = call %storagemap_get_word_with_salt v0 0.i256;
+        v4.i256 = call %from_word v3;
+        return v4;
 }
 
 func private %get_balance(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = call %get v2;
-        return v3;
+        v2.i256 = call %get v0;
+        return v2;
 }
 
 func private %main() -> i256 {
@@ -71,82 +62,53 @@ func private %new() {
 
 func inline(always) private %set(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v0 i256;
         jump block1;
 
     block1:
-        v5.i256 = call %to_word v1;
-        v6.i256 = mload v2 i256;
-        call %storagemap_set_word_with_salt v6 0.i256 v5;
+        v4.i256 = call %to_word v1;
+        call %storagemap_set_word_with_salt v0 0.i256 v4;
         return;
 }
 
 func private %set_balance(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        call %set v4 v5;
+        call %set v0 v1;
         return;
 }
 
 func inline(always) private %storagemap_get_word_with_salt(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v3 i256;
-        v5.i256 = mload v2 i256;
-        v6.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__ge513_3954_0 v5 v4;
-        v7.i256 = evm_sload v6;
-        return v7;
+        v4.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__ge513_3954_0 v0 v1;
+        v5.i256 = evm_sload v4;
+        return v5;
 }
 
 func inline(always) private %storagemap_set_word_with_salt(v0.i256, v1.i256, v2.i256) {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        mstore v3 v0 i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
         jump block1;
 
     block1:
-        v6.i256 = mload v4 i256;
-        v7.i256 = mload v3 i256;
-        v8.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__ge513_3954 v7 v6;
-        v9.i256 = mload v5 i256;
-        evm_sstore v8 v9;
+        v5.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__ge513_3954 v0 v1;
+        evm_sstore v5 v2;
         return;
 }
 
 func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__ge513_3954(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v5.*i8 = evm_malloc 0.i256;
-        v6.i256 = ptr_to_int v5 i256;
-        v7.i256 = mload v2 i256;
-        v8.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_2db6 v6 v7;
-        (v9.i256, v10.i1) = uaddo v6 v8;
-        br v10 block2 block3;
+        v3.*i8 = evm_malloc 0.i256;
+        v4.i256 = ptr_to_int v3 i256;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_2db6 v4 v0;
+        (v7.i256, v8.i1) = uaddo v4 v6;
+        br v8 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -154,31 +116,25 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot
         evm_revert 0.i256 36.i256;
 
     block3:
-        v15.i256 = mload v3 i256;
-        mstore v9 v15 i256;
-        (v19.i256, v20.i1) = uaddo v8 32.i256;
-        br v20 block2 block4;
+        mstore v7 v1 i256;
+        (v17.i256, v18.i1) = uaddo v6 32.i256;
+        br v18 block2 block4;
 
     block4:
-        v22.i256 = evm_keccak256 v6 v19;
-        return v22;
+        v20.i256 = evm_keccak256 v4 v17;
+        return v20;
 }
 
 func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__ge513_3954_0(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v5.*i8 = evm_malloc 0.i256;
-        v6.i256 = ptr_to_int v5 i256;
-        v7.i256 = mload v2 i256;
-        v8.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_2db6_0 v6 v7;
-        (v9.i256, v10.i1) = uaddo v6 v8;
-        br v10 block2 block3;
+        v3.*i8 = evm_malloc 0.i256;
+        v4.i256 = ptr_to_int v3 i256;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_2db6_0 v4 v0;
+        (v7.i256, v8.i1) = uaddo v4 v6;
+        br v8 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -186,14 +142,13 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot
         evm_revert 0.i256 36.i256;
 
     block3:
-        v15.i256 = mload v3 i256;
-        mstore v9 v15 i256;
-        (v19.i256, v20.i1) = uaddo v8 32.i256;
-        br v20 block2 block4;
+        mstore v7 v1 i256;
+        (v17.i256, v18.i1) = uaddo v6 32.i256;
+        br v18 block2 block4;
 
     block4:
-        v22.i256 = evm_keccak256 v6 v19;
-        return v22;
+        v20.i256 = evm_keccak256 v4 v17;
+        return v20;
 }
 
 func private %to_word(v0.i256) -> i256 {
@@ -206,31 +161,19 @@ func private %to_word(v0.i256) -> i256 {
 
 func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_2db6(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        mstore v4 v5 i256;
+        mstore v0 v1 i256;
         return 32.i256;
 }
 
 func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_2db6_0(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        mstore v4 v5 i256;
+        mstore v0 v1 i256;
         return 32.i256;
 }
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/storage_map_contract.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/storage_map_contract.snap
@@ -7,141 +7,102 @@ target = "evm-ethereum-osaka"
 
 func private %abi_encode(v0.i256) {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v1 i256;
-        call %mstore 0.i256 v3;
+        call %mstore 0.i256 v0;
         call %std__lib__evm__effects__impl_trait_Evm_0098__return_data_c635 0.i256 32.i256;
         unreachable;
 }
 
 func private %calldataload(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = evm_calldata_load v2;
-        return v3;
+        v2.i256 = evm_calldata_load v0;
+        return v2;
 }
 
 func private %codecopy(v0.i256, v1.i256, v2.i256) {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        mstore v3 v0 i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
         jump block1;
 
     block1:
-        v6.i256 = mload v3 i256;
-        v7.i256 = mload v4 i256;
-        v8.i256 = mload v5 i256;
-        evm_code_copy v6 v7 v8;
+        evm_code_copy v0 v1 v2;
         return;
 }
 
 func private %std__lib__evm__word__impl_trait_u256_1f9e__from_word_461b(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        return v2;
+        return v0;
 }
 
 func private %std__lib__evm__word__impl_trait_u256_1f9e__from_word_461b_0(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        return v2;
+        return v0;
 }
 
 func private %std__lib__evm__word__impl_trait_u256_1f9e__from_word_461b_1(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        return v2;
+        return v0;
 }
 
 func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__get__gcbe1_9b00(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v1 i256;
-        v4.i256 = call %std__lib__evm__storage_map__storagemap_get_word_with_salt__ge513_a5dc_0 v3 0.i256;
-        v5.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__from_word_461b_0 v4;
-        return v5;
+        v3.i256 = call %std__lib__evm__storage_map__storagemap_get_word_with_salt__ge513_a5dc_0 v0 0.i256;
+        v4.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__from_word_461b_0 v3;
+        return v4;
 }
 
 func inline(always) private %std__lib__evm__storage_map__impl_StorageMap_9f54__get__gcbe1_9b00_0(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v1 i256;
-        v4.i256 = call %std__lib__evm__storage_map__storagemap_get_word_with_salt__ge513_a5dc_1 v3 0.i256;
-        v5.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__from_word_461b_1 v4;
-        return v5;
+        v3.i256 = call %std__lib__evm__storage_map__storagemap_get_word_with_salt__ge513_a5dc_1 v0 0.i256;
+        v4.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__from_word_461b_1 v3;
+        return v4;
 }
 
 func private %get_allowance(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = call %get__g7fdf v2;
-        return v3;
+        v2.i256 = call %get__g7fdf v0;
+        return v2;
 }
 
 func private %get_balance(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get__gcbe1_9b00 v2;
-        return v3;
+        v2.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get__gcbe1_9b00 v0;
+        return v2;
 }
 
 func inline(always) private %get__g7fdf(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v1 i256;
-        v4.i256 = call %std__lib__evm__storage_map__storagemap_get_word_with_salt__ge513_a5dc v3 1.i256;
-        v5.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__from_word_461b v4;
-        return v5;
+        v3.i256 = call %std__lib__evm__storage_map__storagemap_get_word_with_salt__ge513_a5dc v0 1.i256;
+        v4.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__from_word_461b v3;
+        return v4;
 }
 
 func private %init() {
@@ -178,16 +139,10 @@ func private %manual_contract_runtime_root_BalanceMap() {
 
 func private %mstore(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        mstore v4 v5 i256;
+        mstore v0 v1 i256;
         return;
 }
 
@@ -209,44 +164,26 @@ func private %new__g7fdf() {
 
 func private %std__lib__evm__effects__impl_trait_Evm_0098__return_data_ad81(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        evm_return v4 v5;
+        evm_return v0 v1;
 }
 
 func private %std__lib__evm__effects__impl_trait_Evm_0098__return_data_ad81_0(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        evm_return v4 v5;
+        evm_return v0 v1;
 }
 
 func private %std__lib__evm__effects__impl_trait_Evm_0098__return_data_c635(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        evm_return v4 v5;
+        evm_return v0 v1;
 }
 
 func private %runtime() {
@@ -321,161 +258,102 @@ func private %runtime() {
 
 func inline(always) private %set__g7fdf(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v0 i256;
         jump block1;
 
     block1:
-        v5.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__to_word_1ead v1;
-        v6.i256 = mload v2 i256;
-        call %std__lib__evm__storage_map__storagemap_set_word_with_salt__ge513_d78d v6 1.i256 v5;
+        v4.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__to_word_1ead v1;
+        call %std__lib__evm__storage_map__storagemap_set_word_with_salt__ge513_d78d v0 1.i256 v4;
         return;
 }
 
 func inline(always) private %set__gcbe1(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v0 i256;
         jump block1;
 
     block1:
-        v5.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__to_word_1ead_0 v1;
-        v6.i256 = mload v2 i256;
-        call %std__lib__evm__storage_map__storagemap_set_word_with_salt__ge513_d78d_0 v6 0.i256 v5;
+        v4.i256 = call %std__lib__evm__word__impl_trait_u256_1f9e__to_word_1ead_0 v1;
+        call %std__lib__evm__storage_map__storagemap_set_word_with_salt__ge513_d78d_0 v0 0.i256 v4;
         return;
 }
 
 func private %set_allowance(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        call %set__g7fdf v4 v5;
+        call %set__g7fdf v0 v1;
         return;
 }
 
 func private %set_balance(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        call %set__gcbe1 v4 v5;
+        call %set__gcbe1 v0 v1;
         return;
 }
 
 func inline(always) private %std__lib__evm__storage_map__storagemap_get_word_with_salt__ge513_a5dc(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v3 i256;
-        v5.i256 = mload v2 i256;
-        v6.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__ge513_f97d v5 v4;
-        v7.i256 = evm_sload v6;
-        return v7;
+        v4.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__ge513_f97d v0 v1;
+        v5.i256 = evm_sload v4;
+        return v5;
 }
 
 func inline(always) private %std__lib__evm__storage_map__storagemap_get_word_with_salt__ge513_a5dc_0(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v3 i256;
-        v5.i256 = mload v2 i256;
-        v6.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__ge513_f97d_1 v5 v4;
-        v7.i256 = evm_sload v6;
-        return v7;
+        v4.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__ge513_f97d_1 v0 v1;
+        v5.i256 = evm_sload v4;
+        return v5;
 }
 
 func inline(always) private %std__lib__evm__storage_map__storagemap_get_word_with_salt__ge513_a5dc_1(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v3 i256;
-        v5.i256 = mload v2 i256;
-        v6.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__ge513_f97d_2 v5 v4;
-        v7.i256 = evm_sload v6;
-        return v7;
+        v4.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__ge513_f97d_2 v0 v1;
+        v5.i256 = evm_sload v4;
+        return v5;
 }
 
 func inline(always) private %std__lib__evm__storage_map__storagemap_set_word_with_salt__ge513_d78d(v0.i256, v1.i256, v2.i256) {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        mstore v3 v0 i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
         jump block1;
 
     block1:
-        v6.i256 = mload v4 i256;
-        v7.i256 = mload v3 i256;
-        v8.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__ge513_f97d_0 v7 v6;
-        v9.i256 = mload v5 i256;
-        evm_sstore v8 v9;
+        v5.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__ge513_f97d_0 v0 v1;
+        evm_sstore v5 v2;
         return;
 }
 
 func inline(always) private %std__lib__evm__storage_map__storagemap_set_word_with_salt__ge513_d78d_0(v0.i256, v1.i256, v2.i256) {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        mstore v3 v0 i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
         jump block1;
 
     block1:
-        v6.i256 = mload v4 i256;
-        v7.i256 = mload v3 i256;
-        v8.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__ge513_f97d_2 v7 v6;
-        v9.i256 = mload v5 i256;
-        evm_sstore v8 v9;
+        v5.i256 = call %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__ge513_f97d_2 v0 v1;
+        evm_sstore v5 v2;
         return;
 }
 
 func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__ge513_f97d(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v5.*i8 = evm_malloc 0.i256;
-        v6.i256 = ptr_to_int v5 i256;
-        v7.i256 = mload v2 i256;
-        v8.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_bd6c v6 v7;
-        (v9.i256, v10.i1) = uaddo v6 v8;
-        br v10 block2 block3;
+        v3.*i8 = evm_malloc 0.i256;
+        v4.i256 = ptr_to_int v3 i256;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_bd6c v4 v0;
+        (v7.i256, v8.i1) = uaddo v4 v6;
+        br v8 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -483,31 +361,25 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot
         evm_revert 0.i256 36.i256;
 
     block3:
-        v15.i256 = mload v3 i256;
-        mstore v9 v15 i256;
-        (v19.i256, v20.i1) = uaddo v8 32.i256;
-        br v20 block2 block4;
+        mstore v7 v1 i256;
+        (v17.i256, v18.i1) = uaddo v6 32.i256;
+        br v18 block2 block4;
 
     block4:
-        v22.i256 = evm_keccak256 v6 v19;
-        return v22;
+        v20.i256 = evm_keccak256 v4 v17;
+        return v20;
 }
 
 func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__ge513_f97d_0(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v5.*i8 = evm_malloc 0.i256;
-        v6.i256 = ptr_to_int v5 i256;
-        v7.i256 = mload v2 i256;
-        v8.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_bd6c_0 v6 v7;
-        (v9.i256, v10.i1) = uaddo v6 v8;
-        br v10 block2 block3;
+        v3.*i8 = evm_malloc 0.i256;
+        v4.i256 = ptr_to_int v3 i256;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_bd6c_0 v4 v0;
+        (v7.i256, v8.i1) = uaddo v4 v6;
+        br v8 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -515,31 +387,25 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot
         evm_revert 0.i256 36.i256;
 
     block3:
-        v15.i256 = mload v3 i256;
-        mstore v9 v15 i256;
-        (v19.i256, v20.i1) = uaddo v8 32.i256;
-        br v20 block2 block4;
+        mstore v7 v1 i256;
+        (v17.i256, v18.i1) = uaddo v6 32.i256;
+        br v18 block2 block4;
 
     block4:
-        v22.i256 = evm_keccak256 v6 v19;
-        return v22;
+        v20.i256 = evm_keccak256 v4 v17;
+        return v20;
 }
 
 func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__ge513_f97d_1(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v5.*i8 = evm_malloc 0.i256;
-        v6.i256 = ptr_to_int v5 i256;
-        v7.i256 = mload v2 i256;
-        v8.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_bd6c_1 v6 v7;
-        (v9.i256, v10.i1) = uaddo v6 v8;
-        br v10 block2 block3;
+        v3.*i8 = evm_malloc 0.i256;
+        v4.i256 = ptr_to_int v3 i256;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_bd6c_1 v4 v0;
+        (v7.i256, v8.i1) = uaddo v4 v6;
+        br v8 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -547,31 +413,25 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot
         evm_revert 0.i256 36.i256;
 
     block3:
-        v15.i256 = mload v3 i256;
-        mstore v9 v15 i256;
-        (v19.i256, v20.i1) = uaddo v8 32.i256;
-        br v20 block2 block4;
+        mstore v7 v1 i256;
+        (v17.i256, v18.i1) = uaddo v6 32.i256;
+        br v18 block2 block4;
 
     block4:
-        v22.i256 = evm_keccak256 v6 v19;
-        return v22;
+        v20.i256 = evm_keccak256 v4 v17;
+        return v20;
 }
 
 func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot_with_salt__ge513_f97d_2(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v5.*i8 = evm_malloc 0.i256;
-        v6.i256 = ptr_to_int v5 i256;
-        v7.i256 = mload v2 i256;
-        v8.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_bd6c_2 v6 v7;
-        (v9.i256, v10.i1) = uaddo v6 v8;
-        br v10 block2 block3;
+        v3.*i8 = evm_malloc 0.i256;
+        v4.i256 = ptr_to_int v3 i256;
+        v6.i256 = call %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_bd6c_2 v4 v0;
+        (v7.i256, v8.i1) = uaddo v4 v6;
+        br v8 block2 block3;
 
     block2:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -579,14 +439,13 @@ func inline(always) private %std__lib__evm__storage_map__storagemap_storage_slot
         evm_revert 0.i256 36.i256;
 
     block3:
-        v15.i256 = mload v3 i256;
-        mstore v9 v15 i256;
-        (v19.i256, v20.i1) = uaddo v8 32.i256;
-        br v20 block2 block4;
+        mstore v7 v1 i256;
+        (v17.i256, v18.i1) = uaddo v6 32.i256;
+        br v18 block2 block4;
 
     block4:
-        v22.i256 = evm_keccak256 v6 v19;
-        return v22;
+        v20.i256 = evm_keccak256 v4 v17;
+        return v20;
 }
 
 func private %std__lib__evm__word__impl_trait_u256_1f9e__to_word_1ead(v0.i256) -> i256 {
@@ -607,20 +466,12 @@ func private %std__lib__evm__word__impl_trait_u256_1f9e__to_word_1ead_0(v0.i256)
 
 func private %transfer(v0.i256, v1.i256, v2.i256) -> i256 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        mstore v3 v0 i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
         jump block1;
 
     block1:
-        v6.i256 = mload v3 i256;
-        v7.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get__gcbe1_9b00_0 v6;
-        v8.i256 = mload v5 i256;
-        v9.i1 = lt v7 v8;
-        br v9 block2 block3;
+        v4.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get__gcbe1_9b00_0 v0;
+        v6.i1 = lt v4 v2;
+        br v6 block2 block3;
 
     block2:
         return 1.i256;
@@ -629,12 +480,9 @@ func private %transfer(v0.i256, v1.i256, v2.i256) -> i256 {
         jump block4;
 
     block4:
-        v11.i256 = mload v4 i256;
-        v12.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get__gcbe1_9b00_0 v11;
-        v13.i256 = mload v3 i256;
-        v14.i256 = mload v5 i256;
-        (v16.i256, v17.i1) = usubo v7 v14;
-        br v17 block5 block6;
+        v9.i256 = call %std__lib__evm__storage_map__impl_StorageMap_9f54__get__gcbe1_9b00_0 v1;
+        (v13.i256, v14.i1) = usubo v4 v2;
+        br v14 block5 block6;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -642,74 +490,48 @@ func private %transfer(v0.i256, v1.i256, v2.i256) -> i256 {
         evm_revert 0.i256 36.i256;
 
     block6:
-        call %set__gcbe1 v13 v16;
-        v25.i256 = mload v4 i256;
-        v26.i256 = mload v5 i256;
-        (v28.i256, v29.i1) = uaddo v12 v26;
-        br v29 block5 block7;
+        call %set__gcbe1 v0 v13;
+        (v25.i256, v26.i1) = uaddo v9 v2;
+        br v26 block5 block7;
 
     block7:
-        call %set__gcbe1 v25 v28;
+        call %set__gcbe1 v1 v25;
         return 0.i256;
 }
 
 func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_bd6c(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        mstore v4 v5 i256;
+        mstore v0 v1 i256;
         return 32.i256;
 }
 
 func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_bd6c_0(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        mstore v4 v5 i256;
+        mstore v0 v1 i256;
         return 32.i256;
 }
 
 func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_bd6c_1(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        mstore v4 v5 i256;
+        mstore v0 v1 i256;
         return 32.i256;
 }
 
 func inline(always) private %std__lib__evm__storage_map__impl_trait_u256_0dfe__write_key_bd6c_2(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        mstore v4 v5 i256;
+        mstore v0 v1 i256;
         return 32.i256;
 }
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/storage_packed_array.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/storage_packed_array.snap
@@ -12,33 +12,26 @@ type @layout_0 = enum {
 
 func inline(always) private %get(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v9.i256 = mload v1 i256;
-        v10.i256 = evm_udiv v9 32.i256;
-        v11.i256 = add 18569430475105882587588266137607568536673111973893317399460219858819262702947.i256 v10;
-        v12.i256 = mload v1 i256;
-        v13.i256 = evm_umod v12 32.i256;
-        v14.i256 = mul v13 8.i256;
-        v15.i256 = evm_sload v11;
-        v16.i256 = shr v14 v15;
-        v17.i256 = and v16 255.i256;
-        return v17;
+        v9.i256 = evm_udiv v0 32.i256;
+        v10.i256 = add 18569430475105882587588266137607568536673111973893317399460219858819262702947.i256 v9;
+        v11.i256 = evm_umod v0 32.i256;
+        v12.i256 = mul v11 8.i256;
+        v13.i256 = evm_sload v10;
+        v14.i256 = shr v12 v13;
+        v15.i256 = and v14 255.i256;
+        return v15;
 }
 
 func private %get_status(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = call %get v2;
-        return v3;
+        v2.i256 = call %get v0;
+        return v2;
 }
 
 func private %main() -> i256 {
@@ -76,106 +69,87 @@ func private %search(v0.i256, v1.i256, v2.i256) -> @layout_0 {
         v3.*i256 = alloca i256;
         v4.*i256 = alloca i256;
         v5.*i256 = alloca i256;
-        v6.*i256 = alloca i256;
-        v7.*i256 = alloca i256;
-        v8.*i256 = alloca i256;
-        mstore v3 v0 i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
         jump block1;
 
     block1:
-        v16.i256 = mload v4 i256;
-        mstore v6 v16 i256;
+        mstore v3 v1 i256;
         jump block2;
 
     block2:
-        v17.i256 = mload v6 i256;
-        v18.i256 = mload v5 i256;
-        v19.i1 = lt v17 v18;
-        br v19 block3 block4;
+        v14.i256 = mload v3 i256;
+        v16.i1 = lt v14 v2;
+        br v16 block3 block4;
 
     block3:
-        v20.i256 = mload v6 i256;
-        v22.i256 = evm_udiv v20 32.i256;
-        v24.i256 = add 18569430475105882587588266137607568536673111973893317399460219858819262702947.i256 v22;
-        v25.i256 = evm_sload v24;
-        v26.i256 = mload v6 i256;
-        v27.i256 = evm_umod v26 32.i256;
-        mstore v7 v27 i256;
+        v17.i256 = mload v3 i256;
+        v19.i256 = evm_udiv v17 32.i256;
+        v21.i256 = add 18569430475105882587588266137607568536673111973893317399460219858819262702947.i256 v19;
+        v22.i256 = evm_sload v21;
+        v23.i256 = mload v3 i256;
+        v24.i256 = evm_umod v23 32.i256;
+        mstore v4 v24 i256;
         jump block5;
 
     block4:
-        v28.@layout_0 = enum.make @layout_0 #None;
-        return v28;
+        v25.@layout_0 = enum.make @layout_0 #None;
+        return v25;
 
     block5:
-        mstore v8 32.i256 i256;
-        v29.i256 = mload v7 i256;
-        v30.i256 = mload v8 i256;
-        v31.i1 = lt v29 v30;
-        br v31 block8 block7;
+        mstore v5 32.i256 i256;
+        v26.i256 = mload v4 i256;
+        v27.i256 = mload v5 i256;
+        v28.i1 = lt v26 v27;
+        br v28 block8 block7;
 
     block6:
-        v32.i256 = mload v7 i256;
-        v33.i256 = mul v32 8.i256;
-        v35.i256 = shr v33 v25;
-        v37.i256 = and v35 255.i256;
-        v38.i256 = mload v3 i256;
-        v39.i1 = eq v37 v38;
-        br v39 block9 block10;
+        v29.i256 = mload v4 i256;
+        v30.i256 = mul v29 8.i256;
+        v32.i256 = shr v30 v22;
+        v34.i256 = and v32 255.i256;
+        v36.i1 = eq v34 v0;
+        br v36 block9 block10;
 
     block7:
         jump block2;
 
     block8:
-        v40.i256 = mload v6 i256;
-        v41.i256 = mload v5 i256;
-        v42.i1 = lt v40 v41;
-        br v42 block6 block7;
+        v37.i256 = mload v3 i256;
+        v39.i1 = lt v37 v2;
+        br v39 block6 block7;
 
     block9:
-        v43.i256 = mload v6 i256;
-        v44.@layout_0 = enum.make @layout_0 #Some v43;
-        return v44;
+        v40.i256 = mload v3 i256;
+        v41.@layout_0 = enum.make @layout_0 #Some v40;
+        return v41;
 
     block10:
         jump block11;
 
     block11:
-        v45.i256 = ptr_to_int v7 i256;
+        v42.i256 = ptr_to_int v4 i256;
+        v43.i256 = mload v42 i256;
+        v44.i256 = add v43 1.i256;
+        mstore v42 v44 i256;
+        v45.i256 = ptr_to_int v3 i256;
         v46.i256 = mload v45 i256;
         v47.i256 = add v46 1.i256;
         mstore v45 v47 i256;
-        v48.i256 = ptr_to_int v6 i256;
-        v49.i256 = mload v48 i256;
-        v50.i256 = add v49 1.i256;
-        mstore v48 v50 i256;
         jump block5;
 }
 
 func private %search_status(v0.i256, v1.i256, v2.i256) -> i256 {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        v5.*i256 = alloca i256;
-        mstore v3 v0 i256;
-        mstore v4 v1 i256;
-        mstore v5 v2 i256;
         jump block1;
 
     block1:
-        v6.i256 = mload v3 i256;
-        v7.i256 = mload v4 i256;
-        v8.i256 = mload v5 i256;
-        v9.@layout_0 = call %search v6 v7 v8;
-        v10.enumtag(@layout_0) = enum.tag v9;
-        br_table v10 (0.enumtag(@layout_0) block2) (1.enumtag(@layout_0) block3);
+        v6.@layout_0 = call %search v0 v1 v2;
+        v7.enumtag(@layout_0) = enum.tag v6;
+        br_table v7 (0.enumtag(@layout_0) block2) (1.enumtag(@layout_0) block3);
 
     block2:
-        enum.assert_variant v9 #Some;
-        v15.i256 = enum.extract v9 #Some 0.i256;
-        return v15;
+        enum.assert_variant v6 #Some;
+        v12.i256 = enum.extract v6 #Some 0.i256;
+        return v12;
 
     block3:
         return -1.i256;
@@ -183,43 +157,30 @@ func private %search_status(v0.i256, v1.i256, v2.i256) -> i256 {
 
 func inline(always) private %set(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v11.i256 = mload v2 i256;
-        v12.i256 = evm_udiv v11 32.i256;
-        v13.i256 = add 18569430475105882587588266137607568536673111973893317399460219858819262702947.i256 v12;
-        v14.i256 = mload v2 i256;
-        v15.i256 = evm_umod v14 32.i256;
-        v16.i256 = mul v15 8.i256;
-        v17.i256 = shl v16 255.i256;
-        v18.i256 = evm_sload v13;
-        v20.i256 = xor -1.i256 v17;
-        v21.i256 = and v18 v20;
-        v22.i256 = mload v3 i256;
-        v23.i256 = and v22 255.i256;
-        v24.i256 = shl v16 v23;
-        v25.i256 = or v21 v24;
-        evm_sstore v13 v25;
+        v10.i256 = evm_udiv v0 32.i256;
+        v11.i256 = add 18569430475105882587588266137607568536673111973893317399460219858819262702947.i256 v10;
+        v12.i256 = evm_umod v0 32.i256;
+        v13.i256 = mul v12 8.i256;
+        v14.i256 = shl v13 255.i256;
+        v15.i256 = evm_sload v11;
+        v17.i256 = xor -1.i256 v14;
+        v18.i256 = and v15 v17;
+        v20.i256 = and v1 255.i256;
+        v21.i256 = shl v13 v20;
+        v22.i256 = or v18 v21;
+        evm_sstore v11 v22;
         return;
 }
 
 func private %set_status(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        call %set v4 v5;
+        call %set v0 v1;
         return;
 }
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/tstor_ptr_contract.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/tstor_ptr_contract.snap
@@ -49,24 +49,21 @@ func private %__GuardContract_recv_0_0(v0.i256, v1.i256) -> i1 {
 
 func private %abi_field_size(v0.i1) -> i256 {
     block0:
-        v1.*i1 = alloca i1;
-        mstore v1 v0 i1;
         jump block1;
 
     block1:
-        v2.i1 = mload v1 i1;
-        v3.i256 = call %core__lib__abi__trait_AbiSize__payload_size__gda9b_f558_0 v2;
+        v2.i256 = call %core__lib__abi__trait_AbiSize__payload_size__gda9b_f558_0 v0;
         br 0.i1 block2 block3;
 
     block2:
-        (v7.i256, v8.i1) = uaddo 32.i256 v3;
-        br v8 block5 block6;
+        (v6.i256, v7.i1) = uaddo 32.i256 v2;
+        br v7 block5 block6;
 
     block3:
         jump block4;
 
     block4:
-        return v3;
+        return v2;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -74,19 +71,16 @@ func private %abi_field_size(v0.i1) -> i256 {
         evm_revert 0.i256 36.i256;
 
     block6:
-        return v7;
+        return v6;
 }
 
 func private %abi_single_root_size(v0.i1) -> i256 {
     block0:
-        v1.*i1 = alloca i1;
-        mstore v1 v0 i1;
         jump block1;
 
     block1:
-        v2.i1 = mload v1 i1;
-        v3.i256 = call %abi_field_size v2;
-        return v3;
+        v2.i256 = call %abi_field_size v0;
+        return v2;
 }
 
 func private %abort() {
@@ -100,16 +94,12 @@ func private %abort() {
 
 func inline(always) private %at(v0.i256) -> @layout_0 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = mload v1 i256;
-        v6.@layout_0 = insert_value undef.@layout_0 0.i256 v2;
-        v8.@layout_0 = insert_value v6 1.i256 v3;
-        return v8;
+        v4.@layout_0 = insert_value undef.@layout_0 0.i256 v0;
+        v6.@layout_0 = insert_value v4 1.i256 v0;
+        return v6;
 }
 
 func private %base(v0.objref<@layout_0>) -> i256 {
@@ -200,8 +190,6 @@ func private %contract_runtime_root_GuardContract() {
 
 func inline(always) private %decode_from(v0.@layout_1, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
@@ -210,16 +198,10 @@ func inline(always) private %decode_from(v0.@layout_1, v1.i256) {
 
 func inline(always) private %decode_from_prechecked_head(v0.@layout_1, v1.i256, v2.i256) {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v4 i256;
-        v7.i256 = mload v3 i256;
-        call %decode_from v0 v7;
+        call %decode_from v0 v1;
         return;
 }
 
@@ -227,14 +209,12 @@ func inline(always) private %decode_runtime_args(v0.objref<@layout_3>) {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v4.@layout_1 = call %input;
-        v6.i256 = call %len v4;
-        mstore v1 v6 i256;
-        mstore v2 4.i256 i256;
+        v3.@layout_1 = call %input;
+        v5.i256 = call %len v3;
+        mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
 
     block2:
@@ -245,16 +225,14 @@ func inline(always) private %decode_runtime_args(v0.objref<@layout_3>) {
         jump block4;
 
     block4:
-        v11.i256 = mload v1 i256;
-        call %decode_from_prechecked_head v4 4.i256 v11;
+        call %decode_from_prechecked_head v3 4.i256 v5;
         return;
 
     block5:
-        v13.i256 = mload v1 i256;
-        mstore v3 v13 i256;
-        v15.i256 = mload v3 i256;
-        v16.i1 = gt 4.i256 v15;
-        br v16 block2 block3;
+        mstore v2 v5 i256;
+        v14.i256 = mload v2 i256;
+        v15.i1 = gt 4.i256 v14;
+        br v15 block2 block3;
 }
 
 func private %encode(v0.i1, v1.objref<@layout_0>) {
@@ -360,21 +338,17 @@ func private %encode_single_root_alloc(v0.i1) -> @layout_4 {
 
 func private %encode_to_ptr(v0.i1, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
         br v0 block2 block3;
 
     block2:
-        v4.i256 = mload v2 i256;
-        call %store_word v4 1.i256;
+        call %store_word v1 1.i256;
         jump block4;
 
     block3:
-        v7.i256 = mload v2 i256;
-        call %store_word v7 0.i256;
+        call %store_word v1 0.i256;
         jump block4;
 
     block4:
@@ -383,14 +357,11 @@ func private %encode_to_ptr(v0.i1, v1.i256) {
 
 func private %encoder_new(v0.i256) -> @layout_0 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.@layout_0 = call %impl_SolEncoder__new v2;
-        return v3;
+        v2.@layout_0 = call %impl_SolEncoder__new v0;
+        return v2;
 }
 
 func private %input() -> @layout_1 {
@@ -405,31 +376,27 @@ func private %input() -> @layout_1 {
 func inline(always) private %len(v0.@layout_1) -> i256 {
     block0:
         v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.i256 = extract_value v0 0.i256;
-        v7.i256 = mload v1 i256;
-        mstore v2 v7 i256;
-        v8.i256 = mload v2 i256;
-        v9.i1 = gt v6 v8;
-        br v9 block2 block3;
+        v2.i256 = evm_calldata_size;
+        v5.i256 = extract_value v0 0.i256;
+        mstore v1 v2 i256;
+        v6.i256 = mload v1 i256;
+        v7.i1 = gt v5 v6;
+        br v7 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v11.i256 = extract_value v0 0.i256;
-        v12.i256 = mload v1 i256;
-        (v13.i256, v14.i1) = usubo v12 v11;
-        br v14 block5 block6;
+        v9.i256 = extract_value v0 0.i256;
+        (v11.i256, v12.i1) = usubo v2 v9;
+        br v12 block5 block6;
 
     block4:
-        v19.i256 = phi (0.i256 block2) (v13 block6);
-        return v19;
+        v17.i256 = phi (0.i256 block2) (v11 block6);
+        return v17;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -442,28 +409,24 @@ func inline(always) private %len(v0.@layout_1) -> i256 {
 
 func private %impl_SolEncoder__new(v0.i256) -> @layout_0 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v4.i1 = eq v2 0.i256;
-        br v4 block2 block3;
+        v3.i1 = eq v0 0.i256;
+        br v3 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v5.i256 = mload v1 i256;
-        v6.*i8 = evm_malloc v5;
-        v7.i256 = ptr_to_int v6 i256;
+        v5.*i8 = evm_malloc v0;
+        v6.i256 = ptr_to_int v5 i256;
         jump block4;
 
     block4:
-        v8.i256 = phi (0.i256 block2) (v7 block3);
-        v9.@layout_0 = call %at v8;
-        return v9;
+        v7.i256 = phi (0.i256 block2) (v6 block3);
+        v8.@layout_0 = call %at v7;
+        return v8;
 }
 
 func inline(always) private %impl_CallData__new() -> @layout_1 {
@@ -480,8 +443,6 @@ func inline(always) private %impl_CallData__new() -> @layout_1 {
 
 func private %core__lib__abi__trait_AbiSize__payload_size__gda9b_f558(v0.i1) -> i256 {
     block0:
-        v1.*i1 = alloca i1;
-        mstore v1 v0 i1;
         jump block1;
 
     block1:
@@ -490,8 +451,6 @@ func private %core__lib__abi__trait_AbiSize__payload_size__gda9b_f558(v0.i1) -> 
 
 func private %core__lib__abi__trait_AbiSize__payload_size__gda9b_f558_0(v0.i1) -> i256 {
     block0:
-        v1.*i1 = alloca i1;
-        mstore v1 v0 i1;
         jump block1;
 
     block1:
@@ -510,90 +469,66 @@ func private %pos(v0.objref<@layout_0>) -> i256 {
 
 func private %revert(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        evm_revert v4 v5;
+        evm_revert v0 v1;
 }
 
 func private %set_base(v0.objref<@layout_0>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        obj.store v6 v3;
+        v5.objref<i256> = obj.proj v0 0.i256;
+        obj.store v5 v1;
         return;
 }
 
 func private %set_pos(v0.objref<@layout_0>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 1.i256;
-        obj.store v6 v3;
+        v5.objref<i256> = obj.proj v0 1.i256;
+        obj.store v5 v1;
         return;
 }
 
 func private %store_word(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        mstore v4 v5 i256;
+        mstore v0 v1 i256;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_74a3(v0.objref<@layout_0>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 1.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        mstore v6 v7 i256;
-        v10.i256 = add v6 32.i256;
-        v11.objref<i256> = obj.proj v0 1.i256;
-        obj.store v11 v10;
+        v4.objref<i256> = obj.proj v0 1.i256;
+        v5.i256 = obj.load v4;
+        mstore v5 v1 i256;
+        v9.i256 = add v5 32.i256;
+        v10.objref<i256> = obj.proj v0 1.i256;
+        obj.store v10 v9;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_9a9f(v0.objref<@layout_0>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 1.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        mstore v6 v7 i256;
-        v10.i256 = add v6 32.i256;
-        v11.objref<i256> = obj.proj v0 1.i256;
-        obj.store v11 v10;
+        v4.objref<i256> = obj.proj v0 1.i256;
+        v5.i256 = obj.load v4;
+        mstore v5 v1 i256;
+        v9.i256 = add v5 32.i256;
+        v10.objref<i256> = obj.proj v0 1.i256;
+        obj.store v10 v9;
         return;
 }
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/tuple_return_contract.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/tuple_return_contract.snap
@@ -74,16 +74,12 @@ func private %abort() {
 
 func inline(always) private %at(v0.i256) -> @layout_2 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.i256 = mload v1 i256;
-        v6.@layout_2 = insert_value undef.@layout_2 0.i256 v2;
-        v8.@layout_2 = insert_value v6 1.i256 v3;
-        return v8;
+        v4.@layout_2 = insert_value undef.@layout_2 0.i256 v0;
+        v6.@layout_2 = insert_value v4 1.i256 v0;
+        return v6;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__base_8e95(v0.objref<@layout_2>) -> i256 {
@@ -183,8 +179,6 @@ func private %contract_runtime_root_TupleReturnContract() {
 
 func inline(always) private %decode_from(v0.@layout_3, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
@@ -193,16 +187,10 @@ func inline(always) private %decode_from(v0.@layout_3, v1.i256) {
 
 func inline(always) private %decode_from_prechecked_head(v0.@layout_3, v1.i256, v2.i256) {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v4 i256;
-        v7.i256 = mload v3 i256;
-        call %decode_from v0 v7;
+        call %decode_from v0 v1;
         return;
 }
 
@@ -210,14 +198,12 @@ func inline(always) private %decode_runtime_args(v0.objref<@layout_5>) {
     block0:
         v1.*i256 = alloca i256;
         v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v4.@layout_3 = call %input;
-        v6.i256 = call %len v4;
-        mstore v1 v6 i256;
-        mstore v2 4.i256 i256;
+        v3.@layout_3 = call %input;
+        v5.i256 = call %len v3;
+        mstore v1 4.i256 i256;
         br 0.i1 block2 block5;
 
     block2:
@@ -228,16 +214,14 @@ func inline(always) private %decode_runtime_args(v0.objref<@layout_5>) {
         jump block4;
 
     block4:
-        v11.i256 = mload v1 i256;
-        call %decode_from_prechecked_head v4 4.i256 v11;
+        call %decode_from_prechecked_head v3 4.i256 v5;
         return;
 
     block5:
-        v13.i256 = mload v1 i256;
-        mstore v3 v13 i256;
-        v15.i256 = mload v3 i256;
-        v16.i1 = gt 4.i256 v15;
-        br v16 block2 block3;
+        mstore v2 v5 i256;
+        v14.i256 = mload v2 i256;
+        v15.i1 = gt 4.i256 v14;
+        br v15 block2 block3;
 }
 
 func private %core__lib__abi__dynamic_payload_size__g67a8_baae(v0.@layout_0) -> i256 {
@@ -278,17 +262,14 @@ func private %core__lib__abi__dynamic_payload_size__g67a8_baae_0(v0.@layout_0) -
 
 func private %core__lib__abi__dynamic_payload_size__ge513_f973(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v3.i256 = mload v1 i256;
-        v4.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_c169 v3;
-        return v4;
+        v3.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_c169 v0;
+        return v3;
 
     block3:
         jump block4;
@@ -299,17 +280,14 @@ func private %core__lib__abi__dynamic_payload_size__ge513_f973(v0.i256) -> i256 
 
 func private %core__lib__abi__dynamic_payload_size__ge513_f973_0(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v3.i256 = mload v1 i256;
-        v4.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_c169_0 v3;
-        return v4;
+        v3.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_c169_0 v0;
+        return v3;
 
     block3:
         jump block4;
@@ -407,32 +385,25 @@ func private %encode_field(v0.@layout_1, v1.objref<@layout_2>, v2.i256) {
 
 func inline(always) private %encode_field_at__gf6b4(v0.@layout_0, v1.objref<@layout_2>, v2.i256, v3.i256, v4.i256) {
     block0:
-        v5.*i256 = alloca i256;
-        v6.*i256 = alloca i256;
-        mstore v5 v2 i256;
-        mstore v6 v3 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v10.i256 = call %core__lib__abi__trait_AbiSize__payload_size__g67a8_7cab v0;
-        v11.i256 = mload v6 i256;
-        v12.i256 = mload v5 i256;
-        v13.i256 = mload v4 i256;
-        v14.i256 = sub v13 v12;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_at_9d2f v1 v11 v14;
+        v8.i256 = call %core__lib__abi__trait_AbiSize__payload_size__g67a8_7cab v0;
+        v11.i256 = mload v4 i256;
+        v12.i256 = sub v11 v2;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_at_9d2f v1 v3 v12;
+        v15.i256 = mload v4 i256;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_3ff5 v1 v15;
         v17.i256 = mload v4 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_3ff5 v1 v17;
-        v19.i256 = mload v4 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_0d08 v1 v19;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_0d08 v1 v17;
         call %impl_trait_Address__encode__g426c v0 v1;
-        v22.i256 = mload v5 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_3ff5 v1 v22;
-        v24.i256 = mload v4 i256;
-        v25.i256 = add v24 v10;
-        mstore v4 v25 i256;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_3ff5 v1 v2;
+        v21.i256 = mload v4 i256;
+        v22.i256 = add v21 v8;
+        mstore v4 v22 i256;
         return;
 
     block3:
@@ -442,48 +413,39 @@ func inline(always) private %encode_field_at__gf6b4(v0.@layout_0, v1.objref<@lay
         br 1.i1 block5 block6;
 
     block5:
-        v27.i256 = mload v6 i256;
-        call %std__lib__evm__effects__impl_trait_Address_ed76__encode_to_ptr__gf13e_8bc3 v0 v27;
+        call %std__lib__evm__effects__impl_trait_Address_ed76__encode_to_ptr__gf13e_8bc3 v0 v3;
         return;
 
     block6:
         jump block7;
 
     block7:
-        v30.i256 = mload v6 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_0d08 v1 v30;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_0d08 v1 v3;
         call %impl_trait_Address__encode__g426c v0 v1;
         return;
 }
 
 func inline(always) private %encode_field_at__g2e64(v0.i256, v1.objref<@layout_2>, v2.i256, v3.i256, v4.i256) {
     block0:
-        v5.*i256 = alloca i256;
-        v6.*i256 = alloca i256;
-        mstore v5 v2 i256;
-        mstore v6 v3 i256;
         jump block1;
 
     block1:
         br 0.i1 block2 block3;
 
     block2:
-        v10.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_7c20 v0;
-        v11.i256 = mload v6 i256;
-        v12.i256 = mload v5 i256;
-        v13.i256 = mload v4 i256;
-        v14.i256 = sub v13 v12;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_at_9d2f_0 v1 v11 v14;
+        v8.i256 = call %core__lib__abi__trait_AbiSize__payload_size__ge513_7c20 v0;
+        v11.i256 = mload v4 i256;
+        v12.i256 = sub v11 v2;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_at_9d2f_0 v1 v3 v12;
+        v15.i256 = mload v4 i256;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_3ff5_0 v1 v15;
         v17.i256 = mload v4 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_3ff5_0 v1 v17;
-        v19.i256 = mload v4 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_0d08_0 v1 v19;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_0d08_0 v1 v17;
         call %impl_trait_u256__encode__g426c v0 v1;
-        v22.i256 = mload v5 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_3ff5_0 v1 v22;
-        v24.i256 = mload v4 i256;
-        v25.i256 = add v24 v10;
-        mstore v4 v25 i256;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_3ff5_0 v1 v2;
+        v21.i256 = mload v4 i256;
+        v22.i256 = add v21 v8;
+        mstore v4 v22 i256;
         return;
 
     block3:
@@ -493,16 +455,14 @@ func inline(always) private %encode_field_at__g2e64(v0.i256, v1.objref<@layout_2
         br 1.i1 block5 block6;
 
     block5:
-        v27.i256 = mload v6 i256;
-        call %core__lib__abi__impl_trait_u256_d99e__encode_to_ptr__gf13e_3ddf v0 v27;
+        call %core__lib__abi__impl_trait_u256_d99e__encode_to_ptr__gf13e_3ddf v0 v3;
         return;
 
     block6:
         jump block7;
 
     block7:
-        v30.i256 = mload v6 i256;
-        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_0d08_0 v1 v30;
+        call %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_0d08_0 v1 v3;
         call %impl_trait_u256__encode__g426c v0 v1;
         return;
 }
@@ -544,81 +504,62 @@ func private %encode_single_root_alloc(v0.@layout_1) -> @layout_6 {
 
 func private %core__lib__abi__impl_trait_u256_d99e__encode_to_ptr__gf13e_3ddf(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__store_word_5688 v3 v0;
+        call %std__lib__abi__sol__impl_trait_Sol_1f5f__store_word_5688 v1 v0;
         return;
 }
 
 func private %core__lib__abi__impl_trait_u256_d99e__encode_to_ptr__gf13e_3ddf_0(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__store_word_5688 v3 v0;
+        call %std__lib__abi__sol__impl_trait_Sol_1f5f__store_word_5688 v1 v0;
         return;
 }
 
 func private %encode_to_ptr__g753b(v0.@layout_1, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.i256 = extract_value v0 0.i256;
-        v6.i256 = mload v2 i256;
-        call %core__lib__abi__impl_trait_u256_d99e__encode_to_ptr__gf13e_3ddf_0 v5 v6;
-        v9.@layout_0 = extract_value v0 1.i256;
-        v10.i256 = mload v2 i256;
-        v12.i256 = add v10 32.i256;
-        call %std__lib__evm__effects__impl_trait_Address_ed76__encode_to_ptr__gf13e_8bc3_0 v9 v12;
+        v4.i256 = extract_value v0 0.i256;
+        call %core__lib__abi__impl_trait_u256_d99e__encode_to_ptr__gf13e_3ddf_0 v4 v1;
+        v8.@layout_0 = extract_value v0 1.i256;
+        v10.i256 = add v1 32.i256;
+        call %std__lib__evm__effects__impl_trait_Address_ed76__encode_to_ptr__gf13e_8bc3_0 v8 v10;
         return;
 }
 
 func private %std__lib__evm__effects__impl_trait_Address_ed76__encode_to_ptr__gf13e_8bc3(v0.@layout_0, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.i256 = extract_value v0 0.i256;
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__store_word_001d v3 v6;
+        v5.i256 = extract_value v0 0.i256;
+        call %std__lib__abi__sol__impl_trait_Sol_1f5f__store_word_001d v1 v5;
         return;
 }
 
 func private %std__lib__evm__effects__impl_trait_Address_ed76__encode_to_ptr__gf13e_8bc3_0(v0.@layout_0, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.i256 = extract_value v0 0.i256;
-        call %std__lib__abi__sol__impl_trait_Sol_1f5f__store_word_001d_0 v3 v6;
+        v5.i256 = extract_value v0 0.i256;
+        call %std__lib__abi__sol__impl_trait_Sol_1f5f__store_word_001d_0 v1 v5;
         return;
 }
 
 func private %encoder_new(v0.i256) -> @layout_2 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v3.@layout_2 = call %impl_SolEncoder__new v2;
-        return v3;
+        v2.@layout_2 = call %impl_SolEncoder__new v0;
+        return v2;
 }
 
 func private %input() -> @layout_3 {
@@ -633,31 +574,27 @@ func private %input() -> @layout_3 {
 func inline(always) private %len(v0.@layout_3) -> i256 {
     block0:
         v1.*i256 = alloca i256;
-        v2.*i256 = alloca i256;
         jump block1;
 
     block1:
-        v3.i256 = evm_calldata_size;
-        mstore v1 v3 i256;
-        v6.i256 = extract_value v0 0.i256;
-        v7.i256 = mload v1 i256;
-        mstore v2 v7 i256;
-        v8.i256 = mload v2 i256;
-        v9.i1 = gt v6 v8;
-        br v9 block2 block3;
+        v2.i256 = evm_calldata_size;
+        v5.i256 = extract_value v0 0.i256;
+        mstore v1 v2 i256;
+        v6.i256 = mload v1 i256;
+        v7.i1 = gt v5 v6;
+        br v7 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v11.i256 = extract_value v0 0.i256;
-        v12.i256 = mload v1 i256;
-        (v13.i256, v14.i1) = usubo v12 v11;
-        br v14 block5 block6;
+        v9.i256 = extract_value v0 0.i256;
+        (v11.i256, v12.i1) = usubo v2 v9;
+        br v12 block5 block6;
 
     block4:
-        v19.i256 = phi (0.i256 block2) (v13 block6);
-        return v19;
+        v17.i256 = phi (0.i256 block2) (v11 block6);
+        return v17;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -682,28 +619,24 @@ func inline(always) private %impl_CallData__new() -> @layout_3 {
 
 func private %impl_SolEncoder__new(v0.i256) -> @layout_2 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v4.i1 = eq v2 0.i256;
-        br v4 block2 block3;
+        v3.i1 = eq v0 0.i256;
+        br v3 block2 block3;
 
     block2:
         jump block4;
 
     block3:
-        v5.i256 = mload v1 i256;
-        v6.*i8 = evm_malloc v5;
-        v7.i256 = ptr_to_int v6 i256;
+        v5.*i8 = evm_malloc v0;
+        v6.i256 = ptr_to_int v5 i256;
         jump block4;
 
     block4:
-        v8.i256 = phi (0.i256 block2) (v7 block3);
-        v9.@layout_2 = call %at v8;
-        return v9;
+        v7.i256 = phi (0.i256 block2) (v6 block3);
+        v8.@layout_2 = call %at v7;
+        return v8;
 }
 
 func private %core__lib__abi__trait_AbiSize__payload_size__g67a8_75f0(v0.@layout_0) -> i256 {
@@ -724,8 +657,6 @@ func private %core__lib__abi__trait_AbiSize__payload_size__g67a8_75f0_0(v0.@layo
 
 func private %core__lib__abi__trait_AbiSize__payload_size__ge513_7c20(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
@@ -742,8 +673,6 @@ func private %core__lib__abi__trait_AbiSize__payload_size__g67a8_7cab(v0.@layout
 
 func private %core__lib__abi__trait_AbiSize__payload_size__ge513_c169(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
@@ -752,8 +681,6 @@ func private %core__lib__abi__trait_AbiSize__payload_size__ge513_c169(v0.i256) -
 
 func private %core__lib__abi__trait_AbiSize__payload_size__ge513_c169_0(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
@@ -800,232 +727,166 @@ func private %pos(v0.objref<@layout_2>) -> i256 {
 
 func private %revert(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        evm_revert v4 v5;
+        evm_revert v0 v1;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_3ff5(v0.objref<@layout_2>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        obj.store v6 v3;
+        v5.objref<i256> = obj.proj v0 0.i256;
+        obj.store v5 v1;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_3ff5_0(v0.objref<@layout_2>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        obj.store v6 v3;
+        v5.objref<i256> = obj.proj v0 0.i256;
+        obj.store v5 v1;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_base_80f4(v0.objref<@layout_2>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 0.i256;
-        obj.store v6 v3;
+        v5.objref<i256> = obj.proj v0 0.i256;
+        obj.store v5 v1;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_0d08(v0.objref<@layout_2>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 1.i256;
-        obj.store v6 v3;
+        v5.objref<i256> = obj.proj v0 1.i256;
+        obj.store v5 v1;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_0d08_0(v0.objref<@layout_2>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 1.i256;
-        obj.store v6 v3;
+        v5.objref<i256> = obj.proj v0 1.i256;
+        obj.store v5 v1;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_0d08_1(v0.objref<@layout_2>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 1.i256;
-        obj.store v6 v3;
+        v5.objref<i256> = obj.proj v0 1.i256;
+        obj.store v5 v1;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__set_pos_516e(v0.objref<@layout_2>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v3.i256 = mload v2 i256;
-        v6.objref<i256> = obj.proj v0 1.i256;
-        obj.store v6 v3;
+        v5.objref<i256> = obj.proj v0 1.i256;
+        obj.store v5 v1;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_Sol_1f5f__store_word_001d(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        mstore v4 v5 i256;
+        mstore v0 v1 i256;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_Sol_1f5f__store_word_001d_0(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        mstore v4 v5 i256;
+        mstore v0 v1 i256;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_Sol_1f5f__store_word_5688(v0.i256, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        mstore v4 v5 i256;
+        mstore v0 v1 i256;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_4363(v0.objref<@layout_2>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 1.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        mstore v6 v7 i256;
-        v10.i256 = add v6 32.i256;
-        v11.objref<i256> = obj.proj v0 1.i256;
-        obj.store v11 v10;
+        v4.objref<i256> = obj.proj v0 1.i256;
+        v5.i256 = obj.load v4;
+        mstore v5 v1 i256;
+        v9.i256 = add v5 32.i256;
+        v10.objref<i256> = obj.proj v0 1.i256;
+        obj.store v10 v9;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_a864(v0.objref<@layout_2>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 1.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        mstore v6 v7 i256;
-        v10.i256 = add v6 32.i256;
-        v11.objref<i256> = obj.proj v0 1.i256;
-        obj.store v11 v10;
+        v4.objref<i256> = obj.proj v0 1.i256;
+        v5.i256 = obj.load v4;
+        mstore v5 v1 i256;
+        v9.i256 = add v5 32.i256;
+        v10.objref<i256> = obj.proj v0 1.i256;
+        obj.store v10 v9;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_at_9d2f(v0.objref<@layout_2>, v1.i256, v2.i256) {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v3 i256;
-        v6.i256 = mload v4 i256;
-        mstore v5 v6 i256;
+        mstore v1 v2 i256;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_at_9d2f_0(v0.objref<@layout_2>, v1.i256, v2.i256) {
     block0:
-        v3.*i256 = alloca i256;
-        v4.*i256 = alloca i256;
-        mstore v3 v1 i256;
-        mstore v4 v2 i256;
         jump block1;
 
     block1:
-        v5.i256 = mload v3 i256;
-        v6.i256 = mload v4 i256;
-        mstore v5 v6 i256;
+        mstore v1 v2 i256;
         return;
 }
 
 func private %std__lib__abi__sol__impl_trait_SolEncoder_19ce__write_word_e52b(v0.objref<@layout_2>, v1.i256) {
     block0:
-        v2.*i256 = alloca i256;
-        mstore v2 v1 i256;
         jump block1;
 
     block1:
-        v5.objref<i256> = obj.proj v0 1.i256;
-        v6.i256 = obj.load v5;
-        v7.i256 = mload v2 i256;
-        mstore v6 v7 i256;
-        v10.i256 = add v6 32.i256;
-        v11.objref<i256> = obj.proj v0 1.i256;
-        obj.store v11 v10;
+        v4.objref<i256> = obj.proj v0 1.i256;
+        v5.i256 = obj.load v4;
+        mstore v5 v1 i256;
+        v9.i256 = add v5 32.i256;
+        v10.objref<i256> = obj.proj v0 1.i256;
+        obj.store v10 v9;
         return;
 }
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/tuple_single_element_peeling.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/tuple_single_element_peeling.snap
@@ -69,45 +69,36 @@ func private %match_single_element_tuple(v0.constref<@layout_1>) -> i8 {
 
 func private %tuple_single_nested_passthrough(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v5.@layout_2 = insert_value undef.@layout_2 0.i256 v2;
-        v7.@layout_3 = insert_value undef.@layout_3 0.i256 v5;
-        v8.@layout_2 = extract_value v7 0.i256;
-        v9.i256 = extract_value v8 0.i256;
-        return v9;
+        v4.@layout_2 = insert_value undef.@layout_2 0.i256 v0;
+        v6.@layout_3 = insert_value undef.@layout_3 0.i256 v4;
+        v7.@layout_2 = extract_value v6 0.i256;
+        v8.i256 = extract_value v7 0.i256;
+        return v8;
 }
 
 func private %tuple_single_passthrough(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v5.@layout_2 = insert_value undef.@layout_2 0.i256 v2;
-        v6.i256 = extract_value v5 0.i256;
-        return v6;
+        v4.@layout_2 = insert_value undef.@layout_2 0.i256 v0;
+        v5.i256 = extract_value v4 0.i256;
+        return v5;
 }
 
 func private %tuple_single_struct_newtype_nested(v0.i256) -> i256 {
     block0:
-        v1.*i256 = alloca i256;
-        mstore v1 v0 i256;
         jump block1;
 
     block1:
-        v2.i256 = mload v1 i256;
-        v5.@layout_4 = insert_value undef.@layout_4 0.i256 v2;
-        v7.@layout_5 = insert_value undef.@layout_5 0.i256 v5;
-        v8.@layout_4 = extract_value v7 0.i256;
-        v9.i256 = extract_value v8 0.i256;
-        return v9;
+        v4.@layout_4 = insert_value undef.@layout_4 0.i256 v0;
+        v6.@layout_5 = insert_value undef.@layout_5 0.i256 v4;
+        v7.@layout_4 = extract_value v6 0.i256;
+        v8.i256 = extract_value v7 0.i256;
+        return v8;
 }
 
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/view_param_aggregate_value.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/view_param_aggregate_value.snap
@@ -46,19 +46,13 @@ func private %sum(v0.@layout_0) -> i256 {
 
 func private %view_param_aggregate_value(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        v8.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
-        v10.@layout_0 = insert_value v8 1.i256 v5;
-        v11.i256 = call %sum v10;
-        return v11;
+        v6.@layout_0 = insert_value undef.@layout_0 0.i256 v0;
+        v8.@layout_0 = insert_value v6 1.i256 v1;
+        v9.i256 = call %sum v8;
+        return v9;
 }
 
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/while.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/while.snap
@@ -7,23 +7,22 @@ target = "evm-ethereum-osaka"
 
 func private %do_while() -> i64 {
     block0:
-        v0.*i64 = alloca i64;
         jump block1;
 
     block1:
         jump block2;
 
     block2:
-        v3.i64 = phi (0.i64 block1) (v15 block6);
-        v4.i1 = lt v3 10.i64;
-        br v4 block3 block4;
+        v2.i64 = phi (0.i64 block1) (v6 block6);
+        v3.i1 = lt v2 10.i64;
+        br v3 block3 block4;
 
     block3:
-        (v7.i64, v8.i1) = uaddo v3 1.i64;
-        br v8 block5 block6;
+        (v6.i64, v7.i1) = uaddo v2 1.i64;
+        br v7 block5 block6;
 
     block4:
-        return v3;
+        return v2;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -31,9 +30,6 @@ func private %do_while() -> i64 {
         evm_revert 0.i256 36.i256;
 
     block6:
-        mstore v0 v7 i64;
-        v14.i256 = mload v0 i256;
-        v15.i64 = trunc v14 i64;
         jump block2;
 }
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/while_cond_call.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/while_cond_call.snap
@@ -7,14 +7,11 @@ target = "evm-ethereum-osaka"
 
 func private %lt_ten(v0.i64) -> i1 {
     block0:
-        v1.*i64 = alloca i64;
-        mstore v1 v0 i64;
         jump block1;
 
     block1:
-        v2.i64 = mload v1 i64;
-        v4.i1 = lt v2 10.i64;
-        return v4;
+        v3.i1 = lt v0 10.i64;
+        return v3;
 }
 
 func private %main_root() {
@@ -28,23 +25,22 @@ func private %main_root() {
 
 func private %while_cond_call() -> i64 {
     block0:
-        v0.*i64 = alloca i64;
         jump block1;
 
     block1:
         jump block2;
 
     block2:
-        v2.i64 = phi (0.i64 block1) (v14 block6);
-        v3.i1 = call %lt_ten v2;
-        br v3 block3 block4;
+        v1.i64 = phi (0.i64 block1) (v5 block6);
+        v2.i1 = call %lt_ten v1;
+        br v2 block3 block4;
 
     block3:
-        (v6.i64, v7.i1) = uaddo v2 1.i64;
-        br v7 block5 block6;
+        (v5.i64, v6.i1) = uaddo v1 1.i64;
+        br v6 block5 block6;
 
     block4:
-        return v2;
+        return v1;
 
     block5:
         mstore 0.i256 35408467139433450592217433187231851964531694900788300625387963629091585785856.i256 i256;
@@ -52,9 +48,6 @@ func private %while_cond_call() -> i64 {
         evm_revert 0.i256 36.i256;
 
     block6:
-        mstore v0 v6 i64;
-        v13.i256 = mload v0 i256;
-        v14.i64 = trunc v13 i64;
         jump block2;
 }
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/wrapping_saturating.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/wrapping_saturating.snap
@@ -36,278 +36,166 @@ func private %main_root() {
 
 func private %impl_trait_u256__saturating_add(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        v6.i256 = uaddsat v4 v5;
-        return v6;
+        v4.i256 = uaddsat v0 v1;
+        return v4;
 }
 
 func private %impl_trait_u64__saturating_add(v0.i64, v1.i64) -> i64 {
     block0:
-        v2.*i64 = alloca i64;
-        v3.*i64 = alloca i64;
-        mstore v2 v0 i64;
-        mstore v3 v1 i64;
         jump block1;
 
     block1:
-        v4.i64 = mload v2 i64;
-        v5.i64 = mload v3 i64;
-        v6.i64 = uaddsat v4 v5;
-        return v6;
+        v4.i64 = uaddsat v0 v1;
+        return v4;
 }
 
 func private %impl_trait_u256__saturating_mul(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        v6.i256 = umulsat v4 v5;
-        return v6;
+        v4.i256 = umulsat v0 v1;
+        return v4;
 }
 
 func private %impl_trait_u64__saturating_mul(v0.i64, v1.i64) -> i64 {
     block0:
-        v2.*i64 = alloca i64;
-        v3.*i64 = alloca i64;
-        mstore v2 v0 i64;
-        mstore v3 v1 i64;
         jump block1;
 
     block1:
-        v4.i64 = mload v2 i64;
-        v5.i64 = mload v3 i64;
-        v6.i64 = umulsat v4 v5;
-        return v6;
+        v4.i64 = umulsat v0 v1;
+        return v4;
 }
 
 func private %saturating_ops_u256(v0.i256, v1.i256) -> @layout_1 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        v6.i256 = call %impl_trait_u256__saturating_add v4 v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = mload v3 i256;
-        v9.i256 = call %impl_trait_u256__saturating_sub v7 v8;
-        v10.i256 = mload v2 i256;
-        v11.i256 = mload v3 i256;
-        v12.i256 = call %impl_trait_u256__saturating_mul v10 v11;
-        v15.@layout_1 = insert_value undef.@layout_1 0.i256 v6;
-        v17.@layout_1 = insert_value v15 1.i256 v9;
-        v19.@layout_1 = insert_value v17 2.i256 v12;
-        return v19;
+        v4.i256 = call %impl_trait_u256__saturating_add v0 v1;
+        v5.i256 = call %impl_trait_u256__saturating_sub v0 v1;
+        v6.i256 = call %impl_trait_u256__saturating_mul v0 v1;
+        v9.@layout_1 = insert_value undef.@layout_1 0.i256 v4;
+        v11.@layout_1 = insert_value v9 1.i256 v5;
+        v13.@layout_1 = insert_value v11 2.i256 v6;
+        return v13;
 }
 
 func private %saturating_ops_u64(v0.i64, v1.i64) -> @layout_0 {
     block0:
-        v2.*i64 = alloca i64;
-        v3.*i64 = alloca i64;
-        mstore v2 v0 i64;
-        mstore v3 v1 i64;
         jump block1;
 
     block1:
-        v4.i64 = mload v2 i64;
-        v5.i64 = mload v3 i64;
-        v6.i64 = call %impl_trait_u64__saturating_add v4 v5;
-        v7.i64 = mload v2 i64;
-        v8.i64 = mload v3 i64;
-        v9.i64 = call %impl_trait_u64__saturating_sub v7 v8;
-        v10.i64 = mload v2 i64;
-        v11.i64 = mload v3 i64;
-        v12.i64 = call %impl_trait_u64__saturating_mul v10 v11;
-        v15.@layout_0 = insert_value undef.@layout_0 0.i256 v6;
-        v17.@layout_0 = insert_value v15 1.i256 v9;
-        v19.@layout_0 = insert_value v17 2.i256 v12;
-        return v19;
+        v4.i64 = call %impl_trait_u64__saturating_add v0 v1;
+        v5.i64 = call %impl_trait_u64__saturating_sub v0 v1;
+        v6.i64 = call %impl_trait_u64__saturating_mul v0 v1;
+        v9.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
+        v11.@layout_0 = insert_value v9 1.i256 v5;
+        v13.@layout_0 = insert_value v11 2.i256 v6;
+        return v13;
 }
 
 func private %impl_trait_u64__saturating_sub(v0.i64, v1.i64) -> i64 {
     block0:
-        v2.*i64 = alloca i64;
-        v3.*i64 = alloca i64;
-        mstore v2 v0 i64;
-        mstore v3 v1 i64;
         jump block1;
 
     block1:
-        v4.i64 = mload v2 i64;
-        v5.i64 = mload v3 i64;
-        v6.i64 = usubsat v4 v5;
-        return v6;
+        v4.i64 = usubsat v0 v1;
+        return v4;
 }
 
 func private %impl_trait_u256__saturating_sub(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        v6.i256 = usubsat v4 v5;
-        return v6;
+        v4.i256 = usubsat v0 v1;
+        return v4;
 }
 
 func private %impl_trait_u256__wrapping_add(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        v6.i256 = add v4 v5;
-        return v6;
+        v4.i256 = add v0 v1;
+        return v4;
 }
 
 func private %impl_trait_u64__wrapping_add(v0.i64, v1.i64) -> i64 {
     block0:
-        v2.*i64 = alloca i64;
-        v3.*i64 = alloca i64;
-        mstore v2 v0 i64;
-        mstore v3 v1 i64;
         jump block1;
 
     block1:
-        v4.i64 = mload v2 i64;
-        v5.i64 = mload v3 i64;
-        v6.i64 = add v4 v5;
-        return v6;
+        v4.i64 = add v0 v1;
+        return v4;
 }
 
 func private %impl_trait_u64__wrapping_mul(v0.i64, v1.i64) -> i64 {
     block0:
-        v2.*i64 = alloca i64;
-        v3.*i64 = alloca i64;
-        mstore v2 v0 i64;
-        mstore v3 v1 i64;
         jump block1;
 
     block1:
-        v4.i64 = mload v2 i64;
-        v5.i64 = mload v3 i64;
-        v6.i64 = mul v4 v5;
-        return v6;
+        v4.i64 = mul v0 v1;
+        return v4;
 }
 
 func private %impl_trait_u256__wrapping_mul(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        v6.i256 = mul v4 v5;
-        return v6;
+        v4.i256 = mul v0 v1;
+        return v4;
 }
 
 func private %wrapping_ops_u256(v0.i256, v1.i256) -> @layout_1 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        v6.i256 = call %impl_trait_u256__wrapping_add v4 v5;
-        v7.i256 = mload v2 i256;
-        v8.i256 = mload v3 i256;
-        v9.i256 = call %impl_trait_u256__wrapping_sub v7 v8;
-        v10.i256 = mload v2 i256;
-        v11.i256 = mload v3 i256;
-        v12.i256 = call %impl_trait_u256__wrapping_mul v10 v11;
-        v15.@layout_1 = insert_value undef.@layout_1 0.i256 v6;
-        v17.@layout_1 = insert_value v15 1.i256 v9;
-        v19.@layout_1 = insert_value v17 2.i256 v12;
-        return v19;
+        v4.i256 = call %impl_trait_u256__wrapping_add v0 v1;
+        v5.i256 = call %impl_trait_u256__wrapping_sub v0 v1;
+        v6.i256 = call %impl_trait_u256__wrapping_mul v0 v1;
+        v9.@layout_1 = insert_value undef.@layout_1 0.i256 v4;
+        v11.@layout_1 = insert_value v9 1.i256 v5;
+        v13.@layout_1 = insert_value v11 2.i256 v6;
+        return v13;
 }
 
 func private %wrapping_ops_u64(v0.i64, v1.i64) -> @layout_0 {
     block0:
-        v2.*i64 = alloca i64;
-        v3.*i64 = alloca i64;
-        mstore v2 v0 i64;
-        mstore v3 v1 i64;
         jump block1;
 
     block1:
-        v4.i64 = mload v2 i64;
-        v5.i64 = mload v3 i64;
-        v6.i64 = call %impl_trait_u64__wrapping_add v4 v5;
-        v7.i64 = mload v2 i64;
-        v8.i64 = mload v3 i64;
-        v9.i64 = call %impl_trait_u64__wrapping_sub v7 v8;
-        v10.i64 = mload v2 i64;
-        v11.i64 = mload v3 i64;
-        v12.i64 = call %impl_trait_u64__wrapping_mul v10 v11;
-        v15.@layout_0 = insert_value undef.@layout_0 0.i256 v6;
-        v17.@layout_0 = insert_value v15 1.i256 v9;
-        v19.@layout_0 = insert_value v17 2.i256 v12;
-        return v19;
+        v4.i64 = call %impl_trait_u64__wrapping_add v0 v1;
+        v5.i64 = call %impl_trait_u64__wrapping_sub v0 v1;
+        v6.i64 = call %impl_trait_u64__wrapping_mul v0 v1;
+        v9.@layout_0 = insert_value undef.@layout_0 0.i256 v4;
+        v11.@layout_0 = insert_value v9 1.i256 v5;
+        v13.@layout_0 = insert_value v11 2.i256 v6;
+        return v13;
 }
 
 func private %impl_trait_u64__wrapping_sub(v0.i64, v1.i64) -> i64 {
     block0:
-        v2.*i64 = alloca i64;
-        v3.*i64 = alloca i64;
-        mstore v2 v0 i64;
-        mstore v3 v1 i64;
         jump block1;
 
     block1:
-        v4.i64 = mload v2 i64;
-        v5.i64 = mload v3 i64;
-        v6.i64 = sub v4 v5;
-        return v6;
+        v4.i64 = sub v0 v1;
+        return v4;
 }
 
 func private %impl_trait_u256__wrapping_sub(v0.i256, v1.i256) -> i256 {
     block0:
-        v2.*i256 = alloca i256;
-        v3.*i256 = alloca i256;
-        mstore v2 v0 i256;
-        mstore v3 v1 i256;
         jump block1;
 
     block1:
-        v4.i256 = mload v2 i256;
-        v5.i256 = mload v3 i256;
-        v6.i256 = sub v4 v5;
-        return v6;
+        v4.i256 = sub v0 v1;
+        return v4;
 }
 
 

--- a/crates/codegen/tests/runtime_handle_preservation.rs
+++ b/crates/codegen/tests/runtime_handle_preservation.rs
@@ -688,6 +688,112 @@ fn entry() -> Inner {
 }
 
 #[test]
+fn read_only_scalar_params_used_as_indices_stay_unrooted() {
+    let source = r#"
+const VALS: [u256; 3] = [10, 20, 30]
+
+fn sum_two(i: usize, j: usize) -> u256 {
+    VALS[i] + VALS[j]
+}
+
+fn entry() -> u256 {
+    sum_two(i: 0, j: 1)
+}
+"#;
+
+    with_runtime_package!(
+        "read_only_scalar_params_used_as_indices_stay_unrooted.fe",
+        source,
+        |db, package| {
+            let body = runtime_body_for_symbol(&db, package, "sum_two");
+
+            assert!(
+                matches!(body.locals[0].root, RuntimeLocalRoot::None),
+                "read-only scalar index param `i` should not get a runtime root:\n{body:#?}"
+            );
+            assert!(
+                matches!(body.locals[1].root, RuntimeLocalRoot::None),
+                "read-only scalar index param `j` should not get a runtime root:\n{body:#?}"
+            );
+        }
+    );
+
+    let ir = sonatina_ir_for_source(
+        "read_only_scalar_params_used_as_indices_stay_unrooted.fe",
+        source,
+    );
+    let sum_two = sonatina_function_body(&ir, "sum_two");
+
+    assert!(
+        !sum_two.contains("alloca i256"),
+        "read-only scalar index params should not allocate stack slots:\n{sum_two}"
+    );
+    assert!(
+        !sum_two.contains("mload"),
+        "read-only scalar index params should be used directly, not reloaded:\n{sum_two}"
+    );
+}
+
+#[test]
+fn mutated_scalar_locals_stay_rooted() {
+    with_runtime_package!(
+        "mutated_scalar_locals_stay_rooted.fe",
+        r#"
+fn bump(size: u256) -> u256 {
+    let mut value: u256 = size
+    value += 1
+    value
+}
+
+fn entry() -> u256 {
+    bump(size: 1)
+}
+"#,
+        |db, package| {
+            let body = runtime_body_for_symbol(&db, package, "bump");
+
+            assert!(
+                matches!(body.locals[0].root, RuntimeLocalRoot::None),
+                "read-only scalar param should not get a runtime root:\n{body:#?}"
+            );
+            let rooted_scalar = body
+                .locals
+                .iter()
+                .enumerate()
+                .find_map(|(idx, local)| {
+                    matches!(local.root, RuntimeLocalRoot::Slot(RuntimeClass::Scalar(_)))
+                        .then(|| RLocalId::from_u32(idx as u32))
+                })
+                .unwrap_or_else(|| {
+                    panic!("mutated scalar local should keep runtime storage:\n{body:#?}")
+                });
+            let rooted_ptr = runtime_body_stmts(&body)
+                .find_map(|stmt| match stmt {
+                    RStmt::Assign {
+                        dst,
+                        expr: RExpr::AddrOf { place },
+                    } if place.root == PlaceRoot::Slot(rooted_scalar) => Some(*dst),
+                    _ => None,
+                })
+                .unwrap_or_else(|| {
+                    panic!("mutated scalar local should take the address of its rooted slot:\n{body:#?}")
+                });
+            let stored_ptr = transported_local_from_param(&body, rooted_ptr);
+            assert!(
+                runtime_body_stmts(&body).any(|stmt| {
+                    matches!(
+                        stmt,
+                        RStmt::Store { dst, .. }
+                            if matches!(dst.root, PlaceRoot::Ptr { addr, .. } if addr == stored_ptr)
+                    )
+                }),
+                "mutated scalar local should store through the rooted slot pointer:\n{body:#?}"
+            );
+        }
+    );
+}
+
+#[test]
 fn immutable_own_aggregate_param_field_reads_stay_unrooted() {
     with_runtime_package!(
         "immutable_own_aggregate_param_field_reads_stay_unrooted.fe",

--- a/crates/fe/tests/differential_deposit/gas_report.snap
+++ b/crates/fe/tests/differential_deposit/gas_report.snap
@@ -5,13 +5,13 @@ expression: report
 bytecode size
 path         fe-O2        sol     sol-IR   fe vs sol-IR
 -----------------------------------------------------------
-init          2674       4819       3082  -408 (-13.2%)
-runtime       2590       4445       2844   -254 (-8.9%)
+init          2562       4819       3082  -520 (-16.9%)
+runtime       2478       4445       2844  -366 (-12.9%)
 
 deployment gas
 path        fe-O2        sol     sol-IR    fe vs sol-IR
 -----------------------------------------------------------
-deploy    1314217    1738847    1379411  -65194 (-4.7%)
+deploy    1290072    1738847    1379411  -89339 (-6.5%)
 
 call gas
 path                            fe-O2        sol     sol-IR    fe vs sol-IR
@@ -19,15 +19,15 @@ path                            fe-O2        sol     sol-IR    fe vs sol-IR
 supportsInterface(erc165)       21600      21603      21600      +0 (+0.0%)
 supportsInterface(deposit)      21600      21641      21600      +0 (+0.0%)
 supportsInterface(unknown)      21600      21641      21600      +0 (+0.0%)
-get_deposit_root(empty)        102972     117558     109178   -6206 (-5.7%)
-get_deposit_count(empty)        23622      24510      24099    -477 (-2.0%)
-deposit#0                       79951      84626      81089   -1138 (-1.4%)
-get_deposit_root(after#0)      102980     117570     109174   -6194 (-5.7%)
-get_deposit_count(after#0)      23622      24510      24099    -477 (-2.0%)
-deposit#1                       65320      70411      66629   -1309 (-2.0%)
-get_deposit_root(after#1)      102980     117570     109174   -6194 (-5.7%)
-get_deposit_count(after#1)      23622      24510      24099    -477 (-2.0%)
-deposit#2                       45739      50414      46877   -1138 (-2.4%)
-get_deposit_root(after#2)      102988     117582     109170   -6182 (-5.7%)
-get_deposit_count(after#2)      23622      24510      24099    -477 (-2.0%)
-TOTAL                          762218     838656     792487  -30269 (-3.8%)
+get_deposit_root(empty)        102969     117558     109178   -6209 (-5.7%)
+get_deposit_count(empty)        23616      24510      24099    -483 (-2.0%)
+deposit#0                       79719      84626      81089   -1370 (-1.7%)
+get_deposit_root(after#0)      102977     117570     109174   -6197 (-5.7%)
+get_deposit_count(after#0)      23616      24510      24099    -483 (-2.0%)
+deposit#1                       65088      70411      66629   -1541 (-2.3%)
+get_deposit_root(after#1)      102977     117570     109174   -6197 (-5.7%)
+get_deposit_count(after#1)      23616      24510      24099    -483 (-2.0%)
+deposit#2                       45507      50414      46877   -1370 (-2.9%)
+get_deposit_root(after#2)      102985     117582     109170   -6185 (-5.7%)
+get_deposit_count(after#2)      23616      24510      24099    -483 (-2.0%)
+TOTAL                          761486     838656     792487  -31001 (-3.9%)

--- a/crates/mir/src/runtime/lower/infer.rs
+++ b/crates/mir/src/runtime/lower/infer.rs
@@ -648,9 +648,15 @@ fn local_lowers_as_direct_read_value<'db>(
     scope: Option<hir::hir_def::scope_graph::ScopeId<'db>>,
     assumptions: PredicateListId<'db>,
 ) -> bool {
-    let Some(class @ RuntimeClass::AggregateValue { .. }) = carrier.value_class().cloned() else {
+    let Some(class) = carrier.value_class().cloned() else {
         return false;
     };
+    if !matches!(
+        class,
+        RuntimeClass::Scalar(_) | RuntimeClass::AggregateValue { .. }
+    ) {
+        return false;
+    }
     match local.facts.interface {
         SemanticLocalKind::DirectValue => local_direct_value_lowers_as_unrooted(local, db, &class),
         SemanticLocalKind::PlaceCarrier => {
@@ -719,7 +725,10 @@ fn unrooted_read_value_candidate_carrier<'db>(
     carrier: &RuntimeCarrier<'db>,
 ) -> Option<RuntimeCarrier<'db>> {
     let class = carrier.value_class().cloned()?;
-    if matches!(class, RuntimeClass::AggregateValue { .. }) {
+    if matches!(
+        class,
+        RuntimeClass::Scalar(_) | RuntimeClass::AggregateValue { .. }
+    ) {
         return Some(RuntimeCarrier::Value(class));
     }
     if !matches!(local.facts.interface, SemanticLocalKind::DirectValue) {

--- a/newsfragments/1489.performance.md
+++ b/newsfragments/1489.performance.md
@@ -1,0 +1,1 @@
+Avoid lowering read-only scalars as memory-backed places.


### PR DESCRIPTION
We were lowering some read-only scalars to memory alloc/store/load. Sonatina optimized many of these away, but not all.