### PR TITLE
Add tracing subscriber to tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6435,7 +6435,7 @@ dependencies = [
 [[package]]
 name = "sonatina-codegen"
 version = "0.0.3-alpha"
-source = "git+https://github.com/fe-lang/sonatina?rev=a74b939#a74b939c8d8f9ef9e3b066652a6f5e67100f5c83"
+source = "git+https://github.com/fe-lang/sonatina?rev=039a9f5#039a9f530856a7c0097ffc9dad904eed3bf33fe3"
 dependencies = [
  "bit-set",
  "cranelift-entity 0.126.2",
@@ -6455,7 +6455,7 @@ dependencies = [
 [[package]]
 name = "sonatina-ir"
 version = "0.0.3-alpha"
-source = "git+https://github.com/fe-lang/sonatina?rev=a74b939#a74b939c8d8f9ef9e3b066652a6f5e67100f5c83"
+source = "git+https://github.com/fe-lang/sonatina?rev=039a9f5#039a9f530856a7c0097ffc9dad904eed3bf33fe3"
 dependencies = [
  "bit-set",
  "bitflags 2.11.0",
@@ -6478,7 +6478,7 @@ dependencies = [
 [[package]]
 name = "sonatina-macros"
 version = "0.0.3-alpha"
-source = "git+https://github.com/fe-lang/sonatina?rev=a74b939#a74b939c8d8f9ef9e3b066652a6f5e67100f5c83"
+source = "git+https://github.com/fe-lang/sonatina?rev=039a9f5#039a9f530856a7c0097ffc9dad904eed3bf33fe3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6488,7 +6488,7 @@ dependencies = [
 [[package]]
 name = "sonatina-parser"
 version = "0.0.3-alpha"
-source = "git+https://github.com/fe-lang/sonatina?rev=a74b939#a74b939c8d8f9ef9e3b066652a6f5e67100f5c83"
+source = "git+https://github.com/fe-lang/sonatina?rev=039a9f5#039a9f530856a7c0097ffc9dad904eed3bf33fe3"
 dependencies = [
  "annotate-snippets",
  "bimap",
@@ -6509,7 +6509,7 @@ dependencies = [
 [[package]]
 name = "sonatina-triple"
 version = "0.0.3-alpha"
-source = "git+https://github.com/fe-lang/sonatina?rev=a74b939#a74b939c8d8f9ef9e3b066652a6f5e67100f5c83"
+source = "git+https://github.com/fe-lang/sonatina?rev=039a9f5#039a9f530856a7c0097ffc9dad904eed3bf33fe3"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -6517,7 +6517,7 @@ dependencies = [
 [[package]]
 name = "sonatina-verifier"
 version = "0.0.3-alpha"
-source = "git+https://github.com/fe-lang/sonatina?rev=a74b939#a74b939c8d8f9ef9e3b066652a6f5e67100f5c83"
+source = "git+https://github.com/fe-lang/sonatina?rev=039a9f5#039a9f530856a7c0097ffc9dad904eed3bf33fe3"
 dependencies = [
  "cranelift-entity 0.126.2",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,10 +50,10 @@ tracing-tree = "0.4.0"
 wasm-bindgen-test = "0.3"
 semver = "1.0.26"
 petgraph = "0.8"
-sonatina-ir = { git = "https://github.com/fe-lang/sonatina", rev = "a74b939" }
-sonatina-triple = { git = "https://github.com/fe-lang/sonatina", rev = "a74b939" }
-sonatina-codegen = { git = "https://github.com/fe-lang/sonatina", rev = "a74b939" }
-sonatina-verifier = { git = "https://github.com/fe-lang/sonatina", rev = "a74b939" }
+sonatina-ir = { git = "https://github.com/fe-lang/sonatina", rev = "039a9f5" }
+sonatina-triple = { git = "https://github.com/fe-lang/sonatina", rev = "039a9f5" }
+sonatina-codegen = { git = "https://github.com/fe-lang/sonatina", rev = "039a9f5" }
+sonatina-verifier = { git = "https://github.com/fe-lang/sonatina", rev = "039a9f5" }
 
 [profile.dev]
 # Set to 0 to make the build faster and debugging more difficult.

--- a/crates/codegen/tests/sonatina_ir.rs
+++ b/crates/codegen/tests/sonatina_ir.rs
@@ -12,6 +12,7 @@ use driver::DriverDataBase;
 use fe_codegen::emit_module_sonatina_ir;
 use std::{collections::HashSet, path::Path};
 use test_utils::_macro_support::_insta::{self, Settings};
+use tracing::{info, warn};
 use url::Url;
 
 fn with_top_mod_for_source<T>(
@@ -420,6 +421,7 @@ pub contract C {
     glob: "*.fe"
 )]
 fn sonatina_ir_snap(fixture: Fixture<&str>) {
+    let _logging = test_utils::setup_test_tracing();
     let mut db = DriverDataBase::default();
     let file_url = Url::from_file_path(fixture.path()).expect("fixture path should be absolute");
     db.workspace().touch(
@@ -436,11 +438,11 @@ fn sonatina_ir_snap(fixture: Fixture<&str>) {
     let output = match emit_module_sonatina_ir(&db, top_mod) {
         Ok(ir) => ir,
         Err(fe_codegen::LowerError::Unsupported(msg)) => {
-            tracing::info!("SKIP {}: unsupported ({msg})", fixture.path());
+            info!("SKIP {}: unsupported ({msg})", fixture.path());
             return;
         }
         Err(fe_codegen::LowerError::Internal(msg)) => {
-            tracing::warn!("SKIP {}: internal error ({msg})", fixture.path());
+            warn!("SKIP {}: internal error ({msg})", fixture.path());
             return;
         }
         Err(err) => panic!("Sonatina IR lowering failed: {err}"),

--- a/crates/language-server/src/functionality/handlers.rs
+++ b/crates/language-server/src/functionality/handlers.rs
@@ -350,7 +350,7 @@ pub async fn handle_did_change_watched_files(
             FileChangeType::CREATED => ChangeKind::Create,
             FileChangeType::DELETED => ChangeKind::Delete,
             _ => {
-                tracing::warn!("unknown FileChangeType {:?}, skipping", event.typ);
+                warn!("unknown FileChangeType {:?}, skipping", event.typ);
                 continue;
             }
         };

--- a/crates/language-server/src/lsp_actor/mod.rs
+++ b/crates/language-server/src/lsp_actor/mod.rs
@@ -141,7 +141,9 @@ mod tests {
     use service::LspActorService;
     use std::ops::ControlFlow;
     use tower::Service;
-    use tracing::info;
+    use tracing::{info, subscriber::set_global_default};
+
+    static INIT: std::sync::Once = std::sync::Once::new();
 
     #[derive(Debug)]
     enum Initialize {}
@@ -164,8 +166,16 @@ mod tests {
         initialized: bool,
     }
 
+    fn init_global_test_tracing() {
+        INIT.call_once(|| {
+            let subscriber = test_utils::test_subscriber();
+            let _ = set_global_default(subscriber);
+        });
+    }
+
     #[tokio::test]
     async fn test_lsp_actor() {
+        init_global_test_tracing();
         let actor_ref = ActorBuilder::new()
             .with_state_init(|| {
                 let initial_state = TestState { initialized: false };

--- a/crates/parser/src/ast/item.rs
+++ b/crates/parser/src/ast/item.rs
@@ -790,6 +790,7 @@ mod tests {
     where
         T: TryFrom<ItemKind, Error = TryIntoError<ItemKind>>,
     {
+        let _logging = test_utils::setup_test_tracing();
         let lexer = Lexer::new(source);
         let mut parser = Parser::new(lexer, RecoveryMode::Recover);
 

--- a/crates/parser/tests/test_runner.rs
+++ b/crates/parser/tests/test_runner.rs
@@ -13,17 +13,6 @@ use fe_parser::{
 use test_utils::normalize::normalize_newlines;
 use tracing::error;
 
-static INIT: Once = Once::new();
-
-fn init_tracing() {
-    INIT.call_once(|| {
-        tracing_subscriber::fmt()
-            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-            .with_test_writer()
-            .init();
-    });
-}
-
 type BoxedParseFn = Box<dyn Fn(&mut Parser<lexer::Lexer>) -> Result<(), Recovery<ErrProof>>>;
 pub struct TestRunner {
     f: BoxedParseFn,
@@ -106,7 +95,7 @@ impl TestRunner {
     }
 
     pub fn run(&self, input: &str) -> (SyntaxNode, Vec<ParseError>) {
-        init_tracing();
+        let _logging = test_utils::setup_test_tracing();
         let input = normalize_newlines(input);
         let input = input.as_ref();
         let lexer = lexer::Lexer::new(input);

--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -8,7 +8,7 @@ use tracing::{
     level_filters::LevelFilter,
     subscriber::{DefaultGuard, set_default},
 };
-use tracing_subscriber::{EnvFilter, layer::SubscriberExt};
+use tracing_subscriber::{EnvFilter, fmt::TestWriter, layer::SubscriberExt};
 use tracing_tree::HierarchicalLayer;
 
 pub fn setup_tracing_with_filter(filter: &str) -> DefaultGuard {
@@ -19,6 +19,30 @@ pub fn setup_tracing_with_filter(filter: &str) -> DefaultGuard {
 pub fn setup_tracing(level: Level) -> DefaultGuard {
     let subscriber = default_subscriber().with(LevelFilter::from_level(level));
     set_default(subscriber)
+}
+
+pub fn setup_test_tracing() -> DefaultGuard {
+    let subscriber = test_subscriber();
+    set_default(subscriber)
+}
+
+pub fn test_subscriber() -> impl Subscriber + Send + Sync {
+    tracing_subscriber::registry()
+        .with(
+            EnvFilter::builder()
+                .with_default_directive(LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .with(
+            HierarchicalLayer::new(2)
+                .with_targets(true)
+                .with_thread_ids(true)
+                .with_thread_names(true)
+                .with_indent_lines(true)
+                .with_bracketed_fields(true)
+                .with_ansi(false)
+                .with_writer(TestWriter::default()),
+        )
 }
 
 fn default_subscriber() -> impl Subscriber + Send + Sync {


### PR DESCRIPTION
Fixes #1153.

This PR properly adds a tracing subscriber to all tests that needs to emit log events during testing.

The default behaviour of the subscriber is to read from `RUST_LOG` to determine the appropriate log level, and, failing that, defaults to the INFO log level. Successful test cases will discard the log captured by the subscriber; only test failures would be printed out to stdout/stderr depending on log level. This is done to reduce the noisy output from successful tests, but can still be instructed to output all logs by running `cargo test -- --show-output`.