### PR TITLE
parser: Recover instead of panicking on a missing = in a LetExpr

### DIFF
--- a/crates/parser/src/parser/expr.rs
+++ b/crates/parser/src/parser/expr.rs
@@ -266,7 +266,7 @@ impl super::Parse for LetExprScope {
         parser.bump_expected(SyntaxKind::LetKw);
         parser.set_newline_as_trivia(false);
         parse_pat(parser)?;
-        parser.bump_expected(SyntaxKind::Eq);
+        parser.bump_or_recover(SyntaxKind::Eq, "expected `=` after `let` pattern")?;
         parse_expr_with_min_bp(parser, LET_CONDITION_RHS_MIN_BP, false, false, None)
     }
 }

--- a/crates/parser/test_files/error_recovery/exprs/if_let.fe
+++ b/crates/parser/test_files/error_recovery/exprs/if_let.fe
@@ -1,0 +1,4 @@
+if let Foo(i,j) foo {}
+if let (x, y) = (1, 2) {
+
+}

--- a/crates/parser/test_files/error_recovery/exprs/if_let.snap
+++ b/crates/parser/test_files/error_recovery/exprs/if_let.snap
@@ -1,0 +1,76 @@
+---
+source: crates/parser/tests/error_recovery.rs
+assertion_line: 41
+expression: node
+input_file: test_files/error_recovery/exprs/if_let.fe
+---
+Root@0..50
+  IfExpr@0..22
+    IfKw@0..2 "if"
+    WhiteSpace@2..3 " "
+    LetExpr@3..19
+      LetKw@3..6 "let"
+      WhiteSpace@6..7 " "
+      PathTuplePat@7..15
+        Path@7..10
+          PathSegment@7..10
+            Ident@7..10 "Foo"
+        TuplePatElemList@10..15
+          LParen@10..11 "("
+          PathPat@11..12
+            Path@11..12
+              PathSegment@11..12
+                Ident@11..12 "i"
+          Comma@12..13 ","
+          PathPat@13..14
+            Path@13..14
+              PathSegment@13..14
+                Ident@13..14 "j"
+          RParen@14..15 ")"
+      WhiteSpace@15..16 " "
+      Error@16..19
+        Ident@16..19 "foo"
+    WhiteSpace@19..20 " "
+    BlockExpr@20..22
+      LBrace@20..21 "{"
+      RBrace@21..22 "}"
+  Newline@22..23 "\n"
+  IfExpr@23..50
+    IfKw@23..25 "if"
+    WhiteSpace@25..26 " "
+    LetExpr@26..45
+      LetKw@26..29 "let"
+      WhiteSpace@29..30 " "
+      TuplePat@30..36
+        TuplePatElemList@30..36
+          LParen@30..31 "("
+          PathPat@31..32
+            Path@31..32
+              PathSegment@31..32
+                Ident@31..32 "x"
+          Comma@32..33 ","
+          WhiteSpace@33..34 " "
+          PathPat@34..35
+            Path@34..35
+              PathSegment@34..35
+                Ident@34..35 "y"
+          RParen@35..36 ")"
+      WhiteSpace@36..37 " "
+      Eq@37..38 "="
+      WhiteSpace@38..39 " "
+      TupleExpr@39..45
+        LParen@39..40 "("
+        LitExpr@40..41
+          Lit@40..41
+            Int@40..41 "1"
+        Comma@41..42 ","
+        WhiteSpace@42..43 " "
+        LitExpr@43..44
+          Lit@43..44
+            Int@43..44 "2"
+        RParen@44..45 ")"
+    WhiteSpace@45..46 " "
+    BlockExpr@46..50
+      LBrace@46..47 "{"
+      Newline@47..49 "\n\n"
+      RBrace@49..50 "}"

--- a/crates/parser/test_files/no_recovery/exprs/if_let.fe
+++ b/crates/parser/test_files/no_recovery/exprs/if_let.fe
@@ -1,0 +1,4 @@
+if let Foo(i,j) foo {}
+if let (x, y) = (1, 2) {
+
+}

--- a/crates/parser/test_files/no_recovery/exprs/if_let.snap
+++ b/crates/parser/test_files/no_recovery/exprs/if_let.snap
@@ -1,0 +1,7 @@
+---
+source: crates/parser/tests/no_recovery.rs
+assertion_line: 50
+expression: output
+input_file: test_files/no_recovery/exprs/if_let.fe
+---
+expected `=` after `let` pattern@15..15

--- a/newsfragments/1497.bugfix.md
+++ b/newsfragments/1497.bugfix.md
@@ -1,0 +1,1 @@
+Fixed a compiler panic when an `if let`/`while let` condition's pattern was not followed by `=`. The parser now reports a "expected `=`" error and recovers instead of crashing.


### PR DESCRIPTION
Fixes #1411.

This PR removes a compiler panic and replaces it with a recoverable error when a `=` token is missing during the parsing of a let expr node.