### PR TITLE
parser: Better diagnostics for turbofish syntax in path segments

### DIFF
--- a/crates/parser/src/parser/path.rs
+++ b/crates/parser/src/parser/path.rs
@@ -39,12 +39,20 @@ impl super::Parse for PathSegmentScope {
             Some(kind) if is_path_segment(kind) => {
                 parser.bump();
 
-                if parser.current_kind_same_line() == Some(SyntaxKind::Lt)
-                    && !(is_lt_eq(parser) || is_lshift(parser))
+                let is_turbofish = parser.current_kind_same_line() == Some(SyntaxKind::Colon2)
+                    && parser.peek_two() == (Some(SyntaxKind::Colon2), Some(SyntaxKind::Lt));
+
+                if (is_turbofish
+                    || (parser.current_kind_same_line() == Some(SyntaxKind::Lt)
+                        && !(is_lt_eq(parser) || is_lshift(parser))))
                     && parser.dry_run(|parser| {
+                        parser.bump_if(SyntaxKind::Colon2);
                         parser.parses_without_error(GenericArgListScope::new(self.is_expr))
                     })
                 {
+                    if is_turbofish {
+                        parser.bump_expected(SyntaxKind::Colon2);
+                    }
                     parser
                         .parse(GenericArgListScope::new(self.is_expr))
                         .expect("dry_run suggests this will succeed");

--- a/crates/parser/src/parser/path.rs
+++ b/crates/parser/src/parser/path.rs
@@ -54,7 +54,7 @@ impl super::Parse for PathSegmentScope {
                         parser.bump_trivias();
                         parser.add_error(ParseError::Unexpected(
                             "unexpected turbofish syntax `::<`; remove the double colons".into(),
-                            TextRange::at(parser.end_of_prev_token, TextSize::from(3)),
+                            TextRange::at(parser.current_pos, TextSize::from(3)),
                         ));
                         parser.bump_expected(SyntaxKind::Colon2);
                     }

--- a/crates/parser/src/parser/path.rs
+++ b/crates/parser/src/parser/path.rs
@@ -51,6 +51,7 @@ impl super::Parse for PathSegmentScope {
                     })
                 {
                     if is_turbofish {
+                        parser.bump_trivias();
                         parser.add_error(ParseError::Unexpected(
                             "unexpected turbofish syntax `::<`; remove the double colons".into(),
                             TextRange::at(parser.end_of_prev_token, TextSize::from(3)),

--- a/crates/parser/src/parser/path.rs
+++ b/crates/parser/src/parser/path.rs
@@ -1,4 +1,4 @@
-use crate::{ParseError, SyntaxKind};
+use crate::{ParseError, SyntaxKind, TextRange, TextSize};
 
 use super::{
     Parser, define_scope,
@@ -51,6 +51,10 @@ impl super::Parse for PathSegmentScope {
                     })
                 {
                     if is_turbofish {
+                        parser.add_error(ParseError::Unexpected(
+                            "unexpected turbofish syntax `::<`; remove the double colons".into(),
+                            TextRange::at(parser.end_of_prev_token, TextSize::from(3)),
+                        ));
                         parser.bump_expected(SyntaxKind::Colon2);
                     }
                     parser

--- a/crates/parser/test_files/error_recovery/exprs/turbofish.fe
+++ b/crates/parser/test_files/error_recovery/exprs/turbofish.fe
@@ -1,0 +1,1 @@
+StorageMap::<u256, u256, 0>::new()

--- a/crates/parser/test_files/error_recovery/exprs/turbofish.snap
+++ b/crates/parser/test_files/error_recovery/exprs/turbofish.snap
@@ -1,0 +1,40 @@
+---
+source: crates/parser/tests/error_recovery.rs
+assertion_line: 41
+expression: node
+input_file: test_files/error_recovery/exprs/turbofish.fe
+---
+Root@0..34
+  CallExpr@0..34
+    PathExpr@0..32
+      Path@0..32
+        PathSegment@0..27
+          Ident@0..10 "StorageMap"
+          Colon2@10..12 "::"
+          GenericArgList@12..27
+            Lt@12..13 "<"
+            TypeGenericArg@13..17
+              PathType@13..17
+                Path@13..17
+                  PathSegment@13..17
+                    Ident@13..17 "u256"
+            Comma@17..18 ","
+            WhiteSpace@18..19 " "
+            TypeGenericArg@19..23
+              PathType@19..23
+                Path@19..23
+                  PathSegment@19..23
+                    Ident@19..23 "u256"
+            Comma@23..24 ","
+            WhiteSpace@24..25 " "
+            ConstGenericArg@25..26
+              LitExpr@25..26
+                Lit@25..26
+                  Int@25..26 "0"
+            Gt@26..27 ">"
+        Colon2@27..29 "::"
+        PathSegment@29..32
+          Ident@29..32 "new"
+    CallArgList@32..34
+      LParen@32..33 "("
+      RParen@33..34 ")"

--- a/crates/parser/test_files/no_recovery/exprs/turbofish.fe
+++ b/crates/parser/test_files/no_recovery/exprs/turbofish.fe
@@ -1,0 +1,1 @@
+StorageMap::<u256, u256, 0>::new()

--- a/crates/parser/test_files/no_recovery/exprs/turbofish.snap
+++ b/crates/parser/test_files/no_recovery/exprs/turbofish.snap
@@ -1,0 +1,7 @@
+---
+source: crates/parser/tests/no_recovery.rs
+assertion_line: 50
+expression: output
+input_file: test_files/no_recovery/exprs/turbofish.fe
+---
+unexpected turbofish syntax `::<`; remove the double colons@10..13

--- a/newsfragments/1498.bugfix.md
+++ b/newsfragments/1498.bugfix.md
@@ -1,0 +1,1 @@
+Improved the parser diagnostic for Rust-style turbofish syntax. Writing `Name::<...>` (for example `StorageMap::<u256, u256, 0>::new()`) now reports a clear "remove the double colons" error pointing at the `::`, instead of a confusing "expected newline or `}`" message. Use the bare `Name<...>` form instead.


### PR DESCRIPTION
Fixes #1402.

This PR allows the turbofish syntax from Rust to appear in path segments.

Making a draft because a decision has to be made on whether this is desirable, or that we should instead emit an error asking to use the `PathSegment<GenericArgList>` syntax instead (i.e. no double colons in between the path segment and the opening angle bracket).