### PR TITLE
Replace sol-compat int trait impl boilerplate with blanket impls

### DIFF
--- a/crates/codegen/tests/fixtures/sonatina_ir/effect_ptr_domains.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/effect_ptr_domains.snap
@@ -92,7 +92,7 @@ func private %bump__gb2d8(v0.objref<@layout_0>) {
         return;
 }
 
-func private %impl_trait_StorPtr__from_raw__gb2d8(v0.i256) -> i256 {
+func private %impl_trait_MemPtr__from_raw__gb2d8(v0.i256) -> i256 {
     block0:
         jump block1;
 
@@ -100,7 +100,7 @@ func private %impl_trait_StorPtr__from_raw__gb2d8(v0.i256) -> i256 {
         return v0;
 }
 
-func private %impl_trait_MemPtr__from_raw__gb2d8(v0.i256) -> i256 {
+func private %impl_trait_StorPtr__from_raw__gb2d8(v0.i256) -> i256 {
     block0:
         jump block1;
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/erc20_low_level.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/erc20_low_level.snap
@@ -201,7 +201,7 @@ func private %std__lib__evm__effects__impl_trait_Address_3ffb__eq_fb60(v0.@layou
         return v7;
 }
 
-func private %core__lib__effect_ref__impl_trait_StorPtr_27da__from_raw__gb51e_b944(v0.i256) -> i256 {
+func private %core__lib__effect_ref__impl_trait_StorPtr_27da__from_raw__gb51e_866d(v0.i256) -> i256 {
     block0:
         jump block1;
 
@@ -209,7 +209,7 @@ func private %core__lib__effect_ref__impl_trait_StorPtr_27da__from_raw__gb51e_b9
         return v0;
 }
 
-func private %core__lib__effect_ref__impl_trait_StorPtr_27da__from_raw__gb51e_b944_0(v0.i256) -> i256 {
+func private %core__lib__effect_ref__impl_trait_StorPtr_27da__from_raw__gb51e_866d_0(v0.i256) -> i256 {
     block0:
         jump block1;
 
@@ -790,7 +790,7 @@ func private %std__lib__evm__effects__trait_RawStorage__stor_ptr__g3730_6bd4(v0.
         jump block1;
 
     block1:
-        v2.i256 = call %core__lib__effect_ref__impl_trait_StorPtr_27da__from_raw__gb51e_b944 v0;
+        v2.i256 = call %core__lib__effect_ref__impl_trait_StorPtr_27da__from_raw__gb51e_866d v0;
         return v2;
 }
 
@@ -799,7 +799,7 @@ func private %std__lib__evm__effects__trait_RawStorage__stor_ptr__g3730_6bd4_0(v
         jump block1;
 
     block1:
-        v2.i256 = call %core__lib__effect_ref__impl_trait_StorPtr_27da__from_raw__gb51e_b944_0 v0;
+        v2.i256 = call %core__lib__effect_ref__impl_trait_StorPtr_27da__from_raw__gb51e_866d_0 v0;
         return v2;
 }
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/explicit_raw_boundaries.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/explicit_raw_boundaries.snap
@@ -36,7 +36,7 @@ func private %explicit_raw_boundaries() {
         return;
 }
 
-func private %from_raw__ge513(v0.i256) -> i256 {
+func private %from_raw__g4a95(v0.i256) -> i256 {
     block0:
         jump block1;
 
@@ -44,7 +44,7 @@ func private %from_raw__ge513(v0.i256) -> i256 {
         return v0;
 }
 
-func private %from_raw__g4a95(v0.i256) -> i256 {
+func private %from_raw__ge513(v0.i256) -> i256 {
     block0:
         jump block1;
 
@@ -97,7 +97,7 @@ func private %std__lib__evm__effects__impl_trait_Evm_d0d8__mstore_c9f4_0(v0.i256
         return;
 }
 
-func private %core__lib__effect_ref__impl_trait_MemPtr_ec03__raw__g4a95_0a9d(v0.i256) -> i256 {
+func private %core__lib__effect_ref__impl_trait_MemPtr_ec03__raw__g4a95_c621(v0.i256) -> i256 {
     block0:
         jump block1;
 
@@ -105,7 +105,7 @@ func private %core__lib__effect_ref__impl_trait_MemPtr_ec03__raw__g4a95_0a9d(v0.
         return v0;
 }
 
-func private %core__lib__effect_ref__impl_trait_MemPtr_ec03__raw__g4a95_0a9d_0(v0.i256) -> i256 {
+func private %core__lib__effect_ref__impl_trait_MemPtr_ec03__raw__g4a95_c621_0(v0.i256) -> i256 {
     block0:
         jump block1;
 
@@ -118,7 +118,7 @@ func private %raw_store__gc18b(v0.i256) {
         jump block1;
 
     block1:
-        v2.i256 = call %core__lib__effect_ref__impl_trait_MemPtr_ec03__raw__g4a95_0a9d_0 v0;
+        v2.i256 = call %core__lib__effect_ref__impl_trait_MemPtr_ec03__raw__g4a95_c621_0 v0;
         call %std__lib__evm__effects__impl_trait_Evm_d0d8__mstore_c9f4_0 v2 8.i256;
         return;
 }
@@ -128,7 +128,7 @@ func private %raw_store__g64c6(v0.i256) {
         jump block1;
 
     block1:
-        v2.i256 = call %core__lib__effect_ref__impl_trait_MemPtr_ec03__raw__g4a95_0a9d v0;
+        v2.i256 = call %core__lib__effect_ref__impl_trait_MemPtr_ec03__raw__g4a95_c621 v0;
         call %std__lib__evm__effects__impl_trait_Evm_d0d8__mstore_c9f4 v2 8.i256;
         return;
 }

--- a/crates/codegen/tests/fixtures/sonatina_ir/storage.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/storage.snap
@@ -118,7 +118,7 @@ func private %credit_bob(v0.i256, v1.i256, v2.i256) -> i256 {
         return v25;
 }
 
-func private %from_raw__g9438(v0.i256) -> i256 {
+func private %from_raw__gf198(v0.i256) -> i256 {
     block0:
         jump block1;
 
@@ -126,7 +126,7 @@ func private %from_raw__g9438(v0.i256) -> i256 {
         return v0;
 }
 
-func private %from_raw__gf198(v0.i256) -> i256 {
+func private %from_raw__g9438(v0.i256) -> i256 {
     block0:
         jump block1;
 

--- a/crates/codegen/tests/fixtures/sonatina_ir/wrapping_saturating.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/wrapping_saturating.snap
@@ -52,21 +52,21 @@ func private %impl_trait_u64__saturating_add(v0.i64, v1.i64) -> i64 {
         return v4;
 }
 
-func private %impl_trait_u256__saturating_mul(v0.i256, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = umulsat v0 v1;
-        return v4;
-}
-
 func private %impl_trait_u64__saturating_mul(v0.i64, v1.i64) -> i64 {
     block0:
         jump block1;
 
     block1:
         v4.i64 = umulsat v0 v1;
+        return v4;
+}
+
+func private %impl_trait_u256__saturating_mul(v0.i256, v1.i256) -> i256 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.i256 = umulsat v0 v1;
         return v4;
 }
 
@@ -116,15 +116,6 @@ func private %impl_trait_u256__saturating_sub(v0.i256, v1.i256) -> i256 {
         return v4;
 }
 
-func private %impl_trait_u256__wrapping_add(v0.i256, v1.i256) -> i256 {
-    block0:
-        jump block1;
-
-    block1:
-        v4.i256 = add v0 v1;
-        return v4;
-}
-
 func private %impl_trait_u64__wrapping_add(v0.i64, v1.i64) -> i64 {
     block0:
         jump block1;
@@ -134,12 +125,12 @@ func private %impl_trait_u64__wrapping_add(v0.i64, v1.i64) -> i64 {
         return v4;
 }
 
-func private %impl_trait_u64__wrapping_mul(v0.i64, v1.i64) -> i64 {
+func private %impl_trait_u256__wrapping_add(v0.i256, v1.i256) -> i256 {
     block0:
         jump block1;
 
     block1:
-        v4.i64 = mul v0 v1;
+        v4.i256 = add v0 v1;
         return v4;
 }
 
@@ -149,6 +140,15 @@ func private %impl_trait_u256__wrapping_mul(v0.i256, v1.i256) -> i256 {
 
     block1:
         v4.i256 = mul v0 v1;
+        return v4;
+}
+
+func private %impl_trait_u64__wrapping_mul(v0.i64, v1.i64) -> i64 {
+    block0:
+        jump block1;
+
+    block1:
+        v4.i64 = mul v0 v1;
         return v4;
 }
 

--- a/crates/fe/tests/fixtures/fe_test/sealed_marker_blanket_impl_disjointness.fe
+++ b/crates/fe/tests/fixtures/fe_test/sealed_marker_blanket_impl_disjointness.fe
@@ -1,0 +1,118 @@
+use core::ops::{WrappingAdd, WrappingMul, WrappingSub}
+
+trait LeftWide {}
+trait LeftNarrow {}
+trait RightWide {}
+
+struct X {
+    value: u256,
+}
+
+struct Y {
+    value: u256,
+}
+
+struct Z {
+    value: u256,
+}
+
+impl LeftWide for X {}
+impl LeftWide for Y {}
+
+impl LeftNarrow for X {}
+impl LeftNarrow for Z {}
+
+impl RightWide for Y {}
+impl RightWide for Z {}
+
+impl<T: LeftWide + LeftNarrow> WrappingAdd for T {
+    fn wrapping_add(self, _ other: T) -> Self {
+        self
+    }
+}
+
+impl<T: RightWide> WrappingAdd for T {
+    fn wrapping_add(self, _ other: T) -> Self {
+        other
+    }
+}
+
+trait EmptyMarker {}
+trait FullMarker {}
+
+struct Full {
+    value: u256,
+}
+
+impl FullMarker for Full {}
+
+impl<T: EmptyMarker> WrappingSub for T {
+    fn wrapping_sub(self, _ other: T) -> Self {
+        self
+    }
+}
+
+impl<T: FullMarker> WrappingSub for T {
+    fn wrapping_sub(self, _ other: T) -> Self {
+        other
+    }
+}
+
+trait LeftOnly {}
+trait RightOnly {}
+trait Common {}
+
+struct Left {
+    value: u256,
+}
+
+struct Right {
+    value: u256,
+}
+
+impl LeftOnly for Left {}
+impl Common for Left {}
+
+impl RightOnly for Right {}
+impl Common for Right {}
+
+impl<T: LeftOnly + Common> WrappingMul for T {
+    fn wrapping_mul(self, _ other: T) -> Self {
+        self
+    }
+}
+
+impl<T: RightOnly + Common> WrappingMul for T {
+    fn wrapping_mul(self, _ other: T) -> Self {
+        other
+    }
+}
+
+#[test]
+fn sealed_marker_blanket_impl_global_intersection_disjoint() {
+    let left = X { value: 11 }
+    let left_other = X { value: 31 }
+    assert!(left.wrapping_add(left_other).value == 11)
+
+    let right = Y { value: 5 }
+    let right_other = Y { value: 7 }
+    assert!(right.wrapping_add(right_other).value == 7)
+}
+
+#[test]
+fn sealed_marker_blanket_impl_empty_marker_targets_are_unreachable() {
+    let full = Full { value: 13 }
+    let full_other = Full { value: 17 }
+    assert!(full.wrapping_sub(full_other).value == 17)
+}
+
+#[test]
+fn sealed_marker_blanket_impl_single_disjoint_pair_is_enough() {
+    let left = Left { value: 23 }
+    let left_other = Left { value: 29 }
+    assert!(left.wrapping_mul(left_other).value == 23)
+
+    let right = Right { value: 37 }
+    let right_other = Right { value: 41 }
+    assert!(right.wrapping_mul(right_other).value == 41)
+}

--- a/crates/fe/tests/fixtures/fe_test/sol_compat_int_abi_roundtrip.fe
+++ b/crates/fe/tests/fixtures/fe_test/sol_compat_int_abi_roundtrip.fe
@@ -1,0 +1,80 @@
+// Runtime coverage for the ABI traits on custom-width Solidity int wrappers
+// (`Encode` / `Decode` / `AbiSize` / `AbiSpan` / `TopicValue`), which are
+// provided by marker-gated blanket impls in `std::abi::sol::ints`. Round-trips
+// a value through a contract call (caller-side `Encode`, callee-side `Decode`,
+// and the re-`Encode`d return) and emits an event whose indexed field uses
+// `TopicValue`.
+use std::abi::sol
+use std::abi::sol::{Uint160, Int24}
+use std::evm::{Evm, Log}
+
+msg M {
+    #[selector = sol("rtU160(uint160)")]
+    RtU160 { v: Uint160 } -> Uint160,
+    #[selector = sol("rtI24(int24)")]
+    RtI24 { v: Int24 } -> Int24,
+    #[selector = sol("emitSwap(uint160,int24)")]
+    EmitSwap { sender: Uint160, tick: Int24 },
+}
+
+#[event]
+struct Swap {
+    #[indexed]
+    sender: Uint160,
+    tick: Int24,
+}
+
+pub contract C uses (log: mut Log) {
+    init() {}
+
+    recv M {
+        RtU160 { v } -> Uint160 {
+            v
+        }
+        RtI24 { v } -> Int24 {
+            v
+        }
+        EmitSwap { sender, tick } uses (mut log) {
+            log.emit(Swap { sender: sender, tick: tick })
+        }
+    }
+}
+
+#[test]
+fn uint160_abi_roundtrip() uses (evm: mut Evm) {
+    let c = evm.create2<C>(value: 0, args: (), salt: 0)
+
+    let max_u160: u256 = ((1 as u256) << 160) - 1
+    let r: Uint160 = evm.call(addr: c, gas: 2000000, value: 0, message: M::RtU160 { v: Uint160 { val: max_u160 } })
+    assert(r.val == max_u160)
+
+    let r: Uint160 = evm.call(addr: c, gas: 2000000, value: 0, message: M::RtU160 { v: Uint160 { val: 0x1234 } })
+    assert(r.val == 0x1234)
+}
+
+#[test]
+fn int24_abi_roundtrip() uses (evm: mut Evm) {
+    let c = evm.create2<C>(value: 0, args: (), salt: 2)
+
+    // Exercises signed custom-width decode/encode (sign-extension) directly,
+    // across the full int24 range including negatives.
+    let r: Int24 = evm.call(addr: c, gas: 2000000, value: 0, message: M::RtI24 { v: Int24 { val: 8388607 } })
+    assert(r.val == 8388607)
+
+    let r: Int24 = evm.call(addr: c, gas: 2000000, value: 0, message: M::RtI24 { v: Int24 { val: -8388608 } })
+    assert(r.val == -8388608)
+
+    let r: Int24 = evm.call(addr: c, gas: 2000000, value: 0, message: M::RtI24 { v: Int24 { val: -1 } })
+    assert(r.val == -1)
+}
+
+#[test]
+fn event_indexed_uint160_topic() uses (evm: mut Evm) {
+    let c = evm.create2<C>(value: 0, args: (), salt: 1)
+    evm.call(
+        addr: c,
+        gas: 2000000,
+        value: 0,
+        message: M::EmitSwap { sender: Uint160 { val: 0xabcdef }, tick: Int24 { val: -42 } },
+    )
+}

--- a/crates/fe/tests/fixtures/fe_test/sol_compat_int_wrapping.fe
+++ b/crates/fe/tests/fixtures/fe_test/sol_compat_int_wrapping.fe
@@ -1,0 +1,55 @@
+use core::ops::{WrappingAdd, WrappingMul, WrappingSub}
+use std::abi::sol::{Int24, Int56, Int160, Uint24, Uint160}
+use std::evm::effects::assert
+
+#[test]
+fn sol_unsigned_wrapping_methods() {
+    let max_u24 = Uint24 { val: 0xffffff }
+    let zero_u24 = Uint24 { val: 0 }
+    let one_u24 = Uint24 { val: 1 }
+    let u24_mul = Uint24 { val: 0x1000 }
+
+    assert(max_u24.wrapping_add(one_u24).val == 0)
+    assert(zero_u24.wrapping_sub(one_u24).val == 0xffffff)
+    assert(u24_mul.wrapping_mul(u24_mul).val == 0)
+
+    let u160_modulus: u256 = (1 as u256) << 160
+    let max_u160 = Uint160 { val: u160_modulus - 1 }
+    let zero_u160 = Uint160 { val: 0 }
+    let one_u160 = Uint160 { val: 1 }
+    let u160_mul = Uint160 { val: (1 as u256) << 80 }
+
+    assert(max_u160.wrapping_add(one_u160).val == 0)
+    assert(zero_u160.wrapping_sub(one_u160).val == u160_modulus - 1)
+    assert(u160_mul.wrapping_mul(u160_mul).val == 0)
+}
+
+#[test]
+fn sol_signed_wrapping_methods() {
+    let max_i24 = Int24 { val: 8388607 }
+    let min_i24 = Int24 { val: -8388608 }
+    let one_i24 = Int24 { val: 1 }
+    let i24_mul = Int24 { val: 4096 }
+
+    assert(max_i24.wrapping_add(one_i24).val == min_i24.val)
+    assert(min_i24.wrapping_sub(one_i24).val == max_i24.val)
+    assert(i24_mul.wrapping_mul(i24_mul).val == 0)
+
+    let max_i56 = Int56 { val: 36028797018963967 }
+    let min_i56 = Int56 { val: -36028797018963968 }
+    let one_i56 = Int56 { val: 1 }
+
+    assert(max_i56.wrapping_add(one_i56).val == min_i56.val)
+    assert(min_i56.wrapping_sub(one_i56).val == max_i56.val)
+
+    let i160_min_word: i256 = -((1 as i256) << 159)
+    let i160_max_word: i256 = ((1 as i256) << 159) - 1
+    let max_i160 = Int160 { val: i160_max_word }
+    let min_i160 = Int160 { val: i160_min_word }
+    let one_i160 = Int160 { val: 1 }
+    let i160_mul = Int160 { val: (1 as i256) << 80 }
+
+    assert(max_i160.wrapping_add(one_i160).val == min_i160.val)
+    assert(min_i160.wrapping_sub(one_i160).val == max_i160.val)
+    assert(i160_mul.wrapping_mul(i160_mul).val == 0)
+}

--- a/crates/fe/tests/fixtures/fe_test_runner/sol_compat_int_event_logs.fe
+++ b/crates/fe/tests/fixtures/fe_test_runner/sol_compat_int_event_logs.fe
@@ -1,0 +1,26 @@
+// Asserts the *contents* of event topics/data for custom-width Solidity int
+// wrappers, whose `TopicValue` (indexed fields) and `Encode` (data fields) are
+// provided by blanket impls in `std::abi::sol::ints`. The emitted log is
+// snapshotted, so the exact encoded words are checked:
+//   - an unsigned `Uint160` indexed topic is left-padded,
+//   - a *negative* `Int24` indexed topic is sign-extended to 32 bytes,
+//   - a non-indexed `Uint24` is encoded into the data word.
+use std::abi::sol::{Int24, Uint24, Uint160}
+
+#[event]
+struct Swap {
+    #[indexed]
+    sender: Uint160,
+    #[indexed]
+    tick: Int24,
+    amount: Uint24,
+}
+
+#[test]
+fn sol_int_event_topics() uses (evm: mut Evm) {
+    evm.emit(Swap {
+        sender: Uint160 { val: 0xabcdef },
+        tick: Int24 { val: -42 },
+        amount: Uint24 { val: 0x123456 },
+    })
+}

--- a/crates/fe/tests/fixtures/fe_test_runner/sol_compat_int_event_logs.snap
+++ b/crates/fe/tests/fixtures/fe_test_runner/sol_compat_int_event_logs.snap
@@ -1,0 +1,12 @@
+---
+source: crates/fe/tests/cli_output.rs
+expression: output
+input_file: tests/fixtures/fe_test_runner/sol_compat_int_event_logs.fe
+---
+=== STDOUT ===
+PASS  [<time>] sol_int_event_topics
+    log Log { address: 0xbd770416a3345f91e4b34576cb804a576fa48eb1, data: LogData { topics: [0x2d712881462e431c20bc1699080e9fad0f74afda152aad71a85554f2d2a4118f, 0x0000000000000000000000000000000000000000000000000000000000abcdef, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd6], data: 0x0000000000000000000000000000000000000000000000000000000000123456 } }
+
+test result: ok. 1 passed; 0 failed
+
+=== EXIT CODE: 0 ===

--- a/crates/hir/src/analysis/diagnostics.rs
+++ b/crates/hir/src/analysis/diagnostics.rs
@@ -5,7 +5,10 @@
 
 use crate::analysis::{
     HirAnalysisDb,
-    name_resolution::diagnostics::{ImportDiag, PathResDiag},
+    name_resolution::{
+        diagnostics::{ImportDiag, PathResDiag},
+        is_scope_visible_from,
+    },
     ty::{
         diagnostics::{
             BodyDiag, CallConstraintDiagInfo, DefConflictError, FuncBodyDiag, ImplDiag,
@@ -4527,12 +4530,24 @@ impl DiagnosticVoucher for TraitConstraintDiag<'_> {
                     primary_goal.pretty_print(db, false)
                 );
 
-                let unsat_subgoal = unsat_subgoal.map(|unsat| {
-                    format!(
-                        "trait bound `{}` is not satisfied",
-                        unsat.pretty_print(db, true)
-                    )
-                });
+                // Only surface the specific unsatisfied sub-goal when its trait
+                // is visible from where the error is reported. A bound on a
+                // trait the reader cannot name (e.g. a private sealed marker in
+                // another module) is unactionable noise, so we keep just the
+                // primary goal in that case.
+                let unsat_subgoal = unsat_subgoal
+                    .filter(|unsat| {
+                        let Some(from_scope) = span.scope() else {
+                            return true;
+                        };
+                        is_scope_visible_from(db, unsat.def(db).scope(), from_scope)
+                    })
+                    .map(|unsat| {
+                        format!(
+                            "trait bound `{}` is not satisfied",
+                            unsat.pretty_print(db, true)
+                        )
+                    });
 
                 let mut sub_diagnostics = vec![SubDiagnostic {
                     style: LabelStyle::Primary,

--- a/crates/hir/src/analysis/name_resolution/method_selection.rs
+++ b/crates/hir/src/analysis/name_resolution/method_selection.rs
@@ -100,6 +100,7 @@ pub struct AmbiguousTraitMethods<'db> {
     pub diagnostic_traits: ThinVec<TraitInstId<'db>>,
 }
 
+#[derive(Clone, Copy)]
 enum TraitCandidateCheck<'db> {
     Confirmed(TraitMethodCand<'db>),
     NeedsConfirmation(TraitMethodCand<'db>),
@@ -345,45 +346,80 @@ impl<'db, 'a> MethodSelector<'db, 'a> {
     /// * `Err(MethodSelectionError)` - An error indicating the reason for
     ///   failure.
     fn select_trait_methods(&self) -> Result<MethodCandidate<'db>, MethodSelectionError<'db>> {
-        let traits = &self.candidates.traits;
-
-        if traits.len() == 1 {
-            return match self.check_trait_cand(*traits.iter().next().unwrap()) {
-                TraitCandidateCheck::Confirmed(cand) => Ok(MethodCandidate::TraitMethod(cand)),
-                TraitCandidateCheck::NeedsConfirmation(cand)
-                | TraitCandidateCheck::Unsatisfied(cand) => {
-                    Ok(MethodCandidate::NeedsConfirmation(cand))
+        // For a fully-known receiver, drop trait candidates whose impl is
+        // provably inapplicable: either the self type cannot unify
+        // (`Rejected`) or the impl's `where`-clause is unsatisfiable
+        // (`Unsatisfied`). Otherwise a blanket `impl<T: Marker> Trait for T`
+        // that cannot apply to this receiver would still count as a competing
+        // candidate below and could, for instance, turn an otherwise
+        // unambiguous `concrete.method()` call into a spurious "import the
+        // trait" error (the single-candidate path resolves without requiring
+        // the trait to be in scope, but a second, inapplicable candidate
+        // defeats it).
+        //
+        // With an inference-variable receiver we cannot prove inapplicability
+        // yet, so everything is kept (matching the prior behavior). If pruning
+        // would remove every candidate, the originals are kept so the
+        // unsatisfied-bound diagnostics below still fire instead of reporting
+        // "not found".
+        //
+        // Each candidate is checked exactly once here and the result is carried
+        // through pruning and selection, so the trait solver isn't re-run for
+        // the same candidate.
+        let checked: Vec<(AssembledTraitMethodCand<'db>, TraitCandidateCheck<'db>)> = self
+            .candidates
+            .traits
+            .iter()
+            .copied()
+            .map(|cand| (cand, self.check_trait_cand(cand)))
+            .collect();
+        let checked: Vec<(AssembledTraitMethodCand<'db>, TraitCandidateCheck<'db>)> =
+            if checked.len() > 1 && !self.receiver.original().has_var(self.db) {
+                let applicable: Vec<_> = checked
+                    .iter()
+                    .copied()
+                    .filter(|(_, check)| {
+                        !matches!(
+                            check,
+                            TraitCandidateCheck::Rejected | TraitCandidateCheck::Unsatisfied(_)
+                        )
+                    })
+                    .collect();
+                if applicable.is_empty() {
+                    checked
+                } else {
+                    applicable
                 }
-                TraitCandidateCheck::Rejected => Err(MethodSelectionError::NotFound),
+            } else {
+                checked
             };
+
+        if checked.len() == 1 {
+            return Self::finalize_sole_check(checked[0].1);
         }
 
         let available_traits = self.available_traits();
-        let visible_traits: Vec<_> = traits
+        let visible: Vec<_> = checked
             .iter()
             .copied()
-            .filter(|cand| available_traits.contains(&cand.trait_def(self.db)))
+            .filter(|(cand, _)| available_traits.contains(&cand.trait_def(self.db)))
             .collect();
 
-        match visible_traits.len() {
+        match visible.len() {
             0 => {
-                if traits.is_empty() {
+                if checked.is_empty() {
                     Err(MethodSelectionError::NotFound)
                 } else {
                     // Suggests trait imports.
-                    let traits = traits.iter().map(|cand| cand.trait_def(self.db)).collect();
+                    let traits = checked
+                        .iter()
+                        .map(|(cand, _)| cand.trait_def(self.db))
+                        .collect();
                     Err(MethodSelectionError::InvisibleTraitMethod(traits))
                 }
             }
 
-            1 => match self.check_trait_cand(visible_traits[0]) {
-                TraitCandidateCheck::Confirmed(cand) => Ok(MethodCandidate::TraitMethod(cand)),
-                TraitCandidateCheck::NeedsConfirmation(cand)
-                | TraitCandidateCheck::Unsatisfied(cand) => {
-                    Ok(MethodCandidate::NeedsConfirmation(cand))
-                }
-                TraitCandidateCheck::Rejected => Err(MethodSelectionError::NotFound),
-            },
+            1 => Self::finalize_sole_check(visible[0].1),
 
             _ => {
                 // Some candidates are equivalent after trait solving (e.g., an explicit
@@ -392,8 +428,8 @@ impl<'db, 'a> MethodSelector<'db, 'a> {
                 // constraints can disambiguate them.
                 let mut selected = IndexMap::default();
                 let mut unsatisfied = IndexSet::default();
-                for cand in visible_traits.iter().copied() {
-                    match self.check_trait_cand(cand) {
+                for (_, check) in visible.iter().copied() {
+                    match check {
                         TraitCandidateCheck::Confirmed(cand) => {
                             selected
                                 .entry(cand)
@@ -417,9 +453,9 @@ impl<'db, 'a> MethodSelector<'db, 'a> {
                         ));
                     }
                     if !unsatisfied.is_empty() {
-                        let diagnostic_traits = visible_traits
+                        let diagnostic_traits = visible
                             .iter()
-                            .map(|cand| cand.diagnostic_inst(self.db))
+                            .map(|(cand, _)| cand.diagnostic_inst(self.db))
                             .collect();
                         let candidates = unsatisfied
                             .into_iter()
@@ -461,9 +497,9 @@ impl<'db, 'a> MethodSelector<'db, 'a> {
                     return Ok(MethodCandidate::TraitMethod(confirmed[0]));
                 }
 
-                let diagnostic_traits = visible_traits
+                let diagnostic_traits = visible
                     .iter()
-                    .map(|cand| cand.diagnostic_inst(self.db))
+                    .map(|(cand, _)| cand.diagnostic_inst(self.db))
                     .collect();
                 let candidates = selected
                     .into_iter()
@@ -479,6 +515,23 @@ impl<'db, 'a> MethodSelector<'db, 'a> {
                     },
                 ))
             }
+        }
+    }
+
+    /// Resolves the outcome when a single trait candidate remains (the only
+    /// assembled candidate, or the only visible one). An unsatisfiable
+    /// candidate is still surfaced as `NeedsConfirmation` so the unmet bound is
+    /// reported downstream rather than as a bare "method not found".
+    fn finalize_sole_check(
+        check: TraitCandidateCheck<'db>,
+    ) -> Result<MethodCandidate<'db>, MethodSelectionError<'db>> {
+        match check {
+            TraitCandidateCheck::Confirmed(cand) => Ok(MethodCandidate::TraitMethod(cand)),
+            TraitCandidateCheck::NeedsConfirmation(cand)
+            | TraitCandidateCheck::Unsatisfied(cand) => {
+                Ok(MethodCandidate::NeedsConfirmation(cand))
+            }
+            TraitCandidateCheck::Rejected => Err(MethodSelectionError::NotFound),
         }
     }
 

--- a/crates/hir/src/analysis/name_resolution/method_selection.rs
+++ b/crates/hir/src/analysis/name_resolution/method_selection.rs
@@ -607,7 +607,16 @@ impl<'db, 'a> MethodSelector<'db, 'a> {
             let constraint = constraint.fold_with(self.db, &mut table);
             let query = CanonicalGoalQuery::new(self.db, constraint, self.assumptions);
             match is_goal_query_satisfiable(self.db, solve_cx, &query) {
-                GoalSatisfiability::Satisfied(_) => {}
+                GoalSatisfiability::Satisfied(solution) => {
+                    // A unique solution can bind impl parameters that the self
+                    // type doesn't determine (e.g. a trait argument fixed only
+                    // by this bound). Unify it back into the table so the trait
+                    // instance built below reflects those bindings instead of
+                    // leaving them as unconstrained inference variables (which
+                    // would drop the bound from the inferred method signature).
+                    let solved = query.extract_solution(&mut table, solution).inst;
+                    let _ = table.unify(constraint, solved);
+                }
                 GoalSatisfiability::NeedsConfirmation(_) | GoalSatisfiability::ContainsInvalid => {
                     needs_confirmation = true;
                 }

--- a/crates/hir/src/analysis/name_resolution/method_selection.rs
+++ b/crates/hir/src/analysis/name_resolution/method_selection.rs
@@ -1,6 +1,6 @@
 use crate::core::hir_def::{IdentId, Trait, scope_graph::ScopeId};
 use common::indexmap::{IndexMap, IndexSet};
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashSet;
 use thin_vec::ThinVec;
 
 use crate::analysis::{
@@ -9,8 +9,8 @@ use crate::analysis::{
     ty::{
         binder::Binder,
         canonical::{Canonical, Canonicalized, Solution},
+        fold::TyFoldable as _,
         method_table::{ProbedMethod, probe_method},
-        fold::{TyFoldable as _, TyFolder},
         trait_def::{ImplementorId, TraitInstId, impls_for_ty},
         trait_resolution::{
             CanonicalGoalQuery, GoalSatisfiability, PredicateListId, TraitSolveCx,
@@ -56,6 +56,38 @@ impl<'db> TraitMethodCand<'db> {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum AssembledTraitMethodCand<'db> {
+    Impl {
+        implementor: Binder<ImplementorId<'db>>,
+        method: Func<'db>,
+    },
+    Assumption {
+        inst: TraitInstId<'db>,
+        method: Func<'db>,
+    },
+}
+
+impl<'db> AssembledTraitMethodCand<'db> {
+    fn trait_def(self, db: &'db dyn HirAnalysisDb) -> Trait<'db> {
+        match self {
+            AssembledTraitMethodCand::Impl { implementor, .. } => {
+                implementor.skip_binder().trait_def(db)
+            }
+            AssembledTraitMethodCand::Assumption { inst, .. } => inst.def(db),
+        }
+    }
+
+    fn diagnostic_inst(self, db: &'db dyn HirAnalysisDb) -> TraitInstId<'db> {
+        match self {
+            AssembledTraitMethodCand::Impl { implementor, .. } => {
+                implementor.skip_binder().trait_(db)
+            }
+            AssembledTraitMethodCand::Assumption { inst, .. } => inst,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, salsa::Update)]
 pub struct AmbiguousTraitMethodCand<'db> {
     pub cand: TraitMethodCand<'db>,
@@ -66,6 +98,13 @@ pub struct AmbiguousTraitMethodCand<'db> {
 pub struct AmbiguousTraitMethods<'db> {
     pub candidates: ThinVec<AmbiguousTraitMethodCand<'db>>,
     pub diagnostic_traits: ThinVec<TraitInstId<'db>>,
+}
+
+enum TraitCandidateCheck<'db> {
+    Confirmed(TraitMethodCand<'db>),
+    NeedsConfirmation(TraitMethodCand<'db>),
+    Unsatisfied(TraitMethodCand<'db>),
+    Rejected,
 }
 
 pub(crate) fn select_method_candidate<'db>(
@@ -178,9 +217,7 @@ impl<'db, 'a> CandidateAssembler<'db, 'a> {
             ];
             for ingot in search_ingots.into_iter().flatten() {
                 for &imp in impls_for_ty(self.db, ingot, self.receiver.canonical()) {
-                    if let Some(inst) = self.impl_trait_inst_for_receiver(imp) {
-                        self.insert_trait_method_cand(inst);
-                    }
+                    self.insert_impl_trait_method_cand(imp);
                 }
             }
         }
@@ -215,13 +252,18 @@ impl<'db, 'a> CandidateAssembler<'db, 'a> {
         self.trait_.map(|t| t == trait_def).unwrap_or(true)
     }
 
-    fn insert_trait_method_cand(&mut self, inst: TraitInstId<'db>) {
-        let trait_def = inst.def(self.db);
+    fn insert_impl_trait_method_cand(&mut self, implementor: Binder<ImplementorId<'db>>) {
+        let trait_def = implementor.skip_binder().trait_def(self.db);
         if !self.allow_trait(trait_def) {
             return;
         }
         if let Some(&trait_method) = trait_def.method_defs(self.db).get(&self.method_name) {
-            self.candidates.traits.insert((inst, trait_method));
+            self.candidates
+                .traits
+                .insert(AssembledTraitMethodCand::Impl {
+                    implementor,
+                    method: trait_method,
+                });
         }
     }
 
@@ -230,58 +272,13 @@ impl<'db, 'a> CandidateAssembler<'db, 'a> {
         if self.allow_trait(trait_def)
             && let Some(&trait_method) = trait_def.method_defs(self.db).get(&self.method_name)
         {
-            self.candidates.traits.insert((inst, trait_method));
             self.candidates
-                .assumption_traits
-                .insert((inst, trait_method));
+                .traits
+                .insert(AssembledTraitMethodCand::Assumption {
+                    inst,
+                    method: trait_method,
+                });
         }
-    }
-
-    fn impl_trait_inst_for_receiver(
-        &self,
-        implementor: Binder<ImplementorId<'db>>,
-    ) -> Option<TraitInstId<'db>> {
-        let mut table = UnificationTable::new(self.db);
-        let original = implementor.skip_binder();
-        let receiver_ty = self.receiver.canonical().extract_identity(&mut table);
-        let implementor = table.instantiate_with_fresh_vars(implementor);
-        let impl_ty = table.instantiate_to_term(implementor.self_ty(self.db));
-        let receiver_ty = table.instantiate_to_term(receiver_ty);
-        table.unify(impl_ty, receiver_ty).ok()?;
-
-        let mut param_subst = FxHashMap::default();
-        for (&original_param, &instantiated_param) in original
-            .params(self.db)
-            .iter()
-            .zip(implementor.params(self.db).iter())
-        {
-            let resolved = instantiated_param.fold_with(self.db, &mut table);
-            let resolved = if resolved.has_var(self.db) {
-                original_param
-            } else {
-                resolved
-            };
-            param_subst.insert(original_param, resolved);
-        }
-
-        struct ParamSubst<'db> {
-            map: FxHashMap<TyId<'db>, TyId<'db>>,
-        }
-
-        impl<'db> TyFolder<'db> for ParamSubst<'db> {
-            fn fold_ty(&mut self, db: &'db dyn HirAnalysisDb, ty: TyId<'db>) -> TyId<'db> {
-                self.map
-                    .get(&ty)
-                    .copied()
-                    .unwrap_or_else(|| ty.super_fold_with(db, self))
-            }
-        }
-
-        Some(
-            original
-                .trait_(self.db)
-                .fold_with(self.db, &mut ParamSubst { map: param_subst }),
-        )
     }
 }
 
@@ -351,15 +348,21 @@ impl<'db, 'a> MethodSelector<'db, 'a> {
         let traits = &self.candidates.traits;
 
         if traits.len() == 1 {
-            let (inst, method) = traits.iter().next().unwrap();
-            return Ok(self.check_inst(*inst, *method));
+            return match self.check_trait_cand(*traits.iter().next().unwrap()) {
+                TraitCandidateCheck::Confirmed(cand) => Ok(MethodCandidate::TraitMethod(cand)),
+                TraitCandidateCheck::NeedsConfirmation(cand)
+                | TraitCandidateCheck::Unsatisfied(cand) => {
+                    Ok(MethodCandidate::NeedsConfirmation(cand))
+                }
+                TraitCandidateCheck::Rejected => Err(MethodSelectionError::NotFound),
+            };
         }
 
         let available_traits = self.available_traits();
         let visible_traits: Vec<_> = traits
             .iter()
             .copied()
-            .filter(|(inst, _method)| available_traits.contains(&inst.def(self.db)))
+            .filter(|cand| available_traits.contains(&cand.trait_def(self.db)))
             .collect();
 
         match visible_traits.len() {
@@ -368,15 +371,19 @@ impl<'db, 'a> MethodSelector<'db, 'a> {
                     Err(MethodSelectionError::NotFound)
                 } else {
                     // Suggests trait imports.
-                    let traits = traits.iter().map(|(inst, _)| inst.def(self.db)).collect();
+                    let traits = traits.iter().map(|cand| cand.trait_def(self.db)).collect();
                     Err(MethodSelectionError::InvisibleTraitMethod(traits))
                 }
             }
 
-            1 => {
-                let (def, method) = visible_traits[0];
-                Ok(self.check_inst(def, method))
-            }
+            1 => match self.check_trait_cand(visible_traits[0]) {
+                TraitCandidateCheck::Confirmed(cand) => Ok(MethodCandidate::TraitMethod(cand)),
+                TraitCandidateCheck::NeedsConfirmation(cand)
+                | TraitCandidateCheck::Unsatisfied(cand) => {
+                    Ok(MethodCandidate::NeedsConfirmation(cand))
+                }
+                TraitCandidateCheck::Rejected => Err(MethodSelectionError::NotFound),
+            },
 
             _ => {
                 // Some candidates are equivalent after trait solving (e.g., an explicit
@@ -384,40 +391,56 @@ impl<'db, 'a> MethodSelector<'db, 'a> {
                 // must still treat distinct methods as ambiguous so later return-type
                 // constraints can disambiguate them.
                 let mut selected = IndexMap::default();
-                for (inst, method) in visible_traits.iter().copied() {
-                    let from_assumption =
-                        self.candidates.assumption_traits.contains(&(inst, method));
-                    match self.check_inst(inst, method) {
-                        MethodCandidate::TraitMethod(cand) => {
+                let mut unsatisfied = IndexSet::default();
+                for cand in visible_traits.iter().copied() {
+                    match self.check_trait_cand(cand) {
+                        TraitCandidateCheck::Confirmed(cand) => {
                             selected
                                 .entry(cand)
-                                .and_modify(|origin: &mut SelectedTraitMethodOrigin| {
-                                    origin.confirmed = true;
-                                    origin.from_assumption |= from_assumption;
-                                })
-                                .or_insert(SelectedTraitMethodOrigin {
-                                    confirmed: true,
-                                    from_assumption,
-                                });
+                                .and_modify(|confirmed| *confirmed = true)
+                                .or_insert(true);
                         }
-                        MethodCandidate::NeedsConfirmation(cand) => {
-                            selected
-                                .entry(cand)
-                                .and_modify(|origin: &mut SelectedTraitMethodOrigin| {
-                                    origin.from_assumption |= from_assumption;
-                                })
-                                .or_insert(SelectedTraitMethodOrigin {
-                                    confirmed: false,
-                                    from_assumption,
-                                });
+                        TraitCandidateCheck::NeedsConfirmation(cand) => {
+                            selected.entry(cand).or_insert(false);
                         }
-                        MethodCandidate::InherentMethod(_) => unreachable!(),
+                        TraitCandidateCheck::Unsatisfied(cand) => {
+                            unsatisfied.insert(cand);
+                        }
+                        TraitCandidateCheck::Rejected => {}
                     }
                 }
 
+                if selected.is_empty() {
+                    if unsatisfied.len() == 1 {
+                        return Ok(MethodCandidate::NeedsConfirmation(
+                            *unsatisfied.iter().next().unwrap(),
+                        ));
+                    }
+                    if !unsatisfied.is_empty() {
+                        let diagnostic_traits = visible_traits
+                            .iter()
+                            .map(|cand| cand.diagnostic_inst(self.db))
+                            .collect();
+                        let candidates = unsatisfied
+                            .into_iter()
+                            .map(|cand| AmbiguousTraitMethodCand {
+                                cand,
+                                needs_confirmation: true,
+                            })
+                            .collect();
+                        return Err(MethodSelectionError::AmbiguousTraitMethod(
+                            AmbiguousTraitMethods {
+                                candidates,
+                                diagnostic_traits,
+                            },
+                        ));
+                    }
+                    return Err(MethodSelectionError::NotFound);
+                }
+
                 if selected.len() == 1 {
-                    let (cand, origin) = selected.into_iter().next().unwrap();
-                    return Ok(if origin.confirmed {
+                    let (cand, confirmed) = selected.into_iter().next().unwrap();
+                    return Ok(if confirmed {
                         MethodCandidate::TraitMethod(cand)
                     } else {
                         MethodCandidate::NeedsConfirmation(cand)
@@ -426,29 +449,27 @@ impl<'db, 'a> MethodSelector<'db, 'a> {
 
                 let confirmed: Vec<_> = selected
                     .iter()
-                    .filter_map(|(&cand, origin)| origin.confirmed.then_some(cand))
+                    .filter_map(|(&cand, &confirmed)| confirmed.then_some(cand))
                     .collect();
                 if confirmed.len() == 1
                     && (self.receiver.original().has_var(self.db)
                         || selected
                             .iter()
-                            .filter_map(|(&cand, origin)| {
-                                (!origin.confirmed).then_some((cand, origin))
-                            })
-                            .all(|(cand, origin)| {
-                                (!origin.from_assumption && self.candidate_is_unsatisfied(cand))
-                                    || self.candidate_specializes_to(cand, confirmed[0])
-                            }))
+                            .filter_map(|(&cand, &confirmed)| (!confirmed).then_some(cand))
+                            .all(|cand| self.candidate_specializes_to(cand, confirmed[0])))
                 {
                     return Ok(MethodCandidate::TraitMethod(confirmed[0]));
                 }
 
-                let diagnostic_traits = visible_traits.iter().map(|cand| cand.0).collect();
+                let diagnostic_traits = visible_traits
+                    .iter()
+                    .map(|cand| cand.diagnostic_inst(self.db))
+                    .collect();
                 let candidates = selected
                     .into_iter()
-                    .map(|(cand, origin)| AmbiguousTraitMethodCand {
+                    .map(|(cand, confirmed)| AmbiguousTraitMethodCand {
                         cand,
-                        needs_confirmation: !origin.confirmed,
+                        needs_confirmation: !confirmed,
                     })
                     .collect();
                 Err(MethodSelectionError::AmbiguousTraitMethod(
@@ -494,15 +515,71 @@ impl<'db, 'a> MethodSelector<'db, 'a> {
         }
     }
 
-    fn candidate_is_unsatisfied(&self, candidate: TraitMethodCand<'db>) -> bool {
+    fn check_trait_cand(&self, cand: AssembledTraitMethodCand<'db>) -> TraitCandidateCheck<'db> {
+        match cand {
+            AssembledTraitMethodCand::Impl {
+                implementor,
+                method,
+            } => self.check_impl_cand(implementor, method),
+            AssembledTraitMethodCand::Assumption { inst, method } => {
+                match self.check_inst(inst, method) {
+                    MethodCandidate::TraitMethod(cand) => TraitCandidateCheck::Confirmed(cand),
+                    MethodCandidate::NeedsConfirmation(cand) => {
+                        TraitCandidateCheck::NeedsConfirmation(cand)
+                    }
+                    MethodCandidate::InherentMethod(_) => unreachable!(),
+                }
+            }
+        }
+    }
+
+    fn check_impl_cand(
+        &self,
+        implementor: Binder<ImplementorId<'db>>,
+        method: Func<'db>,
+    ) -> TraitCandidateCheck<'db> {
         let mut table = UnificationTable::new(self.db);
-        let candidate_inst = self.receiver.extract_solution(&mut table, candidate.inst);
+        let receiver_ty = self.receiver.canonical().extract_identity(&mut table);
+        let implementor = table.instantiate_with_fresh_vars(implementor);
+        let impl_ty = table.instantiate_to_term(implementor.self_ty(self.db));
+        let receiver_ty = table.instantiate_to_term(receiver_ty);
+        if table.unify(impl_ty, receiver_ty).is_err() {
+            return TraitCandidateCheck::Rejected;
+        }
+
         let solve_cx = TraitSolveCx::new(self.db, self.scope).with_assumptions(self.assumptions);
-        let query = CanonicalGoalQuery::new(self.db, candidate_inst, self.assumptions);
-        matches!(
-            is_goal_query_satisfiable(self.db, solve_cx, &query),
-            GoalSatisfiability::UnSat(_)
-        )
+        let mut needs_confirmation = false;
+        let mut unsatisfied = false;
+        for &constraint in implementor.constraints(self.db).list(self.db) {
+            let constraint = constraint.fold_with(self.db, &mut table);
+            let query = CanonicalGoalQuery::new(self.db, constraint, self.assumptions);
+            match is_goal_query_satisfiable(self.db, solve_cx, &query) {
+                GoalSatisfiability::Satisfied(_) => {}
+                GoalSatisfiability::NeedsConfirmation(_) | GoalSatisfiability::ContainsInvalid => {
+                    needs_confirmation = true;
+                }
+                GoalSatisfiability::UnSat(_) => {
+                    unsatisfied = true;
+                    break;
+                }
+            }
+        }
+
+        let inst = implementor
+            .trait_inst(self.db)
+            .fold_with(self.db, &mut table);
+        let cand = TraitMethodCand::new(
+            self.receiver
+                .canonicalize_solution(self.db, &mut table, inst),
+            method,
+        );
+        if unsatisfied {
+            TraitCandidateCheck::Unsatisfied(cand)
+        } else if needs_confirmation {
+            TraitCandidateCheck::NeedsConfirmation(cand)
+        } else {
+            TraitCandidateCheck::Confirmed(cand)
+        }
     }
 
     /// Finds an instance of a trait method for the given trait definition and
@@ -611,20 +688,13 @@ pub enum MethodSelectionError<'db> {
 #[derive(Default)]
 struct AssembledCandidates<'db> {
     inherent_methods: FxHashSet<ProbedMethod<'db>>,
-    traits: IndexSet<(TraitInstId<'db>, Func<'db>)>,
-    assumption_traits: FxHashSet<(TraitInstId<'db>, Func<'db>)>,
+    traits: IndexSet<AssembledTraitMethodCand<'db>>,
 }
 
 impl<'db> AssembledCandidates<'db> {
     fn insert_inherent_method(&mut self, method: ProbedMethod<'db>) {
         self.inherent_methods.insert(method);
     }
-}
-
-#[derive(Clone, Copy, Default)]
-struct SelectedTraitMethodOrigin {
-    confirmed: bool,
-    from_assumption: bool,
 }
 
 #[cfg(test)]

--- a/crates/hir/src/analysis/name_resolution/method_selection.rs
+++ b/crates/hir/src/analysis/name_resolution/method_selection.rs
@@ -1,6 +1,6 @@
 use crate::core::hir_def::{IdentId, Trait, scope_graph::ScopeId};
 use common::indexmap::{IndexMap, IndexSet};
-use rustc_hash::FxHashSet;
+use rustc_hash::{FxHashMap, FxHashSet};
 use thin_vec::ThinVec;
 
 use crate::analysis::{
@@ -10,7 +10,8 @@ use crate::analysis::{
         binder::Binder,
         canonical::{Canonical, Canonicalized, Solution},
         method_table::{ProbedMethod, probe_method},
-        trait_def::{TraitInstId, impls_for_ty},
+        fold::{TyFoldable as _, TyFolder},
+        trait_def::{ImplementorId, TraitInstId, impls_for_ty},
         trait_resolution::{
             CanonicalGoalQuery, GoalSatisfiability, PredicateListId, TraitSolveCx,
             is_goal_query_satisfiable,
@@ -177,7 +178,9 @@ impl<'db, 'a> CandidateAssembler<'db, 'a> {
             ];
             for ingot in search_ingots.into_iter().flatten() {
                 for &imp in impls_for_ty(self.db, ingot, self.receiver.canonical()) {
-                    self.insert_trait_method_cand(imp.skip_binder().trait_(self.db));
+                    if let Some(inst) = self.impl_trait_inst_for_receiver(imp) {
+                        self.insert_trait_method_cand(inst);
+                    }
                 }
             }
         }
@@ -196,10 +199,10 @@ impl<'db, 'a> CandidateAssembler<'db, 'a> {
                 };
 
                 if cx.unify::<TyId<'db>>(receiver, self_ty).is_ok() {
-                    self.insert_trait_method_cand(pred);
+                    self.insert_assumption_trait_method_cand(pred);
                     for super_trait in pred.def(self.db).super_traits(self.db) {
                         let super_trait = super_trait.instantiate(self.db, pred.args(self.db));
-                        self.insert_trait_method_cand(super_trait);
+                        self.insert_assumption_trait_method_cand(super_trait);
                     }
                 }
 
@@ -220,6 +223,65 @@ impl<'db, 'a> CandidateAssembler<'db, 'a> {
         if let Some(&trait_method) = trait_def.method_defs(self.db).get(&self.method_name) {
             self.candidates.traits.insert((inst, trait_method));
         }
+    }
+
+    fn insert_assumption_trait_method_cand(&mut self, inst: TraitInstId<'db>) {
+        let trait_def = inst.def(self.db);
+        if self.allow_trait(trait_def)
+            && let Some(&trait_method) = trait_def.method_defs(self.db).get(&self.method_name)
+        {
+            self.candidates.traits.insert((inst, trait_method));
+            self.candidates
+                .assumption_traits
+                .insert((inst, trait_method));
+        }
+    }
+
+    fn impl_trait_inst_for_receiver(
+        &self,
+        implementor: Binder<ImplementorId<'db>>,
+    ) -> Option<TraitInstId<'db>> {
+        let mut table = UnificationTable::new(self.db);
+        let original = implementor.skip_binder();
+        let receiver_ty = self.receiver.canonical().extract_identity(&mut table);
+        let implementor = table.instantiate_with_fresh_vars(implementor);
+        let impl_ty = table.instantiate_to_term(implementor.self_ty(self.db));
+        let receiver_ty = table.instantiate_to_term(receiver_ty);
+        table.unify(impl_ty, receiver_ty).ok()?;
+
+        let mut param_subst = FxHashMap::default();
+        for (&original_param, &instantiated_param) in original
+            .params(self.db)
+            .iter()
+            .zip(implementor.params(self.db).iter())
+        {
+            let resolved = instantiated_param.fold_with(self.db, &mut table);
+            let resolved = if resolved.has_var(self.db) {
+                original_param
+            } else {
+                resolved
+            };
+            param_subst.insert(original_param, resolved);
+        }
+
+        struct ParamSubst<'db> {
+            map: FxHashMap<TyId<'db>, TyId<'db>>,
+        }
+
+        impl<'db> TyFolder<'db> for ParamSubst<'db> {
+            fn fold_ty(&mut self, db: &'db dyn HirAnalysisDb, ty: TyId<'db>) -> TyId<'db> {
+                self.map
+                    .get(&ty)
+                    .copied()
+                    .unwrap_or_else(|| ty.super_fold_with(db, self))
+            }
+        }
+
+        Some(
+            original
+                .trait_(self.db)
+                .fold_with(self.db, &mut ParamSubst { map: param_subst }),
+        )
     }
 }
 
@@ -323,20 +385,39 @@ impl<'db, 'a> MethodSelector<'db, 'a> {
                 // constraints can disambiguate them.
                 let mut selected = IndexMap::default();
                 for (inst, method) in visible_traits.iter().copied() {
+                    let from_assumption =
+                        self.candidates.assumption_traits.contains(&(inst, method));
                     match self.check_inst(inst, method) {
                         MethodCandidate::TraitMethod(cand) => {
-                            selected.insert(cand, true);
+                            selected
+                                .entry(cand)
+                                .and_modify(|origin: &mut SelectedTraitMethodOrigin| {
+                                    origin.confirmed = true;
+                                    origin.from_assumption |= from_assumption;
+                                })
+                                .or_insert(SelectedTraitMethodOrigin {
+                                    confirmed: true,
+                                    from_assumption,
+                                });
                         }
                         MethodCandidate::NeedsConfirmation(cand) => {
-                            selected.entry(cand).or_insert(false);
+                            selected
+                                .entry(cand)
+                                .and_modify(|origin: &mut SelectedTraitMethodOrigin| {
+                                    origin.from_assumption |= from_assumption;
+                                })
+                                .or_insert(SelectedTraitMethodOrigin {
+                                    confirmed: false,
+                                    from_assumption,
+                                });
                         }
                         MethodCandidate::InherentMethod(_) => unreachable!(),
                     }
                 }
 
                 if selected.len() == 1 {
-                    let (cand, confirmed) = selected.into_iter().next().unwrap();
-                    return Ok(if confirmed {
+                    let (cand, origin) = selected.into_iter().next().unwrap();
+                    return Ok(if origin.confirmed {
                         MethodCandidate::TraitMethod(cand)
                     } else {
                         MethodCandidate::NeedsConfirmation(cand)
@@ -345,14 +426,19 @@ impl<'db, 'a> MethodSelector<'db, 'a> {
 
                 let confirmed: Vec<_> = selected
                     .iter()
-                    .filter_map(|(&cand, &is_confirmed)| is_confirmed.then_some(cand))
+                    .filter_map(|(&cand, origin)| origin.confirmed.then_some(cand))
                     .collect();
                 if confirmed.len() == 1
                     && (self.receiver.original().has_var(self.db)
                         || selected
                             .iter()
-                            .filter_map(|(&cand, &is_confirmed)| (!is_confirmed).then_some(cand))
-                            .all(|cand| self.candidate_specializes_to(cand, confirmed[0])))
+                            .filter_map(|(&cand, origin)| {
+                                (!origin.confirmed).then_some((cand, origin))
+                            })
+                            .all(|(cand, origin)| {
+                                (!origin.from_assumption && self.candidate_is_unsatisfied(cand))
+                                    || self.candidate_specializes_to(cand, confirmed[0])
+                            }))
                 {
                     return Ok(MethodCandidate::TraitMethod(confirmed[0]));
                 }
@@ -360,9 +446,9 @@ impl<'db, 'a> MethodSelector<'db, 'a> {
                 let diagnostic_traits = visible_traits.iter().map(|cand| cand.0).collect();
                 let candidates = selected
                     .into_iter()
-                    .map(|(cand, confirmed)| AmbiguousTraitMethodCand {
+                    .map(|(cand, origin)| AmbiguousTraitMethodCand {
                         cand,
-                        needs_confirmation: !confirmed,
+                        needs_confirmation: !origin.confirmed,
                     })
                     .collect();
                 Err(MethodSelectionError::AmbiguousTraitMethod(
@@ -406,6 +492,17 @@ impl<'db, 'a> MethodSelector<'db, 'a> {
             }
             GoalSatisfiability::ContainsInvalid | GoalSatisfiability::UnSat(_) => false,
         }
+    }
+
+    fn candidate_is_unsatisfied(&self, candidate: TraitMethodCand<'db>) -> bool {
+        let mut table = UnificationTable::new(self.db);
+        let candidate_inst = self.receiver.extract_solution(&mut table, candidate.inst);
+        let solve_cx = TraitSolveCx::new(self.db, self.scope).with_assumptions(self.assumptions);
+        let query = CanonicalGoalQuery::new(self.db, candidate_inst, self.assumptions);
+        matches!(
+            is_goal_query_satisfiable(self.db, solve_cx, &query),
+            GoalSatisfiability::UnSat(_)
+        )
     }
 
     /// Finds an instance of a trait method for the given trait definition and
@@ -515,12 +612,19 @@ pub enum MethodSelectionError<'db> {
 struct AssembledCandidates<'db> {
     inherent_methods: FxHashSet<ProbedMethod<'db>>,
     traits: IndexSet<(TraitInstId<'db>, Func<'db>)>,
+    assumption_traits: FxHashSet<(TraitInstId<'db>, Func<'db>)>,
 }
 
 impl<'db> AssembledCandidates<'db> {
     fn insert_inherent_method(&mut self, method: ProbedMethod<'db>) {
         self.inherent_methods.insert(method);
     }
+}
+
+#[derive(Clone, Copy, Default)]
+struct SelectedTraitMethodOrigin {
+    confirmed: bool,
+    from_assumption: bool,
 }
 
 #[cfg(test)]

--- a/crates/hir/src/analysis/name_resolution/path_resolver.rs
+++ b/crates/hir/src/analysis/name_resolution/path_resolver.rs
@@ -34,7 +34,7 @@ use crate::analysis::{
         layout_holes::layout_hole_with_fallback_ty,
         method_table::probe_method,
         normalize::normalize_ty,
-        trait_def::{TraitInstId, impls_for_ty_with_constraints},
+        trait_def::{TraitInstId, impls_for_ty_with_satisfied_constraints},
         trait_lower::{TraitArgError, TraitRefLowerError, lower_trait_ref, lower_trait_ref_impl},
         trait_resolution::{
             GoalSatisfiability, PredicateListId, TraitSolveCx, constraint::collect_constraints,
@@ -1498,7 +1498,9 @@ fn select_assoc_const_candidate<'db>(
 
     let mut matches: IndexSet<TraitInstId<'db>> = IndexSet::default();
     for ingot in search_ingots.into_iter().flatten() {
-        for cand in impls_for_ty_with_constraints(db, ingot, canonical_receiver, assumptions) {
+        for cand in
+            impls_for_ty_with_satisfied_constraints(db, ingot, canonical_receiver, assumptions)
+        {
             let inst = cand.skip_binder().trait_(db);
             let trait_ = inst.def(db);
             if trait_.const_(db, name).is_some() {
@@ -1594,17 +1596,21 @@ pub(crate) fn find_associated_type<'db>(
 
         // Search both the call-site ingot and the receiver's ingot so local
         // traits on external types and external traits on local types are both visible.
-        for ingot in search_ingots.into_iter().flatten() {
-            for impl_ in impls_for_ty_with_constraints(db, ingot, canonical_ty, assumptions) {
-                if let Some(Some((inst, assoc_ty))) =
-                    cx.with_impl_assoc_ty(impl_, lhs_ty, name, |cx, inst, assoc_ty| {
-                        Some((
-                            cx.try_extract::<TraitInstId<'db>>(inst)?,
-                            cx.try_extract::<TyId<'db>>(assoc_ty)?,
-                        ))
-                    })
+        if !matches!(original_ty.data(db), TyData::TyParam(_)) {
+            for ingot in search_ingots.into_iter().flatten() {
+                for impl_ in
+                    impls_for_ty_with_satisfied_constraints(db, ingot, canonical_ty, assumptions)
                 {
-                    candidates.push((inst, assoc_ty));
+                    if let Some(Some((inst, assoc_ty))) =
+                        cx.with_impl_assoc_ty(impl_, lhs_ty, name, |cx, inst, assoc_ty| {
+                            Some((
+                                cx.try_extract::<TraitInstId<'db>>(inst)?,
+                                cx.try_extract::<TyId<'db>>(assoc_ty)?,
+                            ))
+                        })
+                    {
+                        candidates.push((inst, assoc_ty));
+                    }
                 }
             }
         }

--- a/crates/hir/src/analysis/ty/fold.rs
+++ b/crates/hir/src/analysis/ty/fold.rs
@@ -557,7 +557,9 @@ impl<'db> TyFolder<'db> for AssocTySubst<'db> {
                 let folded_trait = assoc_ty.trait_.fold_with(db, self);
 
                 // Check if this associated type belongs to our trait instance
-                if assoc_ty.trait_.def(db) == self.trait_inst.def(db) {
+                if folded_trait.def(db) == self.trait_inst.def(db)
+                    && folded_trait.args(db) == self.trait_inst.args(db)
+                {
                     // Check if we have a binding for this associated type
                     if let Some(&bound_ty) =
                         self.trait_inst.assoc_type_bindings(db).get(&assoc_ty.name)

--- a/crates/hir/src/analysis/ty/normalize.rs
+++ b/crates/hir/src/analysis/ty/normalize.rs
@@ -14,7 +14,7 @@ use super::{
     canonical::Canonical,
     canonical::Canonicalized,
     fold::{TyFoldable, TyFolder},
-    trait_def::{TraitInstId, impls_for_ty_with_constraints},
+    trait_def::{TraitInstId, impls_for_ty_with_possible_constraints},
     trait_resolution::{PredicateListId, TraitSolveCx},
     ty_def::{AssocTy, TyData, TyId, TyParam},
     visitor::{TyVisitable, TyVisitor},
@@ -252,7 +252,7 @@ impl<'db> TypeNormalizer<'db> {
         canonical_target.with_materialized(self.db, |cx| {
             let target_inst = cx.query();
             for ingot in search_ingots.into_iter().flatten() {
-                for implementor in impls_for_ty_with_constraints(
+                for implementor in impls_for_ty_with_possible_constraints(
                     self.db,
                     ingot,
                     canonical_self_ty,

--- a/crates/hir/src/analysis/ty/trait_def.rs
+++ b/crates/hir/src/analysis/ty/trait_def.rs
@@ -234,12 +234,32 @@ pub fn resolve_trait_method_instance<'db>(
     Some((func, trait_args))
 }
 
-/// Returns all implementors for the given `ty` that satisfy the given assumptions.
-pub(crate) fn impls_for_ty_with_constraints<'db>(
+/// Returns all implementors for the given `ty` whose constraints are fully proven.
+pub(crate) fn impls_for_ty_with_satisfied_constraints<'db>(
     db: &'db dyn HirAnalysisDb,
     ingot: Ingot<'db>,
     ty: Canonical<TyId<'db>>,
     assumptions: PredicateListId<'db>,
+) -> Vec<Binder<ImplementorId<'db>>> {
+    impls_for_ty_with_constraint_mode(db, ingot, ty, assumptions, false)
+}
+
+/// Returns implementors whose constraints are not known to be unsatisfied.
+pub(crate) fn impls_for_ty_with_possible_constraints<'db>(
+    db: &'db dyn HirAnalysisDb,
+    ingot: Ingot<'db>,
+    ty: Canonical<TyId<'db>>,
+    assumptions: PredicateListId<'db>,
+) -> Vec<Binder<ImplementorId<'db>>> {
+    impls_for_ty_with_constraint_mode(db, ingot, ty, assumptions, true)
+}
+
+fn impls_for_ty_with_constraint_mode<'db>(
+    db: &'db dyn HirAnalysisDb,
+    ingot: Ingot<'db>,
+    ty: Canonical<TyId<'db>>,
+    assumptions: PredicateListId<'db>,
+    allow_needs_confirmation: bool,
 ) -> Vec<Binder<ImplementorId<'db>>> {
     let mut table = UnificationTable::new(db);
     let ty = ty.extract_identity(&mut table);
@@ -279,7 +299,6 @@ pub(crate) fn impls_for_ty_with_constraints<'db>(
             let unifies = table.unify(impl_ty, ty_term).is_ok();
 
             if unifies {
-                // Filter out impls that don't satisfy assumptions
                 let impl_constraints = inst.constraints(db);
                 if impl_constraints.is_empty(db) {
                     table.rollback_to(snapshot);
@@ -287,14 +306,18 @@ pub(crate) fn impls_for_ty_with_constraints<'db>(
                 }
 
                 for &constraint in impl_constraints.list(db) {
-                    match is_goal_satisfiable(db, solve_cx, constraint) {
-                        GoalSatisfiability::UnSat(_) => {
-                            table.rollback_to(snapshot);
-                            return false;
-                        }
-                        _ => {
-                            // Ignoring the NeedsConfirmation case for now
-                        }
+                    let constraint = constraint.fold_with(db, &mut table);
+                    let satisfiability = is_goal_satisfiable(db, solve_cx, constraint);
+                    let constraint_holds =
+                        matches!(satisfiability, GoalSatisfiability::Satisfied(_))
+                            || (allow_needs_confirmation
+                                && matches!(
+                                    satisfiability,
+                                    GoalSatisfiability::NeedsConfirmation(_)
+                                ));
+                    if !constraint_holds {
+                        table.rollback_to(snapshot);
+                        return false;
                     }
                 }
             }

--- a/crates/hir/src/core/semantic/mod.rs
+++ b/crates/hir/src/core/semantic/mod.rs
@@ -4639,14 +4639,30 @@ impl<'db> ImplTrait<'db> {
         a: ImplTrait<'db>,
         b: ImplTrait<'db>,
     ) -> bool {
-        let a_markers = Self::sealed_local_marker_anchors(db, a);
-        let b_markers = Self::sealed_local_marker_anchors(db, b);
-        a_markers.iter().any(|&a_marker| {
-            let a_roots = Self::sealed_marker_target_roots(db, a_marker);
-            b_markers.iter().any(|&b_marker| {
-                a_roots.is_disjoint(&Self::sealed_marker_target_roots(db, b_marker))
-            })
-        })
+        let Some(a_roots) = Self::sealed_marker_possible_target_roots(db, a) else {
+            return false;
+        };
+        let Some(b_roots) = Self::sealed_marker_possible_target_roots(db, b) else {
+            return false;
+        };
+
+        a_roots.is_disjoint(&b_roots)
+    }
+
+    fn sealed_marker_possible_target_roots(
+        db: &'db dyn HirAnalysisDb,
+        impl_trait: ImplTrait<'db>,
+    ) -> Option<FxHashSet<TyBase<'db>>> {
+        let markers = Self::sealed_local_marker_anchors(db, impl_trait);
+        let (&first, rest) = markers.split_first()?;
+        let mut roots = Self::sealed_marker_target_roots(db, first);
+
+        for &marker in rest {
+            let marker_roots = Self::sealed_marker_target_roots(db, marker);
+            roots.retain(|root| marker_roots.contains(root));
+        }
+
+        Some(roots)
     }
 
     fn sealed_local_marker_anchors(

--- a/crates/hir/src/core/semantic/mod.rs
+++ b/crates/hir/src/core/semantic/mod.rs
@@ -4482,7 +4482,13 @@ impl<'db> ImplTrait<'db> {
                 if cand_impl_trait == self {
                     continue;
                 }
-                if does_impl_trait_conflict(db, cand_view, implementor) {
+                if does_impl_trait_conflict(db, cand_view, implementor)
+                    && !Self::impl_trait_conflict_is_sealed_marker_disjoint(
+                        db,
+                        cand_impl_trait,
+                        self,
+                    )
+                {
                     return Err(ImplTraitLowerError::Conflict {
                         primary: cand_impl_trait,
                         conflict: self,
@@ -4628,17 +4634,72 @@ impl<'db> ImplTrait<'db> {
         .is_ok_and(|inst| inst.def(db) == marker)
     }
 
+    fn impl_trait_conflict_is_sealed_marker_disjoint(
+        db: &'db dyn HirAnalysisDb,
+        a: ImplTrait<'db>,
+        b: ImplTrait<'db>,
+    ) -> bool {
+        let a_markers = Self::sealed_local_marker_anchors(db, a);
+        let b_markers = Self::sealed_local_marker_anchors(db, b);
+        a_markers.iter().any(|&a_marker| {
+            let a_roots = Self::sealed_marker_target_roots(db, a_marker);
+            b_markers.iter().any(|&b_marker| {
+                a_roots.is_disjoint(&Self::sealed_marker_target_roots(db, b_marker))
+            })
+        })
+    }
+
+    fn sealed_local_marker_anchors(
+        db: &'db dyn HirAnalysisDb,
+        impl_trait: ImplTrait<'db>,
+    ) -> Vec<Trait<'db>> {
+        let impl_trait_ingot = impl_trait.top_mod(db).ingot(db);
+        let ty = impl_trait.ty(db);
+        constraints_for(db, impl_trait.into())
+            .list(db)
+            .iter()
+            .filter_map(|pred| {
+                let marker = pred.def(db);
+                (pred.self_ty(db) == ty
+                    && Self::is_sealed_local_marker_anchor(db, marker, impl_trait_ingot))
+                .then_some(marker)
+            })
+            .collect()
+    }
+
+    fn sealed_marker_target_roots(
+        db: &'db dyn HirAnalysisDb,
+        marker: Trait<'db>,
+    ) -> FxHashSet<TyBase<'db>> {
+        marker
+            .ingot(db)
+            .all_impl_traits(db)
+            .iter()
+            .copied()
+            .filter(|&impl_| Self::impl_trait_implements_marker(db, impl_, marker))
+            .filter_map(|impl_| Self::impl_trait_local_nominal_root(db, impl_))
+            .collect()
+    }
+
     fn impl_trait_targets_local_nominal_root(
         db: &'db dyn HirAnalysisDb,
         impl_trait: ImplTrait<'db>,
         impl_trait_ingot: common::ingot::Ingot<'db>,
     ) -> bool {
+        Self::impl_trait_local_nominal_root(db, impl_trait).is_some_and(|root| match root {
+            TyBase::Adt(adt) => adt.ingot(db) == impl_trait_ingot,
+            TyBase::Contract(contract) => contract.top_mod(db).ingot(db) == impl_trait_ingot,
+            TyBase::Prim(_) | TyBase::Func(_) => false,
+        })
+    }
+
+    fn impl_trait_local_nominal_root(
+        db: &'db dyn HirAnalysisDb,
+        impl_trait: ImplTrait<'db>,
+    ) -> Option<TyBase<'db>> {
         match impl_trait.ty(db).base_ty(db).data(db) {
-            TyData::TyBase(TyBase::Adt(adt)) => adt.ingot(db) == impl_trait_ingot,
-            TyData::TyBase(TyBase::Contract(contract)) => {
-                contract.top_mod(db).ingot(db) == impl_trait_ingot
-            }
-            _ => false,
+            TyData::TyBase(root @ (TyBase::Adt(_) | TyBase::Contract(_))) => Some(*root),
+            _ => None,
         }
     }
 

--- a/crates/hir/src/core/span/mod.rs
+++ b/crates/hir/src/core/span/mod.rs
@@ -6,7 +6,7 @@ use crate::{
     HirDb, SpannedHirDb,
     core::hir_def::{
         Body, Const, Contract, Enum, Func, Impl, ImplTrait, Mod, StaticAssert, Struct, TopLevelMod,
-        Trait, TypeAlias, Use,
+        Trait, TypeAlias, Use, scope_graph::ScopeId,
     },
     core::lower::top_mod_ast,
 };
@@ -78,6 +78,12 @@ impl<'db> DynLazySpan<'db> {
 
     pub fn top_mod(&self, db: &'db dyn HirDb) -> Option<TopLevelMod<'db>> {
         self.0.as_ref().map(|chain| chain.top_mod(db))
+    }
+
+    /// The HIR scope this span originates from (the item or body the span was
+    /// built from), suitable as the "from scope" for visibility checks.
+    pub fn scope(&self) -> Option<ScopeId<'db>> {
+        self.0.as_ref().map(|chain| chain.scope())
     }
 }
 impl LazySpan for DynLazySpan<'_> {

--- a/crates/hir/src/core/span/transition.rs
+++ b/crates/hir/src/core/span/transition.rs
@@ -18,7 +18,7 @@ use crate::{
     HirDb, SpannedHirDb,
     hir_def::{
         Body, Const, Contract, Enum, Func, Impl, ImplTrait, ItemKind, Mod, StaticAssert, Struct,
-        TopLevelMod, Trait, TypeAlias, Use,
+        TopLevelMod, Trait, TypeAlias, Use, scope_graph::ScopeId,
     },
     lower::top_mod_ast,
 };
@@ -85,6 +85,32 @@ impl<'db> SpanTransitionChain<'db> {
             ChainRoot::Stmt(s) => s.body.top_mod(db),
             ChainRoot::Expr(e) => e.body.top_mod(db),
             ChainRoot::Pat(p) => p.body.top_mod(db),
+        }
+    }
+
+    /// The HIR scope this span originates from, used e.g. for visibility
+    /// checks at the error location. For body-relative roots this is the
+    /// body's scope; for item roots it is the item's own scope.
+    pub(super) fn scope(&self) -> ScopeId<'db> {
+        match self.root {
+            ChainRoot::ItemKind(item) => ScopeId::from_item(item),
+            ChainRoot::TopMod(top_mod) => ScopeId::from_item(top_mod.into()),
+            ChainRoot::Mod(m) => ScopeId::from_item(m.into()),
+            ChainRoot::Func(f) => ScopeId::from_item(f.into()),
+            ChainRoot::Struct(s) => ScopeId::from_item(s.into()),
+            ChainRoot::Contract(c) => ScopeId::from_item(c.into()),
+            ChainRoot::Enum(e) => ScopeId::from_item(e.into()),
+            ChainRoot::TypeAlias(t) => ScopeId::from_item(t.into()),
+            ChainRoot::Impl(i) => ScopeId::from_item(i.into()),
+            ChainRoot::Trait(t) => ScopeId::from_item(t.into()),
+            ChainRoot::ImplTrait(i) => ScopeId::from_item(i.into()),
+            ChainRoot::Const(c) => ScopeId::from_item(c.into()),
+            ChainRoot::StaticAssert(a) => ScopeId::from_item(a.into()),
+            ChainRoot::Use(u) => ScopeId::from_item(u.into()),
+            ChainRoot::Body(b) => b.scope(),
+            ChainRoot::Stmt(s) => s.body.scope(),
+            ChainRoot::Expr(e) => e.body.scope(),
+            ChainRoot::Pat(p) => p.body.scope(),
         }
     }
 

--- a/crates/uitest/fixtures/ty/def/local_bound_blanket_foreign_trait_impl_sealed_marker_conflict.fe
+++ b/crates/uitest/fixtures/ty/def/local_bound_blanket_foreign_trait_impl_sealed_marker_conflict.fe
@@ -1,0 +1,23 @@
+use core::ops::WrappingAdd
+
+trait MarkerA {}
+trait MarkerB {}
+
+struct Both {
+    value: u256,
+}
+
+impl MarkerA for Both {}
+impl MarkerB for Both {}
+
+impl<T: MarkerA> WrappingAdd for T {
+    fn wrapping_add(self, _ other: T) -> Self {
+        self
+    }
+}
+
+impl<T: MarkerB> WrappingAdd for T {
+    fn wrapping_add(self, _ other: T) -> Self {
+        other
+    }
+}

--- a/crates/uitest/fixtures/ty/def/local_bound_blanket_foreign_trait_impl_sealed_marker_conflict.snap
+++ b/crates/uitest/fixtures/ty/def/local_bound_blanket_foreign_trait_impl_sealed_marker_conflict.snap
@@ -1,0 +1,14 @@
+---
+source: crates/uitest/tests/ty.rs
+assertion_line: 27
+expression: diags
+input_file: fixtures/ty/def/local_bound_blanket_foreign_trait_impl_sealed_marker_conflict.fe
+---
+error[5-0001]: conflicting trait implementations
+   ┌─ local_bound_blanket_foreign_trait_impl_sealed_marker_conflict.fe:13:34
+   │
+13 │ impl<T: MarkerA> WrappingAdd for T {
+   │                                  ^ this trait implementation
+   ·
+19 │ impl<T: MarkerB> WrappingAdd for T {
+   │                                  - conflicts with this trait implementation

--- a/crates/uitest/fixtures/ty_check/error_unsupported_field_type.snap
+++ b/crates/uitest/fixtures/ty_check/error_unsupported_field_type.snap
@@ -15,12 +15,11 @@ error[2-0010]: no method named `encode_to_ptr` found for struct `StorageMap`
 error[6-0003]: trait bound is not satisfied
     ┌─ error_unsupported_field_type.fe:3:1
     │
-  3 │ ╭ ╭ #[error]
-  4 │ │ │ struct Bad {
-  5 │ │ │     value: StorageMap<Address, u256, 0>,
-  6 │ │ │ }
-    │ ╰─│─^ `StorageMap<Address, u256, 0>` doesn't implement `AbiSize`
-    │   ╰─' trait bound `StorageMap<Address, u256, 0>: SolInt` is not satisfied
+  3 │ ╭ #[error]
+  4 │ │ struct Bad {
+  5 │ │     value: StorageMap<Address, u256, 0>,
+  6 │ │ }
+    │ ╰─^ `StorageMap<Address, u256, 0>` doesn't implement `AbiSize`
     │
     ┌─ src/abi.fe:317:32
     │
@@ -30,12 +29,11 @@ error[6-0003]: trait bound is not satisfied
 error[6-0003]: trait bound is not satisfied
     ┌─ error_unsupported_field_type.fe:3:1
     │
-  3 │ ╭ ╭ #[error]
-  4 │ │ │ struct Bad {
-  5 │ │ │     value: StorageMap<Address, u256, 0>,
-  6 │ │ │ }
-    │ ╰─│─^ `StorageMap<Address, u256, 0>` doesn't implement `Encode<Sol>`
-    │   ╰─' trait bound `StorageMap<Address, u256, 0>: SolInt` is not satisfied
+  3 │ ╭ #[error]
+  4 │ │ struct Bad {
+  5 │ │     value: StorageMap<Address, u256, 0>,
+  6 │ │ }
+    │ ╰─^ `StorageMap<Address, u256, 0>` doesn't implement `Encode<Sol>`
     │
     ┌─ src/abi.fe:437:14
     │
@@ -45,12 +43,11 @@ error[6-0003]: trait bound is not satisfied
 error[6-0003]: trait bound is not satisfied
     ┌─ error_unsupported_field_type.fe:3:1
     │
-  3 │ ╭ ╭ #[error]
-  4 │ │ │ struct Bad {
-  5 │ │ │     value: StorageMap<Address, u256, 0>,
-  6 │ │ │ }
-    │ ╰─│─^ `StorageMap<Address, u256, 0>` doesn't implement `AbiSize`
-    │   ╰─' trait bound `StorageMap<Address, u256, 0>: SolInt` is not satisfied
+  3 │ ╭ #[error]
+  4 │ │ struct Bad {
+  5 │ │     value: StorageMap<Address, u256, 0>,
+  6 │ │ }
+    │ ╰─^ `StorageMap<Address, u256, 0>` doesn't implement `AbiSize`
     │
     ┌─ src/abi.fe:437:26
     │

--- a/crates/uitest/fixtures/ty_check/error_unsupported_field_type.snap
+++ b/crates/uitest/fixtures/ty_check/error_unsupported_field_type.snap
@@ -15,11 +15,12 @@ error[2-0010]: no method named `encode_to_ptr` found for struct `StorageMap`
 error[6-0003]: trait bound is not satisfied
     ┌─ error_unsupported_field_type.fe:3:1
     │
-  3 │ ╭ #[error]
-  4 │ │ struct Bad {
-  5 │ │     value: StorageMap<Address, u256, 0>,
-  6 │ │ }
-    │ ╰─^ `StorageMap<Address, u256, 0>` doesn't implement `AbiSize`
+  3 │ ╭ ╭ #[error]
+  4 │ │ │ struct Bad {
+  5 │ │ │     value: StorageMap<Address, u256, 0>,
+  6 │ │ │ }
+    │ ╰─│─^ `StorageMap<Address, u256, 0>` doesn't implement `AbiSize`
+    │   ╰─' trait bound `StorageMap<Address, u256, 0>: SolInt` is not satisfied
     │
     ┌─ src/abi.fe:317:32
     │
@@ -29,11 +30,12 @@ error[6-0003]: trait bound is not satisfied
 error[6-0003]: trait bound is not satisfied
     ┌─ error_unsupported_field_type.fe:3:1
     │
-  3 │ ╭ #[error]
-  4 │ │ struct Bad {
-  5 │ │     value: StorageMap<Address, u256, 0>,
-  6 │ │ }
-    │ ╰─^ `StorageMap<Address, u256, 0>` doesn't implement `Encode<Sol>`
+  3 │ ╭ ╭ #[error]
+  4 │ │ │ struct Bad {
+  5 │ │ │     value: StorageMap<Address, u256, 0>,
+  6 │ │ │ }
+    │ ╰─│─^ `StorageMap<Address, u256, 0>` doesn't implement `Encode<Sol>`
+    │   ╰─' trait bound `StorageMap<Address, u256, 0>: SolInt` is not satisfied
     │
     ┌─ src/abi.fe:437:14
     │
@@ -43,11 +45,12 @@ error[6-0003]: trait bound is not satisfied
 error[6-0003]: trait bound is not satisfied
     ┌─ error_unsupported_field_type.fe:3:1
     │
-  3 │ ╭ #[error]
-  4 │ │ struct Bad {
-  5 │ │     value: StorageMap<Address, u256, 0>,
-  6 │ │ }
-    │ ╰─^ `StorageMap<Address, u256, 0>` doesn't implement `AbiSize`
+  3 │ ╭ ╭ #[error]
+  4 │ │ │ struct Bad {
+  5 │ │ │     value: StorageMap<Address, u256, 0>,
+  6 │ │ │ }
+    │ ╰─│─^ `StorageMap<Address, u256, 0>` doesn't implement `AbiSize`
+    │   ╰─' trait bound `StorageMap<Address, u256, 0>: SolInt` is not satisfied
     │
     ┌─ src/abi.fe:437:26
     │

--- a/crates/uitest/fixtures/ty_check/event_shadowed_address_type.snap
+++ b/crates/uitest/fixtures/ty_check/event_shadowed_address_type.snap
@@ -6,12 +6,11 @@ input_file: fixtures/ty_check/event_shadowed_address_type.fe
 error[6-0003]: trait bound is not satisfied
    ┌─ event_shadowed_address_type.fe:5:1
    │
- 5 │ ╭ ╭ #[event]
- 6 │ │ │ struct BadEvent {
- 7 │ │ │     #[indexed]
- 8 │ │ │     from: Address,
- 9 │ │ │     #[indexed]
-10 │ │ │     to: std::evm::Address,
-11 │ │ │ }
-   │ ╰─│─^ `Address` doesn't implement `TopicValue`
-   │   ╰─' trait bound `Address: SolInt` is not satisfied
+ 5 │ ╭ #[event]
+ 6 │ │ struct BadEvent {
+ 7 │ │     #[indexed]
+ 8 │ │     from: Address,
+ 9 │ │     #[indexed]
+10 │ │     to: std::evm::Address,
+11 │ │ }
+   │ ╰─^ `Address` doesn't implement `TopicValue`

--- a/crates/uitest/fixtures/ty_check/event_shadowed_address_type.snap
+++ b/crates/uitest/fixtures/ty_check/event_shadowed_address_type.snap
@@ -3,14 +3,15 @@ source: crates/uitest/tests/ty_check.rs
 expression: diags
 input_file: fixtures/ty_check/event_shadowed_address_type.fe
 ---
-error[2-0010]: no method named `as_topic` found for struct `Address`
+error[6-0003]: trait bound is not satisfied
    ┌─ event_shadowed_address_type.fe:5:1
    │
- 5 │ ╭ #[event]
- 6 │ │ struct BadEvent {
- 7 │ │     #[indexed]
- 8 │ │     from: Address,
- 9 │ │     #[indexed]
-10 │ │     to: std::evm::Address,
-11 │ │ }
-   │ ╰─^ method not found in `Address`
+ 5 │ ╭ ╭ #[event]
+ 6 │ │ │ struct BadEvent {
+ 7 │ │ │     #[indexed]
+ 8 │ │ │     from: Address,
+ 9 │ │ │     #[indexed]
+10 │ │ │     to: std::evm::Address,
+11 │ │ │ }
+   │ ╰─│─^ `Address` doesn't implement `TopicValue`
+   │   ╰─' trait bound `Address: SolInt` is not satisfied

--- a/crates/uitest/fixtures/ty_check/event_unsupported_field_type.snap
+++ b/crates/uitest/fixtures/ty_check/event_unsupported_field_type.snap
@@ -6,12 +6,11 @@ input_file: fixtures/ty_check/event_unsupported_field_type.fe
 error[6-0003]: trait bound is not satisfied
     ┌─ event_unsupported_field_type.fe:3:1
     │
-  3 │ ╭ ╭ #[event]
-  4 │ │ │ struct Bad {
-  5 │ │ │     value: StorageMap<Address, u256, 0>,
-  6 │ │ │ }
-    │ ╰─│─^ `StorageMap<Address, u256, 0>` doesn't implement `Encode<Sol>`
-    │   ╰─' trait bound `StorageMap<Address, u256, 0>: SolInt` is not satisfied
+  3 │ ╭ #[event]
+  4 │ │ struct Bad {
+  5 │ │     value: StorageMap<Address, u256, 0>,
+  6 │ │ }
+    │ ╰─^ `StorageMap<Address, u256, 0>` doesn't implement `Encode<Sol>`
     │
     ┌─ src/evm/effects.fe:431:14
     │
@@ -21,12 +20,11 @@ error[6-0003]: trait bound is not satisfied
 error[6-0003]: trait bound is not satisfied
     ┌─ event_unsupported_field_type.fe:3:1
     │
-  3 │ ╭ ╭ #[event]
-  4 │ │ │ struct Bad {
-  5 │ │ │     value: StorageMap<Address, u256, 0>,
-  6 │ │ │ }
-    │ ╰─│─^ `StorageMap<Address, u256, 0>` doesn't implement `AbiSize`
-    │   ╰─' trait bound `StorageMap<Address, u256, 0>: SolInt` is not satisfied
+  3 │ ╭ #[event]
+  4 │ │ struct Bad {
+  5 │ │     value: StorageMap<Address, u256, 0>,
+  6 │ │ }
+    │ ╰─^ `StorageMap<Address, u256, 0>` doesn't implement `AbiSize`
     │
     ┌─ src/evm/effects.fe:431:28
     │

--- a/crates/uitest/fixtures/ty_check/event_unsupported_field_type.snap
+++ b/crates/uitest/fixtures/ty_check/event_unsupported_field_type.snap
@@ -1,17 +1,17 @@
 ---
 source: crates/uitest/tests/ty_check.rs
-assertion_line: 27
 expression: diags
 input_file: fixtures/ty_check/event_unsupported_field_type.fe
 ---
 error[6-0003]: trait bound is not satisfied
     ┌─ event_unsupported_field_type.fe:3:1
     │
-  3 │ ╭ #[event]
-  4 │ │ struct Bad {
-  5 │ │     value: StorageMap<Address, u256, 0>,
-  6 │ │ }
-    │ ╰─^ `StorageMap<Address, u256, 0>` doesn't implement `Encode<Sol>`
+  3 │ ╭ ╭ #[event]
+  4 │ │ │ struct Bad {
+  5 │ │ │     value: StorageMap<Address, u256, 0>,
+  6 │ │ │ }
+    │ ╰─│─^ `StorageMap<Address, u256, 0>` doesn't implement `Encode<Sol>`
+    │   ╰─' trait bound `StorageMap<Address, u256, 0>: SolInt` is not satisfied
     │
     ┌─ src/evm/effects.fe:431:14
     │
@@ -21,11 +21,12 @@ error[6-0003]: trait bound is not satisfied
 error[6-0003]: trait bound is not satisfied
     ┌─ event_unsupported_field_type.fe:3:1
     │
-  3 │ ╭ #[event]
-  4 │ │ struct Bad {
-  5 │ │     value: StorageMap<Address, u256, 0>,
-  6 │ │ }
-    │ ╰─^ `StorageMap<Address, u256, 0>` doesn't implement `AbiSize`
+  3 │ ╭ ╭ #[event]
+  4 │ │ │ struct Bad {
+  5 │ │ │     value: StorageMap<Address, u256, 0>,
+  6 │ │ │ }
+    │ ╰─│─^ `StorageMap<Address, u256, 0>` doesn't implement `AbiSize`
+    │   ╰─' trait bound `StorageMap<Address, u256, 0>: SolInt` is not satisfied
     │
     ┌─ src/evm/effects.fe:431:28
     │

--- a/crates/uitest/fixtures/ty_check/impl_param_fixed_by_bound.fe
+++ b/crates/uitest/fixtures/ty_check/impl_param_fixed_by_bound.fe
@@ -1,0 +1,27 @@
+// Regression: an impl parameter that the self type doesn't determine but a
+// `where`-clause does (here `U`, fixed by `U: Marker`) must stay bound when the
+// method is selected. Otherwise `U` is left unconstrained and the `U: Marker`
+// obligation is dropped, so `x.consume(Bar {})` would type-check even though
+// `Bar` is not a `Marker` (and then fail only at codegen).
+//
+// With the bound applied, `U` resolves to the sole `Marker` type `Foo`, so
+// passing a `Bar` is correctly rejected here in the frontend.
+trait Marker {}
+
+struct Foo {}
+impl Marker for Foo {}
+
+struct Bar {}
+
+trait Consume<U> {
+    fn consume(self, _ u: U)
+}
+
+impl<T, U: Marker> Consume<U> for T {
+    fn consume(self, _ u: U) {}
+}
+
+fn caller() {
+    let x = Bar {}
+    x.consume(Bar {})
+}

--- a/crates/uitest/fixtures/ty_check/impl_param_fixed_by_bound.snap
+++ b/crates/uitest/fixtures/ty_check/impl_param_fixed_by_bound.snap
@@ -1,0 +1,10 @@
+---
+source: crates/uitest/tests/ty_check.rs
+expression: diags
+input_file: fixtures/ty_check/impl_param_fixed_by_bound.fe
+---
+error[8-0000]: type mismatch
+   ┌─ impl_param_fixed_by_bound.fe:26:15
+   │
+26 │     x.consume(Bar {})
+   │               ^^^^^^ expected `Foo`, but `Bar` is given

--- a/ingots/std/src/abi/sol/ints.fe
+++ b/ingots/std/src/abi/sol/ints.fe
@@ -1,6 +1,7 @@
 use core::abi::{Abi, AbiDecoder, AbiEncoder, AbiSize, AbiSpan, ByteInput, Decode, Encode}
 use core::num::IntDowncast
-use ingot::evm::{TopicValue, ops::revert}
+use core::ops::{WrappingAdd, WrappingMul, WrappingSub}
+use ingot::evm::{TopicValue, ops::{revert, signextend}}
 
 use super::types::SolCompat
 
@@ -89,6 +90,67 @@ fn decode_int_i256(word: u256, bits: u256) -> i256 {
 
 pub trait SolWordRepr {
     fn canonical_word(self) -> u256
+}
+
+trait SolWrappingInt: Copy {
+    fn raw_word(self) -> u256
+    fn from_wrapping_word(self, _: u256) -> Self
+}
+
+trait SolWrappingIntMarker {}
+
+fn wrapping_unsigned_word(word: u256, bits: u256) -> u256 {
+    word & (((1 as u256) << bits) - 1)
+}
+
+fn wrapping_signed_word(word: u256, bits: u256) -> u256 {
+    signextend(byte: (bits / 8) - 1, value: word)
+}
+
+fn wrapping_unsigned_u32(word: u256, bits: u256) -> u32 {
+    wrapping_unsigned_word(word: word, bits: bits).downcast_unchecked()
+}
+
+fn wrapping_unsigned_u64(word: u256, bits: u256) -> u64 {
+    wrapping_unsigned_word(word: word, bits: bits).downcast_unchecked()
+}
+
+fn wrapping_unsigned_u128(word: u256, bits: u256) -> u128 {
+    wrapping_unsigned_word(word: word, bits: bits).downcast_unchecked()
+}
+
+fn wrapping_signed_i32(word: u256, bits: u256) -> i32 {
+    let signed: i256 = wrapping_signed_word(word: word, bits: bits).downcast_unchecked()
+    signed.downcast_unchecked()
+}
+
+fn wrapping_signed_i64(word: u256, bits: u256) -> i64 {
+    let signed: i256 = wrapping_signed_word(word: word, bits: bits).downcast_unchecked()
+    signed.downcast_unchecked()
+}
+
+fn wrapping_signed_i128(word: u256, bits: u256) -> i128 {
+    let signed: i256 = wrapping_signed_word(word: word, bits: bits).downcast_unchecked()
+    signed.downcast_unchecked()
+}
+
+fn wrapping_signed_i256(word: u256, bits: u256) -> i256 {
+    wrapping_signed_word(word: word, bits: bits).downcast_unchecked()
+}
+
+#[arithmetic(unchecked)]
+fn sol_wrapping_add<T: SolWrappingInt>(a: T, b: T) -> T {
+    a.from_wrapping_word(a.raw_word() + b.raw_word())
+}
+
+#[arithmetic(unchecked)]
+fn sol_wrapping_sub<T: SolWrappingInt>(a: T, b: T) -> T {
+    a.from_wrapping_word(a.raw_word() - b.raw_word())
+}
+
+#[arithmetic(unchecked)]
+fn sol_wrapping_mul<T: SolWrappingInt>(a: T, b: T) -> T {
+    a.from_wrapping_word(a.raw_word() * b.raw_word())
 }
 
 // ---------------------------------------------------------------------------
@@ -530,6 +592,278 @@ impl SolCompat for Int248 {
 }
 impl SolWordRepr for Int248 {
     fn canonical_word(self) -> u256 { canonical_custom_signed_word(word: self.val.downcast_unchecked(), bits: 248) }
+}
+
+impl SolWrappingInt for Uint24 {
+    fn raw_word(self) -> u256 { self.val as u256 }
+    fn from_wrapping_word(self, _ word: u256) -> Self { Uint24 { val: wrapping_unsigned_u32(word: word, bits: 24) } }
+}
+impl SolWrappingIntMarker for Uint24 {}
+impl SolWrappingInt for Uint40 {
+    fn raw_word(self) -> u256 { self.val as u256 }
+    fn from_wrapping_word(self, _ word: u256) -> Self { Uint40 { val: wrapping_unsigned_u64(word: word, bits: 40) } }
+}
+impl SolWrappingIntMarker for Uint40 {}
+impl SolWrappingInt for Uint48 {
+    fn raw_word(self) -> u256 { self.val as u256 }
+    fn from_wrapping_word(self, _ word: u256) -> Self { Uint48 { val: wrapping_unsigned_u64(word: word, bits: 48) } }
+}
+impl SolWrappingIntMarker for Uint48 {}
+impl SolWrappingInt for Uint56 {
+    fn raw_word(self) -> u256 { self.val as u256 }
+    fn from_wrapping_word(self, _ word: u256) -> Self { Uint56 { val: wrapping_unsigned_u64(word: word, bits: 56) } }
+}
+impl SolWrappingIntMarker for Uint56 {}
+impl SolWrappingInt for Uint72 {
+    fn raw_word(self) -> u256 { self.val as u256 }
+    fn from_wrapping_word(self, _ word: u256) -> Self { Uint72 { val: wrapping_unsigned_u128(word: word, bits: 72) } }
+}
+impl SolWrappingIntMarker for Uint72 {}
+impl SolWrappingInt for Uint80 {
+    fn raw_word(self) -> u256 { self.val as u256 }
+    fn from_wrapping_word(self, _ word: u256) -> Self { Uint80 { val: wrapping_unsigned_u128(word: word, bits: 80) } }
+}
+impl SolWrappingIntMarker for Uint80 {}
+impl SolWrappingInt for Uint88 {
+    fn raw_word(self) -> u256 { self.val as u256 }
+    fn from_wrapping_word(self, _ word: u256) -> Self { Uint88 { val: wrapping_unsigned_u128(word: word, bits: 88) } }
+}
+impl SolWrappingIntMarker for Uint88 {}
+impl SolWrappingInt for Uint96 {
+    fn raw_word(self) -> u256 { self.val as u256 }
+    fn from_wrapping_word(self, _ word: u256) -> Self { Uint96 { val: wrapping_unsigned_u128(word: word, bits: 96) } }
+}
+impl SolWrappingIntMarker for Uint96 {}
+impl SolWrappingInt for Uint104 {
+    fn raw_word(self) -> u256 { self.val as u256 }
+    fn from_wrapping_word(self, _ word: u256) -> Self { Uint104 { val: wrapping_unsigned_u128(word: word, bits: 104) } }
+}
+impl SolWrappingIntMarker for Uint104 {}
+impl SolWrappingInt for Uint112 {
+    fn raw_word(self) -> u256 { self.val as u256 }
+    fn from_wrapping_word(self, _ word: u256) -> Self { Uint112 { val: wrapping_unsigned_u128(word: word, bits: 112) } }
+}
+impl SolWrappingIntMarker for Uint112 {}
+impl SolWrappingInt for Uint120 {
+    fn raw_word(self) -> u256 { self.val as u256 }
+    fn from_wrapping_word(self, _ word: u256) -> Self { Uint120 { val: wrapping_unsigned_u128(word: word, bits: 120) } }
+}
+impl SolWrappingIntMarker for Uint120 {}
+impl SolWrappingInt for Uint136 {
+    fn raw_word(self) -> u256 { self.val }
+    fn from_wrapping_word(self, _ word: u256) -> Self { Uint136 { val: wrapping_unsigned_word(word: word, bits: 136) } }
+}
+impl SolWrappingIntMarker for Uint136 {}
+impl SolWrappingInt for Uint144 {
+    fn raw_word(self) -> u256 { self.val }
+    fn from_wrapping_word(self, _ word: u256) -> Self { Uint144 { val: wrapping_unsigned_word(word: word, bits: 144) } }
+}
+impl SolWrappingIntMarker for Uint144 {}
+impl SolWrappingInt for Uint152 {
+    fn raw_word(self) -> u256 { self.val }
+    fn from_wrapping_word(self, _ word: u256) -> Self { Uint152 { val: wrapping_unsigned_word(word: word, bits: 152) } }
+}
+impl SolWrappingIntMarker for Uint152 {}
+impl SolWrappingInt for Uint160 {
+    fn raw_word(self) -> u256 { self.val }
+    fn from_wrapping_word(self, _ word: u256) -> Self { Uint160 { val: wrapping_unsigned_word(word: word, bits: 160) } }
+}
+impl SolWrappingIntMarker for Uint160 {}
+impl SolWrappingInt for Uint168 {
+    fn raw_word(self) -> u256 { self.val }
+    fn from_wrapping_word(self, _ word: u256) -> Self { Uint168 { val: wrapping_unsigned_word(word: word, bits: 168) } }
+}
+impl SolWrappingIntMarker for Uint168 {}
+impl SolWrappingInt for Uint176 {
+    fn raw_word(self) -> u256 { self.val }
+    fn from_wrapping_word(self, _ word: u256) -> Self { Uint176 { val: wrapping_unsigned_word(word: word, bits: 176) } }
+}
+impl SolWrappingIntMarker for Uint176 {}
+impl SolWrappingInt for Uint184 {
+    fn raw_word(self) -> u256 { self.val }
+    fn from_wrapping_word(self, _ word: u256) -> Self { Uint184 { val: wrapping_unsigned_word(word: word, bits: 184) } }
+}
+impl SolWrappingIntMarker for Uint184 {}
+impl SolWrappingInt for Uint192 {
+    fn raw_word(self) -> u256 { self.val }
+    fn from_wrapping_word(self, _ word: u256) -> Self { Uint192 { val: wrapping_unsigned_word(word: word, bits: 192) } }
+}
+impl SolWrappingIntMarker for Uint192 {}
+impl SolWrappingInt for Uint200 {
+    fn raw_word(self) -> u256 { self.val }
+    fn from_wrapping_word(self, _ word: u256) -> Self { Uint200 { val: wrapping_unsigned_word(word: word, bits: 200) } }
+}
+impl SolWrappingIntMarker for Uint200 {}
+impl SolWrappingInt for Uint208 {
+    fn raw_word(self) -> u256 { self.val }
+    fn from_wrapping_word(self, _ word: u256) -> Self { Uint208 { val: wrapping_unsigned_word(word: word, bits: 208) } }
+}
+impl SolWrappingIntMarker for Uint208 {}
+impl SolWrappingInt for Uint216 {
+    fn raw_word(self) -> u256 { self.val }
+    fn from_wrapping_word(self, _ word: u256) -> Self { Uint216 { val: wrapping_unsigned_word(word: word, bits: 216) } }
+}
+impl SolWrappingIntMarker for Uint216 {}
+impl SolWrappingInt for Uint224 {
+    fn raw_word(self) -> u256 { self.val }
+    fn from_wrapping_word(self, _ word: u256) -> Self { Uint224 { val: wrapping_unsigned_word(word: word, bits: 224) } }
+}
+impl SolWrappingIntMarker for Uint224 {}
+impl SolWrappingInt for Uint232 {
+    fn raw_word(self) -> u256 { self.val }
+    fn from_wrapping_word(self, _ word: u256) -> Self { Uint232 { val: wrapping_unsigned_word(word: word, bits: 232) } }
+}
+impl SolWrappingIntMarker for Uint232 {}
+impl SolWrappingInt for Uint240 {
+    fn raw_word(self) -> u256 { self.val }
+    fn from_wrapping_word(self, _ word: u256) -> Self { Uint240 { val: wrapping_unsigned_word(word: word, bits: 240) } }
+}
+impl SolWrappingIntMarker for Uint240 {}
+impl SolWrappingInt for Uint248 {
+    fn raw_word(self) -> u256 { self.val }
+    fn from_wrapping_word(self, _ word: u256) -> Self { Uint248 { val: wrapping_unsigned_word(word: word, bits: 248) } }
+}
+impl SolWrappingIntMarker for Uint248 {}
+
+impl SolWrappingInt for Int24 {
+    fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
+    fn from_wrapping_word(self, _ word: u256) -> Self { Int24 { val: wrapping_signed_i32(word: word, bits: 24) } }
+}
+impl SolWrappingIntMarker for Int24 {}
+impl SolWrappingInt for Int40 {
+    fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
+    fn from_wrapping_word(self, _ word: u256) -> Self { Int40 { val: wrapping_signed_i64(word: word, bits: 40) } }
+}
+impl SolWrappingIntMarker for Int40 {}
+impl SolWrappingInt for Int48 {
+    fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
+    fn from_wrapping_word(self, _ word: u256) -> Self { Int48 { val: wrapping_signed_i64(word: word, bits: 48) } }
+}
+impl SolWrappingIntMarker for Int48 {}
+impl SolWrappingInt for Int56 {
+    fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
+    fn from_wrapping_word(self, _ word: u256) -> Self { Int56 { val: wrapping_signed_i64(word: word, bits: 56) } }
+}
+impl SolWrappingIntMarker for Int56 {}
+impl SolWrappingInt for Int72 {
+    fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
+    fn from_wrapping_word(self, _ word: u256) -> Self { Int72 { val: wrapping_signed_i128(word: word, bits: 72) } }
+}
+impl SolWrappingIntMarker for Int72 {}
+impl SolWrappingInt for Int80 {
+    fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
+    fn from_wrapping_word(self, _ word: u256) -> Self { Int80 { val: wrapping_signed_i128(word: word, bits: 80) } }
+}
+impl SolWrappingIntMarker for Int80 {}
+impl SolWrappingInt for Int88 {
+    fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
+    fn from_wrapping_word(self, _ word: u256) -> Self { Int88 { val: wrapping_signed_i128(word: word, bits: 88) } }
+}
+impl SolWrappingIntMarker for Int88 {}
+impl SolWrappingInt for Int96 {
+    fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
+    fn from_wrapping_word(self, _ word: u256) -> Self { Int96 { val: wrapping_signed_i128(word: word, bits: 96) } }
+}
+impl SolWrappingIntMarker for Int96 {}
+impl SolWrappingInt for Int104 {
+    fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
+    fn from_wrapping_word(self, _ word: u256) -> Self { Int104 { val: wrapping_signed_i128(word: word, bits: 104) } }
+}
+impl SolWrappingIntMarker for Int104 {}
+impl SolWrappingInt for Int112 {
+    fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
+    fn from_wrapping_word(self, _ word: u256) -> Self { Int112 { val: wrapping_signed_i128(word: word, bits: 112) } }
+}
+impl SolWrappingIntMarker for Int112 {}
+impl SolWrappingInt for Int120 {
+    fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
+    fn from_wrapping_word(self, _ word: u256) -> Self { Int120 { val: wrapping_signed_i128(word: word, bits: 120) } }
+}
+impl SolWrappingIntMarker for Int120 {}
+impl SolWrappingInt for Int136 {
+    fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
+    fn from_wrapping_word(self, _ word: u256) -> Self { Int136 { val: wrapping_signed_i256(word: word, bits: 136) } }
+}
+impl SolWrappingIntMarker for Int136 {}
+impl SolWrappingInt for Int144 {
+    fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
+    fn from_wrapping_word(self, _ word: u256) -> Self { Int144 { val: wrapping_signed_i256(word: word, bits: 144) } }
+}
+impl SolWrappingIntMarker for Int144 {}
+impl SolWrappingInt for Int152 {
+    fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
+    fn from_wrapping_word(self, _ word: u256) -> Self { Int152 { val: wrapping_signed_i256(word: word, bits: 152) } }
+}
+impl SolWrappingIntMarker for Int152 {}
+impl SolWrappingInt for Int160 {
+    fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
+    fn from_wrapping_word(self, _ word: u256) -> Self { Int160 { val: wrapping_signed_i256(word: word, bits: 160) } }
+}
+impl SolWrappingIntMarker for Int160 {}
+impl SolWrappingInt for Int168 {
+    fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
+    fn from_wrapping_word(self, _ word: u256) -> Self { Int168 { val: wrapping_signed_i256(word: word, bits: 168) } }
+}
+impl SolWrappingIntMarker for Int168 {}
+impl SolWrappingInt for Int176 {
+    fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
+    fn from_wrapping_word(self, _ word: u256) -> Self { Int176 { val: wrapping_signed_i256(word: word, bits: 176) } }
+}
+impl SolWrappingIntMarker for Int176 {}
+impl SolWrappingInt for Int184 {
+    fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
+    fn from_wrapping_word(self, _ word: u256) -> Self { Int184 { val: wrapping_signed_i256(word: word, bits: 184) } }
+}
+impl SolWrappingIntMarker for Int184 {}
+impl SolWrappingInt for Int192 {
+    fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
+    fn from_wrapping_word(self, _ word: u256) -> Self { Int192 { val: wrapping_signed_i256(word: word, bits: 192) } }
+}
+impl SolWrappingIntMarker for Int192 {}
+impl SolWrappingInt for Int200 {
+    fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
+    fn from_wrapping_word(self, _ word: u256) -> Self { Int200 { val: wrapping_signed_i256(word: word, bits: 200) } }
+}
+impl SolWrappingIntMarker for Int200 {}
+impl SolWrappingInt for Int208 {
+    fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
+    fn from_wrapping_word(self, _ word: u256) -> Self { Int208 { val: wrapping_signed_i256(word: word, bits: 208) } }
+}
+impl SolWrappingIntMarker for Int208 {}
+impl SolWrappingInt for Int216 {
+    fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
+    fn from_wrapping_word(self, _ word: u256) -> Self { Int216 { val: wrapping_signed_i256(word: word, bits: 216) } }
+}
+impl SolWrappingIntMarker for Int216 {}
+impl SolWrappingInt for Int224 {
+    fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
+    fn from_wrapping_word(self, _ word: u256) -> Self { Int224 { val: wrapping_signed_i256(word: word, bits: 224) } }
+}
+impl SolWrappingIntMarker for Int224 {}
+impl SolWrappingInt for Int232 {
+    fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
+    fn from_wrapping_word(self, _ word: u256) -> Self { Int232 { val: wrapping_signed_i256(word: word, bits: 232) } }
+}
+impl SolWrappingIntMarker for Int232 {}
+impl SolWrappingInt for Int240 {
+    fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
+    fn from_wrapping_word(self, _ word: u256) -> Self { Int240 { val: wrapping_signed_i256(word: word, bits: 240) } }
+}
+impl SolWrappingIntMarker for Int240 {}
+impl SolWrappingInt for Int248 {
+    fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
+    fn from_wrapping_word(self, _ word: u256) -> Self { Int248 { val: wrapping_signed_i256(word: word, bits: 248) } }
+}
+impl SolWrappingIntMarker for Int248 {}
+
+impl<T: SolWrappingInt + SolWrappingIntMarker> WrappingAdd for T {
+    fn wrapping_add(self, _ other: T) -> T { sol_wrapping_add(a: self, b: other) }
+}
+impl<T: SolWrappingInt + SolWrappingIntMarker> WrappingSub for T {
+    fn wrapping_sub(self, _ other: T) -> T { sol_wrapping_sub(a: self, b: other) }
+}
+impl<T: SolWrappingInt + SolWrappingIntMarker> WrappingMul for T {
+    fn wrapping_mul(self, _ other: T) -> T { sol_wrapping_mul(a: self, b: other) }
 }
 
 impl<A: Abi> Encode<A> for Uint24 {

--- a/ingots/std/src/abi/sol/ints.fe
+++ b/ingots/std/src/abi/sol/ints.fe
@@ -94,7 +94,7 @@ pub trait SolWordRepr {
 
 trait SolWrappingInt: Copy {
     fn raw_word(self) -> u256
-    fn from_wrapping_word(self, _: u256) -> Self
+    fn from_wrapping_word(_: u256) -> Self
 }
 
 trait SolWrappingIntMarker {}
@@ -140,17 +140,17 @@ fn wrapping_signed_i256(word: u256, bits: u256) -> i256 {
 
 #[arithmetic(unchecked)]
 fn sol_wrapping_add<T: SolWrappingInt>(a: T, b: T) -> T {
-    a.from_wrapping_word(a.raw_word() + b.raw_word())
+    T::from_wrapping_word(a.raw_word() + b.raw_word())
 }
 
 #[arithmetic(unchecked)]
 fn sol_wrapping_sub<T: SolWrappingInt>(a: T, b: T) -> T {
-    a.from_wrapping_word(a.raw_word() - b.raw_word())
+    T::from_wrapping_word(a.raw_word() - b.raw_word())
 }
 
 #[arithmetic(unchecked)]
 fn sol_wrapping_mul<T: SolWrappingInt>(a: T, b: T) -> T {
-    a.from_wrapping_word(a.raw_word() * b.raw_word())
+    T::from_wrapping_word(a.raw_word() * b.raw_word())
 }
 
 // ---------------------------------------------------------------------------
@@ -596,263 +596,263 @@ impl SolWordRepr for Int248 {
 
 impl SolWrappingInt for Uint24 {
     fn raw_word(self) -> u256 { self.val as u256 }
-    fn from_wrapping_word(self, _ word: u256) -> Self { Uint24 { val: wrapping_unsigned_u32(word: word, bits: 24) } }
+    fn from_wrapping_word(_ word: u256) -> Self { Uint24 { val: wrapping_unsigned_u32(word: word, bits: 24) } }
 }
 impl SolWrappingIntMarker for Uint24 {}
 impl SolWrappingInt for Uint40 {
     fn raw_word(self) -> u256 { self.val as u256 }
-    fn from_wrapping_word(self, _ word: u256) -> Self { Uint40 { val: wrapping_unsigned_u64(word: word, bits: 40) } }
+    fn from_wrapping_word(_ word: u256) -> Self { Uint40 { val: wrapping_unsigned_u64(word: word, bits: 40) } }
 }
 impl SolWrappingIntMarker for Uint40 {}
 impl SolWrappingInt for Uint48 {
     fn raw_word(self) -> u256 { self.val as u256 }
-    fn from_wrapping_word(self, _ word: u256) -> Self { Uint48 { val: wrapping_unsigned_u64(word: word, bits: 48) } }
+    fn from_wrapping_word(_ word: u256) -> Self { Uint48 { val: wrapping_unsigned_u64(word: word, bits: 48) } }
 }
 impl SolWrappingIntMarker for Uint48 {}
 impl SolWrappingInt for Uint56 {
     fn raw_word(self) -> u256 { self.val as u256 }
-    fn from_wrapping_word(self, _ word: u256) -> Self { Uint56 { val: wrapping_unsigned_u64(word: word, bits: 56) } }
+    fn from_wrapping_word(_ word: u256) -> Self { Uint56 { val: wrapping_unsigned_u64(word: word, bits: 56) } }
 }
 impl SolWrappingIntMarker for Uint56 {}
 impl SolWrappingInt for Uint72 {
     fn raw_word(self) -> u256 { self.val as u256 }
-    fn from_wrapping_word(self, _ word: u256) -> Self { Uint72 { val: wrapping_unsigned_u128(word: word, bits: 72) } }
+    fn from_wrapping_word(_ word: u256) -> Self { Uint72 { val: wrapping_unsigned_u128(word: word, bits: 72) } }
 }
 impl SolWrappingIntMarker for Uint72 {}
 impl SolWrappingInt for Uint80 {
     fn raw_word(self) -> u256 { self.val as u256 }
-    fn from_wrapping_word(self, _ word: u256) -> Self { Uint80 { val: wrapping_unsigned_u128(word: word, bits: 80) } }
+    fn from_wrapping_word(_ word: u256) -> Self { Uint80 { val: wrapping_unsigned_u128(word: word, bits: 80) } }
 }
 impl SolWrappingIntMarker for Uint80 {}
 impl SolWrappingInt for Uint88 {
     fn raw_word(self) -> u256 { self.val as u256 }
-    fn from_wrapping_word(self, _ word: u256) -> Self { Uint88 { val: wrapping_unsigned_u128(word: word, bits: 88) } }
+    fn from_wrapping_word(_ word: u256) -> Self { Uint88 { val: wrapping_unsigned_u128(word: word, bits: 88) } }
 }
 impl SolWrappingIntMarker for Uint88 {}
 impl SolWrappingInt for Uint96 {
     fn raw_word(self) -> u256 { self.val as u256 }
-    fn from_wrapping_word(self, _ word: u256) -> Self { Uint96 { val: wrapping_unsigned_u128(word: word, bits: 96) } }
+    fn from_wrapping_word(_ word: u256) -> Self { Uint96 { val: wrapping_unsigned_u128(word: word, bits: 96) } }
 }
 impl SolWrappingIntMarker for Uint96 {}
 impl SolWrappingInt for Uint104 {
     fn raw_word(self) -> u256 { self.val as u256 }
-    fn from_wrapping_word(self, _ word: u256) -> Self { Uint104 { val: wrapping_unsigned_u128(word: word, bits: 104) } }
+    fn from_wrapping_word(_ word: u256) -> Self { Uint104 { val: wrapping_unsigned_u128(word: word, bits: 104) } }
 }
 impl SolWrappingIntMarker for Uint104 {}
 impl SolWrappingInt for Uint112 {
     fn raw_word(self) -> u256 { self.val as u256 }
-    fn from_wrapping_word(self, _ word: u256) -> Self { Uint112 { val: wrapping_unsigned_u128(word: word, bits: 112) } }
+    fn from_wrapping_word(_ word: u256) -> Self { Uint112 { val: wrapping_unsigned_u128(word: word, bits: 112) } }
 }
 impl SolWrappingIntMarker for Uint112 {}
 impl SolWrappingInt for Uint120 {
     fn raw_word(self) -> u256 { self.val as u256 }
-    fn from_wrapping_word(self, _ word: u256) -> Self { Uint120 { val: wrapping_unsigned_u128(word: word, bits: 120) } }
+    fn from_wrapping_word(_ word: u256) -> Self { Uint120 { val: wrapping_unsigned_u128(word: word, bits: 120) } }
 }
 impl SolWrappingIntMarker for Uint120 {}
 impl SolWrappingInt for Uint136 {
     fn raw_word(self) -> u256 { self.val }
-    fn from_wrapping_word(self, _ word: u256) -> Self { Uint136 { val: wrapping_unsigned_word(word: word, bits: 136) } }
+    fn from_wrapping_word(_ word: u256) -> Self { Uint136 { val: wrapping_unsigned_word(word: word, bits: 136) } }
 }
 impl SolWrappingIntMarker for Uint136 {}
 impl SolWrappingInt for Uint144 {
     fn raw_word(self) -> u256 { self.val }
-    fn from_wrapping_word(self, _ word: u256) -> Self { Uint144 { val: wrapping_unsigned_word(word: word, bits: 144) } }
+    fn from_wrapping_word(_ word: u256) -> Self { Uint144 { val: wrapping_unsigned_word(word: word, bits: 144) } }
 }
 impl SolWrappingIntMarker for Uint144 {}
 impl SolWrappingInt for Uint152 {
     fn raw_word(self) -> u256 { self.val }
-    fn from_wrapping_word(self, _ word: u256) -> Self { Uint152 { val: wrapping_unsigned_word(word: word, bits: 152) } }
+    fn from_wrapping_word(_ word: u256) -> Self { Uint152 { val: wrapping_unsigned_word(word: word, bits: 152) } }
 }
 impl SolWrappingIntMarker for Uint152 {}
 impl SolWrappingInt for Uint160 {
     fn raw_word(self) -> u256 { self.val }
-    fn from_wrapping_word(self, _ word: u256) -> Self { Uint160 { val: wrapping_unsigned_word(word: word, bits: 160) } }
+    fn from_wrapping_word(_ word: u256) -> Self { Uint160 { val: wrapping_unsigned_word(word: word, bits: 160) } }
 }
 impl SolWrappingIntMarker for Uint160 {}
 impl SolWrappingInt for Uint168 {
     fn raw_word(self) -> u256 { self.val }
-    fn from_wrapping_word(self, _ word: u256) -> Self { Uint168 { val: wrapping_unsigned_word(word: word, bits: 168) } }
+    fn from_wrapping_word(_ word: u256) -> Self { Uint168 { val: wrapping_unsigned_word(word: word, bits: 168) } }
 }
 impl SolWrappingIntMarker for Uint168 {}
 impl SolWrappingInt for Uint176 {
     fn raw_word(self) -> u256 { self.val }
-    fn from_wrapping_word(self, _ word: u256) -> Self { Uint176 { val: wrapping_unsigned_word(word: word, bits: 176) } }
+    fn from_wrapping_word(_ word: u256) -> Self { Uint176 { val: wrapping_unsigned_word(word: word, bits: 176) } }
 }
 impl SolWrappingIntMarker for Uint176 {}
 impl SolWrappingInt for Uint184 {
     fn raw_word(self) -> u256 { self.val }
-    fn from_wrapping_word(self, _ word: u256) -> Self { Uint184 { val: wrapping_unsigned_word(word: word, bits: 184) } }
+    fn from_wrapping_word(_ word: u256) -> Self { Uint184 { val: wrapping_unsigned_word(word: word, bits: 184) } }
 }
 impl SolWrappingIntMarker for Uint184 {}
 impl SolWrappingInt for Uint192 {
     fn raw_word(self) -> u256 { self.val }
-    fn from_wrapping_word(self, _ word: u256) -> Self { Uint192 { val: wrapping_unsigned_word(word: word, bits: 192) } }
+    fn from_wrapping_word(_ word: u256) -> Self { Uint192 { val: wrapping_unsigned_word(word: word, bits: 192) } }
 }
 impl SolWrappingIntMarker for Uint192 {}
 impl SolWrappingInt for Uint200 {
     fn raw_word(self) -> u256 { self.val }
-    fn from_wrapping_word(self, _ word: u256) -> Self { Uint200 { val: wrapping_unsigned_word(word: word, bits: 200) } }
+    fn from_wrapping_word(_ word: u256) -> Self { Uint200 { val: wrapping_unsigned_word(word: word, bits: 200) } }
 }
 impl SolWrappingIntMarker for Uint200 {}
 impl SolWrappingInt for Uint208 {
     fn raw_word(self) -> u256 { self.val }
-    fn from_wrapping_word(self, _ word: u256) -> Self { Uint208 { val: wrapping_unsigned_word(word: word, bits: 208) } }
+    fn from_wrapping_word(_ word: u256) -> Self { Uint208 { val: wrapping_unsigned_word(word: word, bits: 208) } }
 }
 impl SolWrappingIntMarker for Uint208 {}
 impl SolWrappingInt for Uint216 {
     fn raw_word(self) -> u256 { self.val }
-    fn from_wrapping_word(self, _ word: u256) -> Self { Uint216 { val: wrapping_unsigned_word(word: word, bits: 216) } }
+    fn from_wrapping_word(_ word: u256) -> Self { Uint216 { val: wrapping_unsigned_word(word: word, bits: 216) } }
 }
 impl SolWrappingIntMarker for Uint216 {}
 impl SolWrappingInt for Uint224 {
     fn raw_word(self) -> u256 { self.val }
-    fn from_wrapping_word(self, _ word: u256) -> Self { Uint224 { val: wrapping_unsigned_word(word: word, bits: 224) } }
+    fn from_wrapping_word(_ word: u256) -> Self { Uint224 { val: wrapping_unsigned_word(word: word, bits: 224) } }
 }
 impl SolWrappingIntMarker for Uint224 {}
 impl SolWrappingInt for Uint232 {
     fn raw_word(self) -> u256 { self.val }
-    fn from_wrapping_word(self, _ word: u256) -> Self { Uint232 { val: wrapping_unsigned_word(word: word, bits: 232) } }
+    fn from_wrapping_word(_ word: u256) -> Self { Uint232 { val: wrapping_unsigned_word(word: word, bits: 232) } }
 }
 impl SolWrappingIntMarker for Uint232 {}
 impl SolWrappingInt for Uint240 {
     fn raw_word(self) -> u256 { self.val }
-    fn from_wrapping_word(self, _ word: u256) -> Self { Uint240 { val: wrapping_unsigned_word(word: word, bits: 240) } }
+    fn from_wrapping_word(_ word: u256) -> Self { Uint240 { val: wrapping_unsigned_word(word: word, bits: 240) } }
 }
 impl SolWrappingIntMarker for Uint240 {}
 impl SolWrappingInt for Uint248 {
     fn raw_word(self) -> u256 { self.val }
-    fn from_wrapping_word(self, _ word: u256) -> Self { Uint248 { val: wrapping_unsigned_word(word: word, bits: 248) } }
+    fn from_wrapping_word(_ word: u256) -> Self { Uint248 { val: wrapping_unsigned_word(word: word, bits: 248) } }
 }
 impl SolWrappingIntMarker for Uint248 {}
 
 impl SolWrappingInt for Int24 {
     fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
-    fn from_wrapping_word(self, _ word: u256) -> Self { Int24 { val: wrapping_signed_i32(word: word, bits: 24) } }
+    fn from_wrapping_word(_ word: u256) -> Self { Int24 { val: wrapping_signed_i32(word: word, bits: 24) } }
 }
 impl SolWrappingIntMarker for Int24 {}
 impl SolWrappingInt for Int40 {
     fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
-    fn from_wrapping_word(self, _ word: u256) -> Self { Int40 { val: wrapping_signed_i64(word: word, bits: 40) } }
+    fn from_wrapping_word(_ word: u256) -> Self { Int40 { val: wrapping_signed_i64(word: word, bits: 40) } }
 }
 impl SolWrappingIntMarker for Int40 {}
 impl SolWrappingInt for Int48 {
     fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
-    fn from_wrapping_word(self, _ word: u256) -> Self { Int48 { val: wrapping_signed_i64(word: word, bits: 48) } }
+    fn from_wrapping_word(_ word: u256) -> Self { Int48 { val: wrapping_signed_i64(word: word, bits: 48) } }
 }
 impl SolWrappingIntMarker for Int48 {}
 impl SolWrappingInt for Int56 {
     fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
-    fn from_wrapping_word(self, _ word: u256) -> Self { Int56 { val: wrapping_signed_i64(word: word, bits: 56) } }
+    fn from_wrapping_word(_ word: u256) -> Self { Int56 { val: wrapping_signed_i64(word: word, bits: 56) } }
 }
 impl SolWrappingIntMarker for Int56 {}
 impl SolWrappingInt for Int72 {
     fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
-    fn from_wrapping_word(self, _ word: u256) -> Self { Int72 { val: wrapping_signed_i128(word: word, bits: 72) } }
+    fn from_wrapping_word(_ word: u256) -> Self { Int72 { val: wrapping_signed_i128(word: word, bits: 72) } }
 }
 impl SolWrappingIntMarker for Int72 {}
 impl SolWrappingInt for Int80 {
     fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
-    fn from_wrapping_word(self, _ word: u256) -> Self { Int80 { val: wrapping_signed_i128(word: word, bits: 80) } }
+    fn from_wrapping_word(_ word: u256) -> Self { Int80 { val: wrapping_signed_i128(word: word, bits: 80) } }
 }
 impl SolWrappingIntMarker for Int80 {}
 impl SolWrappingInt for Int88 {
     fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
-    fn from_wrapping_word(self, _ word: u256) -> Self { Int88 { val: wrapping_signed_i128(word: word, bits: 88) } }
+    fn from_wrapping_word(_ word: u256) -> Self { Int88 { val: wrapping_signed_i128(word: word, bits: 88) } }
 }
 impl SolWrappingIntMarker for Int88 {}
 impl SolWrappingInt for Int96 {
     fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
-    fn from_wrapping_word(self, _ word: u256) -> Self { Int96 { val: wrapping_signed_i128(word: word, bits: 96) } }
+    fn from_wrapping_word(_ word: u256) -> Self { Int96 { val: wrapping_signed_i128(word: word, bits: 96) } }
 }
 impl SolWrappingIntMarker for Int96 {}
 impl SolWrappingInt for Int104 {
     fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
-    fn from_wrapping_word(self, _ word: u256) -> Self { Int104 { val: wrapping_signed_i128(word: word, bits: 104) } }
+    fn from_wrapping_word(_ word: u256) -> Self { Int104 { val: wrapping_signed_i128(word: word, bits: 104) } }
 }
 impl SolWrappingIntMarker for Int104 {}
 impl SolWrappingInt for Int112 {
     fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
-    fn from_wrapping_word(self, _ word: u256) -> Self { Int112 { val: wrapping_signed_i128(word: word, bits: 112) } }
+    fn from_wrapping_word(_ word: u256) -> Self { Int112 { val: wrapping_signed_i128(word: word, bits: 112) } }
 }
 impl SolWrappingIntMarker for Int112 {}
 impl SolWrappingInt for Int120 {
     fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
-    fn from_wrapping_word(self, _ word: u256) -> Self { Int120 { val: wrapping_signed_i128(word: word, bits: 120) } }
+    fn from_wrapping_word(_ word: u256) -> Self { Int120 { val: wrapping_signed_i128(word: word, bits: 120) } }
 }
 impl SolWrappingIntMarker for Int120 {}
 impl SolWrappingInt for Int136 {
     fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
-    fn from_wrapping_word(self, _ word: u256) -> Self { Int136 { val: wrapping_signed_i256(word: word, bits: 136) } }
+    fn from_wrapping_word(_ word: u256) -> Self { Int136 { val: wrapping_signed_i256(word: word, bits: 136) } }
 }
 impl SolWrappingIntMarker for Int136 {}
 impl SolWrappingInt for Int144 {
     fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
-    fn from_wrapping_word(self, _ word: u256) -> Self { Int144 { val: wrapping_signed_i256(word: word, bits: 144) } }
+    fn from_wrapping_word(_ word: u256) -> Self { Int144 { val: wrapping_signed_i256(word: word, bits: 144) } }
 }
 impl SolWrappingIntMarker for Int144 {}
 impl SolWrappingInt for Int152 {
     fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
-    fn from_wrapping_word(self, _ word: u256) -> Self { Int152 { val: wrapping_signed_i256(word: word, bits: 152) } }
+    fn from_wrapping_word(_ word: u256) -> Self { Int152 { val: wrapping_signed_i256(word: word, bits: 152) } }
 }
 impl SolWrappingIntMarker for Int152 {}
 impl SolWrappingInt for Int160 {
     fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
-    fn from_wrapping_word(self, _ word: u256) -> Self { Int160 { val: wrapping_signed_i256(word: word, bits: 160) } }
+    fn from_wrapping_word(_ word: u256) -> Self { Int160 { val: wrapping_signed_i256(word: word, bits: 160) } }
 }
 impl SolWrappingIntMarker for Int160 {}
 impl SolWrappingInt for Int168 {
     fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
-    fn from_wrapping_word(self, _ word: u256) -> Self { Int168 { val: wrapping_signed_i256(word: word, bits: 168) } }
+    fn from_wrapping_word(_ word: u256) -> Self { Int168 { val: wrapping_signed_i256(word: word, bits: 168) } }
 }
 impl SolWrappingIntMarker for Int168 {}
 impl SolWrappingInt for Int176 {
     fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
-    fn from_wrapping_word(self, _ word: u256) -> Self { Int176 { val: wrapping_signed_i256(word: word, bits: 176) } }
+    fn from_wrapping_word(_ word: u256) -> Self { Int176 { val: wrapping_signed_i256(word: word, bits: 176) } }
 }
 impl SolWrappingIntMarker for Int176 {}
 impl SolWrappingInt for Int184 {
     fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
-    fn from_wrapping_word(self, _ word: u256) -> Self { Int184 { val: wrapping_signed_i256(word: word, bits: 184) } }
+    fn from_wrapping_word(_ word: u256) -> Self { Int184 { val: wrapping_signed_i256(word: word, bits: 184) } }
 }
 impl SolWrappingIntMarker for Int184 {}
 impl SolWrappingInt for Int192 {
     fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
-    fn from_wrapping_word(self, _ word: u256) -> Self { Int192 { val: wrapping_signed_i256(word: word, bits: 192) } }
+    fn from_wrapping_word(_ word: u256) -> Self { Int192 { val: wrapping_signed_i256(word: word, bits: 192) } }
 }
 impl SolWrappingIntMarker for Int192 {}
 impl SolWrappingInt for Int200 {
     fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
-    fn from_wrapping_word(self, _ word: u256) -> Self { Int200 { val: wrapping_signed_i256(word: word, bits: 200) } }
+    fn from_wrapping_word(_ word: u256) -> Self { Int200 { val: wrapping_signed_i256(word: word, bits: 200) } }
 }
 impl SolWrappingIntMarker for Int200 {}
 impl SolWrappingInt for Int208 {
     fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
-    fn from_wrapping_word(self, _ word: u256) -> Self { Int208 { val: wrapping_signed_i256(word: word, bits: 208) } }
+    fn from_wrapping_word(_ word: u256) -> Self { Int208 { val: wrapping_signed_i256(word: word, bits: 208) } }
 }
 impl SolWrappingIntMarker for Int208 {}
 impl SolWrappingInt for Int216 {
     fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
-    fn from_wrapping_word(self, _ word: u256) -> Self { Int216 { val: wrapping_signed_i256(word: word, bits: 216) } }
+    fn from_wrapping_word(_ word: u256) -> Self { Int216 { val: wrapping_signed_i256(word: word, bits: 216) } }
 }
 impl SolWrappingIntMarker for Int216 {}
 impl SolWrappingInt for Int224 {
     fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
-    fn from_wrapping_word(self, _ word: u256) -> Self { Int224 { val: wrapping_signed_i256(word: word, bits: 224) } }
+    fn from_wrapping_word(_ word: u256) -> Self { Int224 { val: wrapping_signed_i256(word: word, bits: 224) } }
 }
 impl SolWrappingIntMarker for Int224 {}
 impl SolWrappingInt for Int232 {
     fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
-    fn from_wrapping_word(self, _ word: u256) -> Self { Int232 { val: wrapping_signed_i256(word: word, bits: 232) } }
+    fn from_wrapping_word(_ word: u256) -> Self { Int232 { val: wrapping_signed_i256(word: word, bits: 232) } }
 }
 impl SolWrappingIntMarker for Int232 {}
 impl SolWrappingInt for Int240 {
     fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
-    fn from_wrapping_word(self, _ word: u256) -> Self { Int240 { val: wrapping_signed_i256(word: word, bits: 240) } }
+    fn from_wrapping_word(_ word: u256) -> Self { Int240 { val: wrapping_signed_i256(word: word, bits: 240) } }
 }
 impl SolWrappingIntMarker for Int240 {}
 impl SolWrappingInt for Int248 {
     fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
-    fn from_wrapping_word(self, _ word: u256) -> Self { Int248 { val: wrapping_signed_i256(word: word, bits: 248) } }
+    fn from_wrapping_word(_ word: u256) -> Self { Int248 { val: wrapping_signed_i256(word: word, bits: 248) } }
 }
 impl SolWrappingIntMarker for Int248 {}
 

--- a/ingots/std/src/abi/sol/ints.fe
+++ b/ingots/std/src/abi/sol/ints.fe
@@ -97,7 +97,15 @@ trait SolWrappingInt: Copy {
     fn from_wrapping_word(_: u256) -> Self
 }
 
-trait SolWrappingIntMarker {}
+// Sealed marker for the custom-width Solidity int wrappers below. It lets the
+// blanket impls of the foreign ABI/event traits (`Encode`, `AbiSize`,
+// `AbiSpan`, `TopicValue`, and the `Wrapping*` ops) apply only to these
+// newtypes: a private, empty marker whose every impl targets a local nominal
+// type is "sealed", which is what makes a local blanket impl of a foreign
+// trait admissible. It must stay non-`pub` and be implemented per-type (a
+// blanket `impl<T: ..> SolInt for T` would break the sealing), so each wrapper
+// has its own `impl SolInt`.
+trait SolInt {}
 
 fn wrapping_unsigned_word(word: u256, bits: u256) -> u256 {
     word & (((1 as u256) << bits) - 1)
@@ -598,683 +606,275 @@ impl SolWrappingInt for Uint24 {
     fn raw_word(self) -> u256 { self.val as u256 }
     fn from_wrapping_word(_ word: u256) -> Self { Uint24 { val: wrapping_unsigned_u32(word: word, bits: 24) } }
 }
-impl SolWrappingIntMarker for Uint24 {}
+impl SolInt for Uint24 {}
 impl SolWrappingInt for Uint40 {
     fn raw_word(self) -> u256 { self.val as u256 }
     fn from_wrapping_word(_ word: u256) -> Self { Uint40 { val: wrapping_unsigned_u64(word: word, bits: 40) } }
 }
-impl SolWrappingIntMarker for Uint40 {}
+impl SolInt for Uint40 {}
 impl SolWrappingInt for Uint48 {
     fn raw_word(self) -> u256 { self.val as u256 }
     fn from_wrapping_word(_ word: u256) -> Self { Uint48 { val: wrapping_unsigned_u64(word: word, bits: 48) } }
 }
-impl SolWrappingIntMarker for Uint48 {}
+impl SolInt for Uint48 {}
 impl SolWrappingInt for Uint56 {
     fn raw_word(self) -> u256 { self.val as u256 }
     fn from_wrapping_word(_ word: u256) -> Self { Uint56 { val: wrapping_unsigned_u64(word: word, bits: 56) } }
 }
-impl SolWrappingIntMarker for Uint56 {}
+impl SolInt for Uint56 {}
 impl SolWrappingInt for Uint72 {
     fn raw_word(self) -> u256 { self.val as u256 }
     fn from_wrapping_word(_ word: u256) -> Self { Uint72 { val: wrapping_unsigned_u128(word: word, bits: 72) } }
 }
-impl SolWrappingIntMarker for Uint72 {}
+impl SolInt for Uint72 {}
 impl SolWrappingInt for Uint80 {
     fn raw_word(self) -> u256 { self.val as u256 }
     fn from_wrapping_word(_ word: u256) -> Self { Uint80 { val: wrapping_unsigned_u128(word: word, bits: 80) } }
 }
-impl SolWrappingIntMarker for Uint80 {}
+impl SolInt for Uint80 {}
 impl SolWrappingInt for Uint88 {
     fn raw_word(self) -> u256 { self.val as u256 }
     fn from_wrapping_word(_ word: u256) -> Self { Uint88 { val: wrapping_unsigned_u128(word: word, bits: 88) } }
 }
-impl SolWrappingIntMarker for Uint88 {}
+impl SolInt for Uint88 {}
 impl SolWrappingInt for Uint96 {
     fn raw_word(self) -> u256 { self.val as u256 }
     fn from_wrapping_word(_ word: u256) -> Self { Uint96 { val: wrapping_unsigned_u128(word: word, bits: 96) } }
 }
-impl SolWrappingIntMarker for Uint96 {}
+impl SolInt for Uint96 {}
 impl SolWrappingInt for Uint104 {
     fn raw_word(self) -> u256 { self.val as u256 }
     fn from_wrapping_word(_ word: u256) -> Self { Uint104 { val: wrapping_unsigned_u128(word: word, bits: 104) } }
 }
-impl SolWrappingIntMarker for Uint104 {}
+impl SolInt for Uint104 {}
 impl SolWrappingInt for Uint112 {
     fn raw_word(self) -> u256 { self.val as u256 }
     fn from_wrapping_word(_ word: u256) -> Self { Uint112 { val: wrapping_unsigned_u128(word: word, bits: 112) } }
 }
-impl SolWrappingIntMarker for Uint112 {}
+impl SolInt for Uint112 {}
 impl SolWrappingInt for Uint120 {
     fn raw_word(self) -> u256 { self.val as u256 }
     fn from_wrapping_word(_ word: u256) -> Self { Uint120 { val: wrapping_unsigned_u128(word: word, bits: 120) } }
 }
-impl SolWrappingIntMarker for Uint120 {}
+impl SolInt for Uint120 {}
 impl SolWrappingInt for Uint136 {
     fn raw_word(self) -> u256 { self.val }
     fn from_wrapping_word(_ word: u256) -> Self { Uint136 { val: wrapping_unsigned_word(word: word, bits: 136) } }
 }
-impl SolWrappingIntMarker for Uint136 {}
+impl SolInt for Uint136 {}
 impl SolWrappingInt for Uint144 {
     fn raw_word(self) -> u256 { self.val }
     fn from_wrapping_word(_ word: u256) -> Self { Uint144 { val: wrapping_unsigned_word(word: word, bits: 144) } }
 }
-impl SolWrappingIntMarker for Uint144 {}
+impl SolInt for Uint144 {}
 impl SolWrappingInt for Uint152 {
     fn raw_word(self) -> u256 { self.val }
     fn from_wrapping_word(_ word: u256) -> Self { Uint152 { val: wrapping_unsigned_word(word: word, bits: 152) } }
 }
-impl SolWrappingIntMarker for Uint152 {}
+impl SolInt for Uint152 {}
 impl SolWrappingInt for Uint160 {
     fn raw_word(self) -> u256 { self.val }
     fn from_wrapping_word(_ word: u256) -> Self { Uint160 { val: wrapping_unsigned_word(word: word, bits: 160) } }
 }
-impl SolWrappingIntMarker for Uint160 {}
+impl SolInt for Uint160 {}
 impl SolWrappingInt for Uint168 {
     fn raw_word(self) -> u256 { self.val }
     fn from_wrapping_word(_ word: u256) -> Self { Uint168 { val: wrapping_unsigned_word(word: word, bits: 168) } }
 }
-impl SolWrappingIntMarker for Uint168 {}
+impl SolInt for Uint168 {}
 impl SolWrappingInt for Uint176 {
     fn raw_word(self) -> u256 { self.val }
     fn from_wrapping_word(_ word: u256) -> Self { Uint176 { val: wrapping_unsigned_word(word: word, bits: 176) } }
 }
-impl SolWrappingIntMarker for Uint176 {}
+impl SolInt for Uint176 {}
 impl SolWrappingInt for Uint184 {
     fn raw_word(self) -> u256 { self.val }
     fn from_wrapping_word(_ word: u256) -> Self { Uint184 { val: wrapping_unsigned_word(word: word, bits: 184) } }
 }
-impl SolWrappingIntMarker for Uint184 {}
+impl SolInt for Uint184 {}
 impl SolWrappingInt for Uint192 {
     fn raw_word(self) -> u256 { self.val }
     fn from_wrapping_word(_ word: u256) -> Self { Uint192 { val: wrapping_unsigned_word(word: word, bits: 192) } }
 }
-impl SolWrappingIntMarker for Uint192 {}
+impl SolInt for Uint192 {}
 impl SolWrappingInt for Uint200 {
     fn raw_word(self) -> u256 { self.val }
     fn from_wrapping_word(_ word: u256) -> Self { Uint200 { val: wrapping_unsigned_word(word: word, bits: 200) } }
 }
-impl SolWrappingIntMarker for Uint200 {}
+impl SolInt for Uint200 {}
 impl SolWrappingInt for Uint208 {
     fn raw_word(self) -> u256 { self.val }
     fn from_wrapping_word(_ word: u256) -> Self { Uint208 { val: wrapping_unsigned_word(word: word, bits: 208) } }
 }
-impl SolWrappingIntMarker for Uint208 {}
+impl SolInt for Uint208 {}
 impl SolWrappingInt for Uint216 {
     fn raw_word(self) -> u256 { self.val }
     fn from_wrapping_word(_ word: u256) -> Self { Uint216 { val: wrapping_unsigned_word(word: word, bits: 216) } }
 }
-impl SolWrappingIntMarker for Uint216 {}
+impl SolInt for Uint216 {}
 impl SolWrappingInt for Uint224 {
     fn raw_word(self) -> u256 { self.val }
     fn from_wrapping_word(_ word: u256) -> Self { Uint224 { val: wrapping_unsigned_word(word: word, bits: 224) } }
 }
-impl SolWrappingIntMarker for Uint224 {}
+impl SolInt for Uint224 {}
 impl SolWrappingInt for Uint232 {
     fn raw_word(self) -> u256 { self.val }
     fn from_wrapping_word(_ word: u256) -> Self { Uint232 { val: wrapping_unsigned_word(word: word, bits: 232) } }
 }
-impl SolWrappingIntMarker for Uint232 {}
+impl SolInt for Uint232 {}
 impl SolWrappingInt for Uint240 {
     fn raw_word(self) -> u256 { self.val }
     fn from_wrapping_word(_ word: u256) -> Self { Uint240 { val: wrapping_unsigned_word(word: word, bits: 240) } }
 }
-impl SolWrappingIntMarker for Uint240 {}
+impl SolInt for Uint240 {}
 impl SolWrappingInt for Uint248 {
     fn raw_word(self) -> u256 { self.val }
     fn from_wrapping_word(_ word: u256) -> Self { Uint248 { val: wrapping_unsigned_word(word: word, bits: 248) } }
 }
-impl SolWrappingIntMarker for Uint248 {}
+impl SolInt for Uint248 {}
 
 impl SolWrappingInt for Int24 {
     fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
     fn from_wrapping_word(_ word: u256) -> Self { Int24 { val: wrapping_signed_i32(word: word, bits: 24) } }
 }
-impl SolWrappingIntMarker for Int24 {}
+impl SolInt for Int24 {}
 impl SolWrappingInt for Int40 {
     fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
     fn from_wrapping_word(_ word: u256) -> Self { Int40 { val: wrapping_signed_i64(word: word, bits: 40) } }
 }
-impl SolWrappingIntMarker for Int40 {}
+impl SolInt for Int40 {}
 impl SolWrappingInt for Int48 {
     fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
     fn from_wrapping_word(_ word: u256) -> Self { Int48 { val: wrapping_signed_i64(word: word, bits: 48) } }
 }
-impl SolWrappingIntMarker for Int48 {}
+impl SolInt for Int48 {}
 impl SolWrappingInt for Int56 {
     fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
     fn from_wrapping_word(_ word: u256) -> Self { Int56 { val: wrapping_signed_i64(word: word, bits: 56) } }
 }
-impl SolWrappingIntMarker for Int56 {}
+impl SolInt for Int56 {}
 impl SolWrappingInt for Int72 {
     fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
     fn from_wrapping_word(_ word: u256) -> Self { Int72 { val: wrapping_signed_i128(word: word, bits: 72) } }
 }
-impl SolWrappingIntMarker for Int72 {}
+impl SolInt for Int72 {}
 impl SolWrappingInt for Int80 {
     fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
     fn from_wrapping_word(_ word: u256) -> Self { Int80 { val: wrapping_signed_i128(word: word, bits: 80) } }
 }
-impl SolWrappingIntMarker for Int80 {}
+impl SolInt for Int80 {}
 impl SolWrappingInt for Int88 {
     fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
     fn from_wrapping_word(_ word: u256) -> Self { Int88 { val: wrapping_signed_i128(word: word, bits: 88) } }
 }
-impl SolWrappingIntMarker for Int88 {}
+impl SolInt for Int88 {}
 impl SolWrappingInt for Int96 {
     fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
     fn from_wrapping_word(_ word: u256) -> Self { Int96 { val: wrapping_signed_i128(word: word, bits: 96) } }
 }
-impl SolWrappingIntMarker for Int96 {}
+impl SolInt for Int96 {}
 impl SolWrappingInt for Int104 {
     fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
     fn from_wrapping_word(_ word: u256) -> Self { Int104 { val: wrapping_signed_i128(word: word, bits: 104) } }
 }
-impl SolWrappingIntMarker for Int104 {}
+impl SolInt for Int104 {}
 impl SolWrappingInt for Int112 {
     fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
     fn from_wrapping_word(_ word: u256) -> Self { Int112 { val: wrapping_signed_i128(word: word, bits: 112) } }
 }
-impl SolWrappingIntMarker for Int112 {}
+impl SolInt for Int112 {}
 impl SolWrappingInt for Int120 {
     fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
     fn from_wrapping_word(_ word: u256) -> Self { Int120 { val: wrapping_signed_i128(word: word, bits: 120) } }
 }
-impl SolWrappingIntMarker for Int120 {}
+impl SolInt for Int120 {}
 impl SolWrappingInt for Int136 {
     fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
     fn from_wrapping_word(_ word: u256) -> Self { Int136 { val: wrapping_signed_i256(word: word, bits: 136) } }
 }
-impl SolWrappingIntMarker for Int136 {}
+impl SolInt for Int136 {}
 impl SolWrappingInt for Int144 {
     fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
     fn from_wrapping_word(_ word: u256) -> Self { Int144 { val: wrapping_signed_i256(word: word, bits: 144) } }
 }
-impl SolWrappingIntMarker for Int144 {}
+impl SolInt for Int144 {}
 impl SolWrappingInt for Int152 {
     fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
     fn from_wrapping_word(_ word: u256) -> Self { Int152 { val: wrapping_signed_i256(word: word, bits: 152) } }
 }
-impl SolWrappingIntMarker for Int152 {}
+impl SolInt for Int152 {}
 impl SolWrappingInt for Int160 {
     fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
     fn from_wrapping_word(_ word: u256) -> Self { Int160 { val: wrapping_signed_i256(word: word, bits: 160) } }
 }
-impl SolWrappingIntMarker for Int160 {}
+impl SolInt for Int160 {}
 impl SolWrappingInt for Int168 {
     fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
     fn from_wrapping_word(_ word: u256) -> Self { Int168 { val: wrapping_signed_i256(word: word, bits: 168) } }
 }
-impl SolWrappingIntMarker for Int168 {}
+impl SolInt for Int168 {}
 impl SolWrappingInt for Int176 {
     fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
     fn from_wrapping_word(_ word: u256) -> Self { Int176 { val: wrapping_signed_i256(word: word, bits: 176) } }
 }
-impl SolWrappingIntMarker for Int176 {}
+impl SolInt for Int176 {}
 impl SolWrappingInt for Int184 {
     fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
     fn from_wrapping_word(_ word: u256) -> Self { Int184 { val: wrapping_signed_i256(word: word, bits: 184) } }
 }
-impl SolWrappingIntMarker for Int184 {}
+impl SolInt for Int184 {}
 impl SolWrappingInt for Int192 {
     fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
     fn from_wrapping_word(_ word: u256) -> Self { Int192 { val: wrapping_signed_i256(word: word, bits: 192) } }
 }
-impl SolWrappingIntMarker for Int192 {}
+impl SolInt for Int192 {}
 impl SolWrappingInt for Int200 {
     fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
     fn from_wrapping_word(_ word: u256) -> Self { Int200 { val: wrapping_signed_i256(word: word, bits: 200) } }
 }
-impl SolWrappingIntMarker for Int200 {}
+impl SolInt for Int200 {}
 impl SolWrappingInt for Int208 {
     fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
     fn from_wrapping_word(_ word: u256) -> Self { Int208 { val: wrapping_signed_i256(word: word, bits: 208) } }
 }
-impl SolWrappingIntMarker for Int208 {}
+impl SolInt for Int208 {}
 impl SolWrappingInt for Int216 {
     fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
     fn from_wrapping_word(_ word: u256) -> Self { Int216 { val: wrapping_signed_i256(word: word, bits: 216) } }
 }
-impl SolWrappingIntMarker for Int216 {}
+impl SolInt for Int216 {}
 impl SolWrappingInt for Int224 {
     fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
     fn from_wrapping_word(_ word: u256) -> Self { Int224 { val: wrapping_signed_i256(word: word, bits: 224) } }
 }
-impl SolWrappingIntMarker for Int224 {}
+impl SolInt for Int224 {}
 impl SolWrappingInt for Int232 {
     fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
     fn from_wrapping_word(_ word: u256) -> Self { Int232 { val: wrapping_signed_i256(word: word, bits: 232) } }
 }
-impl SolWrappingIntMarker for Int232 {}
+impl SolInt for Int232 {}
 impl SolWrappingInt for Int240 {
     fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
     fn from_wrapping_word(_ word: u256) -> Self { Int240 { val: wrapping_signed_i256(word: word, bits: 240) } }
 }
-impl SolWrappingIntMarker for Int240 {}
+impl SolInt for Int240 {}
 impl SolWrappingInt for Int248 {
     fn raw_word(self) -> u256 { self.val.downcast_unchecked() }
     fn from_wrapping_word(_ word: u256) -> Self { Int248 { val: wrapping_signed_i256(word: word, bits: 248) } }
 }
-impl SolWrappingIntMarker for Int248 {}
+impl SolInt for Int248 {}
 
-impl<T: SolWrappingInt + SolWrappingIntMarker> WrappingAdd for T {
+impl<T: SolWrappingInt + SolInt> WrappingAdd for T {
     fn wrapping_add(self, _ other: T) -> T { sol_wrapping_add(a: self, b: other) }
 }
-impl<T: SolWrappingInt + SolWrappingIntMarker> WrappingSub for T {
+impl<T: SolWrappingInt + SolInt> WrappingSub for T {
     fn wrapping_sub(self, _ other: T) -> T { sol_wrapping_sub(a: self, b: other) }
 }
-impl<T: SolWrappingInt + SolWrappingIntMarker> WrappingMul for T {
+impl<T: SolWrappingInt + SolInt> WrappingMul for T {
     fn wrapping_mul(self, _ other: T) -> T { sol_wrapping_mul(a: self, b: other) }
 }
 
-impl<A: Abi> Encode<A> for Uint24 {
-    const DIRECT_ENCODE: bool = true
-
-    fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) { e.write_word(self.canonical_word()) }
-
-    fn encode_to_ptr(own self, _ ptr: u256) { A::store_word(ptr: ptr, value: self.canonical_word()) }
-}
-
-impl<A: Abi> Encode<A> for Uint40 {
-    const DIRECT_ENCODE: bool = true
-
-    fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) { e.write_word(self.canonical_word()) }
-
-    fn encode_to_ptr(own self, _ ptr: u256) { A::store_word(ptr: ptr, value: self.canonical_word()) }
-}
-
-impl<A: Abi> Encode<A> for Uint48 {
-    const DIRECT_ENCODE: bool = true
-
-    fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) { e.write_word(self.canonical_word()) }
-
-    fn encode_to_ptr(own self, _ ptr: u256) { A::store_word(ptr: ptr, value: self.canonical_word()) }
-}
-
-impl<A: Abi> Encode<A> for Uint56 {
-    const DIRECT_ENCODE: bool = true
-
-    fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) { e.write_word(self.canonical_word()) }
-
-    fn encode_to_ptr(own self, _ ptr: u256) { A::store_word(ptr: ptr, value: self.canonical_word()) }
-}
-
-impl<A: Abi> Encode<A> for Uint72 {
-    const DIRECT_ENCODE: bool = true
-
-    fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) { e.write_word(self.canonical_word()) }
-
-    fn encode_to_ptr(own self, _ ptr: u256) { A::store_word(ptr: ptr, value: self.canonical_word()) }
-}
-
-impl<A: Abi> Encode<A> for Uint80 {
-    const DIRECT_ENCODE: bool = true
-
-    fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) { e.write_word(self.canonical_word()) }
-
-    fn encode_to_ptr(own self, _ ptr: u256) { A::store_word(ptr: ptr, value: self.canonical_word()) }
-}
-
-impl<A: Abi> Encode<A> for Uint88 {
-    const DIRECT_ENCODE: bool = true
-
-    fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) { e.write_word(self.canonical_word()) }
-
-    fn encode_to_ptr(own self, _ ptr: u256) { A::store_word(ptr: ptr, value: self.canonical_word()) }
-}
-
-impl<A: Abi> Encode<A> for Uint96 {
-    const DIRECT_ENCODE: bool = true
-
-    fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) { e.write_word(self.canonical_word()) }
-
-    fn encode_to_ptr(own self, _ ptr: u256) { A::store_word(ptr: ptr, value: self.canonical_word()) }
-}
-
-impl<A: Abi> Encode<A> for Uint104 {
-    const DIRECT_ENCODE: bool = true
-
-    fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) { e.write_word(self.canonical_word()) }
-
-    fn encode_to_ptr(own self, _ ptr: u256) { A::store_word(ptr: ptr, value: self.canonical_word()) }
-}
-
-impl<A: Abi> Encode<A> for Uint112 {
-    const DIRECT_ENCODE: bool = true
-
-    fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) { e.write_word(self.canonical_word()) }
-
-    fn encode_to_ptr(own self, _ ptr: u256) { A::store_word(ptr: ptr, value: self.canonical_word()) }
-}
-
-impl<A: Abi> Encode<A> for Uint120 {
-    const DIRECT_ENCODE: bool = true
-
-    fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) { e.write_word(self.canonical_word()) }
-
-    fn encode_to_ptr(own self, _ ptr: u256) { A::store_word(ptr: ptr, value: self.canonical_word()) }
-}
-
-impl<A: Abi> Encode<A> for Uint136 {
-    const DIRECT_ENCODE: bool = true
-
-    fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) { e.write_word(self.canonical_word()) }
-
-    fn encode_to_ptr(own self, _ ptr: u256) { A::store_word(ptr: ptr, value: self.canonical_word()) }
-}
-
-impl<A: Abi> Encode<A> for Uint144 {
-    const DIRECT_ENCODE: bool = true
-
-    fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) { e.write_word(self.canonical_word()) }
-
-    fn encode_to_ptr(own self, _ ptr: u256) { A::store_word(ptr: ptr, value: self.canonical_word()) }
-}
-
-impl<A: Abi> Encode<A> for Uint152 {
-    const DIRECT_ENCODE: bool = true
-
-    fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) { e.write_word(self.canonical_word()) }
-
-    fn encode_to_ptr(own self, _ ptr: u256) { A::store_word(ptr: ptr, value: self.canonical_word()) }
-}
-
-impl<A: Abi> Encode<A> for Uint160 {
-    const DIRECT_ENCODE: bool = true
-
-    fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) { e.write_word(self.canonical_word()) }
-
-    fn encode_to_ptr(own self, _ ptr: u256) { A::store_word(ptr: ptr, value: self.canonical_word()) }
-}
-
-impl<A: Abi> Encode<A> for Uint168 {
-    const DIRECT_ENCODE: bool = true
-
-    fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) { e.write_word(self.canonical_word()) }
-
-    fn encode_to_ptr(own self, _ ptr: u256) { A::store_word(ptr: ptr, value: self.canonical_word()) }
-}
-
-impl<A: Abi> Encode<A> for Uint176 {
-    const DIRECT_ENCODE: bool = true
-
-    fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) { e.write_word(self.canonical_word()) }
-
-    fn encode_to_ptr(own self, _ ptr: u256) { A::store_word(ptr: ptr, value: self.canonical_word()) }
-}
-
-impl<A: Abi> Encode<A> for Uint184 {
-    const DIRECT_ENCODE: bool = true
-
-    fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) { e.write_word(self.canonical_word()) }
-
-    fn encode_to_ptr(own self, _ ptr: u256) { A::store_word(ptr: ptr, value: self.canonical_word()) }
-}
-
-impl<A: Abi> Encode<A> for Uint192 {
-    const DIRECT_ENCODE: bool = true
-
-    fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) { e.write_word(self.canonical_word()) }
-
-    fn encode_to_ptr(own self, _ ptr: u256) { A::store_word(ptr: ptr, value: self.canonical_word()) }
-}
-
-impl<A: Abi> Encode<A> for Uint200 {
-    const DIRECT_ENCODE: bool = true
-
-    fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) { e.write_word(self.canonical_word()) }
-
-    fn encode_to_ptr(own self, _ ptr: u256) { A::store_word(ptr: ptr, value: self.canonical_word()) }
-}
-
-impl<A: Abi> Encode<A> for Uint208 {
-    const DIRECT_ENCODE: bool = true
-
-    fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) { e.write_word(self.canonical_word()) }
-
-    fn encode_to_ptr(own self, _ ptr: u256) { A::store_word(ptr: ptr, value: self.canonical_word()) }
-}
-
-impl<A: Abi> Encode<A> for Uint216 {
-    const DIRECT_ENCODE: bool = true
-
-    fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) { e.write_word(self.canonical_word()) }
-
-    fn encode_to_ptr(own self, _ ptr: u256) { A::store_word(ptr: ptr, value: self.canonical_word()) }
-}
-
-impl<A: Abi> Encode<A> for Uint224 {
-    const DIRECT_ENCODE: bool = true
-
-    fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) { e.write_word(self.canonical_word()) }
-
-    fn encode_to_ptr(own self, _ ptr: u256) { A::store_word(ptr: ptr, value: self.canonical_word()) }
-}
-
-impl<A: Abi> Encode<A> for Uint232 {
-    const DIRECT_ENCODE: bool = true
-
-    fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) { e.write_word(self.canonical_word()) }
-
-    fn encode_to_ptr(own self, _ ptr: u256) { A::store_word(ptr: ptr, value: self.canonical_word()) }
-}
-
-impl<A: Abi> Encode<A> for Uint240 {
-    const DIRECT_ENCODE: bool = true
-
-    fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) { e.write_word(self.canonical_word()) }
-
-    fn encode_to_ptr(own self, _ ptr: u256) { A::store_word(ptr: ptr, value: self.canonical_word()) }
-}
-
-impl<A: Abi> Encode<A> for Uint248 {
-    const DIRECT_ENCODE: bool = true
-
-    fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) { e.write_word(self.canonical_word()) }
-
-    fn encode_to_ptr(own self, _ ptr: u256) { A::store_word(ptr: ptr, value: self.canonical_word()) }
-}
-
-impl<A: Abi> Encode<A> for Int24 {
-    const DIRECT_ENCODE: bool = true
-
-    fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) { e.write_word(self.canonical_word()) }
-
-    fn encode_to_ptr(own self, _ ptr: u256) { A::store_word(ptr: ptr, value: self.canonical_word()) }
-}
-
-impl<A: Abi> Encode<A> for Int40 {
-    const DIRECT_ENCODE: bool = true
-
-    fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) { e.write_word(self.canonical_word()) }
-
-    fn encode_to_ptr(own self, _ ptr: u256) { A::store_word(ptr: ptr, value: self.canonical_word()) }
-}
-
-impl<A: Abi> Encode<A> for Int48 {
-    const DIRECT_ENCODE: bool = true
-
-    fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) { e.write_word(self.canonical_word()) }
-
-    fn encode_to_ptr(own self, _ ptr: u256) { A::store_word(ptr: ptr, value: self.canonical_word()) }
-}
-
-impl<A: Abi> Encode<A> for Int56 {
-    const DIRECT_ENCODE: bool = true
-
-    fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) { e.write_word(self.canonical_word()) }
-
-    fn encode_to_ptr(own self, _ ptr: u256) { A::store_word(ptr: ptr, value: self.canonical_word()) }
-}
-
-impl<A: Abi> Encode<A> for Int72 {
-    const DIRECT_ENCODE: bool = true
-
-    fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) { e.write_word(self.canonical_word()) }
-
-    fn encode_to_ptr(own self, _ ptr: u256) { A::store_word(ptr: ptr, value: self.canonical_word()) }
-}
-
-impl<A: Abi> Encode<A> for Int80 {
-    const DIRECT_ENCODE: bool = true
-
-    fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) { e.write_word(self.canonical_word()) }
-
-    fn encode_to_ptr(own self, _ ptr: u256) { A::store_word(ptr: ptr, value: self.canonical_word()) }
-}
-
-impl<A: Abi> Encode<A> for Int88 {
-    const DIRECT_ENCODE: bool = true
-
-    fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) { e.write_word(self.canonical_word()) }
-
-    fn encode_to_ptr(own self, _ ptr: u256) { A::store_word(ptr: ptr, value: self.canonical_word()) }
-}
-
-impl<A: Abi> Encode<A> for Int96 {
-    const DIRECT_ENCODE: bool = true
-
-    fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) { e.write_word(self.canonical_word()) }
-
-    fn encode_to_ptr(own self, _ ptr: u256) { A::store_word(ptr: ptr, value: self.canonical_word()) }
-}
-
-impl<A: Abi> Encode<A> for Int104 {
-    const DIRECT_ENCODE: bool = true
-
-    fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) { e.write_word(self.canonical_word()) }
-
-    fn encode_to_ptr(own self, _ ptr: u256) { A::store_word(ptr: ptr, value: self.canonical_word()) }
-}
-
-impl<A: Abi> Encode<A> for Int112 {
-    const DIRECT_ENCODE: bool = true
-
-    fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) { e.write_word(self.canonical_word()) }
-
-    fn encode_to_ptr(own self, _ ptr: u256) { A::store_word(ptr: ptr, value: self.canonical_word()) }
-}
-
-impl<A: Abi> Encode<A> for Int120 {
-    const DIRECT_ENCODE: bool = true
-
-    fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) { e.write_word(self.canonical_word()) }
-
-    fn encode_to_ptr(own self, _ ptr: u256) { A::store_word(ptr: ptr, value: self.canonical_word()) }
-}
-
-impl<A: Abi> Encode<A> for Int136 {
-    const DIRECT_ENCODE: bool = true
-
-    fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) { e.write_word(self.canonical_word()) }
-
-    fn encode_to_ptr(own self, _ ptr: u256) { A::store_word(ptr: ptr, value: self.canonical_word()) }
-}
-
-impl<A: Abi> Encode<A> for Int144 {
-    const DIRECT_ENCODE: bool = true
-
-    fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) { e.write_word(self.canonical_word()) }
-
-    fn encode_to_ptr(own self, _ ptr: u256) { A::store_word(ptr: ptr, value: self.canonical_word()) }
-}
-
-impl<A: Abi> Encode<A> for Int152 {
-    const DIRECT_ENCODE: bool = true
-
-    fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) { e.write_word(self.canonical_word()) }
-
-    fn encode_to_ptr(own self, _ ptr: u256) { A::store_word(ptr: ptr, value: self.canonical_word()) }
-}
-
-impl<A: Abi> Encode<A> for Int160 {
-    const DIRECT_ENCODE: bool = true
-
-    fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) { e.write_word(self.canonical_word()) }
-
-    fn encode_to_ptr(own self, _ ptr: u256) { A::store_word(ptr: ptr, value: self.canonical_word()) }
-}
-
-impl<A: Abi> Encode<A> for Int168 {
-    const DIRECT_ENCODE: bool = true
-
-    fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) { e.write_word(self.canonical_word()) }
-
-    fn encode_to_ptr(own self, _ ptr: u256) { A::store_word(ptr: ptr, value: self.canonical_word()) }
-}
-
-impl<A: Abi> Encode<A> for Int176 {
-    const DIRECT_ENCODE: bool = true
-
-    fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) { e.write_word(self.canonical_word()) }
-
-    fn encode_to_ptr(own self, _ ptr: u256) { A::store_word(ptr: ptr, value: self.canonical_word()) }
-}
-
-impl<A: Abi> Encode<A> for Int184 {
-    const DIRECT_ENCODE: bool = true
-
-    fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) { e.write_word(self.canonical_word()) }
-
-    fn encode_to_ptr(own self, _ ptr: u256) { A::store_word(ptr: ptr, value: self.canonical_word()) }
-}
-
-impl<A: Abi> Encode<A> for Int192 {
-    const DIRECT_ENCODE: bool = true
-
-    fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) { e.write_word(self.canonical_word()) }
-
-    fn encode_to_ptr(own self, _ ptr: u256) { A::store_word(ptr: ptr, value: self.canonical_word()) }
-}
-
-impl<A: Abi> Encode<A> for Int200 {
-    const DIRECT_ENCODE: bool = true
-
-    fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) { e.write_word(self.canonical_word()) }
-
-    fn encode_to_ptr(own self, _ ptr: u256) { A::store_word(ptr: ptr, value: self.canonical_word()) }
-}
-
-impl<A: Abi> Encode<A> for Int208 {
-    const DIRECT_ENCODE: bool = true
-
-    fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) { e.write_word(self.canonical_word()) }
-
-    fn encode_to_ptr(own self, _ ptr: u256) { A::store_word(ptr: ptr, value: self.canonical_word()) }
-}
-
-impl<A: Abi> Encode<A> for Int216 {
-    const DIRECT_ENCODE: bool = true
-
-    fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) { e.write_word(self.canonical_word()) }
-
-    fn encode_to_ptr(own self, _ ptr: u256) { A::store_word(ptr: ptr, value: self.canonical_word()) }
-}
-
-impl<A: Abi> Encode<A> for Int224 {
-    const DIRECT_ENCODE: bool = true
-
-    fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) { e.write_word(self.canonical_word()) }
-
-    fn encode_to_ptr(own self, _ ptr: u256) { A::store_word(ptr: ptr, value: self.canonical_word()) }
-}
-
-impl<A: Abi> Encode<A> for Int232 {
-    const DIRECT_ENCODE: bool = true
-
-    fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) { e.write_word(self.canonical_word()) }
-
-    fn encode_to_ptr(own self, _ ptr: u256) { A::store_word(ptr: ptr, value: self.canonical_word()) }
-}
-
-impl<A: Abi> Encode<A> for Int240 {
-    const DIRECT_ENCODE: bool = true
-
-    fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) { e.write_word(self.canonical_word()) }
-
-    fn encode_to_ptr(own self, _ ptr: u256) { A::store_word(ptr: ptr, value: self.canonical_word()) }
-}
-
-impl<A: Abi> Encode<A> for Int248 {
+impl<T: SolWordRepr + SolInt, A: Abi> Encode<A> for T {
     const DIRECT_ENCODE: bool = true
 
     fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) { e.write_word(self.canonical_word()) }
@@ -1909,576 +1509,15 @@ impl<A: Abi> Decode<A> for Int248 {
 }
 
 // Custom-width Solidity integers are always single static ABI words.
-impl AbiSize for Uint24 {
-    const HEAD_SIZE: u256 = 32
-    const IS_DYNAMIC: bool = false
-}
-impl AbiSize for Uint40 {
-    const HEAD_SIZE: u256 = 32
-    const IS_DYNAMIC: bool = false
-}
-impl AbiSize for Uint48 {
-    const HEAD_SIZE: u256 = 32
-    const IS_DYNAMIC: bool = false
-}
-impl AbiSize for Uint56 {
-    const HEAD_SIZE: u256 = 32
-    const IS_DYNAMIC: bool = false
-}
-impl AbiSize for Uint72 {
-    const HEAD_SIZE: u256 = 32
-    const IS_DYNAMIC: bool = false
-}
-impl AbiSize for Uint80 {
-    const HEAD_SIZE: u256 = 32
-    const IS_DYNAMIC: bool = false
-}
-impl AbiSize for Uint88 {
-    const HEAD_SIZE: u256 = 32
-    const IS_DYNAMIC: bool = false
-}
-impl AbiSize for Uint96 {
-    const HEAD_SIZE: u256 = 32
-    const IS_DYNAMIC: bool = false
-}
-impl AbiSize for Uint104 {
-    const HEAD_SIZE: u256 = 32
-    const IS_DYNAMIC: bool = false
-}
-impl AbiSize for Uint112 {
-    const HEAD_SIZE: u256 = 32
-    const IS_DYNAMIC: bool = false
-}
-impl AbiSize for Uint120 {
-    const HEAD_SIZE: u256 = 32
-    const IS_DYNAMIC: bool = false
-}
-impl AbiSize for Uint136 {
-    const HEAD_SIZE: u256 = 32
-    const IS_DYNAMIC: bool = false
-}
-impl AbiSize for Uint144 {
-    const HEAD_SIZE: u256 = 32
-    const IS_DYNAMIC: bool = false
-}
-impl AbiSize for Uint152 {
-    const HEAD_SIZE: u256 = 32
-    const IS_DYNAMIC: bool = false
-}
-impl AbiSize for Uint160 {
-    const HEAD_SIZE: u256 = 32
-    const IS_DYNAMIC: bool = false
-}
-impl AbiSize for Uint168 {
-    const HEAD_SIZE: u256 = 32
-    const IS_DYNAMIC: bool = false
-}
-impl AbiSize for Uint176 {
-    const HEAD_SIZE: u256 = 32
-    const IS_DYNAMIC: bool = false
-}
-impl AbiSize for Uint184 {
-    const HEAD_SIZE: u256 = 32
-    const IS_DYNAMIC: bool = false
-}
-impl AbiSize for Uint192 {
-    const HEAD_SIZE: u256 = 32
-    const IS_DYNAMIC: bool = false
-}
-impl AbiSize for Uint200 {
-    const HEAD_SIZE: u256 = 32
-    const IS_DYNAMIC: bool = false
-}
-impl AbiSize for Uint208 {
-    const HEAD_SIZE: u256 = 32
-    const IS_DYNAMIC: bool = false
-}
-impl AbiSize for Uint216 {
-    const HEAD_SIZE: u256 = 32
-    const IS_DYNAMIC: bool = false
-}
-impl AbiSize for Uint224 {
-    const HEAD_SIZE: u256 = 32
-    const IS_DYNAMIC: bool = false
-}
-impl AbiSize for Uint232 {
-    const HEAD_SIZE: u256 = 32
-    const IS_DYNAMIC: bool = false
-}
-impl AbiSize for Uint240 {
-    const HEAD_SIZE: u256 = 32
-    const IS_DYNAMIC: bool = false
-}
-impl AbiSize for Uint248 {
-    const HEAD_SIZE: u256 = 32
-    const IS_DYNAMIC: bool = false
-}
-impl AbiSize for Int24 {
-    const HEAD_SIZE: u256 = 32
-    const IS_DYNAMIC: bool = false
-}
-impl AbiSize for Int40 {
-    const HEAD_SIZE: u256 = 32
-    const IS_DYNAMIC: bool = false
-}
-impl AbiSize for Int48 {
-    const HEAD_SIZE: u256 = 32
-    const IS_DYNAMIC: bool = false
-}
-impl AbiSize for Int56 {
-    const HEAD_SIZE: u256 = 32
-    const IS_DYNAMIC: bool = false
-}
-impl AbiSize for Int72 {
-    const HEAD_SIZE: u256 = 32
-    const IS_DYNAMIC: bool = false
-}
-impl AbiSize for Int80 {
-    const HEAD_SIZE: u256 = 32
-    const IS_DYNAMIC: bool = false
-}
-impl AbiSize for Int88 {
-    const HEAD_SIZE: u256 = 32
-    const IS_DYNAMIC: bool = false
-}
-impl AbiSize for Int96 {
-    const HEAD_SIZE: u256 = 32
-    const IS_DYNAMIC: bool = false
-}
-impl AbiSize for Int104 {
-    const HEAD_SIZE: u256 = 32
-    const IS_DYNAMIC: bool = false
-}
-impl AbiSize for Int112 {
-    const HEAD_SIZE: u256 = 32
-    const IS_DYNAMIC: bool = false
-}
-impl AbiSize for Int120 {
-    const HEAD_SIZE: u256 = 32
-    const IS_DYNAMIC: bool = false
-}
-impl AbiSize for Int136 {
-    const HEAD_SIZE: u256 = 32
-    const IS_DYNAMIC: bool = false
-}
-impl AbiSize for Int144 {
-    const HEAD_SIZE: u256 = 32
-    const IS_DYNAMIC: bool = false
-}
-impl AbiSize for Int152 {
-    const HEAD_SIZE: u256 = 32
-    const IS_DYNAMIC: bool = false
-}
-impl AbiSize for Int160 {
-    const HEAD_SIZE: u256 = 32
-    const IS_DYNAMIC: bool = false
-}
-impl AbiSize for Int168 {
-    const HEAD_SIZE: u256 = 32
-    const IS_DYNAMIC: bool = false
-}
-impl AbiSize for Int176 {
-    const HEAD_SIZE: u256 = 32
-    const IS_DYNAMIC: bool = false
-}
-impl AbiSize for Int184 {
-    const HEAD_SIZE: u256 = 32
-    const IS_DYNAMIC: bool = false
-}
-impl AbiSize for Int192 {
-    const HEAD_SIZE: u256 = 32
-    const IS_DYNAMIC: bool = false
-}
-impl AbiSize for Int200 {
-    const HEAD_SIZE: u256 = 32
-    const IS_DYNAMIC: bool = false
-}
-impl AbiSize for Int208 {
-    const HEAD_SIZE: u256 = 32
-    const IS_DYNAMIC: bool = false
-}
-impl AbiSize for Int216 {
-    const HEAD_SIZE: u256 = 32
-    const IS_DYNAMIC: bool = false
-}
-impl AbiSize for Int224 {
-    const HEAD_SIZE: u256 = 32
-    const IS_DYNAMIC: bool = false
-}
-impl AbiSize for Int232 {
-    const HEAD_SIZE: u256 = 32
-    const IS_DYNAMIC: bool = false
-}
-impl AbiSize for Int240 {
-    const HEAD_SIZE: u256 = 32
-    const IS_DYNAMIC: bool = false
-}
-impl AbiSize for Int248 {
+impl<T: SolInt> AbiSize for T {
     const HEAD_SIZE: u256 = 32
     const IS_DYNAMIC: bool = false
 }
 
-impl<A: Abi> AbiSpan<A> for Uint24 {
-    fn payload_end<I: core::abi::ByteInput>(_: I, base: u256, pos: u256) -> u256 { pos + 32 }
-}
-impl<A: Abi> AbiSpan<A> for Uint40 {
-    fn payload_end<I: core::abi::ByteInput>(_: I, base: u256, pos: u256) -> u256 { pos + 32 }
-}
-impl<A: Abi> AbiSpan<A> for Uint48 {
-    fn payload_end<I: core::abi::ByteInput>(_: I, base: u256, pos: u256) -> u256 { pos + 32 }
-}
-impl<A: Abi> AbiSpan<A> for Uint56 {
-    fn payload_end<I: core::abi::ByteInput>(_: I, base: u256, pos: u256) -> u256 { pos + 32 }
-}
-impl<A: Abi> AbiSpan<A> for Uint72 {
-    fn payload_end<I: core::abi::ByteInput>(_: I, base: u256, pos: u256) -> u256 { pos + 32 }
-}
-impl<A: Abi> AbiSpan<A> for Uint80 {
-    fn payload_end<I: core::abi::ByteInput>(_: I, base: u256, pos: u256) -> u256 { pos + 32 }
-}
-impl<A: Abi> AbiSpan<A> for Uint88 {
-    fn payload_end<I: core::abi::ByteInput>(_: I, base: u256, pos: u256) -> u256 { pos + 32 }
-}
-impl<A: Abi> AbiSpan<A> for Uint96 {
-    fn payload_end<I: core::abi::ByteInput>(_: I, base: u256, pos: u256) -> u256 { pos + 32 }
-}
-impl<A: Abi> AbiSpan<A> for Uint104 {
-    fn payload_end<I: core::abi::ByteInput>(_: I, base: u256, pos: u256) -> u256 { pos + 32 }
-}
-impl<A: Abi> AbiSpan<A> for Uint112 {
-    fn payload_end<I: core::abi::ByteInput>(_: I, base: u256, pos: u256) -> u256 { pos + 32 }
-}
-impl<A: Abi> AbiSpan<A> for Uint120 {
-    fn payload_end<I: core::abi::ByteInput>(_: I, base: u256, pos: u256) -> u256 { pos + 32 }
-}
-impl<A: Abi> AbiSpan<A> for Uint136 {
-    fn payload_end<I: core::abi::ByteInput>(_: I, base: u256, pos: u256) -> u256 { pos + 32 }
-}
-impl<A: Abi> AbiSpan<A> for Uint144 {
-    fn payload_end<I: core::abi::ByteInput>(_: I, base: u256, pos: u256) -> u256 { pos + 32 }
-}
-impl<A: Abi> AbiSpan<A> for Uint152 {
-    fn payload_end<I: core::abi::ByteInput>(_: I, base: u256, pos: u256) -> u256 { pos + 32 }
-}
-impl<A: Abi> AbiSpan<A> for Uint160 {
-    fn payload_end<I: core::abi::ByteInput>(_: I, base: u256, pos: u256) -> u256 { pos + 32 }
-}
-impl<A: Abi> AbiSpan<A> for Uint168 {
-    fn payload_end<I: core::abi::ByteInput>(_: I, base: u256, pos: u256) -> u256 { pos + 32 }
-}
-impl<A: Abi> AbiSpan<A> for Uint176 {
-    fn payload_end<I: core::abi::ByteInput>(_: I, base: u256, pos: u256) -> u256 { pos + 32 }
-}
-impl<A: Abi> AbiSpan<A> for Uint184 {
-    fn payload_end<I: core::abi::ByteInput>(_: I, base: u256, pos: u256) -> u256 { pos + 32 }
-}
-impl<A: Abi> AbiSpan<A> for Uint192 {
-    fn payload_end<I: core::abi::ByteInput>(_: I, base: u256, pos: u256) -> u256 { pos + 32 }
-}
-impl<A: Abi> AbiSpan<A> for Uint200 {
-    fn payload_end<I: core::abi::ByteInput>(_: I, base: u256, pos: u256) -> u256 { pos + 32 }
-}
-impl<A: Abi> AbiSpan<A> for Uint208 {
-    fn payload_end<I: core::abi::ByteInput>(_: I, base: u256, pos: u256) -> u256 { pos + 32 }
-}
-impl<A: Abi> AbiSpan<A> for Uint216 {
-    fn payload_end<I: core::abi::ByteInput>(_: I, base: u256, pos: u256) -> u256 { pos + 32 }
-}
-impl<A: Abi> AbiSpan<A> for Uint224 {
-    fn payload_end<I: core::abi::ByteInput>(_: I, base: u256, pos: u256) -> u256 { pos + 32 }
-}
-impl<A: Abi> AbiSpan<A> for Uint232 {
-    fn payload_end<I: core::abi::ByteInput>(_: I, base: u256, pos: u256) -> u256 { pos + 32 }
-}
-impl<A: Abi> AbiSpan<A> for Uint240 {
-    fn payload_end<I: core::abi::ByteInput>(_: I, base: u256, pos: u256) -> u256 { pos + 32 }
-}
-impl<A: Abi> AbiSpan<A> for Uint248 {
-    fn payload_end<I: core::abi::ByteInput>(_: I, base: u256, pos: u256) -> u256 { pos + 32 }
-}
-impl<A: Abi> AbiSpan<A> for Int24 {
-    fn payload_end<I: core::abi::ByteInput>(_: I, base: u256, pos: u256) -> u256 { pos + 32 }
-}
-impl<A: Abi> AbiSpan<A> for Int40 {
-    fn payload_end<I: core::abi::ByteInput>(_: I, base: u256, pos: u256) -> u256 { pos + 32 }
-}
-impl<A: Abi> AbiSpan<A> for Int48 {
-    fn payload_end<I: core::abi::ByteInput>(_: I, base: u256, pos: u256) -> u256 { pos + 32 }
-}
-impl<A: Abi> AbiSpan<A> for Int56 {
-    fn payload_end<I: core::abi::ByteInput>(_: I, base: u256, pos: u256) -> u256 { pos + 32 }
-}
-impl<A: Abi> AbiSpan<A> for Int72 {
-    fn payload_end<I: core::abi::ByteInput>(_: I, base: u256, pos: u256) -> u256 { pos + 32 }
-}
-impl<A: Abi> AbiSpan<A> for Int80 {
-    fn payload_end<I: core::abi::ByteInput>(_: I, base: u256, pos: u256) -> u256 { pos + 32 }
-}
-impl<A: Abi> AbiSpan<A> for Int88 {
-    fn payload_end<I: core::abi::ByteInput>(_: I, base: u256, pos: u256) -> u256 { pos + 32 }
-}
-impl<A: Abi> AbiSpan<A> for Int96 {
-    fn payload_end<I: core::abi::ByteInput>(_: I, base: u256, pos: u256) -> u256 { pos + 32 }
-}
-impl<A: Abi> AbiSpan<A> for Int104 {
-    fn payload_end<I: core::abi::ByteInput>(_: I, base: u256, pos: u256) -> u256 { pos + 32 }
-}
-impl<A: Abi> AbiSpan<A> for Int112 {
-    fn payload_end<I: core::abi::ByteInput>(_: I, base: u256, pos: u256) -> u256 { pos + 32 }
-}
-impl<A: Abi> AbiSpan<A> for Int120 {
-    fn payload_end<I: core::abi::ByteInput>(_: I, base: u256, pos: u256) -> u256 { pos + 32 }
-}
-impl<A: Abi> AbiSpan<A> for Int136 {
-    fn payload_end<I: core::abi::ByteInput>(_: I, base: u256, pos: u256) -> u256 { pos + 32 }
-}
-impl<A: Abi> AbiSpan<A> for Int144 {
-    fn payload_end<I: core::abi::ByteInput>(_: I, base: u256, pos: u256) -> u256 { pos + 32 }
-}
-impl<A: Abi> AbiSpan<A> for Int152 {
-    fn payload_end<I: core::abi::ByteInput>(_: I, base: u256, pos: u256) -> u256 { pos + 32 }
-}
-impl<A: Abi> AbiSpan<A> for Int160 {
-    fn payload_end<I: core::abi::ByteInput>(_: I, base: u256, pos: u256) -> u256 { pos + 32 }
-}
-impl<A: Abi> AbiSpan<A> for Int168 {
-    fn payload_end<I: core::abi::ByteInput>(_: I, base: u256, pos: u256) -> u256 { pos + 32 }
-}
-impl<A: Abi> AbiSpan<A> for Int176 {
-    fn payload_end<I: core::abi::ByteInput>(_: I, base: u256, pos: u256) -> u256 { pos + 32 }
-}
-impl<A: Abi> AbiSpan<A> for Int184 {
-    fn payload_end<I: core::abi::ByteInput>(_: I, base: u256, pos: u256) -> u256 { pos + 32 }
-}
-impl<A: Abi> AbiSpan<A> for Int192 {
-    fn payload_end<I: core::abi::ByteInput>(_: I, base: u256, pos: u256) -> u256 { pos + 32 }
-}
-impl<A: Abi> AbiSpan<A> for Int200 {
-    fn payload_end<I: core::abi::ByteInput>(_: I, base: u256, pos: u256) -> u256 { pos + 32 }
-}
-impl<A: Abi> AbiSpan<A> for Int208 {
-    fn payload_end<I: core::abi::ByteInput>(_: I, base: u256, pos: u256) -> u256 { pos + 32 }
-}
-impl<A: Abi> AbiSpan<A> for Int216 {
-    fn payload_end<I: core::abi::ByteInput>(_: I, base: u256, pos: u256) -> u256 { pos + 32 }
-}
-impl<A: Abi> AbiSpan<A> for Int224 {
-    fn payload_end<I: core::abi::ByteInput>(_: I, base: u256, pos: u256) -> u256 { pos + 32 }
-}
-impl<A: Abi> AbiSpan<A> for Int232 {
-    fn payload_end<I: core::abi::ByteInput>(_: I, base: u256, pos: u256) -> u256 { pos + 32 }
-}
-impl<A: Abi> AbiSpan<A> for Int240 {
-    fn payload_end<I: core::abi::ByteInput>(_: I, base: u256, pos: u256) -> u256 { pos + 32 }
-}
-impl<A: Abi> AbiSpan<A> for Int248 {
+impl<T: SolInt, A: Abi> AbiSpan<A> for T {
     fn payload_end<I: core::abi::ByteInput>(_: I, base: u256, pos: u256) -> u256 { pos + 32 }
 }
 
-impl TopicValue for Uint24 {
-    fn as_topic(self) -> u256 { self.canonical_word() }
-}
-
-impl TopicValue for Uint40 {
-    fn as_topic(self) -> u256 { self.canonical_word() }
-}
-
-impl TopicValue for Uint48 {
-    fn as_topic(self) -> u256 { self.canonical_word() }
-}
-
-impl TopicValue for Uint56 {
-    fn as_topic(self) -> u256 { self.canonical_word() }
-}
-
-impl TopicValue for Uint72 {
-    fn as_topic(self) -> u256 { self.canonical_word() }
-}
-
-impl TopicValue for Uint80 {
-    fn as_topic(self) -> u256 { self.canonical_word() }
-}
-
-impl TopicValue for Uint88 {
-    fn as_topic(self) -> u256 { self.canonical_word() }
-}
-
-impl TopicValue for Uint96 {
-    fn as_topic(self) -> u256 { self.canonical_word() }
-}
-
-impl TopicValue for Uint104 {
-    fn as_topic(self) -> u256 { self.canonical_word() }
-}
-
-impl TopicValue for Uint112 {
-    fn as_topic(self) -> u256 { self.canonical_word() }
-}
-
-impl TopicValue for Uint120 {
-    fn as_topic(self) -> u256 { self.canonical_word() }
-}
-
-impl TopicValue for Uint136 {
-    fn as_topic(self) -> u256 { self.canonical_word() }
-}
-
-impl TopicValue for Uint144 {
-    fn as_topic(self) -> u256 { self.canonical_word() }
-}
-
-impl TopicValue for Uint152 {
-    fn as_topic(self) -> u256 { self.canonical_word() }
-}
-
-impl TopicValue for Uint160 {
-    fn as_topic(self) -> u256 { self.canonical_word() }
-}
-
-impl TopicValue for Uint168 {
-    fn as_topic(self) -> u256 { self.canonical_word() }
-}
-
-impl TopicValue for Uint176 {
-    fn as_topic(self) -> u256 { self.canonical_word() }
-}
-
-impl TopicValue for Uint184 {
-    fn as_topic(self) -> u256 { self.canonical_word() }
-}
-
-impl TopicValue for Uint192 {
-    fn as_topic(self) -> u256 { self.canonical_word() }
-}
-
-impl TopicValue for Uint200 {
-    fn as_topic(self) -> u256 { self.canonical_word() }
-}
-
-impl TopicValue for Uint208 {
-    fn as_topic(self) -> u256 { self.canonical_word() }
-}
-
-impl TopicValue for Uint216 {
-    fn as_topic(self) -> u256 { self.canonical_word() }
-}
-
-impl TopicValue for Uint224 {
-    fn as_topic(self) -> u256 { self.canonical_word() }
-}
-
-impl TopicValue for Uint232 {
-    fn as_topic(self) -> u256 { self.canonical_word() }
-}
-
-impl TopicValue for Uint240 {
-    fn as_topic(self) -> u256 { self.canonical_word() }
-}
-
-impl TopicValue for Uint248 {
-    fn as_topic(self) -> u256 { self.canonical_word() }
-}
-
-impl TopicValue for Int24 {
-    fn as_topic(self) -> u256 { self.canonical_word() }
-}
-
-impl TopicValue for Int40 {
-    fn as_topic(self) -> u256 { self.canonical_word() }
-}
-
-impl TopicValue for Int48 {
-    fn as_topic(self) -> u256 { self.canonical_word() }
-}
-
-impl TopicValue for Int56 {
-    fn as_topic(self) -> u256 { self.canonical_word() }
-}
-
-impl TopicValue for Int72 {
-    fn as_topic(self) -> u256 { self.canonical_word() }
-}
-
-impl TopicValue for Int80 {
-    fn as_topic(self) -> u256 { self.canonical_word() }
-}
-
-impl TopicValue for Int88 {
-    fn as_topic(self) -> u256 { self.canonical_word() }
-}
-
-impl TopicValue for Int96 {
-    fn as_topic(self) -> u256 { self.canonical_word() }
-}
-
-impl TopicValue for Int104 {
-    fn as_topic(self) -> u256 { self.canonical_word() }
-}
-
-impl TopicValue for Int112 {
-    fn as_topic(self) -> u256 { self.canonical_word() }
-}
-
-impl TopicValue for Int120 {
-    fn as_topic(self) -> u256 { self.canonical_word() }
-}
-
-impl TopicValue for Int136 {
-    fn as_topic(self) -> u256 { self.canonical_word() }
-}
-
-impl TopicValue for Int144 {
-    fn as_topic(self) -> u256 { self.canonical_word() }
-}
-
-impl TopicValue for Int152 {
-    fn as_topic(self) -> u256 { self.canonical_word() }
-}
-
-impl TopicValue for Int160 {
-    fn as_topic(self) -> u256 { self.canonical_word() }
-}
-
-impl TopicValue for Int168 {
-    fn as_topic(self) -> u256 { self.canonical_word() }
-}
-
-impl TopicValue for Int176 {
-    fn as_topic(self) -> u256 { self.canonical_word() }
-}
-
-impl TopicValue for Int184 {
-    fn as_topic(self) -> u256 { self.canonical_word() }
-}
-
-impl TopicValue for Int192 {
-    fn as_topic(self) -> u256 { self.canonical_word() }
-}
-
-impl TopicValue for Int200 {
-    fn as_topic(self) -> u256 { self.canonical_word() }
-}
-
-impl TopicValue for Int208 {
-    fn as_topic(self) -> u256 { self.canonical_word() }
-}
-
-impl TopicValue for Int216 {
-    fn as_topic(self) -> u256 { self.canonical_word() }
-}
-
-impl TopicValue for Int224 {
-    fn as_topic(self) -> u256 { self.canonical_word() }
-}
-
-impl TopicValue for Int232 {
-    fn as_topic(self) -> u256 { self.canonical_word() }
-}
-
-impl TopicValue for Int240 {
-    fn as_topic(self) -> u256 { self.canonical_word() }
-}
-
-impl TopicValue for Int248 {
+impl<T: SolWordRepr + SolInt> TopicValue for T {
     fn as_topic(self) -> u256 { self.canonical_word() }
 }


### PR DESCRIPTION
Replaces the per-type `Encode` / `AbiSize` / `AbiSpan` / `TopicValue` impls
for solidity int compatibility int types with four blanket impls gated on a private `SolInt` marker
(cuts ~1k lines from ints.fe)

Plus resolver improvements that make this feasible:

- **Drop inapplicable trait candidates before visibility check**
  In method selection, for a fully-known receiver, drop candidates whose impl
  is provably inapplicable (self-type mismatch or unsatisfiable where-clause)
  before the single-candidate / visibility / ambiguity decisions. This fixes a blanket 
  `impl<T: Marker> Trait for T` shadowing a concrete impl and
  turning an unambiguous `concrete.method()` into a spurious "import the trait"
  error

- **Hide unsatisfied-bound hint for non-visible traits**
  Suppresses the `trait bound X: Y is not satisfied` sub-diagnostic when `Y`
  isn't visible at the error site, so the private `SolInt` marker doesn't 
  leak into error messages.
