### PR TITLE
std: Add non-terminal read API to StorageBytes

### DIFF
--- a/crates/fe/tests/fixtures/fe_test/storage_bytes_to_memory.fe
+++ b/crates/fe/tests/fixtures/fe_test/storage_bytes_to_memory.fe
@@ -1,0 +1,179 @@
+use std::evm::{Address, Create, Evm, StorageBytes, ceil_words, keccak256, mem}
+
+type Blobs = StorageBytes<u256, 0, 1>
+
+msg BlobMsg {
+    #[selector = 0x01]
+    Set { data: Bytes },
+    #[selector = 0x02]
+    LoadHash -> u256,
+    #[selector = 0x03]
+    GetMarker -> u256,
+    #[selector = 0x04]
+    Deploy { salt: u256 } -> u256,
+    #[selector = 0x05]
+    WordAt { index: u256 } -> u256,
+}
+
+pub contract Blob uses (create: mut Create) {
+    mut blobs: Blobs,
+    mut marker: u256,
+
+    recv BlobMsg {
+        Set { data } uses (mut blobs) {
+            blobs.store_view(key: 0, view: data.view())
+        }
+
+        // Loads the stored bytes back into memory, then keeps executing:
+        // writes `marker` and returns a hash over the zero-padded payload.
+        LoadHash -> u256 uses (blobs, mut marker) {
+            let (ptr, len) = blobs.to_memory(key: 0)
+            let hash = keccak256(ptr, ceil_words(len) * 32)
+            marker = len + 1
+            hash
+        }
+
+        GetMarker -> u256 uses (marker) {
+            marker
+        }
+
+        // The motivating use case: deploy the stored bytes as initcode.
+        Deploy { salt } -> u256 uses (blobs, mut create, mut marker) {
+            let (ptr, len) = blobs.to_memory(key: 0)
+            let deployed = create.create2_raw(value: 0, offset: ptr, len: len, salt: salt)
+            marker = len + 1
+            deployed.inner
+        }
+
+        WordAt { index } -> u256 uses (blobs) {
+            blobs.word_at(key: 0, index: index)
+        }
+    }
+}
+
+fn set_bytes(addr: Address, data: Bytes)
+uses (evm: mut Evm)
+{
+    evm.call(addr: addr, gas: 1000000, value: 0, message: BlobMsg::Set { data: data })
+}
+
+fn load_hash(addr: Address) -> u256
+uses (evm: mut Evm)
+{
+    let hash: u256 = evm.call(addr: addr, gas: 1000000, value: 0, message: BlobMsg::LoadHash {})
+    hash
+}
+
+fn get_marker(addr: Address) -> u256
+uses (evm: mut Evm)
+{
+    let marker: u256 = evm.call(addr: addr, gas: 1000000, value: 0, message: BlobMsg::GetMarker {})
+    marker
+}
+
+#[test]
+fn test_to_memory_empty()
+uses (evm: mut Evm)
+{
+    let blob = evm.create2<Blob>(value: 0, args: (), salt: 0)
+    assert!(blob.inner != 0)
+
+    let data_ptr = mem::alloc(32)
+    evm.mstore(addr: data_ptr, value: 0)
+    set_bytes(addr: blob, data: Bytes { data: data_ptr, len: 0, size: 32 })
+
+    assert!(load_hash(addr: blob) == keccak256(0, 0))
+
+    // Execution continued after the read: the handler wrote `marker`.
+    assert!(get_marker(addr: blob) == 1)
+}
+
+#[test]
+fn test_to_memory_exact_word_multiple()
+uses (evm: mut Evm)
+{
+    let blob = evm.create2<Blob>(value: 0, args: (), salt: 0)
+    assert!(blob.inner != 0)
+
+    let payload_len: u256 = 64
+    let data_ptr = mem::alloc(payload_len + 32)
+    evm.mstore(addr: data_ptr, value: payload_len)
+    evm.mstore(
+        addr: data_ptr + 32,
+        value: 0x1111111111111111111111111111111111111111111111111111111111111111,
+    )
+    evm.mstore(
+        addr: data_ptr + 64,
+        value: 0x2222222222222222222222222222222222222222222222222222222222222222,
+    )
+    set_bytes(addr: blob, data: Bytes { data: data_ptr, len: payload_len, size: payload_len + 32 })
+
+    // Hash of the two payload words, computed locally.
+    let expected = keccak256(data_ptr + 32, 64)
+    assert!(load_hash(addr: blob) == expected)
+    assert!(get_marker(addr: blob) == 65)
+}
+
+#[test]
+fn test_to_memory_partial_trailing_word()
+uses (evm: mut Evm)
+{
+    let blob = evm.create2<Blob>(value: 0, args: (), salt: 0)
+    assert!(blob.inner != 0)
+
+    let payload_len: u256 = 65
+    let data_ptr = mem::alloc(128)
+    evm.mstore(addr: data_ptr, value: payload_len)
+    evm.mstore(
+        addr: data_ptr + 32,
+        value: 0x1111111111111111111111111111111111111111111111111111111111111111,
+    )
+    evm.mstore(
+        addr: data_ptr + 64,
+        value: 0x2222222222222222222222222222222222222222222222222222222222222222,
+    )
+    evm.mstore(
+        addr: data_ptr + 96,
+        value: 0x3300000000000000000000000000000000000000000000000000000000000000,
+    )
+    set_bytes(addr: blob, data: Bytes { data: data_ptr, len: payload_len, size: 128 })
+
+    // The contract hashes ceil_words(65) * 32 = 96 bytes, so a matching hash
+    // proves the 31 padding bytes of the trailing word come back zeroed.
+    let expected = keccak256(data_ptr + 32, 96)
+    assert!(load_hash(addr: blob) == expected)
+    assert!(get_marker(addr: blob) == 66)
+
+    let word0: u256 = evm.call(addr: blob, gas: 1000000, value: 0, message: BlobMsg::WordAt { index: 0 })
+    assert!(word0 == 0x1111111111111111111111111111111111111111111111111111111111111111)
+    let word2: u256 = evm.call(addr: blob, gas: 1000000, value: 0, message: BlobMsg::WordAt { index: 2 })
+    assert!(word2 == 0x3300000000000000000000000000000000000000000000000000000000000000)
+    let word3: u256 = evm.call(addr: blob, gas: 1000000, value: 0, message: BlobMsg::WordAt { index: 3 })
+    assert!(word3 == 0)
+}
+
+#[test]
+fn test_to_memory_deploys_stored_initcode()
+uses (evm: mut Evm)
+{
+    let blob = evm.create2<Blob>(value: 0, args: (), salt: 0)
+    assert!(blob.inner != 0)
+
+    // 22-byte initcode that deploys a 10-byte runtime returning 0x2a:
+    //   600a600c600039600a6000f3  copy runtime to memory and return it
+    //   602a60005260206000f3      runtime: mstore(0, 42); return(0, 32)
+    let payload_len: u256 = 22
+    let data_ptr = mem::alloc(64)
+    evm.mstore(addr: data_ptr, value: payload_len)
+    evm.mstore(
+        addr: data_ptr + 32,
+        value: 0x600a600c600039600a6000f3602a60005260206000f300000000000000000000,
+    )
+    set_bytes(addr: blob, data: Bytes { data: data_ptr, len: payload_len, size: 64 })
+
+    let deployed: u256 = evm.call(addr: blob, gas: 1000000, value: 0, message: BlobMsg::Deploy { salt: 7 })
+    assert!(deployed != 0)
+
+    // Execution continued after the read and the CREATE2.
+    assert!(get_marker(addr: blob) == 23)
+}

--- a/ingots/std/src/evm/storage_bytes.fe
+++ b/ingots/std/src/evm/storage_bytes.fe
@@ -197,6 +197,38 @@ impl<K: StorageKey + Copy, const LEN_SALT: u256, const WORD_SALT: u256>
         }
     }
 
+    /// Copy the stored bytes into freshly allocated memory.
+    ///
+    /// Returns the memory offset of the first payload byte and the byte
+    /// length. Unlike `encode_return`, this does not end the call, so the
+    /// bytes can be post-processed (hashed, deployed via `create2_raw`, etc).
+    /// The trailing partial word, if any, is zero-padded.
+    pub fn to_memory(self, key: K) -> (u256, u256) {
+        let lengths: StorageMap<K, u256, LEN_SALT> = StorageMap::new_unchecked()
+        let words: StorageMap<(K, u256), u256, WORD_SALT> = StorageMap::new_unchecked()
+
+        let len = lengths.get_unchecked(key)
+        let word_count = ceil_words(len)
+        let ptr = mem::alloc(word_count * 32)
+
+        let mut i: u256 = 0
+        while i < word_count {
+            ops::mstore(addr: ptr + i * 32, value: words.get_unchecked((key, i)))
+            i += 1
+        }
+
+        (ptr, len)
+    }
+
+    /// Load the 32-byte payload word at word `index` for `key`.
+    ///
+    /// The last word of a non-word-multiple length is zero-padded; indices
+    /// past `ceil_words(len(key))` read as zero.
+    pub fn word_at(self, key: K, index: u256) -> u256 {
+        let words: StorageMap<(K, u256), u256, WORD_SALT> = StorageMap::new_unchecked()
+        words.get_unchecked((key, index))
+    }
+
     /// Return ABI-encoded `bytes` from storage.
     pub fn encode_return(self, key: K) -> ! {
         let lengths: StorageMap<K, u256, LEN_SALT> = StorageMap::new_unchecked()


### PR DESCRIPTION
StorageBytes could only read stored bytes via encode_return, which ends the call. Add to_memory, which copies the stored bytes into freshly allocated memory and returns (ptr, len) so callers can post-process them (hash, deploy via create2_raw, etc), plus word_at for random access to individual payload words.