### PR TITLE
std: expose encode_msg_calldata and add Address::static convenience

### DIFF
--- a/crates/fe/tests/fixtures/fe_test/address_static_method.fe
+++ b/crates/fe/tests/fixtures/fe_test/address_static_method.fe
@@ -1,0 +1,80 @@
+/// Test the `Address::static` convenience method: typed STATICCALLs that
+/// forward all gas, plus revert-data bubbling on failure.
+
+use std::evm::{Ctx, Evm, encode_msg_calldata, decode_returndata, last_returndata}
+
+msg ViewMsg {
+    #[selector = sol("getValue()")]
+    GetValue -> u256,
+    #[selector = sol("getOwner()")]
+    GetOwner -> Address,
+    #[selector = sol("boom()")]
+    Boom -> u256,
+}
+
+pub contract Viewer {
+    init() {}
+
+    recv ViewMsg {
+        GetValue -> u256 {
+            1234
+        }
+
+        GetOwner -> Address {
+            Address { inner: 0xbeef }
+        }
+
+        Boom -> u256 {
+            let sentinel: u256 = 0xdeadbeef
+            revert(sentinel)
+        }
+    }
+}
+
+msg RelayMsg {
+    #[selector = sol("relayBoom(address)")]
+    RelayBoom { target: Address } -> u256,
+}
+
+/// Calls `target.static(Boom)` so the test can observe the bubbled revert
+/// data from outside the reverting context.
+pub contract Relay uses (call: mut Call) {
+    init() {}
+
+    recv RelayMsg {
+        RelayBoom { target } -> u256 uses (mut call) {
+            target.static(ViewMsg::Boom {})
+        }
+    }
+}
+
+#[test]
+fn test_address_static_happy_path() uses (evm: mut Evm, call: mut Call) {
+    let viewer = evm.create2<Viewer>(value: 0, args: (), salt: 0)
+    assert!(viewer.inner != 0)
+
+    let value: u256 = viewer.static(ViewMsg::GetValue {})
+    assert!(value == 1234)
+
+    let owner: Address = viewer.static(ViewMsg::GetOwner {})
+    assert!(owner.inner == 0xbeef)
+}
+
+#[test(should_revert)]
+fn test_address_static_bubbles_revert() uses (evm: mut Evm, call: mut Call) {
+    let viewer = evm.create2<Viewer>(value: 0, args: (), salt: 0)
+    viewer.static(ViewMsg::Boom {})
+}
+
+#[test]
+fn test_address_static_bubbles_revert_data() uses (evm: mut Evm, call: mut Call, ctx: Ctx) {
+    let viewer = evm.create2<Viewer>(value: 0, args: (), salt: 0)
+    let relay = evm.create2<Relay>(value: 0, args: (), salt: 0)
+
+    let (ptr, len) = encode_msg_calldata(RelayMsg::RelayBoom { target: viewer })
+    let ok = call.raw_call(addr: relay, gas: ctx.gas(), value: 0, args_offset: ptr, args_len: len)
+    assert!(!ok)
+
+    let bubbled: u256 = decode_returndata(last_returndata())
+    assert!(bubbled == 0xdeadbeef)
+}

--- a/crates/fe/tests/fixtures/fe_test/encode_msg_calldata.fe
+++ b/crates/fe/tests/fixtures/fe_test/encode_msg_calldata.fe
@@ -1,0 +1,77 @@
+/// Test that `encode_msg_calldata` produces exactly the bytes a typed
+/// `call<M>` sends: the callee echoes `keccak256` of its full calldata, and
+/// the digest from a typed call must match the digest from a `raw_call` fed
+/// by `encode_msg_calldata`.
+
+use std::evm::{Ctx, Evm, RawOps, encode_msg_calldata, decode_returndata, last_returndata}
+
+msg EchoMsg {
+    #[selector = sol("digestStatic(uint256,address)")]
+    DigestStatic { a: u256, b: Address } -> u256,
+    #[selector = sol("digestDynamic(bytes)")]
+    DigestDynamic { data: Bytes } -> u256,
+}
+
+fn hash_calldata() -> u256 uses (raw: mut RawOps) {
+    let len = raw.calldatasize()
+    let ptr = std::evm::mem::alloc(len)
+    raw.calldatacopy(dest: ptr, offset: 0, len: len)
+    raw.keccak256(offset: ptr, len: len)
+}
+
+pub contract Echo uses (raw: mut RawOps) {
+    init() {}
+
+    recv EchoMsg {
+        DigestStatic { a, b } -> u256 uses (mut raw) {
+            hash_calldata()
+        }
+
+        DigestDynamic { data } -> u256 uses (mut raw) {
+            hash_calldata()
+        }
+    }
+}
+
+/// Build a 64-byte `Bytes` payload. `data` points at the ABI tail: the
+/// length word followed by the packed content words.
+fn build_bytes() -> Bytes
+uses (mem: mut std::evm::RawMem)
+{
+    let data = std::evm::mem::alloc(96)
+    mem.mstore(addr: data, value: 64)
+    mem.mstore(addr: data + 32, value: 0x1234)
+    mem.mstore(addr: data + 64, value: 0x5678)
+    Bytes { data: data, len: 64, size: 96 }
+}
+
+#[test]
+fn test_encode_msg_calldata_static_args() uses (evm: mut Evm, call: mut Call, ctx: Ctx) {
+    let echo = evm.create2<Echo>(value: 0, args: (), salt: 0)
+    assert!(echo.inner != 0)
+
+    let addr_arg = Address { inner: 0xabcdef }
+    let typed_digest: u256 = echo.call(EchoMsg::DigestStatic { a: 42, b: addr_arg })
+
+    let (ptr, len) = encode_msg_calldata(EchoMsg::DigestStatic { a: 42, b: addr_arg })
+    let ok = call.raw_call(addr: echo, gas: ctx.gas(), value: 0, args_offset: ptr, args_len: len)
+    assert!(ok)
+    let raw_digest: u256 = decode_returndata(last_returndata())
+
+    assert!(typed_digest == raw_digest)
+}
+
+#[test]
+fn test_encode_msg_calldata_dynamic_bytes() uses (evm: mut Evm, call: mut Call, ctx: Ctx, mem: mut std::evm::RawMem) {
+    let echo = evm.create2<Echo>(value: 0, args: (), salt: 0)
+    assert!(echo.inner != 0)
+
+    let typed_digest: u256 = echo.call(EchoMsg::DigestDynamic { data: build_bytes() })
+
+    let (ptr, len) = encode_msg_calldata(EchoMsg::DigestDynamic { data: build_bytes() })
+    let ok = call.raw_call(addr: echo, gas: ctx.gas(), value: 0, args_offset: ptr, args_len: len)
+    assert!(ok)
+    let raw_digest: u256 = decode_returndata(last_returndata())
+
+    assert!(typed_digest == raw_digest)
+}

--- a/ingots/std/src/evm/effects.fe
+++ b/ingots/std/src/evm/effects.fe
@@ -514,6 +514,15 @@ impl Address {
     {
         call.call(addr: self, gas: ops::gas(), value: 0, message)
     }
+
+    /// `STATICCALL` a contract at this address with a typed message.
+    ///
+    /// Forwards all available gas. Bubbles the callee's revert data on failure.
+    pub fn static<M>(self, _ message: own M) -> M::Return
+    uses (call: mut Call) where M: MsgVariant<Sol> + Encode<Sol>, M::Return: Decode<Sol> + AbiSize
+    {
+        call.static(addr: self, gas: ops::gas(), message)
+    }
 }
 
 /// Combined EVM capability: provides all EVM effects.
@@ -745,6 +754,15 @@ where M: Encode<Sol>
     message.encode(mut encoder)
 
     (ptr, total_len)
+}
+
+/// ABI-encode a message (4-byte selector + payload) into freshly allocated
+/// memory without performing a call. Returns `(offset, length)` suitable for
+/// `Call::raw_call` / `Call::raw_staticcall`.
+pub fn encode_msg_calldata<M>(_ message: own M) -> (u256, u256)
+where M: MsgVariant<Sol> + Encode<Sol>
+{
+    encode_calldata(<M as MsgVariant<Sol>>::SELECTOR, message)
 }
 
 fn copy_returndata() -> MemoryBytes {


### PR DESCRIPTION
Two ergonomic additions to std::evm for code that drops down to raw_call/raw_staticcall (e.g. tolerant ERC20 transfers):

- encode_msg_calldata<M>: public helper that ABI-encodes a msg variant (4-byte selector + payload) into fresh memory without performing a call, returning (offset, length) for Call::raw_call/raw_staticcall. Delegates to the existing private encode_calldata.
- Address::static<M>: STATICCALL sibling of Address::call, forwarding all gas and bubbling the callee's revert data on failure.

Fixture tests cover encoding equivalence against the typed call path (static args and dynamic Bytes, via a keccak-of-calldata echo callee), Address::static happy paths returning u256 and Address, and revert-data bubbling observed through a relay contract. These also add the first fixture coverage for the typed Call::static path.