### PR TITLE
std: add evm::packed — tightly packed byte encoding (abi.encodePacked…

### DIFF
--- a/crates/codegen/src/sonatina/lower_runtime.rs
+++ b/crates/codegen/src/sonatina/lower_runtime.rs
@@ -225,7 +225,7 @@ impl<'db, 'a> ModuleLowerer<'db, 'a> {
         }
 
         let ty = self.ty_for_layout(region.layout(self.db))?;
-        let init = self.gv_initializer_for_const(region.value(self.db).clone())?;
+        let init = self.gv_initializer_for_const(region.value(self.db).clone(), None)?;
         let name = self.const_name(region);
         let gv = self.builder.declare_gv(GlobalVariableData::constant(
             name,
@@ -240,10 +240,11 @@ impl<'db, 'a> ModuleLowerer<'db, 'a> {
     fn gv_initializer_for_const(
         &mut self,
         node: ConstNode<'db>,
+        class: Option<&RuntimeClass<'db>>,
     ) -> Result<sonatina_ir::global_variable::GvInitializer, LowerError> {
         Ok(match node {
             ConstNode::Scalar(scalar) => sonatina_ir::global_variable::GvInitializer::make_imm(
-                self.immediate_for_const(&scalar, None)?,
+                self.immediate_for_const(&scalar, class)?,
             ),
             ConstNode::Aggregate { layout, fields } => {
                 let ty = self.ty_for_layout(layout)?;
@@ -252,20 +253,37 @@ impl<'db, 'a> ModuleLowerer<'db, 'a> {
                 })?;
                 match compound {
                     CompoundType::Array { .. } => {
+                        let Layout::Array(data) = layout.data(self.db) else {
+                            return Err(LowerError::Internal(format!(
+                                "array const global should have an array layout, got `{layout:?}`"
+                            )));
+                        };
+                        let elem_class = data.elem.clone();
                         sonatina_ir::global_variable::GvInitializer::make_array(
                             fields
                                 .iter()
                                 .cloned()
-                                .map(|field| self.gv_initializer_for_const(field))
+                                .map(|field| {
+                                    self.gv_initializer_for_const(field, Some(&elem_class))
+                                })
                                 .collect::<Result<Vec<_>, _>>()?,
                         )
                     }
                     CompoundType::Struct(_) => {
+                        let Layout::Struct(data) = layout.data(self.db) else {
+                            return Err(LowerError::Internal(format!(
+                                "struct const global should have a struct layout, got `{layout:?}`"
+                            )));
+                        };
+                        let field_classes = data.fields.clone();
                         sonatina_ir::global_variable::GvInitializer::make_struct(
                             fields
                                 .iter()
                                 .cloned()
-                                .map(|field| self.gv_initializer_for_const(field))
+                                .enumerate()
+                                .map(|(idx, field)| {
+                                    self.gv_initializer_for_const(field, field_classes.get(idx))
+                                })
                                 .collect::<Result<Vec<_>, _>>()?,
                         )
                     }
@@ -516,10 +534,19 @@ impl<'db, 'a> ModuleLowerer<'db, 'a> {
                 signed,
                 words,
             } => Immediate::from_i256(bytes_to_i256(words, *signed), int_ty(*bits)),
-            ConstScalar::FixedBytes(bytes) => Immediate::from_i256(
-                bytes_to_i256(bytes, false),
-                fixed_bytes_ty(bytes.len() as u16),
-            ),
+            ConstScalar::FixedBytes(bytes) => {
+                // The value may hold fewer bytes than the declared class
+                // (e.g. a short string literal for a `String<N>` slot), so
+                // type the immediate from the class when we have one.
+                let ty = match class {
+                    Some(RuntimeClass::Scalar(ScalarClass {
+                        repr: mir::ScalarRepr::FixedBytes { len },
+                        ..
+                    })) => fixed_bytes_ty(*len),
+                    _ => fixed_bytes_ty(bytes.len() as u16),
+                };
+                Immediate::from_i256(bytes_to_i256(bytes, false), ty)
+            }
             ConstScalar::Address { bytes, .. } => {
                 Immediate::from_i256(bytes_to_i256(bytes, false), Type::I256)
             }

--- a/crates/codegen/tests/fixtures/sonatina_ir/erc20.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/erc20.snap
@@ -129,8 +129,7 @@ func private %__CoolCoin_recv_0_7() -> i256 {
         jump block1;
 
     block1:
-        v1.i256 = zext 1129271116.i64 i256;
-        return v1;
+        return 1129271116.i256;
 }
 
 func private %__CoolCoin_recv_0_8() -> i8 {

--- a/crates/codegen/tests/fixtures/sonatina_ir/string_literal.snap
+++ b/crates/codegen/tests/fixtures/sonatina_ir/string_literal.snap
@@ -19,8 +19,7 @@ func private %string_literal() -> i256 {
         jump block1;
 
     block1:
-        v1.i256 = zext 448378203247.i64 i256;
-        return v1;
+        return 448378203247.i256;
 }
 
 

--- a/crates/fe/tests/fixtures/fe_test/packed_encoding.fe
+++ b/crates/fe/tests/fixtures/fe_test/packed_encoding.fe
@@ -1,0 +1,262 @@
+// Compatibility tests for `std::evm::packed` (Solidity `abi.encodePacked`
+// parity).
+//
+// Every expected value below was precomputed with Foundry, independent of
+// this implementation:
+//   cast abi-encode --packed "f(<types>)" <values...>   # packed bytes
+//   cast keccak <bytes>                                 # digests
+// The fixture is not its own oracle.
+
+use std::evm::{crypto, RawMem}
+use std::evm::packed::{EncodePacked, Packed, encode_packed, keccak_packed}
+use std::abi::{Bytes4, FixedBytes, bytes_from_words_prefix}
+
+// keccak256(abi.encodePacked(address(0x1111...), address(0x2222...)))
+// — the CREATE2 pair-salt case.
+const SALT_DIGEST: u256 = 0xa284ddd69adb56d959922d24c73d2cd9e6b24d5e789a4106eca975c86ec900e1
+
+#[test]
+fn test_create2_salt_pair() uses (mem: mut RawMem) {
+    let token0 = Address { inner: 0x1111111111111111111111111111111111111111 }
+    let token1 = Address { inner: 0x2222222222222222222222222222222222222222 }
+    assert!(keccak_packed((token0, token1)) == SALT_DIGEST)
+}
+
+// keccak256(abi.encodePacked(uint8(0x19), uint8(0x01), ds, sh))
+const EIP712_DS: u256 = 0x8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f
+const EIP712_SH: u256 = 0xc2f8787176b8ac6bf7215b4adcc1e069bf4ab82d9ab1df05a57a91d425935b6e
+const EIP712_DIGEST: u256 = 0x7995d6d8051ece381c0692159969b2f1ea6f8efa91c78a4779bbc495e54057eb
+
+// Cross-checked three ways: tuple API, `crypto::eip712_digest`, and the
+// precomputed Solidity value.
+#[test]
+fn test_eip712_digest() uses (mem: mut RawMem) {
+    assert!(keccak_packed((0x19 as u8, 0x01 as u8, EIP712_DS, EIP712_SH)) == EIP712_DIGEST)
+    assert!(
+        crypto::eip712_digest(domain_separator: EIP712_DS, struct_hash: EIP712_SH)
+            == EIP712_DIGEST,
+    )
+}
+
+// abi.encodePacked(uint8,uint16,uint32,uint64,uint128,uint256,bool,address):
+// 1 + 2 + 4 + 8 + 16 + 32 + 1 + 20 = 84 bytes.
+const MIXED_U256: u256 = 0xfedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210
+const WETH: u256 = 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2
+const MIXED_DIGEST: u256 = 0x471ad85baf6e428e4cab4bf6dfed5b60e1a42ac767fc6e87113105747a64ac84
+// sha256 of the same 84-byte payload (hashlib.sha256).
+const MIXED_SHA256: u256 = 0xa4cc93b97408bf6c6c91aaf092e19b265b02562fcd56e318a72c14051536509d
+
+#[test]
+fn test_mixed_widths_tuple() uses (mem: mut RawMem) {
+    let p = encode_packed((
+        0xab as u8,
+        0x1234 as u16,
+        0xdeadbeef as u32,
+        0x0102030405060708 as u64,
+        0x000102030405060708090a0b0c0d0e0f as u128,
+        MIXED_U256,
+        true,
+        Address { inner: WETH },
+    ))
+    assert!(p.len() == 84)
+    assert!(p.keccak256() == MIXED_DIGEST)
+}
+
+// The same payload built imperatively must hash identically, through both
+// terminals.
+#[test]
+fn test_builder_matches_tuple_api() uses (mem: mut RawMem) {
+    let mut p = Packed::new()
+    p.u8(0xab)
+    p.u16(0x1234)
+    p.u32(0xdeadbeef)
+    p.u64(0x0102030405060708)
+    p.u128(0x000102030405060708090a0b0c0d0e0f)
+    p.u256(MIXED_U256)
+    p.bool_(true)
+    p.address(Address { inner: WETH })
+    assert!(p.len() == 84)
+    assert!(p.keccak256() == MIXED_DIGEST)
+    assert!(p.sha256() == MIXED_SHA256)
+}
+
+// Signed integers pack as two's complement in their exact width:
+// int8(-1) → 0xff, int16(-2) → 0xfffe.
+const I8_NEG1_DIGEST: u256 = 0x8b1a944cf13a9a1c08facb2c9e98623ef3254d2ddb48113885c3e8e97fec8db9
+const I16_NEG2_DIGEST: u256 = 0xeeb4ce57fda2c1de2e5bd73b1c0172b8029bc8d06145bc2dee844707debc67c7
+// abi.encodePacked(true, uint256(42), int8(-1))
+const BOOL_U256_I8_DIGEST: u256 = 0x47986397ef53bb76085fe6cf289a4dc0394b23a3d7ec7a187639b2124b296099
+
+#[test]
+fn test_signed_twos_complement() uses (mem: mut RawMem) {
+    let a: i8 = -1
+    let b: i16 = -2
+    assert!(keccak_packed((a,)) == I8_NEG1_DIGEST)
+    assert!(keccak_packed((b,)) == I16_NEG2_DIGEST)
+    assert!(keccak_packed((true, 42 as u256, a)) == BOOL_U256_I8_DIGEST)
+}
+
+// abi.encodePacked(bytes4(0x01ffc9a7)) — the 4 raw content bytes, never a
+// zero-padded word.
+const BYTES4_DIGEST: u256 = 0x9c71c307e9d8f8e0832d700582ffc921ebbd3bafe9dd110f65726dc5a219a435
+// abi.encodePacked(uint256(0x01ffc9a7)) — 32 right-aligned bytes.
+const U256_SELECTOR_DIGEST: u256 = 0x38e509caef1c80181deba73914106496c69255ad482c39496a6538d5367c2dd1
+
+#[test]
+fn test_fixed_bytes_alignment() uses (mem: mut RawMem) {
+    let fb = Bytes4 { val: 0x01ffc9a7 }
+    assert!(keccak_packed((fb,)) == BYTES4_DIGEST)
+    // Solidity parity: uint32 with the same bit pattern packs to the same
+    // 4 bytes (cast agrees), while widening to uint256 pads to 32 bytes
+    // and produces a different buffer.
+    assert!(keccak_packed((0x01ffc9a7 as u32,)) == BYTES4_DIGEST)
+    assert!(keccak_packed((0x01ffc9a7 as u256,)) == U256_SELECTOR_DIGEST)
+}
+
+// A hand-built FixedBytes with bits above the low N bytes is non-canonical;
+// the ABI encoder (`FixedBytes::word`) reverts on it, and packing must too
+// instead of silently truncating distinct values into colliding encodings.
+#[test(should_revert)]
+fn test_fixed_bytes_non_canonical_reverts() uses (mem: mut RawMem) {
+    let fb = Bytes4 { val: 0xff01ffc9a7 }
+    keccak_packed((fb,))
+}
+
+// Unsupported widths revert like the ABI encoder (`FixedBytes::word`):
+// N == 0 would otherwise silently contribute zero bytes, quietly omitting
+// the field from the packed hash.
+#[test(should_revert)]
+fn test_fixed_bytes_zero_width_reverts() uses (mem: mut RawMem) {
+    let fb: FixedBytes<0> = FixedBytes { val: 0 }
+    keccak_packed((fb,))
+}
+
+// ...and N > 32 would otherwise trip `append_word`'s width assert (a
+// panic) instead of the empty revert the ABI encoder uses.
+#[test(should_revert)]
+fn test_fixed_bytes_over_width_reverts() uses (mem: mut RawMem) {
+    let fb: FixedBytes<33> = FixedBytes { val: 1 }
+    keccak_packed((fb,))
+}
+
+// Same for a hand-built Address with bits above the low 160 set: packing
+// must revert, not truncate it into a collision with the canonical value.
+#[test(should_revert)]
+fn test_address_non_canonical_reverts() uses (mem: mut RawMem) {
+    let addr = Address { inner: (1 << 160) | 0x1111111111111111111111111111111111111111 }
+    keccak_packed((addr,))
+}
+
+// keccak256("Uniswap V2") — the effective 10 string bytes, not a padded
+// capacity.
+const UNISWAP_V2_DIGEST: u256 = 0xbfcc8ef98ffbf7b6c3fec7bf5185b566b9863e35a9d83acd49ad6824b5969738
+
+#[test]
+fn test_string_effective_bytes() uses (mem: mut RawMem) {
+    // Runtime path validated against both the compile-time path and the
+    // precomputed Solidity value.
+    assert!(keccak_packed(("Uniswap V2",)) == UNISWAP_V2_DIGEST)
+    assert!(keccak_packed(("Uniswap V2",)) == core::keccak("Uniswap V2"))
+
+    let mut p = Packed::new()
+    let name: String<10> = "Uniswap V2"
+    p.string(name)
+    assert!(p.len() == 10)
+    assert!(p.keccak256() == UNISWAP_V2_DIGEST)
+}
+
+// abi.encodePacked(uint8(0xaa), <50 bytes 0x00..0x31>, uint16(0xbbcc)):
+// dynamic bytes contribute their raw payload, no length word.
+const DYN_BYTES_DIGEST: u256 = 0xc678bacd16f81df316a48ba4b0f33527929404604752a156934f55706a85301c
+// abi.encodePacked(uint8(0xaa), "", uint16(0xbbcc))
+const DYN_EMPTY_DIGEST: u256 = 0xccad3f5300e77cf5347e3c6200a08bd8cf71f94a0b347bcb39486b17b88a8a71
+
+fn fifty_bytes() -> Bytes uses (mem: mut RawMem) {
+    bytes_from_words_prefix<50, 2>([
+        0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f,
+        0x202122232425262728292a2b2c2d2e2f30310000000000000000000000000000,
+    ])
+}
+
+#[test]
+fn test_dynamic_bytes_between_scalars() uses (mem: mut RawMem) {
+    assert!(keccak_packed((0xaa as u8, fifty_bytes(), 0xbbcc as u16)) == DYN_BYTES_DIGEST)
+    // A view packs identically to the owning Bytes.
+    assert!(keccak_packed((0xaa as u8, fifty_bytes().view(), 0xbbcc as u16)) == DYN_BYTES_DIGEST)
+    // Zero-length case.
+    assert!(keccak_packed((0xaa as u8, Bytes::empty(), 0xbbcc as u16)) == DYN_EMPTY_DIGEST)
+}
+
+// abi.encodePacked(uint8(0x11), WETH, MIXED_U256)
+const FLAT_DIGEST: u256 = 0x1d14a90c464e40ebf036a55b03363aa6f517a9f7ef1d8bafe272f27459e772f4
+
+#[test]
+fn test_nested_tuple_flattens() uses (mem: mut RawMem) {
+    let weth = Address { inner: WETH }
+    assert!(keccak_packed((0x11 as u8, weth, MIXED_U256)) == FLAT_DIGEST)
+    assert!(keccak_packed((0x11 as u8, (weth, MIXED_U256))) == FLAT_DIGEST)
+}
+
+// keccak256 of the 640-byte concatenation of uint256(0)..uint256(19).
+const GROWTH_DIGEST: u256 = 0x275968f225ff5beab3eb38415d20f03a79a91f856ebde75ca5ea8ac3c2f9fac9
+
+// Appending far past the default 128-byte capacity grows the buffer and
+// hashes identically to an exactly-sized run; nothing traps.
+#[test]
+fn test_growth_matches_exact_capacity() uses (mem: mut RawMem) {
+    let mut grown = Packed::new()
+    let mut exact = Packed::with_capacity(bytes: 640)
+    let mut i: u256 = 0
+    while i < 20 {
+        grown.u256(i)
+        exact.u256(i)
+        i += 1
+    }
+    assert!(grown.len() == 640)
+    assert!(exact.len() == 640)
+    assert!(grown.keccak256() == GROWTH_DIGEST)
+    assert!(exact.keccak256() == GROWTH_DIGEST)
+}
+
+// abi.encodePacked(bytes3(0x010203), uint8(0xff))
+const TINY_DIGEST: u256 = 0x5ed6f5078aed9ab97fe2101f196724b85518d27fbeef8c8256e8e09720f901ac
+
+// A 3-byte capacity forces the byte-granular write path (no whole word
+// fits below the limit) and repeated doubling on growth.
+#[test]
+fn test_tiny_capacity_byte_writes() uses (mem: mut RawMem) {
+    let mut p = Packed::with_capacity(bytes: 3)
+    let arr: [u8; 3] = [0x01, 0x02, 0x03]
+    p.bytes(arr)
+    p.u8(0xff)
+    assert!(p.len() == 4)
+    assert!(p.keccak256() == TINY_DIGEST)
+
+    // Same payload through the tuple API.
+    assert!(keccak_packed((arr, 0xff as u8)) == TINY_DIGEST)
+}
+
+// sha256("abc") — the FIPS 180 reference vector.
+const SHA256_ABC: u256 = 0xba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad
+
+#[test]
+fn test_sha256_terminal() uses (mem: mut RawMem) {
+    let mut p = Packed::new()
+    let abc: [u8; 3] = [0x61, 0x62, 0x63]
+    p.bytes(abc)
+    assert!(p.sha256() == SHA256_ABC)
+}
+
+// `as_bytes` copies out a Solidity-compatible `bytes memory` payload:
+// length word, raw bytes, zeroed padding.
+#[test]
+fn test_as_bytes_roundtrip() uses (mem: mut RawMem) {
+    let mut p = Packed::new()
+    p.address(Address { inner: 0x1111111111111111111111111111111111111111 })
+    p.address(Address { inner: 0x2222222222222222222222222222222222222222 })
+    let b = p.as_bytes()
+    assert!(b.len == 40)
+    assert!(b.size == 96)
+    // Re-packing the copied Bytes hashes identically to the builder.
+    assert!(keccak_packed((b,)) == SALT_DIGEST)
+}

--- a/crates/fe/tests/fixtures/fe_test/string_in_tuple.fe
+++ b/crates/fe/tests/fixtures/fe_test/string_in_tuple.fe
@@ -1,0 +1,22 @@
+// Regression test: a short string (backing narrower than a word) inside a
+// tuple used to crash Sonatina emission with "global initializer immediate
+// type does not match global type" — the tuple's const-region global typed
+// the field I256 (a `String<N>` class is always a full word) while the
+// immediate was typed from the literal's byte length (e.g. I128 for 10
+// bytes).
+
+#[test]
+fn test_short_string_in_tuple() {
+    let s: String<10> = "Uniswap V2"
+    let t = (s, 1 as u8)
+    assert!(t.0.len() == 10)
+    assert!(t.1 == 1)
+}
+
+#[test]
+fn test_tiny_string_in_nested_tuple() {
+    let s: String<3> = "ab"
+    let t = ((s,), 7 as u64)
+    assert!(t.0.0.len() == 2)
+    assert!(t.1 == 7)
+}

--- a/ingots/std/src/evm.fe
+++ b/ingots/std/src/evm.fe
@@ -13,6 +13,7 @@ pub use target::{self, *}
 pub use intrinsic::{code_region_len, code_region_offset, contract_field_slot}
 pub use mem::{self, *}
 pub use mutex::{self, *}
+pub use packed::{self, *}
 pub use ssz::{self, *}
 pub use storage_bytes::{self, *}
 pub use storage_map::{StorageKey, StorageMap}

--- a/ingots/std/src/evm/crypto.fe
+++ b/ingots/std/src/evm/crypto.fe
@@ -11,9 +11,11 @@
 
 use core::option::Option
 use core::result::Result
+use super::effects::RawMem
 use super::memory_input::MemoryBytes
 use super::ops
 use super::mem
+use super::packed
 
 pub const ECRECOVER_ADDRESS: u256 = 0x01
 pub const SHA256_ADDRESS: u256 = 0x02
@@ -174,6 +176,15 @@ pub fn keccak256(_ offset: u256, _ len: u256) -> u256 {
 /// SHA256 hash of a memory region (precompile 0x02).
 pub fn sha256(offset: u256, len: u256) -> Result<PrecompileError, u256> {
     staticcall_word(addr: SHA256_ADDRESS, args_offset: offset, args_len: len)
+}
+
+/// EIP-712 typed-data digest:
+/// `keccak256(0x19 ++ 0x01 ++ domain_separator ++ struct_hash)`.
+#[inline(always)]
+pub fn eip712_digest(domain_separator: u256, struct_hash: u256) -> u256
+uses (mem: mut RawMem)
+{
+    packed::keccak_packed((0x19 as u8, 0x01 as u8, domain_separator, struct_hash))
 }
 
 /// RIPEMD160 hash of a memory region (precompile 0x03).

--- a/ingots/std/src/evm/packed.fe
+++ b/ingots/std/src/evm/packed.fe
@@ -1,0 +1,840 @@
+/// Tightly packed byte encoding — the Fe equivalent of Solidity's
+/// `abi.encodePacked`.
+///
+/// Values are concatenated big-endian with no padding and no length
+/// prefixes: a `u16` contributes exactly 2 bytes, an `Address` exactly
+/// 20, dynamic `Bytes` exactly `len()` payload bytes. This is the
+/// encoding behind CREATE2 salts (`keccak256(token0 ++ token1)`),
+/// EIP-712 / EIP-191 digests
+/// (`keccak256(0x19 ++ 0x01 ++ domain_separator ++ struct_hash)`), and
+/// most ad-hoc byte blobs a contract needs to hash.
+///
+/// ## Which layer to use
+///
+/// Use `keccak_packed` / `encode_packed` with a tuple unless your
+/// payload shape is only known at runtime (loops over collections,
+/// conditional fields, dynamic concatenation); then use the `Packed`
+/// builder directly. For SSZ/consensus hashing use `std::evm::ssz` —
+/// nothing here overlaps that domain.
+///
+/// ```ignore
+/// let salt = keccak_packed((token0, token1))
+/// let digest = keccak_packed((0x19 as u8, 0x01 as u8, domain_separator, struct_hash))
+///
+/// let mut p = Packed::new()
+/// for item in items {
+///     p.u256(item)
+/// }
+/// let root = p.keccak256()
+/// ```
+///
+/// Types without an `EncodePacked` impl (structs, storage handles) are
+/// deliberately compile errors. Implement `EncodePacked` for your own
+/// type — delegating to the `Packed` append methods — to make it
+/// packable.
+///
+/// ## Scope
+///
+/// Strict `abi.encodePacked` parity. Deliberate omissions:
+/// - Arrays with non-byte element types are not packable: Solidity
+///   pads every element of e.g. `uint8[]` to 32 bytes inside
+///   `encodePacked`, a surprising rule this module does not reproduce.
+///   Only `[u8; N]` is supported (N raw bytes, matching `bytesN`
+///   values and Solidity's `bytes`).
+/// - No decoding counterpart: packed encoding is not self-describing,
+///   and Solidity has none either.
+use core::abi::{Bytes, BytesView, MemoryInput}
+use core::num::IntDowncast
+use core::result::Result
+use ingot::abi::FixedBytes
+use super::crypto
+use super::effects::{Address, RawMem}
+use super::mem
+use super::ops
+
+/// Default initial capacity (in bytes) for `Packed::new`.
+const DEFAULT_CAPACITY: u256 = 128
+
+/// A value with a tightly packed byte encoding (Solidity
+/// `abi.encodePacked` semantics).
+///
+/// Implementations delegate to the `Packed` append methods — no
+/// encoding logic lives in the impls themselves.
+pub trait EncodePacked {
+    /// Exact number of bytes this value contributes.
+    fn packed_width(self) -> u256
+
+    /// Append this value to a builder.
+    fn pack_into(own self, _ p: mut Packed) uses (mem: mut RawMem)
+}
+
+/// Pack a value (typically a tuple) into an exactly-sized fresh buffer.
+///
+/// The returned builder holds exactly the packed encoding; call
+/// `keccak256`, `sha256`, or `as_bytes` on it, or keep appending.
+pub fn encode_packed<T: EncodePacked>(_ value: own T) -> Packed uses (mem: mut RawMem) {
+    let mut p = Packed::with_capacity(bytes: value.packed_width())
+    value.pack_into(mut p)
+    p
+}
+
+/// keccak256 of the packed encoding — the dominant consumer.
+pub fn keccak_packed<T: EncodePacked>(_ value: own T) -> u256 uses (mem: mut RawMem) {
+    encode_packed(value).keccak256()
+}
+
+/// Imperative builder for packed byte payloads.
+///
+/// A bump-allocated memory buffer with byte-precise appends. Writes
+/// never touch memory beyond the buffer's current capacity, and the
+/// buffer grows (copy-on-grow, doubling) whenever an append would
+/// exceed it — a wrong capacity hint can cost a copy, never a panic
+/// or memory corruption. Growth moves the buffer, which is safe
+/// because the base pointer is never exposed before the terminal ops.
+///
+/// One unsupported edge: `append_mem` reading from this builder's own
+/// buffer (the source may be stale or overlapping if the append
+/// triggers growth).
+pub struct Packed {
+    base: u256,
+    cursor: u256,
+    limit: u256,
+}
+
+impl Packed {
+    /// Growable buffer with a default initial capacity (128 bytes).
+    pub fn new() -> Self uses (mem: mut RawMem) {
+        Packed::with_capacity(bytes: DEFAULT_CAPACITY)
+    }
+
+    /// Growable buffer with a chosen initial capacity. The capacity is
+    /// a copy-avoidance hint, never a contract — writes past it grow
+    /// the buffer.
+    pub fn with_capacity(bytes: u256) -> Self uses (mem: mut RawMem) {
+        let base = mem::alloc(bytes)
+        Packed { base, cursor: base, limit: base + bytes }
+    }
+
+    /// Append a `u256` as 32 big-endian bytes.
+    pub fn u256(mut self, _ value: u256) uses (mem: mut RawMem) {
+        self.append_word(value, width: 32)
+    }
+
+    /// Append a `u128` as 16 big-endian bytes.
+    pub fn u128(mut self, _ value: u128) uses (mem: mut RawMem) {
+        self.append_word(value: value as u256, width: 16)
+    }
+
+    /// Append a `u64` as 8 big-endian bytes.
+    pub fn u64(mut self, _ value: u64) uses (mem: mut RawMem) {
+        self.append_word(value: value as u256, width: 8)
+    }
+
+    /// Append a `u32` as 4 big-endian bytes.
+    pub fn u32(mut self, _ value: u32) uses (mem: mut RawMem) {
+        self.append_word(value: value as u256, width: 4)
+    }
+
+    /// Append a `u16` as 2 big-endian bytes.
+    pub fn u16(mut self, _ value: u16) uses (mem: mut RawMem) {
+        self.append_word(value: value as u256, width: 2)
+    }
+
+    /// Append a `u8` as 1 byte.
+    pub fn u8(mut self, _ value: u8) uses (mem: mut RawMem) {
+        self.append_word(value: value as u256, width: 1)
+    }
+
+    /// Append a `bool` as 1 byte (`0x00` / `0x01`).
+    pub fn bool_(mut self, _ value: bool) uses (mem: mut RawMem) {
+        self.append_word(value: if value { 1 } else { 0 }, width: 1)
+    }
+
+    /// Append an `Address` as 20 bytes.
+    pub fn address(mut self, _ value: Address) uses (mem: mut RawMem) {
+        // `inner` is a public field, so a caller can hand us a
+        // non-canonical value with bits above the low 160 set. Revert
+        // like `fixed_bytes` does rather than silently truncating
+        // distinct values into colliding encodings.
+        if value.inner >> 160 != 0 {
+            ops::revert(offset: 0, len: 0)
+        }
+        self.append_word(value: value.inner, width: 20)
+    }
+
+    /// Append the *effective* bytes of a fixed-size string — `len()`
+    /// bytes, not the capacity `N` — matching Solidity's packed
+    /// `string`.
+    pub fn string<const N: usize>(mut self, _ value: String<N>) uses (mem: mut RawMem) {
+        self.append_word(value: value as u256, width: value.len() as u256)
+    }
+
+    /// Append a `FixedBytes<N>` as its N raw bytes.
+    ///
+    /// `bytesN` values sit **left-aligned** in an ABI word — the
+    /// opposite of integer alignment and the classic `encodePacked`
+    /// footgun — but packed they are just the N content bytes: a
+    /// `bytes4` contributes 4 bytes, never a zero-padded word.
+    pub fn fixed_bytes<const N: usize>(mut self, _ value: FixedBytes<N>) uses (mem: mut RawMem) {
+        // The ABI encoder (`FixedBytes::word`) reverts on unsupported
+        // widths; do the same rather than silently appending nothing
+        // for `N == 0` or tripping `append_word`'s assert for `N > 32`.
+        if N == 0 || N > 32 {
+            ops::revert(offset: 0, len: 0)
+        }
+        // `val` is a public field, so a caller can hand us a
+        // non-canonical value with bytes above the low N set. The ABI
+        // encoder (`FixedBytes::word`) reverts on those; do the same
+        // rather than silently truncating distinct values into
+        // colliding encodings.
+        if N < 32 && value.val >> ((N as u256) * 8) != 0 {
+            ops::revert(offset: 0, len: 0)
+        }
+        self.append_word(value: value.val, width: N as u256)
+    }
+
+    /// Append a fixed byte array verbatim.
+    pub fn bytes<const N: usize>(mut self, _ value: [u8; N]) uses (mem: mut RawMem) {
+        self.reserve(N as u256)
+        let mut i: usize = 0
+        while i < N {
+            mem.mstore8(addr: self.cursor + (i as u256), value: value[i])
+            i += 1
+        }
+        self.cursor += N as u256
+    }
+
+    /// Append `len` raw bytes copied from memory at `ptr`.
+    ///
+    /// Unsupported edge: `ptr` must not point into this builder's own
+    /// buffer — an append that triggers growth would leave `ptr`
+    /// pointing at the stale allocation.
+    pub fn append_mem(mut self, ptr: u256, len: u256) uses (mem: mut RawMem) {
+        self.reserve(len)
+        copy_bytes(dest: self.cursor, src: ptr, len: len)
+        self.cursor += len
+    }
+
+    /// Bytes written so far.
+    pub fn len(self) -> u256 {
+        self.cursor - self.base
+    }
+
+    /// keccak256 of the bytes written so far.
+    pub fn keccak256(self) -> u256 {
+        ops::keccak256(offset: self.base, len: self.len())
+    }
+
+    /// SHA-256 of the bytes written so far (precompile 0x02). Reverts
+    /// if the precompile call fails.
+    pub fn sha256(self) -> u256 {
+        match crypto::sha256(offset: self.base, len: self.len()) {
+            Result::Ok(digest) => digest,
+            Result::Err(_) => ops::revert(offset: 0, len: 0),
+        }
+    }
+
+    /// Copy out as a Solidity-compatible `bytes memory` payload (fresh
+    /// allocation: length word + zero-padded payload words).
+    pub fn as_bytes(self) -> Bytes uses (mem: mut RawMem) {
+        let len = self.len()
+        let padded = (len + 31) / 32 * 32
+        let data = mem::alloc(32 + padded)
+        mem.mstore(addr: data, value: len)
+        if padded != 0 {
+            // Zero the last payload word so the padding bytes are
+            // canonical regardless of what the copy leaves behind.
+            mem.mstore(addr: data + padded, value: 0)
+        }
+        copy_bytes(dest: data + 32, src: self.base, len: len)
+        Bytes { data, len, size: 32 + padded }
+    }
+
+    /// Write the low `width` bytes of `value` big-endian at the cursor.
+    ///
+    /// Byte-precise: never touches memory beyond the buffer's
+    /// capacity. When a whole word fits below `limit` a single
+    /// left-aligned `mstore` is used (the bytes it zeroes past `width`
+    /// are inside our own capacity and overwritten by later appends);
+    /// otherwise the bytes are written individually.
+    #[arithmetic(unchecked)]
+    fn append_word(mut self, value: u256, width: u256) uses (mem: mut RawMem) {
+        assert!(width <= 32)
+        if width == 0 {
+            return
+        }
+        self.reserve(width)
+        if self.cursor + 32 <= self.limit {
+            mem.mstore(addr: self.cursor, value: value << ((32 - width) * 8))
+        } else {
+            let mut i: u256 = 0
+            while i < width {
+                let b: u8 = (value >> ((width - 1 - i) * 8)).downcast_truncate()
+                mem.mstore8(addr: self.cursor + i, value: b)
+                i += 1
+            }
+        }
+        self.cursor += width
+    }
+
+    /// Ensure `additional` bytes fit below `limit`, growing
+    /// (copy-on-grow, doubling until it fits) if they don't.
+    fn reserve(mut self, _ additional: u256) uses (mem: mut RawMem) {
+        if self.cursor + additional <= self.limit {
+            return
+        }
+        let len = self.len()
+        let needed = len + additional
+        let mut cap = self.limit - self.base
+        if cap == 0 {
+            cap = 32
+        }
+        while cap < needed {
+            cap *= 2
+        }
+        let base = mem::alloc(cap)
+        copy_bytes(dest: base, src: self.base, len: len)
+        self.base = base
+        self.cursor = base + len
+        self.limit = base + cap
+    }
+}
+
+// Byte-precise memory copy: whole words first, then the sub-word tail
+// one byte at a time, so exactly `len` destination bytes are written.
+fn copy_bytes(dest: u256, src: u256, len: u256) uses (mem: mut RawMem) {
+    let words_end = len / 32 * 32
+    let mut off: u256 = 0
+    while off < words_end {
+        mem.mstore(addr: dest + off, value: mem.mload(src + off))
+        off += 32
+    }
+    while off < len {
+        let b: u8 = (mem.mload(src + off) >> 248).downcast_truncate()
+        mem.mstore8(addr: dest + off, value: b)
+        off += 1
+    }
+}
+
+// -----------------------------------------------------------------------------
+// EncodePacked implementations (matching Solidity's `abi.encodePacked`
+// byte-for-byte)
+// -----------------------------------------------------------------------------
+
+impl EncodePacked for u8 {
+    fn packed_width(self) -> u256 { 1 }
+    fn pack_into(own self, _ p: mut Packed) uses (mem: mut RawMem) {
+        p.u8(self)
+    }
+}
+
+impl EncodePacked for u16 {
+    fn packed_width(self) -> u256 { 2 }
+    fn pack_into(own self, _ p: mut Packed) uses (mem: mut RawMem) {
+        p.u16(self)
+    }
+}
+
+impl EncodePacked for u32 {
+    fn packed_width(self) -> u256 { 4 }
+    fn pack_into(own self, _ p: mut Packed) uses (mem: mut RawMem) {
+        p.u32(self)
+    }
+}
+
+impl EncodePacked for u64 {
+    fn packed_width(self) -> u256 { 8 }
+    fn pack_into(own self, _ p: mut Packed) uses (mem: mut RawMem) {
+        p.u64(self)
+    }
+}
+
+impl EncodePacked for u128 {
+    fn packed_width(self) -> u256 { 16 }
+    fn pack_into(own self, _ p: mut Packed) uses (mem: mut RawMem) {
+        p.u128(self)
+    }
+}
+
+impl EncodePacked for u256 {
+    fn packed_width(self) -> u256 { 32 }
+    fn pack_into(own self, _ p: mut Packed) uses (mem: mut RawMem) {
+        p.u256(self)
+    }
+}
+
+// Signed integers pack as two's complement in their exact width:
+// `i8(-1)` is `0xff`, `i16(-2)` is `0xfffe`. `downcast_truncate` to the
+// same-width unsigned type keeps the bit pattern.
+
+impl EncodePacked for i8 {
+    fn packed_width(self) -> u256 { 1 }
+    fn pack_into(own self, _ p: mut Packed) uses (mem: mut RawMem) {
+        let bits: u8 = self.downcast_truncate()
+        p.u8(bits)
+    }
+}
+
+impl EncodePacked for i16 {
+    fn packed_width(self) -> u256 { 2 }
+    fn pack_into(own self, _ p: mut Packed) uses (mem: mut RawMem) {
+        let bits: u16 = self.downcast_truncate()
+        p.u16(bits)
+    }
+}
+
+impl EncodePacked for i32 {
+    fn packed_width(self) -> u256 { 4 }
+    fn pack_into(own self, _ p: mut Packed) uses (mem: mut RawMem) {
+        let bits: u32 = self.downcast_truncate()
+        p.u32(bits)
+    }
+}
+
+impl EncodePacked for i64 {
+    fn packed_width(self) -> u256 { 8 }
+    fn pack_into(own self, _ p: mut Packed) uses (mem: mut RawMem) {
+        let bits: u64 = self.downcast_truncate()
+        p.u64(bits)
+    }
+}
+
+impl EncodePacked for i128 {
+    fn packed_width(self) -> u256 { 16 }
+    fn pack_into(own self, _ p: mut Packed) uses (mem: mut RawMem) {
+        let bits: u128 = self.downcast_truncate()
+        p.u128(bits)
+    }
+}
+
+impl EncodePacked for i256 {
+    fn packed_width(self) -> u256 { 32 }
+    fn pack_into(own self, _ p: mut Packed) uses (mem: mut RawMem) {
+        let bits: u256 = self.downcast_truncate()
+        p.u256(bits)
+    }
+}
+
+impl EncodePacked for bool {
+    fn packed_width(self) -> u256 { 1 }
+    fn pack_into(own self, _ p: mut Packed) uses (mem: mut RawMem) {
+        p.bool_(self)
+    }
+}
+
+impl EncodePacked for Address {
+    fn packed_width(self) -> u256 { 20 }
+    fn pack_into(own self, _ p: mut Packed) uses (mem: mut RawMem) {
+        p.address(self)
+    }
+}
+
+// The effective string bytes (`len()`), not the capacity `N`.
+impl<const N: usize> EncodePacked for String<N> {
+    fn packed_width(self) -> u256 { self.len() as u256 }
+    fn pack_into(own self, _ p: mut Packed) uses (mem: mut RawMem) {
+        p.string(self)
+    }
+}
+
+impl<const N: usize> EncodePacked for [u8; N] {
+    fn packed_width(self) -> u256 { N as u256 }
+    fn pack_into(own self, _ p: mut Packed) uses (mem: mut RawMem) {
+        p.bytes(self)
+    }
+}
+
+// N raw content bytes — see `Packed::fixed_bytes` for the alignment
+// footgun.
+impl<const N: usize> EncodePacked for FixedBytes<N> {
+    fn packed_width(self) -> u256 { N as u256 }
+    fn pack_into(own self, _ p: mut Packed) uses (mem: mut RawMem) {
+        p.fixed_bytes(self)
+    }
+}
+
+// `len()` raw payload bytes, no length word.
+impl EncodePacked for Bytes {
+    fn packed_width(self) -> u256 { self.len }
+    fn pack_into(own self, _ p: mut Packed) uses (mem: mut RawMem) {
+        p.append_mem(ptr: self.payload_ptr(), len: self.len)
+    }
+}
+
+impl EncodePacked for BytesView<MemoryInput> {
+    fn packed_width(self) -> u256 { self.len }
+    fn pack_into(own self, _ p: mut Packed) uses (mem: mut RawMem) {
+        p.append_mem(ptr: self.input.base + self.start, len: self.len)
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Tuple implementations (arity 1..=16, per-arity like `Encode<Sol>`,
+// `AsBytes`, and `ssz::Merkleize`)
+// -----------------------------------------------------------------------------
+//
+// Fields are concatenated in declaration order; nested tuples flatten
+// naturally through recursion.
+
+impl<T0> EncodePacked for (T0,)
+    where T0: EncodePacked
+{
+    fn packed_width(self) -> u256 {
+        self.0.packed_width()
+    }
+    fn pack_into(own self, _ p: mut Packed) uses (mem: mut RawMem) {
+        self.0.pack_into(mut p)
+    }
+}
+
+impl<T0, T1> EncodePacked for (T0, T1)
+    where T0: EncodePacked, T1: EncodePacked
+{
+    fn packed_width(self) -> u256 {
+        self.0.packed_width() + self.1.packed_width()
+    }
+    fn pack_into(own self, _ p: mut Packed) uses (mem: mut RawMem) {
+        self.0.pack_into(mut p)
+        self.1.pack_into(mut p)
+    }
+}
+
+impl<T0, T1, T2> EncodePacked for (T0, T1, T2)
+    where T0: EncodePacked, T1: EncodePacked, T2: EncodePacked
+{
+    fn packed_width(self) -> u256 {
+        self.0.packed_width() + self.1.packed_width() + self.2.packed_width()
+    }
+    fn pack_into(own self, _ p: mut Packed) uses (mem: mut RawMem) {
+        self.0.pack_into(mut p)
+        self.1.pack_into(mut p)
+        self.2.pack_into(mut p)
+    }
+}
+
+impl<T0, T1, T2, T3> EncodePacked for (T0, T1, T2, T3)
+    where T0: EncodePacked, T1: EncodePacked, T2: EncodePacked, T3: EncodePacked
+{
+    fn packed_width(self) -> u256 {
+        self.0.packed_width() + self.1.packed_width() + self.2.packed_width()
+            + self.3.packed_width()
+    }
+    fn pack_into(own self, _ p: mut Packed) uses (mem: mut RawMem) {
+        self.0.pack_into(mut p)
+        self.1.pack_into(mut p)
+        self.2.pack_into(mut p)
+        self.3.pack_into(mut p)
+    }
+}
+
+impl<T0, T1, T2, T3, T4> EncodePacked for (T0, T1, T2, T3, T4)
+    where T0: EncodePacked, T1: EncodePacked, T2: EncodePacked, T3: EncodePacked,
+          T4: EncodePacked
+{
+    fn packed_width(self) -> u256 {
+        self.0.packed_width() + self.1.packed_width() + self.2.packed_width()
+            + self.3.packed_width() + self.4.packed_width()
+    }
+    fn pack_into(own self, _ p: mut Packed) uses (mem: mut RawMem) {
+        self.0.pack_into(mut p)
+        self.1.pack_into(mut p)
+        self.2.pack_into(mut p)
+        self.3.pack_into(mut p)
+        self.4.pack_into(mut p)
+    }
+}
+
+impl<T0, T1, T2, T3, T4, T5> EncodePacked for (T0, T1, T2, T3, T4, T5)
+    where T0: EncodePacked, T1: EncodePacked, T2: EncodePacked, T3: EncodePacked,
+          T4: EncodePacked, T5: EncodePacked
+{
+    fn packed_width(self) -> u256 {
+        self.0.packed_width() + self.1.packed_width() + self.2.packed_width()
+            + self.3.packed_width() + self.4.packed_width() + self.5.packed_width()
+    }
+    fn pack_into(own self, _ p: mut Packed) uses (mem: mut RawMem) {
+        self.0.pack_into(mut p)
+        self.1.pack_into(mut p)
+        self.2.pack_into(mut p)
+        self.3.pack_into(mut p)
+        self.4.pack_into(mut p)
+        self.5.pack_into(mut p)
+    }
+}
+
+impl<T0, T1, T2, T3, T4, T5, T6> EncodePacked for (T0, T1, T2, T3, T4, T5, T6)
+    where T0: EncodePacked, T1: EncodePacked, T2: EncodePacked, T3: EncodePacked,
+          T4: EncodePacked, T5: EncodePacked, T6: EncodePacked
+{
+    fn packed_width(self) -> u256 {
+        self.0.packed_width() + self.1.packed_width() + self.2.packed_width()
+            + self.3.packed_width() + self.4.packed_width() + self.5.packed_width()
+            + self.6.packed_width()
+    }
+    fn pack_into(own self, _ p: mut Packed) uses (mem: mut RawMem) {
+        self.0.pack_into(mut p)
+        self.1.pack_into(mut p)
+        self.2.pack_into(mut p)
+        self.3.pack_into(mut p)
+        self.4.pack_into(mut p)
+        self.5.pack_into(mut p)
+        self.6.pack_into(mut p)
+    }
+}
+
+impl<T0, T1, T2, T3, T4, T5, T6, T7> EncodePacked for (T0, T1, T2, T3, T4, T5, T6, T7)
+    where T0: EncodePacked, T1: EncodePacked, T2: EncodePacked, T3: EncodePacked,
+          T4: EncodePacked, T5: EncodePacked, T6: EncodePacked, T7: EncodePacked
+{
+    fn packed_width(self) -> u256 {
+        self.0.packed_width() + self.1.packed_width() + self.2.packed_width()
+            + self.3.packed_width() + self.4.packed_width() + self.5.packed_width()
+            + self.6.packed_width() + self.7.packed_width()
+    }
+    fn pack_into(own self, _ p: mut Packed) uses (mem: mut RawMem) {
+        self.0.pack_into(mut p)
+        self.1.pack_into(mut p)
+        self.2.pack_into(mut p)
+        self.3.pack_into(mut p)
+        self.4.pack_into(mut p)
+        self.5.pack_into(mut p)
+        self.6.pack_into(mut p)
+        self.7.pack_into(mut p)
+    }
+}
+
+impl<T0, T1, T2, T3, T4, T5, T6, T7, T8> EncodePacked
+    for (T0, T1, T2, T3, T4, T5, T6, T7, T8)
+    where T0: EncodePacked, T1: EncodePacked, T2: EncodePacked, T3: EncodePacked,
+          T4: EncodePacked, T5: EncodePacked, T6: EncodePacked, T7: EncodePacked,
+          T8: EncodePacked
+{
+    fn packed_width(self) -> u256 {
+        self.0.packed_width() + self.1.packed_width() + self.2.packed_width()
+            + self.3.packed_width() + self.4.packed_width() + self.5.packed_width()
+            + self.6.packed_width() + self.7.packed_width() + self.8.packed_width()
+    }
+    fn pack_into(own self, _ p: mut Packed) uses (mem: mut RawMem) {
+        self.0.pack_into(mut p)
+        self.1.pack_into(mut p)
+        self.2.pack_into(mut p)
+        self.3.pack_into(mut p)
+        self.4.pack_into(mut p)
+        self.5.pack_into(mut p)
+        self.6.pack_into(mut p)
+        self.7.pack_into(mut p)
+        self.8.pack_into(mut p)
+    }
+}
+
+impl<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> EncodePacked
+    for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9)
+    where T0: EncodePacked, T1: EncodePacked, T2: EncodePacked, T3: EncodePacked,
+          T4: EncodePacked, T5: EncodePacked, T6: EncodePacked, T7: EncodePacked,
+          T8: EncodePacked, T9: EncodePacked
+{
+    fn packed_width(self) -> u256 {
+        self.0.packed_width() + self.1.packed_width() + self.2.packed_width()
+            + self.3.packed_width() + self.4.packed_width() + self.5.packed_width()
+            + self.6.packed_width() + self.7.packed_width() + self.8.packed_width()
+            + self.9.packed_width()
+    }
+    fn pack_into(own self, _ p: mut Packed) uses (mem: mut RawMem) {
+        self.0.pack_into(mut p)
+        self.1.pack_into(mut p)
+        self.2.pack_into(mut p)
+        self.3.pack_into(mut p)
+        self.4.pack_into(mut p)
+        self.5.pack_into(mut p)
+        self.6.pack_into(mut p)
+        self.7.pack_into(mut p)
+        self.8.pack_into(mut p)
+        self.9.pack_into(mut p)
+    }
+}
+
+impl<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> EncodePacked
+    for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+    where T0: EncodePacked, T1: EncodePacked, T2: EncodePacked, T3: EncodePacked,
+          T4: EncodePacked, T5: EncodePacked, T6: EncodePacked, T7: EncodePacked,
+          T8: EncodePacked, T9: EncodePacked, T10: EncodePacked
+{
+    fn packed_width(self) -> u256 {
+        self.0.packed_width() + self.1.packed_width() + self.2.packed_width()
+            + self.3.packed_width() + self.4.packed_width() + self.5.packed_width()
+            + self.6.packed_width() + self.7.packed_width() + self.8.packed_width()
+            + self.9.packed_width() + self.10.packed_width()
+    }
+    fn pack_into(own self, _ p: mut Packed) uses (mem: mut RawMem) {
+        self.0.pack_into(mut p)
+        self.1.pack_into(mut p)
+        self.2.pack_into(mut p)
+        self.3.pack_into(mut p)
+        self.4.pack_into(mut p)
+        self.5.pack_into(mut p)
+        self.6.pack_into(mut p)
+        self.7.pack_into(mut p)
+        self.8.pack_into(mut p)
+        self.9.pack_into(mut p)
+        self.10.pack_into(mut p)
+    }
+}
+
+impl<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> EncodePacked
+    for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+    where T0: EncodePacked, T1: EncodePacked, T2: EncodePacked, T3: EncodePacked,
+          T4: EncodePacked, T5: EncodePacked, T6: EncodePacked, T7: EncodePacked,
+          T8: EncodePacked, T9: EncodePacked, T10: EncodePacked, T11: EncodePacked
+{
+    fn packed_width(self) -> u256 {
+        self.0.packed_width() + self.1.packed_width() + self.2.packed_width()
+            + self.3.packed_width() + self.4.packed_width() + self.5.packed_width()
+            + self.6.packed_width() + self.7.packed_width() + self.8.packed_width()
+            + self.9.packed_width() + self.10.packed_width() + self.11.packed_width()
+    }
+    fn pack_into(own self, _ p: mut Packed) uses (mem: mut RawMem) {
+        self.0.pack_into(mut p)
+        self.1.pack_into(mut p)
+        self.2.pack_into(mut p)
+        self.3.pack_into(mut p)
+        self.4.pack_into(mut p)
+        self.5.pack_into(mut p)
+        self.6.pack_into(mut p)
+        self.7.pack_into(mut p)
+        self.8.pack_into(mut p)
+        self.9.pack_into(mut p)
+        self.10.pack_into(mut p)
+        self.11.pack_into(mut p)
+    }
+}
+
+impl<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> EncodePacked
+    for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+    where T0: EncodePacked, T1: EncodePacked, T2: EncodePacked, T3: EncodePacked,
+          T4: EncodePacked, T5: EncodePacked, T6: EncodePacked, T7: EncodePacked,
+          T8: EncodePacked, T9: EncodePacked, T10: EncodePacked, T11: EncodePacked,
+          T12: EncodePacked
+{
+    fn packed_width(self) -> u256 {
+        self.0.packed_width() + self.1.packed_width() + self.2.packed_width()
+            + self.3.packed_width() + self.4.packed_width() + self.5.packed_width()
+            + self.6.packed_width() + self.7.packed_width() + self.8.packed_width()
+            + self.9.packed_width() + self.10.packed_width() + self.11.packed_width()
+            + self.12.packed_width()
+    }
+    fn pack_into(own self, _ p: mut Packed) uses (mem: mut RawMem) {
+        self.0.pack_into(mut p)
+        self.1.pack_into(mut p)
+        self.2.pack_into(mut p)
+        self.3.pack_into(mut p)
+        self.4.pack_into(mut p)
+        self.5.pack_into(mut p)
+        self.6.pack_into(mut p)
+        self.7.pack_into(mut p)
+        self.8.pack_into(mut p)
+        self.9.pack_into(mut p)
+        self.10.pack_into(mut p)
+        self.11.pack_into(mut p)
+        self.12.pack_into(mut p)
+    }
+}
+
+impl<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> EncodePacked
+    for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+    where T0: EncodePacked, T1: EncodePacked, T2: EncodePacked, T3: EncodePacked,
+          T4: EncodePacked, T5: EncodePacked, T6: EncodePacked, T7: EncodePacked,
+          T8: EncodePacked, T9: EncodePacked, T10: EncodePacked, T11: EncodePacked,
+          T12: EncodePacked, T13: EncodePacked
+{
+    fn packed_width(self) -> u256 {
+        self.0.packed_width() + self.1.packed_width() + self.2.packed_width()
+            + self.3.packed_width() + self.4.packed_width() + self.5.packed_width()
+            + self.6.packed_width() + self.7.packed_width() + self.8.packed_width()
+            + self.9.packed_width() + self.10.packed_width() + self.11.packed_width()
+            + self.12.packed_width() + self.13.packed_width()
+    }
+    fn pack_into(own self, _ p: mut Packed) uses (mem: mut RawMem) {
+        self.0.pack_into(mut p)
+        self.1.pack_into(mut p)
+        self.2.pack_into(mut p)
+        self.3.pack_into(mut p)
+        self.4.pack_into(mut p)
+        self.5.pack_into(mut p)
+        self.6.pack_into(mut p)
+        self.7.pack_into(mut p)
+        self.8.pack_into(mut p)
+        self.9.pack_into(mut p)
+        self.10.pack_into(mut p)
+        self.11.pack_into(mut p)
+        self.12.pack_into(mut p)
+        self.13.pack_into(mut p)
+    }
+}
+
+impl<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> EncodePacked
+    for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+    where T0: EncodePacked, T1: EncodePacked, T2: EncodePacked, T3: EncodePacked,
+          T4: EncodePacked, T5: EncodePacked, T6: EncodePacked, T7: EncodePacked,
+          T8: EncodePacked, T9: EncodePacked, T10: EncodePacked, T11: EncodePacked,
+          T12: EncodePacked, T13: EncodePacked, T14: EncodePacked
+{
+    fn packed_width(self) -> u256 {
+        self.0.packed_width() + self.1.packed_width() + self.2.packed_width()
+            + self.3.packed_width() + self.4.packed_width() + self.5.packed_width()
+            + self.6.packed_width() + self.7.packed_width() + self.8.packed_width()
+            + self.9.packed_width() + self.10.packed_width() + self.11.packed_width()
+            + self.12.packed_width() + self.13.packed_width() + self.14.packed_width()
+    }
+    fn pack_into(own self, _ p: mut Packed) uses (mem: mut RawMem) {
+        self.0.pack_into(mut p)
+        self.1.pack_into(mut p)
+        self.2.pack_into(mut p)
+        self.3.pack_into(mut p)
+        self.4.pack_into(mut p)
+        self.5.pack_into(mut p)
+        self.6.pack_into(mut p)
+        self.7.pack_into(mut p)
+        self.8.pack_into(mut p)
+        self.9.pack_into(mut p)
+        self.10.pack_into(mut p)
+        self.11.pack_into(mut p)
+        self.12.pack_into(mut p)
+        self.13.pack_into(mut p)
+        self.14.pack_into(mut p)
+    }
+}
+
+impl<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> EncodePacked
+    for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+    where T0: EncodePacked, T1: EncodePacked, T2: EncodePacked, T3: EncodePacked,
+          T4: EncodePacked, T5: EncodePacked, T6: EncodePacked, T7: EncodePacked,
+          T8: EncodePacked, T9: EncodePacked, T10: EncodePacked, T11: EncodePacked,
+          T12: EncodePacked, T13: EncodePacked, T14: EncodePacked, T15: EncodePacked
+{
+    fn packed_width(self) -> u256 {
+        self.0.packed_width() + self.1.packed_width() + self.2.packed_width()
+            + self.3.packed_width() + self.4.packed_width() + self.5.packed_width()
+            + self.6.packed_width() + self.7.packed_width() + self.8.packed_width()
+            + self.9.packed_width() + self.10.packed_width() + self.11.packed_width()
+            + self.12.packed_width() + self.13.packed_width() + self.14.packed_width()
+            + self.15.packed_width()
+    }
+    fn pack_into(own self, _ p: mut Packed) uses (mem: mut RawMem) {
+        self.0.pack_into(mut p)
+        self.1.pack_into(mut p)
+        self.2.pack_into(mut p)
+        self.3.pack_into(mut p)
+        self.4.pack_into(mut p)
+        self.5.pack_into(mut p)
+        self.6.pack_into(mut p)
+        self.7.pack_into(mut p)
+        self.8.pack_into(mut p)
+        self.9.pack_into(mut p)
+        self.10.pack_into(mut p)
+        self.11.pack_into(mut p)
+        self.12.pack_into(mut p)
+        self.13.pack_into(mut p)
+        self.14.pack_into(mut p)
+        self.15.pack_into(mut p)
+    }
+}


### PR DESCRIPTION
std: add evm::packed — tightly packed byte encoding (abi.encodePacked parity)
Adds std::evm::packed with two layers:

- A declarative tuple API: an EncodePacked trait with encode_packed /
  keccak_packed entry points, implemented for u8-u256, i8-i256 (two's
  complement), bool, Address, String<N> (effective len() bytes),
  [u8; N], FixedBytes<N>, Bytes, BytesView<MemoryInput>, and tuples of
  arity 1..=16, so `keccak_packed((token0, token1))` covers CREATE2
  salts and EIP-712 digests with zero size bookkeeping.
- An imperative Packed builder for runtime-shaped payloads, with
  byte-precise writes (full-word mstore fast path only when a whole
  word fits below the buffer limit, mstore8 fallback otherwise) and
  copy-on-grow doubling, plus keccak256/sha256/as_bytes terminals.

Also adds crypto::eip712_digest built on the tuple API.

Fixes a codegen bug this exposed: a tuple/struct const region holding
a String<N> literal of 16 bytes or fewer crashed Sonatina emission
("global initializer immediate type does not match global type") —
the aggregate field type is always I256 while the immediate was typed
from the literal's byte length. gv_initializer_for_const now threads
the layout's per-field RuntimeClass down to immediate_for_const, which
types FixedBytes immediates from the declared class width. As a side
effect, string constants emit as direct .i256 immediates instead of a
small immediate plus zext (two sonatina_ir snapshots updated).

The packed_encoding fixture's expected values are all precomputed with
Foundry (cast abi-encode --packed / cast keccak), so the tests are not
their own oracle. string_in_tuple is a minimal regression fixture for
the codegen fix.