### PR TITLE
fix: ICE when emitting #[event] structs with many fields

### DIFF
--- a/crates/fe/tests/fixtures/fe_test/event_many_fields.fe
+++ b/crates/fe/tests/fixtures/fe_test/event_many_fields.fe
@@ -1,0 +1,173 @@
+// Regression test for events with many fields.
+//
+// The `#[event]` desugar hashes the signature with `core::keccak` over a
+// tuple of string fragments. That tuple has `2 * total_fields + 2` elements,
+// and the `AsBytes` tuple impls stop at arity 16, so events with 8 or more
+// total fields used to leave `TOPIC0` unevaluated and crash MIR lowering.
+// The desugar now nests the tuple into chunks of at most 16 elements, which
+// hashes the same bytes at any field count.
+//
+// The expected TOPIC0 values below are `keccak256` of the canonical event
+// signature (e.g. `E8Data(address,uint256,...)`), computed externally with
+// `cast keccak`.
+
+use std::evm::{Evm, Log}
+
+#[event]
+struct E6Data {
+    #[indexed]
+    who: Address,
+    f0: u256,
+    f1: u256,
+    f2: u256,
+    f3: u256,
+    f4: u256,
+    f5: u256,
+}
+
+#[event]
+struct E7Data {
+    #[indexed]
+    who: Address,
+    f0: u256,
+    f1: u256,
+    f2: u256,
+    f3: u256,
+    f4: u256,
+    f5: u256,
+    f6: u256,
+}
+
+#[event]
+struct E8Data {
+    #[indexed]
+    who: Address,
+    f0: u256,
+    f1: u256,
+    f2: u256,
+    f3: u256,
+    f4: u256,
+    f5: u256,
+    f6: u256,
+    f7: u256,
+}
+
+#[event]
+struct E16Data {
+    #[indexed]
+    who: Address,
+    f0: u256,
+    f1: u256,
+    f2: u256,
+    f3: u256,
+    f4: u256,
+    f5: u256,
+    f6: u256,
+    f7: u256,
+    f8: u256,
+    f9: u256,
+    f10: u256,
+    f11: u256,
+    f12: u256,
+    f13: u256,
+    f14: u256,
+    f15: u256,
+}
+
+#[event]
+struct E7NoIdx {
+    f0: u256,
+    f1: u256,
+    f2: u256,
+    f3: u256,
+    f4: u256,
+    f5: u256,
+    f6: u256,
+}
+
+msg ProbeMsg {
+    #[selector = sol("emitE6Data()")]
+    EmitE6Data -> u256,
+    #[selector = sol("emitE7Data()")]
+    EmitE7Data -> u256,
+    #[selector = sol("emitE8Data()")]
+    EmitE8Data -> u256,
+    #[selector = sol("emitE16Data()")]
+    EmitE16Data -> u256,
+    #[selector = sol("emitE7NoIdx()")]
+    EmitE7NoIdx -> u256,
+}
+
+pub contract Probe uses (log: mut Log) {
+    recv ProbeMsg {
+        EmitE6Data -> u256 uses (mut log) {
+            log.emit(E6Data { who: Address::zero(), f0: 0, f1: 1, f2: 2, f3: 3, f4: 4, f5: 5 })
+            let ret: u256 = 1
+            ret
+        }
+
+        EmitE7Data -> u256 uses (mut log) {
+            log.emit(E7Data { who: Address::zero(), f0: 0, f1: 1, f2: 2, f3: 3, f4: 4, f5: 5, f6: 6 })
+            let ret: u256 = 2
+            ret
+        }
+
+        EmitE8Data -> u256 uses (mut log) {
+            log.emit(E8Data { who: Address::zero(), f0: 0, f1: 1, f2: 2, f3: 3, f4: 4, f5: 5, f6: 6, f7: 7 })
+            let ret: u256 = 3
+            ret
+        }
+
+        EmitE16Data -> u256 uses (mut log) {
+            log.emit(E16Data { who: Address::zero(), f0: 0, f1: 1, f2: 2, f3: 3, f4: 4, f5: 5, f6: 6, f7: 7, f8: 8, f9: 9, f10: 10, f11: 11, f12: 12, f13: 13, f14: 14, f15: 15 })
+            let ret: u256 = 4
+            ret
+        }
+
+        EmitE7NoIdx -> u256 uses (mut log) {
+            log.emit(E7NoIdx { f0: 0, f1: 1, f2: 2, f3: 3, f4: 4, f5: 5, f6: 6 })
+            let ret: u256 = 5
+            ret
+        }
+    }
+}
+
+#[test]
+fn topic0_e6data() {
+    assert!(E6Data::TOPIC0 == 0x7463918f4764895eb86587f42b18b64e71ab12ab37bbc6fe496d5fb1e6afcca1)
+}
+
+#[test]
+fn topic0_e7data() {
+    assert!(E7Data::TOPIC0 == 0x492ad8dcfdc2ae45e68d9860da28463849e0b3786764cf67ff41f547b722344f)
+}
+
+#[test]
+fn topic0_e8data() {
+    assert!(E8Data::TOPIC0 == 0x47ca2fecc9a425cabbe700e22b112fbd1cfe9a9b18d13ad3d3f369d4909a73f8)
+}
+
+#[test]
+fn topic0_e16data() {
+    assert!(E16Data::TOPIC0 == 0x7b8ff7a566201b2975dd0fe44b67e5c8c6cfe52a44562086e166c9cdd54d501a)
+}
+
+#[test]
+fn topic0_e7noidx() {
+    assert!(E7NoIdx::TOPIC0 == 0x34dd3fca85336d31367714898b156d6672983033983d23af9534a4f89df503c2)
+}
+
+#[test]
+fn emit_many_field_events() uses (evm: mut Evm) {
+    let c = evm.create2<Probe>(value: 0, args: (), salt: 0)
+    let r0: u256 = evm.call(addr: c, gas: 5000000, value: 0, message: ProbeMsg::EmitE6Data {})
+    assert!(r0 == 1)
+    let r1: u256 = evm.call(addr: c, gas: 5000000, value: 0, message: ProbeMsg::EmitE7Data {})
+    assert!(r1 == 2)
+    let r2: u256 = evm.call(addr: c, gas: 5000000, value: 0, message: ProbeMsg::EmitE8Data {})
+    assert!(r2 == 3)
+    let r3: u256 = evm.call(addr: c, gas: 5000000, value: 0, message: ProbeMsg::EmitE16Data {})
+    assert!(r3 == 4)
+    let r4: u256 = evm.call(addr: c, gas: 5000000, value: 0, message: ProbeMsg::EmitE7NoIdx {})
+    assert!(r4 == 5)
+}

--- a/crates/hir/src/analysis/ty/ty_check/mod.rs
+++ b/crates/hir/src/analysis/ty/ty_check/mod.rs
@@ -1193,6 +1193,18 @@ impl<'db> TyChecker<'db> {
             return TraitObligationOutcome::Discharged;
         }
 
+        if final_pass {
+            // Apply literal fallbacks (e.g. string type variables defaulting to
+            // `String<N>`) before the last solving attempt. The typed body will
+            // contain the fallback types anyway, and without this an
+            // unsatisfied goal that mentions a literal variable would be
+            // discharged as "not concrete" below, silently suppressing the
+            // diagnostic and letting the error surface as an ICE in later
+            // lowering stages.
+            let mut prober = env::Prober::new(&mut self.table, scope);
+            obligation.goal = obligation.goal.fold_with(db, &mut prober);
+        }
+
         obligation.goal = self.normalize_trait_goal(obligation.goal);
         let goal = obligation.goal;
         let flags = collect_flags(db, goal);

--- a/crates/hir/src/core/lower/event.rs
+++ b/crates/hir/src/core/lower/event.rs
@@ -364,6 +364,23 @@ fn create_topic0_const<'db>(
     )));
     tuple_elems.push(body_ctxt.push_expr(close_paren, origin.clone()));
 
+    // The `AsBytes` tuple impls in `core` stop at arity 16, so nest the
+    // elements into chunks when the signature is longer. Byte concatenation is
+    // associative, so the nesting doesn't change the hashed bytes.
+    const MAX_TUPLE_ARITY: usize = 16;
+    while tuple_elems.len() > MAX_TUPLE_ARITY {
+        tuple_elems = tuple_elems
+            .chunks(MAX_TUPLE_ARITY)
+            .map(|chunk| {
+                if let [single] = chunk {
+                    *single
+                } else {
+                    body_ctxt.push_expr(Expr::Tuple(chunk.to_vec()), origin.clone())
+                }
+            })
+            .collect();
+    }
+
     // Build the tuple expression and wrap in keccak call
     let tuple_expr = Expr::Tuple(tuple_elems);
     let tuple_id = body_ctxt.push_expr(tuple_expr, origin.clone());

--- a/crates/hir/test_files/desugar/event_many_fields.fe
+++ b/crates/hir/test_files/desugar/event_many_fields.fe
@@ -1,0 +1,21 @@
+use std::evm::Address
+
+// 13 total fields -> 28 signature-tuple elements, which exceeds the
+// `AsBytes` tuple arity limit (16), so the TOPIC0 keccak tuple is nested.
+#[event]
+pub struct ManyFields {
+    #[indexed]
+    pub who: Address,
+    pub f0: u256,
+    pub f1: u256,
+    pub f2: u256,
+    pub f3: u256,
+    pub f4: u256,
+    pub f5: u256,
+    pub f6: u256,
+    pub f7: u256,
+    pub f8: u256,
+    pub f9: u256,
+    pub f10: u256,
+    pub f11: u256,
+}

--- a/crates/hir/test_files/desugar/event_many_fields.snap
+++ b/crates/hir/test_files/desugar/event_many_fields.snap
@@ -1,0 +1,34 @@
+---
+source: crates/hir/tests/desugar.rs
+expression: output
+input_file: test_files/desugar/event_many_fields.fe
+---
+use core::prelude::*
+use std::prelude::*
+use std::evm::Address
+
+pub struct ManyFields {
+    pub who: Address,
+    pub f0: u256,
+    pub f1: u256,
+    pub f2: u256,
+    pub f3: u256,
+    pub f4: u256,
+    pub f5: u256,
+    pub f6: u256,
+    pub f7: u256,
+    pub f8: u256,
+    pub f9: u256,
+    pub f10: u256,
+    pub f11: u256,
+}
+
+impl std::evm::Event for ManyFields {
+    const TOPIC0: u256 = core::keccak((("ManyFields", "(", Address::SOL_TYPE, ",", u256::SOL_TYPE, ",", u256::SOL_TYPE, ",", u256::SOL_TYPE, ",", u256::SOL_TYPE, ",", u256::SOL_TYPE, ",", u256::SOL_TYPE, ","), (u256::SOL_TYPE, ",", u256::SOL_TYPE, ",", u256::SOL_TYPE, ",", u256::SOL_TYPE, ",", u256::SOL_TYPE, ",", u256::SOL_TYPE, ")")))
+
+    #[inline(always)]
+    fn emit<L: std::evm::Log>(own self, _ log: mut L) {
+        let (data_ptr, data_len) = std::evm::encode_event_payload((self.f0, self.f1, self.f2, self.f3, self.f4, self.f5, self.f6, self.f7, self.f8, self.f9, self.f10, self.f11))
+        log.log2(offset: data_ptr, len: data_len, topic0: Self::TOPIC0, topic1: self.who.as_topic())
+    }
+}

--- a/crates/mir/src/runtime/lower/body.rs
+++ b/crates/mir/src/runtime/lower/body.rs
@@ -4969,7 +4969,13 @@ impl<'db> RmirEmitter<'db> {
             .semantic(self.db)
             .expect("runtime const reification requires a semantic instance");
         reify_runtime_const_for_ty(self.db, semantic, expected_ty, value).unwrap_or_else(|| {
-            panic!("semantic const should reify for runtime lowering: {value:?}")
+            panic!(
+                "semantic const should reify for runtime lowering: `{}` (expected type `{}`). \
+                 This is a compiler bug: the const failed to evaluate but no diagnostic was \
+                 reported during type checking.",
+                value.pretty_print(self.db),
+                expected_ty.pretty_print(self.db),
+            )
         })
     }
 

--- a/crates/uitest/fixtures/ty_check/event_too_many_data_fields.fe
+++ b/crates/uitest/fixtures/ty_check/event_too_many_data_fields.fe
@@ -1,0 +1,25 @@
+// Events are encoded through the `EventAbiEncode` tuple impls, which stop at
+// arity 16. An event with 17 non-indexed fields must produce a trait-bound
+// diagnostic pointing at the event definition instead of an ICE.
+use std::evm::Log
+
+#[event]
+struct TooWide {
+    f0: u256,
+    f1: u256,
+    f2: u256,
+    f3: u256,
+    f4: u256,
+    f5: u256,
+    f6: u256,
+    f7: u256,
+    f8: u256,
+    f9: u256,
+    f10: u256,
+    f11: u256,
+    f12: u256,
+    f13: u256,
+    f14: u256,
+    f15: u256,
+    f16: u256,
+}

--- a/crates/uitest/fixtures/ty_check/event_too_many_data_fields.snap
+++ b/crates/uitest/fixtures/ty_check/event_too_many_data_fields.snap
@@ -1,0 +1,21 @@
+---
+source: crates/uitest/tests/ty_check.rs
+expression: diags
+input_file: fixtures/ty_check/event_too_many_data_fields.fe
+---
+error[6-0003]: trait bound is not satisfied
+    ┌─ event_too_many_data_fields.fe:6:1
+    │
+  6 │ ╭ #[event]
+  7 │ │ struct TooWide {
+  8 │ │     f0: u256,
+  9 │ │     f1: u256,
+    · │
+ 24 │ │     f16: u256,
+ 25 │ │ }
+    │ ╰─^ `(u256, u256, u256, u256, u256, u256, u256, u256, u256, u256, u256, u256, u256, u256, u256, u256, u256)` doesn't implement `EventAbiEncode<Sol>`
+    │
+    ┌─ src/evm/effects.fe:438:14
+    │
+438 │     where T: EventAbiEncode<Sol>
+    │              ------------------- required by this bound on `encode_event_payload`

--- a/crates/uitest/fixtures/ty_check/string_literal_trait_bound_not_sat.fe
+++ b/crates/uitest/fixtures/ty_check/string_literal_trait_bound_not_sat.fe
@@ -1,0 +1,18 @@
+// Unsatisfied trait bounds on goals that mention string literal types used to
+// be silently discharged: string literals carry a string-sorted inference
+// variable until the `String<N>` fallback is applied, and the final
+// obligation pass treated such goals as "not concrete" and skipped the
+// diagnostic. The error then surfaced as an ICE during MIR lowering.
+use core::AsBytes
+
+fn takes_asbytes<T: AsBytes>(_ x: T) -> u256 {
+    0
+}
+
+fn tuple_with_unsatisfied_elem() -> u256 {
+    takes_asbytes(("a", true))
+}
+
+fn tuple_arity_above_asbytes_impls() -> u256 {
+    core::keccak(("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r"))
+}

--- a/crates/uitest/fixtures/ty_check/string_literal_trait_bound_not_sat.snap
+++ b/crates/uitest/fixtures/ty_check/string_literal_trait_bound_not_sat.snap
@@ -1,0 +1,27 @@
+---
+source: crates/uitest/tests/ty_check.rs
+expression: diags
+input_file: fixtures/ty_check/string_literal_trait_bound_not_sat.fe
+---
+error[6-0003]: trait bound is not satisfied
+   ┌─ string_literal_trait_bound_not_sat.fe:13:5
+   │
+ 8 │ fn takes_asbytes<T: AsBytes>(_ x: T) -> u256 {
+   │                     ------- required by this bound on `takes_asbytes`
+   ·
+13 │     takes_asbytes(("a", true))
+   │     ^^^^^^^^^^^^^
+   │     │
+   │     `(String<1>, bool)` doesn't implement `AsBytes`
+   │     trait bound `bool: AsBytes` is not satisfied
+
+error[6-0003]: trait bound is not satisfied
+    ┌─ string_literal_trait_bound_not_sat.fe:17:5
+    │
+ 17 │     core::keccak(("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r"))
+    │     ^^^^^^^^^^^^ `(String<1>, String<1>, String<1>, String<1>, String<1>, String<1>, String<1>, String<1>, String<1>, String<1>, String<1>, String<1>, String<1>, String<1>, String<1>, String<1>, String<1>, String<1>)` doesn't implement `AsBytes`
+    │
+    ┌─ src/bytes.fe:443:24
+    │
+443 │ pub const fn keccak<T: AsBytes>(_ x: T) -> u256 {
+    │                        ------- required by this bound on `keccak`

--- a/ingots/core/src/abi.fe
+++ b/ingots/core/src/abi.fe
@@ -1337,6 +1337,178 @@ impl<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> AbiSize for (T0, T1, T2, 
     }
 }
 
+impl<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> AbiSize for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+    where T0: AbiSize,
+          T1: AbiSize,
+          T2: AbiSize,
+          T3: AbiSize,
+          T4: AbiSize,
+          T5: AbiSize,
+          T6: AbiSize,
+          T7: AbiSize,
+          T8: AbiSize,
+          T9: AbiSize,
+          T10: AbiSize,
+          T11: AbiSize,
+          T12: AbiSize
+{
+    const HEAD_SIZE: u256 =
+        abi_field_head_size<T0>() + abi_field_head_size<T1>() + abi_field_head_size<T2>() + abi_field_head_size<T3>() + abi_field_head_size<T4>() + abi_field_head_size<T5>() + abi_field_head_size<T6>() + abi_field_head_size<T7>() + abi_field_head_size<T8>() + abi_field_head_size<T9>() + abi_field_head_size<T10>() + abi_field_head_size<T11>() + abi_field_head_size<T12>()
+    const IS_DYNAMIC: bool =
+        T0::IS_DYNAMIC || T1::IS_DYNAMIC || T2::IS_DYNAMIC || T3::IS_DYNAMIC || T4::IS_DYNAMIC || T5::IS_DYNAMIC || T6::IS_DYNAMIC || T7::IS_DYNAMIC || T8::IS_DYNAMIC || T9::IS_DYNAMIC || T10::IS_DYNAMIC || T11::IS_DYNAMIC || T12::IS_DYNAMIC
+
+    #[arithmetic(unchecked)]
+    #[inline(always)]
+    fn payload_size(self) -> u256 {
+        Self::HEAD_SIZE
+            + dynamic_payload_size(self.0)
+            + dynamic_payload_size(self.1)
+            + dynamic_payload_size(self.2)
+            + dynamic_payload_size(self.3)
+            + dynamic_payload_size(self.4)
+            + dynamic_payload_size(self.5)
+            + dynamic_payload_size(self.6)
+            + dynamic_payload_size(self.7)
+            + dynamic_payload_size(self.8)
+            + dynamic_payload_size(self.9)
+            + dynamic_payload_size(self.10)
+            + dynamic_payload_size(self.11)
+            + dynamic_payload_size(self.12)
+    }
+}
+
+impl<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> AbiSize for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+    where T0: AbiSize,
+          T1: AbiSize,
+          T2: AbiSize,
+          T3: AbiSize,
+          T4: AbiSize,
+          T5: AbiSize,
+          T6: AbiSize,
+          T7: AbiSize,
+          T8: AbiSize,
+          T9: AbiSize,
+          T10: AbiSize,
+          T11: AbiSize,
+          T12: AbiSize,
+          T13: AbiSize
+{
+    const HEAD_SIZE: u256 =
+        abi_field_head_size<T0>() + abi_field_head_size<T1>() + abi_field_head_size<T2>() + abi_field_head_size<T3>() + abi_field_head_size<T4>() + abi_field_head_size<T5>() + abi_field_head_size<T6>() + abi_field_head_size<T7>() + abi_field_head_size<T8>() + abi_field_head_size<T9>() + abi_field_head_size<T10>() + abi_field_head_size<T11>() + abi_field_head_size<T12>() + abi_field_head_size<T13>()
+    const IS_DYNAMIC: bool =
+        T0::IS_DYNAMIC || T1::IS_DYNAMIC || T2::IS_DYNAMIC || T3::IS_DYNAMIC || T4::IS_DYNAMIC || T5::IS_DYNAMIC || T6::IS_DYNAMIC || T7::IS_DYNAMIC || T8::IS_DYNAMIC || T9::IS_DYNAMIC || T10::IS_DYNAMIC || T11::IS_DYNAMIC || T12::IS_DYNAMIC || T13::IS_DYNAMIC
+
+    #[arithmetic(unchecked)]
+    #[inline(always)]
+    fn payload_size(self) -> u256 {
+        Self::HEAD_SIZE
+            + dynamic_payload_size(self.0)
+            + dynamic_payload_size(self.1)
+            + dynamic_payload_size(self.2)
+            + dynamic_payload_size(self.3)
+            + dynamic_payload_size(self.4)
+            + dynamic_payload_size(self.5)
+            + dynamic_payload_size(self.6)
+            + dynamic_payload_size(self.7)
+            + dynamic_payload_size(self.8)
+            + dynamic_payload_size(self.9)
+            + dynamic_payload_size(self.10)
+            + dynamic_payload_size(self.11)
+            + dynamic_payload_size(self.12)
+            + dynamic_payload_size(self.13)
+    }
+}
+
+impl<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> AbiSize for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+    where T0: AbiSize,
+          T1: AbiSize,
+          T2: AbiSize,
+          T3: AbiSize,
+          T4: AbiSize,
+          T5: AbiSize,
+          T6: AbiSize,
+          T7: AbiSize,
+          T8: AbiSize,
+          T9: AbiSize,
+          T10: AbiSize,
+          T11: AbiSize,
+          T12: AbiSize,
+          T13: AbiSize,
+          T14: AbiSize
+{
+    const HEAD_SIZE: u256 =
+        abi_field_head_size<T0>() + abi_field_head_size<T1>() + abi_field_head_size<T2>() + abi_field_head_size<T3>() + abi_field_head_size<T4>() + abi_field_head_size<T5>() + abi_field_head_size<T6>() + abi_field_head_size<T7>() + abi_field_head_size<T8>() + abi_field_head_size<T9>() + abi_field_head_size<T10>() + abi_field_head_size<T11>() + abi_field_head_size<T12>() + abi_field_head_size<T13>() + abi_field_head_size<T14>()
+    const IS_DYNAMIC: bool =
+        T0::IS_DYNAMIC || T1::IS_DYNAMIC || T2::IS_DYNAMIC || T3::IS_DYNAMIC || T4::IS_DYNAMIC || T5::IS_DYNAMIC || T6::IS_DYNAMIC || T7::IS_DYNAMIC || T8::IS_DYNAMIC || T9::IS_DYNAMIC || T10::IS_DYNAMIC || T11::IS_DYNAMIC || T12::IS_DYNAMIC || T13::IS_DYNAMIC || T14::IS_DYNAMIC
+
+    #[arithmetic(unchecked)]
+    #[inline(always)]
+    fn payload_size(self) -> u256 {
+        Self::HEAD_SIZE
+            + dynamic_payload_size(self.0)
+            + dynamic_payload_size(self.1)
+            + dynamic_payload_size(self.2)
+            + dynamic_payload_size(self.3)
+            + dynamic_payload_size(self.4)
+            + dynamic_payload_size(self.5)
+            + dynamic_payload_size(self.6)
+            + dynamic_payload_size(self.7)
+            + dynamic_payload_size(self.8)
+            + dynamic_payload_size(self.9)
+            + dynamic_payload_size(self.10)
+            + dynamic_payload_size(self.11)
+            + dynamic_payload_size(self.12)
+            + dynamic_payload_size(self.13)
+            + dynamic_payload_size(self.14)
+    }
+}
+
+impl<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> AbiSize for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+    where T0: AbiSize,
+          T1: AbiSize,
+          T2: AbiSize,
+          T3: AbiSize,
+          T4: AbiSize,
+          T5: AbiSize,
+          T6: AbiSize,
+          T7: AbiSize,
+          T8: AbiSize,
+          T9: AbiSize,
+          T10: AbiSize,
+          T11: AbiSize,
+          T12: AbiSize,
+          T13: AbiSize,
+          T14: AbiSize,
+          T15: AbiSize
+{
+    const HEAD_SIZE: u256 =
+        abi_field_head_size<T0>() + abi_field_head_size<T1>() + abi_field_head_size<T2>() + abi_field_head_size<T3>() + abi_field_head_size<T4>() + abi_field_head_size<T5>() + abi_field_head_size<T6>() + abi_field_head_size<T7>() + abi_field_head_size<T8>() + abi_field_head_size<T9>() + abi_field_head_size<T10>() + abi_field_head_size<T11>() + abi_field_head_size<T12>() + abi_field_head_size<T13>() + abi_field_head_size<T14>() + abi_field_head_size<T15>()
+    const IS_DYNAMIC: bool =
+        T0::IS_DYNAMIC || T1::IS_DYNAMIC || T2::IS_DYNAMIC || T3::IS_DYNAMIC || T4::IS_DYNAMIC || T5::IS_DYNAMIC || T6::IS_DYNAMIC || T7::IS_DYNAMIC || T8::IS_DYNAMIC || T9::IS_DYNAMIC || T10::IS_DYNAMIC || T11::IS_DYNAMIC || T12::IS_DYNAMIC || T13::IS_DYNAMIC || T14::IS_DYNAMIC || T15::IS_DYNAMIC
+
+    #[arithmetic(unchecked)]
+    #[inline(always)]
+    fn payload_size(self) -> u256 {
+        Self::HEAD_SIZE
+            + dynamic_payload_size(self.0)
+            + dynamic_payload_size(self.1)
+            + dynamic_payload_size(self.2)
+            + dynamic_payload_size(self.3)
+            + dynamic_payload_size(self.4)
+            + dynamic_payload_size(self.5)
+            + dynamic_payload_size(self.6)
+            + dynamic_payload_size(self.7)
+            + dynamic_payload_size(self.8)
+            + dynamic_payload_size(self.9)
+            + dynamic_payload_size(self.10)
+            + dynamic_payload_size(self.11)
+            + dynamic_payload_size(self.12)
+            + dynamic_payload_size(self.13)
+            + dynamic_payload_size(self.14)
+            + dynamic_payload_size(self.15)
+    }
+}
+
 impl<T> AbiSize for DynArray<T>
     where T: AbiSize
 {
@@ -3892,6 +4064,360 @@ impl<A: Abi, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Encode<A>
     }
 }
 
+impl<A: Abi, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Encode<A>
+    for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+    where T0: Encode<A> + AbiSize,
+          T1: Encode<A> + AbiSize,
+          T2: Encode<A> + AbiSize,
+          T3: Encode<A> + AbiSize,
+          T4: Encode<A> + AbiSize,
+          T5: Encode<A> + AbiSize,
+          T6: Encode<A> + AbiSize,
+          T7: Encode<A> + AbiSize,
+          T8: Encode<A> + AbiSize,
+          T9: Encode<A> + AbiSize,
+          T10: Encode<A> + AbiSize,
+          T11: Encode<A> + AbiSize,
+          T12: Encode<A> + AbiSize
+{
+    const DIRECT_ENCODE: bool =
+        T0::DIRECT_ENCODE && T1::DIRECT_ENCODE && T2::DIRECT_ENCODE && T3::DIRECT_ENCODE && T4::DIRECT_ENCODE && T5::DIRECT_ENCODE && T6::DIRECT_ENCODE && T7::DIRECT_ENCODE && T8::DIRECT_ENCODE && T9::DIRECT_ENCODE && T10::DIRECT_ENCODE && T11::DIRECT_ENCODE && T12::DIRECT_ENCODE
+
+    #[arithmetic(unchecked)]
+    #[inline(always)]
+    fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) {
+        let base = e.base()
+        let mut tail = base + Self::HEAD_SIZE
+        let head1 = base + abi_field_head_size<T0>()
+        let head2 = head1 + abi_field_head_size<T1>()
+        let head3 = head2 + abi_field_head_size<T2>()
+        let head4 = head3 + abi_field_head_size<T3>()
+        let head5 = head4 + abi_field_head_size<T4>()
+        let head6 = head5 + abi_field_head_size<T5>()
+        let head7 = head6 + abi_field_head_size<T6>()
+        let head8 = head7 + abi_field_head_size<T7>()
+        let head9 = head8 + abi_field_head_size<T8>()
+        let head10 = head9 + abi_field_head_size<T9>()
+        let head11 = head10 + abi_field_head_size<T10>()
+        let head12 = head11 + abi_field_head_size<T11>()
+        encode_field_at<A, T0, E>(self.0, mut e, base, head_pos: base, mut tail)
+        encode_field_at<A, T1, E>(self.1, mut e, base, head_pos: head1, mut tail)
+        encode_field_at<A, T2, E>(self.2, mut e, base, head_pos: head2, mut tail)
+        encode_field_at<A, T3, E>(self.3, mut e, base, head_pos: head3, mut tail)
+        encode_field_at<A, T4, E>(self.4, mut e, base, head_pos: head4, mut tail)
+        encode_field_at<A, T5, E>(self.5, mut e, base, head_pos: head5, mut tail)
+        encode_field_at<A, T6, E>(self.6, mut e, base, head_pos: head6, mut tail)
+        encode_field_at<A, T7, E>(self.7, mut e, base, head_pos: head7, mut tail)
+        encode_field_at<A, T8, E>(self.8, mut e, base, head_pos: head8, mut tail)
+        encode_field_at<A, T9, E>(self.9, mut e, base, head_pos: head9, mut tail)
+        encode_field_at<A, T10, E>(self.10, mut e, base, head_pos: head10, mut tail)
+        encode_field_at<A, T11, E>(self.11, mut e, base, head_pos: head11, mut tail)
+        encode_field_at<A, T12, E>(self.12, mut e, base, head_pos: head12, mut tail)
+        e.set_pos(base + Self::HEAD_SIZE)
+    }
+
+    #[arithmetic(unchecked)]
+    fn encode_to_ptr(own self, _ ptr: u256) {
+        self.0.encode_to_ptr(ptr)
+        self.1.encode_to_ptr(ptr + T0::HEAD_SIZE)
+        self.2
+            .encode_to_ptr(ptr + T0::HEAD_SIZE + T1::HEAD_SIZE)
+        self.3
+            .encode_to_ptr(ptr + T0::HEAD_SIZE + T1::HEAD_SIZE + T2::HEAD_SIZE)
+        self.4
+            .encode_to_ptr(ptr + T0::HEAD_SIZE + T1::HEAD_SIZE + T2::HEAD_SIZE + T3::HEAD_SIZE)
+        self.5
+            .encode_to_ptr(ptr + T0::HEAD_SIZE + T1::HEAD_SIZE + T2::HEAD_SIZE + T3::HEAD_SIZE + T4::HEAD_SIZE)
+        self.6
+            .encode_to_ptr(ptr + T0::HEAD_SIZE + T1::HEAD_SIZE + T2::HEAD_SIZE + T3::HEAD_SIZE + T4::HEAD_SIZE + T5::HEAD_SIZE)
+        self.7
+            .encode_to_ptr(ptr + T0::HEAD_SIZE + T1::HEAD_SIZE + T2::HEAD_SIZE + T3::HEAD_SIZE + T4::HEAD_SIZE + T5::HEAD_SIZE + T6::HEAD_SIZE)
+        self.8
+            .encode_to_ptr(ptr + T0::HEAD_SIZE + T1::HEAD_SIZE + T2::HEAD_SIZE + T3::HEAD_SIZE + T4::HEAD_SIZE + T5::HEAD_SIZE + T6::HEAD_SIZE + T7::HEAD_SIZE)
+        self.9
+            .encode_to_ptr(ptr + T0::HEAD_SIZE + T1::HEAD_SIZE + T2::HEAD_SIZE + T3::HEAD_SIZE + T4::HEAD_SIZE + T5::HEAD_SIZE + T6::HEAD_SIZE + T7::HEAD_SIZE + T8::HEAD_SIZE)
+        self.10
+            .encode_to_ptr(ptr + T0::HEAD_SIZE + T1::HEAD_SIZE + T2::HEAD_SIZE + T3::HEAD_SIZE + T4::HEAD_SIZE + T5::HEAD_SIZE + T6::HEAD_SIZE + T7::HEAD_SIZE + T8::HEAD_SIZE + T9::HEAD_SIZE)
+        self.11
+            .encode_to_ptr(ptr + T0::HEAD_SIZE + T1::HEAD_SIZE + T2::HEAD_SIZE + T3::HEAD_SIZE + T4::HEAD_SIZE + T5::HEAD_SIZE + T6::HEAD_SIZE + T7::HEAD_SIZE + T8::HEAD_SIZE + T9::HEAD_SIZE + T10::HEAD_SIZE)
+        self.12
+            .encode_to_ptr(ptr + T0::HEAD_SIZE + T1::HEAD_SIZE + T2::HEAD_SIZE + T3::HEAD_SIZE + T4::HEAD_SIZE + T5::HEAD_SIZE + T6::HEAD_SIZE + T7::HEAD_SIZE + T8::HEAD_SIZE + T9::HEAD_SIZE + T10::HEAD_SIZE + T11::HEAD_SIZE)
+    }
+}
+
+impl<A: Abi, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Encode<A>
+    for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+    where T0: Encode<A> + AbiSize,
+          T1: Encode<A> + AbiSize,
+          T2: Encode<A> + AbiSize,
+          T3: Encode<A> + AbiSize,
+          T4: Encode<A> + AbiSize,
+          T5: Encode<A> + AbiSize,
+          T6: Encode<A> + AbiSize,
+          T7: Encode<A> + AbiSize,
+          T8: Encode<A> + AbiSize,
+          T9: Encode<A> + AbiSize,
+          T10: Encode<A> + AbiSize,
+          T11: Encode<A> + AbiSize,
+          T12: Encode<A> + AbiSize,
+          T13: Encode<A> + AbiSize
+{
+    const DIRECT_ENCODE: bool =
+        T0::DIRECT_ENCODE && T1::DIRECT_ENCODE && T2::DIRECT_ENCODE && T3::DIRECT_ENCODE && T4::DIRECT_ENCODE && T5::DIRECT_ENCODE && T6::DIRECT_ENCODE && T7::DIRECT_ENCODE && T8::DIRECT_ENCODE && T9::DIRECT_ENCODE && T10::DIRECT_ENCODE && T11::DIRECT_ENCODE && T12::DIRECT_ENCODE && T13::DIRECT_ENCODE
+
+    #[arithmetic(unchecked)]
+    #[inline(always)]
+    fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) {
+        let base = e.base()
+        let mut tail = base + Self::HEAD_SIZE
+        let head1 = base + abi_field_head_size<T0>()
+        let head2 = head1 + abi_field_head_size<T1>()
+        let head3 = head2 + abi_field_head_size<T2>()
+        let head4 = head3 + abi_field_head_size<T3>()
+        let head5 = head4 + abi_field_head_size<T4>()
+        let head6 = head5 + abi_field_head_size<T5>()
+        let head7 = head6 + abi_field_head_size<T6>()
+        let head8 = head7 + abi_field_head_size<T7>()
+        let head9 = head8 + abi_field_head_size<T8>()
+        let head10 = head9 + abi_field_head_size<T9>()
+        let head11 = head10 + abi_field_head_size<T10>()
+        let head12 = head11 + abi_field_head_size<T11>()
+        let head13 = head12 + abi_field_head_size<T12>()
+        encode_field_at<A, T0, E>(self.0, mut e, base, head_pos: base, mut tail)
+        encode_field_at<A, T1, E>(self.1, mut e, base, head_pos: head1, mut tail)
+        encode_field_at<A, T2, E>(self.2, mut e, base, head_pos: head2, mut tail)
+        encode_field_at<A, T3, E>(self.3, mut e, base, head_pos: head3, mut tail)
+        encode_field_at<A, T4, E>(self.4, mut e, base, head_pos: head4, mut tail)
+        encode_field_at<A, T5, E>(self.5, mut e, base, head_pos: head5, mut tail)
+        encode_field_at<A, T6, E>(self.6, mut e, base, head_pos: head6, mut tail)
+        encode_field_at<A, T7, E>(self.7, mut e, base, head_pos: head7, mut tail)
+        encode_field_at<A, T8, E>(self.8, mut e, base, head_pos: head8, mut tail)
+        encode_field_at<A, T9, E>(self.9, mut e, base, head_pos: head9, mut tail)
+        encode_field_at<A, T10, E>(self.10, mut e, base, head_pos: head10, mut tail)
+        encode_field_at<A, T11, E>(self.11, mut e, base, head_pos: head11, mut tail)
+        encode_field_at<A, T12, E>(self.12, mut e, base, head_pos: head12, mut tail)
+        encode_field_at<A, T13, E>(self.13, mut e, base, head_pos: head13, mut tail)
+        e.set_pos(base + Self::HEAD_SIZE)
+    }
+
+    #[arithmetic(unchecked)]
+    fn encode_to_ptr(own self, _ ptr: u256) {
+        self.0.encode_to_ptr(ptr)
+        self.1.encode_to_ptr(ptr + T0::HEAD_SIZE)
+        self.2
+            .encode_to_ptr(ptr + T0::HEAD_SIZE + T1::HEAD_SIZE)
+        self.3
+            .encode_to_ptr(ptr + T0::HEAD_SIZE + T1::HEAD_SIZE + T2::HEAD_SIZE)
+        self.4
+            .encode_to_ptr(ptr + T0::HEAD_SIZE + T1::HEAD_SIZE + T2::HEAD_SIZE + T3::HEAD_SIZE)
+        self.5
+            .encode_to_ptr(ptr + T0::HEAD_SIZE + T1::HEAD_SIZE + T2::HEAD_SIZE + T3::HEAD_SIZE + T4::HEAD_SIZE)
+        self.6
+            .encode_to_ptr(ptr + T0::HEAD_SIZE + T1::HEAD_SIZE + T2::HEAD_SIZE + T3::HEAD_SIZE + T4::HEAD_SIZE + T5::HEAD_SIZE)
+        self.7
+            .encode_to_ptr(ptr + T0::HEAD_SIZE + T1::HEAD_SIZE + T2::HEAD_SIZE + T3::HEAD_SIZE + T4::HEAD_SIZE + T5::HEAD_SIZE + T6::HEAD_SIZE)
+        self.8
+            .encode_to_ptr(ptr + T0::HEAD_SIZE + T1::HEAD_SIZE + T2::HEAD_SIZE + T3::HEAD_SIZE + T4::HEAD_SIZE + T5::HEAD_SIZE + T6::HEAD_SIZE + T7::HEAD_SIZE)
+        self.9
+            .encode_to_ptr(ptr + T0::HEAD_SIZE + T1::HEAD_SIZE + T2::HEAD_SIZE + T3::HEAD_SIZE + T4::HEAD_SIZE + T5::HEAD_SIZE + T6::HEAD_SIZE + T7::HEAD_SIZE + T8::HEAD_SIZE)
+        self.10
+            .encode_to_ptr(ptr + T0::HEAD_SIZE + T1::HEAD_SIZE + T2::HEAD_SIZE + T3::HEAD_SIZE + T4::HEAD_SIZE + T5::HEAD_SIZE + T6::HEAD_SIZE + T7::HEAD_SIZE + T8::HEAD_SIZE + T9::HEAD_SIZE)
+        self.11
+            .encode_to_ptr(ptr + T0::HEAD_SIZE + T1::HEAD_SIZE + T2::HEAD_SIZE + T3::HEAD_SIZE + T4::HEAD_SIZE + T5::HEAD_SIZE + T6::HEAD_SIZE + T7::HEAD_SIZE + T8::HEAD_SIZE + T9::HEAD_SIZE + T10::HEAD_SIZE)
+        self.12
+            .encode_to_ptr(ptr + T0::HEAD_SIZE + T1::HEAD_SIZE + T2::HEAD_SIZE + T3::HEAD_SIZE + T4::HEAD_SIZE + T5::HEAD_SIZE + T6::HEAD_SIZE + T7::HEAD_SIZE + T8::HEAD_SIZE + T9::HEAD_SIZE + T10::HEAD_SIZE + T11::HEAD_SIZE)
+        self.13
+            .encode_to_ptr(ptr + T0::HEAD_SIZE + T1::HEAD_SIZE + T2::HEAD_SIZE + T3::HEAD_SIZE + T4::HEAD_SIZE + T5::HEAD_SIZE + T6::HEAD_SIZE + T7::HEAD_SIZE + T8::HEAD_SIZE + T9::HEAD_SIZE + T10::HEAD_SIZE + T11::HEAD_SIZE + T12::HEAD_SIZE)
+    }
+}
+
+impl<A: Abi, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Encode<A>
+    for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+    where T0: Encode<A> + AbiSize,
+          T1: Encode<A> + AbiSize,
+          T2: Encode<A> + AbiSize,
+          T3: Encode<A> + AbiSize,
+          T4: Encode<A> + AbiSize,
+          T5: Encode<A> + AbiSize,
+          T6: Encode<A> + AbiSize,
+          T7: Encode<A> + AbiSize,
+          T8: Encode<A> + AbiSize,
+          T9: Encode<A> + AbiSize,
+          T10: Encode<A> + AbiSize,
+          T11: Encode<A> + AbiSize,
+          T12: Encode<A> + AbiSize,
+          T13: Encode<A> + AbiSize,
+          T14: Encode<A> + AbiSize
+{
+    const DIRECT_ENCODE: bool =
+        T0::DIRECT_ENCODE && T1::DIRECT_ENCODE && T2::DIRECT_ENCODE && T3::DIRECT_ENCODE && T4::DIRECT_ENCODE && T5::DIRECT_ENCODE && T6::DIRECT_ENCODE && T7::DIRECT_ENCODE && T8::DIRECT_ENCODE && T9::DIRECT_ENCODE && T10::DIRECT_ENCODE && T11::DIRECT_ENCODE && T12::DIRECT_ENCODE && T13::DIRECT_ENCODE && T14::DIRECT_ENCODE
+
+    #[arithmetic(unchecked)]
+    #[inline(always)]
+    fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) {
+        let base = e.base()
+        let mut tail = base + Self::HEAD_SIZE
+        let head1 = base + abi_field_head_size<T0>()
+        let head2 = head1 + abi_field_head_size<T1>()
+        let head3 = head2 + abi_field_head_size<T2>()
+        let head4 = head3 + abi_field_head_size<T3>()
+        let head5 = head4 + abi_field_head_size<T4>()
+        let head6 = head5 + abi_field_head_size<T5>()
+        let head7 = head6 + abi_field_head_size<T6>()
+        let head8 = head7 + abi_field_head_size<T7>()
+        let head9 = head8 + abi_field_head_size<T8>()
+        let head10 = head9 + abi_field_head_size<T9>()
+        let head11 = head10 + abi_field_head_size<T10>()
+        let head12 = head11 + abi_field_head_size<T11>()
+        let head13 = head12 + abi_field_head_size<T12>()
+        let head14 = head13 + abi_field_head_size<T13>()
+        encode_field_at<A, T0, E>(self.0, mut e, base, head_pos: base, mut tail)
+        encode_field_at<A, T1, E>(self.1, mut e, base, head_pos: head1, mut tail)
+        encode_field_at<A, T2, E>(self.2, mut e, base, head_pos: head2, mut tail)
+        encode_field_at<A, T3, E>(self.3, mut e, base, head_pos: head3, mut tail)
+        encode_field_at<A, T4, E>(self.4, mut e, base, head_pos: head4, mut tail)
+        encode_field_at<A, T5, E>(self.5, mut e, base, head_pos: head5, mut tail)
+        encode_field_at<A, T6, E>(self.6, mut e, base, head_pos: head6, mut tail)
+        encode_field_at<A, T7, E>(self.7, mut e, base, head_pos: head7, mut tail)
+        encode_field_at<A, T8, E>(self.8, mut e, base, head_pos: head8, mut tail)
+        encode_field_at<A, T9, E>(self.9, mut e, base, head_pos: head9, mut tail)
+        encode_field_at<A, T10, E>(self.10, mut e, base, head_pos: head10, mut tail)
+        encode_field_at<A, T11, E>(self.11, mut e, base, head_pos: head11, mut tail)
+        encode_field_at<A, T12, E>(self.12, mut e, base, head_pos: head12, mut tail)
+        encode_field_at<A, T13, E>(self.13, mut e, base, head_pos: head13, mut tail)
+        encode_field_at<A, T14, E>(self.14, mut e, base, head_pos: head14, mut tail)
+        e.set_pos(base + Self::HEAD_SIZE)
+    }
+
+    #[arithmetic(unchecked)]
+    fn encode_to_ptr(own self, _ ptr: u256) {
+        self.0.encode_to_ptr(ptr)
+        self.1.encode_to_ptr(ptr + T0::HEAD_SIZE)
+        self.2
+            .encode_to_ptr(ptr + T0::HEAD_SIZE + T1::HEAD_SIZE)
+        self.3
+            .encode_to_ptr(ptr + T0::HEAD_SIZE + T1::HEAD_SIZE + T2::HEAD_SIZE)
+        self.4
+            .encode_to_ptr(ptr + T0::HEAD_SIZE + T1::HEAD_SIZE + T2::HEAD_SIZE + T3::HEAD_SIZE)
+        self.5
+            .encode_to_ptr(ptr + T0::HEAD_SIZE + T1::HEAD_SIZE + T2::HEAD_SIZE + T3::HEAD_SIZE + T4::HEAD_SIZE)
+        self.6
+            .encode_to_ptr(ptr + T0::HEAD_SIZE + T1::HEAD_SIZE + T2::HEAD_SIZE + T3::HEAD_SIZE + T4::HEAD_SIZE + T5::HEAD_SIZE)
+        self.7
+            .encode_to_ptr(ptr + T0::HEAD_SIZE + T1::HEAD_SIZE + T2::HEAD_SIZE + T3::HEAD_SIZE + T4::HEAD_SIZE + T5::HEAD_SIZE + T6::HEAD_SIZE)
+        self.8
+            .encode_to_ptr(ptr + T0::HEAD_SIZE + T1::HEAD_SIZE + T2::HEAD_SIZE + T3::HEAD_SIZE + T4::HEAD_SIZE + T5::HEAD_SIZE + T6::HEAD_SIZE + T7::HEAD_SIZE)
+        self.9
+            .encode_to_ptr(ptr + T0::HEAD_SIZE + T1::HEAD_SIZE + T2::HEAD_SIZE + T3::HEAD_SIZE + T4::HEAD_SIZE + T5::HEAD_SIZE + T6::HEAD_SIZE + T7::HEAD_SIZE + T8::HEAD_SIZE)
+        self.10
+            .encode_to_ptr(ptr + T0::HEAD_SIZE + T1::HEAD_SIZE + T2::HEAD_SIZE + T3::HEAD_SIZE + T4::HEAD_SIZE + T5::HEAD_SIZE + T6::HEAD_SIZE + T7::HEAD_SIZE + T8::HEAD_SIZE + T9::HEAD_SIZE)
+        self.11
+            .encode_to_ptr(ptr + T0::HEAD_SIZE + T1::HEAD_SIZE + T2::HEAD_SIZE + T3::HEAD_SIZE + T4::HEAD_SIZE + T5::HEAD_SIZE + T6::HEAD_SIZE + T7::HEAD_SIZE + T8::HEAD_SIZE + T9::HEAD_SIZE + T10::HEAD_SIZE)
+        self.12
+            .encode_to_ptr(ptr + T0::HEAD_SIZE + T1::HEAD_SIZE + T2::HEAD_SIZE + T3::HEAD_SIZE + T4::HEAD_SIZE + T5::HEAD_SIZE + T6::HEAD_SIZE + T7::HEAD_SIZE + T8::HEAD_SIZE + T9::HEAD_SIZE + T10::HEAD_SIZE + T11::HEAD_SIZE)
+        self.13
+            .encode_to_ptr(ptr + T0::HEAD_SIZE + T1::HEAD_SIZE + T2::HEAD_SIZE + T3::HEAD_SIZE + T4::HEAD_SIZE + T5::HEAD_SIZE + T6::HEAD_SIZE + T7::HEAD_SIZE + T8::HEAD_SIZE + T9::HEAD_SIZE + T10::HEAD_SIZE + T11::HEAD_SIZE + T12::HEAD_SIZE)
+        self.14
+            .encode_to_ptr(ptr + T0::HEAD_SIZE + T1::HEAD_SIZE + T2::HEAD_SIZE + T3::HEAD_SIZE + T4::HEAD_SIZE + T5::HEAD_SIZE + T6::HEAD_SIZE + T7::HEAD_SIZE + T8::HEAD_SIZE + T9::HEAD_SIZE + T10::HEAD_SIZE + T11::HEAD_SIZE + T12::HEAD_SIZE + T13::HEAD_SIZE)
+    }
+}
+
+impl<A: Abi, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> Encode<A>
+    for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+    where T0: Encode<A> + AbiSize,
+          T1: Encode<A> + AbiSize,
+          T2: Encode<A> + AbiSize,
+          T3: Encode<A> + AbiSize,
+          T4: Encode<A> + AbiSize,
+          T5: Encode<A> + AbiSize,
+          T6: Encode<A> + AbiSize,
+          T7: Encode<A> + AbiSize,
+          T8: Encode<A> + AbiSize,
+          T9: Encode<A> + AbiSize,
+          T10: Encode<A> + AbiSize,
+          T11: Encode<A> + AbiSize,
+          T12: Encode<A> + AbiSize,
+          T13: Encode<A> + AbiSize,
+          T14: Encode<A> + AbiSize,
+          T15: Encode<A> + AbiSize
+{
+    const DIRECT_ENCODE: bool =
+        T0::DIRECT_ENCODE && T1::DIRECT_ENCODE && T2::DIRECT_ENCODE && T3::DIRECT_ENCODE && T4::DIRECT_ENCODE && T5::DIRECT_ENCODE && T6::DIRECT_ENCODE && T7::DIRECT_ENCODE && T8::DIRECT_ENCODE && T9::DIRECT_ENCODE && T10::DIRECT_ENCODE && T11::DIRECT_ENCODE && T12::DIRECT_ENCODE && T13::DIRECT_ENCODE && T14::DIRECT_ENCODE && T15::DIRECT_ENCODE
+
+    #[arithmetic(unchecked)]
+    #[inline(always)]
+    fn encode<E: AbiEncoder<A>>(own self, _ e: mut E) {
+        let base = e.base()
+        let mut tail = base + Self::HEAD_SIZE
+        let head1 = base + abi_field_head_size<T0>()
+        let head2 = head1 + abi_field_head_size<T1>()
+        let head3 = head2 + abi_field_head_size<T2>()
+        let head4 = head3 + abi_field_head_size<T3>()
+        let head5 = head4 + abi_field_head_size<T4>()
+        let head6 = head5 + abi_field_head_size<T5>()
+        let head7 = head6 + abi_field_head_size<T6>()
+        let head8 = head7 + abi_field_head_size<T7>()
+        let head9 = head8 + abi_field_head_size<T8>()
+        let head10 = head9 + abi_field_head_size<T9>()
+        let head11 = head10 + abi_field_head_size<T10>()
+        let head12 = head11 + abi_field_head_size<T11>()
+        let head13 = head12 + abi_field_head_size<T12>()
+        let head14 = head13 + abi_field_head_size<T13>()
+        let head15 = head14 + abi_field_head_size<T14>()
+        encode_field_at<A, T0, E>(self.0, mut e, base, head_pos: base, mut tail)
+        encode_field_at<A, T1, E>(self.1, mut e, base, head_pos: head1, mut tail)
+        encode_field_at<A, T2, E>(self.2, mut e, base, head_pos: head2, mut tail)
+        encode_field_at<A, T3, E>(self.3, mut e, base, head_pos: head3, mut tail)
+        encode_field_at<A, T4, E>(self.4, mut e, base, head_pos: head4, mut tail)
+        encode_field_at<A, T5, E>(self.5, mut e, base, head_pos: head5, mut tail)
+        encode_field_at<A, T6, E>(self.6, mut e, base, head_pos: head6, mut tail)
+        encode_field_at<A, T7, E>(self.7, mut e, base, head_pos: head7, mut tail)
+        encode_field_at<A, T8, E>(self.8, mut e, base, head_pos: head8, mut tail)
+        encode_field_at<A, T9, E>(self.9, mut e, base, head_pos: head9, mut tail)
+        encode_field_at<A, T10, E>(self.10, mut e, base, head_pos: head10, mut tail)
+        encode_field_at<A, T11, E>(self.11, mut e, base, head_pos: head11, mut tail)
+        encode_field_at<A, T12, E>(self.12, mut e, base, head_pos: head12, mut tail)
+        encode_field_at<A, T13, E>(self.13, mut e, base, head_pos: head13, mut tail)
+        encode_field_at<A, T14, E>(self.14, mut e, base, head_pos: head14, mut tail)
+        encode_field_at<A, T15, E>(self.15, mut e, base, head_pos: head15, mut tail)
+        e.set_pos(base + Self::HEAD_SIZE)
+    }
+
+    #[arithmetic(unchecked)]
+    fn encode_to_ptr(own self, _ ptr: u256) {
+        self.0.encode_to_ptr(ptr)
+        self.1.encode_to_ptr(ptr + T0::HEAD_SIZE)
+        self.2
+            .encode_to_ptr(ptr + T0::HEAD_SIZE + T1::HEAD_SIZE)
+        self.3
+            .encode_to_ptr(ptr + T0::HEAD_SIZE + T1::HEAD_SIZE + T2::HEAD_SIZE)
+        self.4
+            .encode_to_ptr(ptr + T0::HEAD_SIZE + T1::HEAD_SIZE + T2::HEAD_SIZE + T3::HEAD_SIZE)
+        self.5
+            .encode_to_ptr(ptr + T0::HEAD_SIZE + T1::HEAD_SIZE + T2::HEAD_SIZE + T3::HEAD_SIZE + T4::HEAD_SIZE)
+        self.6
+            .encode_to_ptr(ptr + T0::HEAD_SIZE + T1::HEAD_SIZE + T2::HEAD_SIZE + T3::HEAD_SIZE + T4::HEAD_SIZE + T5::HEAD_SIZE)
+        self.7
+            .encode_to_ptr(ptr + T0::HEAD_SIZE + T1::HEAD_SIZE + T2::HEAD_SIZE + T3::HEAD_SIZE + T4::HEAD_SIZE + T5::HEAD_SIZE + T6::HEAD_SIZE)
+        self.8
+            .encode_to_ptr(ptr + T0::HEAD_SIZE + T1::HEAD_SIZE + T2::HEAD_SIZE + T3::HEAD_SIZE + T4::HEAD_SIZE + T5::HEAD_SIZE + T6::HEAD_SIZE + T7::HEAD_SIZE)
+        self.9
+            .encode_to_ptr(ptr + T0::HEAD_SIZE + T1::HEAD_SIZE + T2::HEAD_SIZE + T3::HEAD_SIZE + T4::HEAD_SIZE + T5::HEAD_SIZE + T6::HEAD_SIZE + T7::HEAD_SIZE + T8::HEAD_SIZE)
+        self.10
+            .encode_to_ptr(ptr + T0::HEAD_SIZE + T1::HEAD_SIZE + T2::HEAD_SIZE + T3::HEAD_SIZE + T4::HEAD_SIZE + T5::HEAD_SIZE + T6::HEAD_SIZE + T7::HEAD_SIZE + T8::HEAD_SIZE + T9::HEAD_SIZE)
+        self.11
+            .encode_to_ptr(ptr + T0::HEAD_SIZE + T1::HEAD_SIZE + T2::HEAD_SIZE + T3::HEAD_SIZE + T4::HEAD_SIZE + T5::HEAD_SIZE + T6::HEAD_SIZE + T7::HEAD_SIZE + T8::HEAD_SIZE + T9::HEAD_SIZE + T10::HEAD_SIZE)
+        self.12
+            .encode_to_ptr(ptr + T0::HEAD_SIZE + T1::HEAD_SIZE + T2::HEAD_SIZE + T3::HEAD_SIZE + T4::HEAD_SIZE + T5::HEAD_SIZE + T6::HEAD_SIZE + T7::HEAD_SIZE + T8::HEAD_SIZE + T9::HEAD_SIZE + T10::HEAD_SIZE + T11::HEAD_SIZE)
+        self.13
+            .encode_to_ptr(ptr + T0::HEAD_SIZE + T1::HEAD_SIZE + T2::HEAD_SIZE + T3::HEAD_SIZE + T4::HEAD_SIZE + T5::HEAD_SIZE + T6::HEAD_SIZE + T7::HEAD_SIZE + T8::HEAD_SIZE + T9::HEAD_SIZE + T10::HEAD_SIZE + T11::HEAD_SIZE + T12::HEAD_SIZE)
+        self.14
+            .encode_to_ptr(ptr + T0::HEAD_SIZE + T1::HEAD_SIZE + T2::HEAD_SIZE + T3::HEAD_SIZE + T4::HEAD_SIZE + T5::HEAD_SIZE + T6::HEAD_SIZE + T7::HEAD_SIZE + T8::HEAD_SIZE + T9::HEAD_SIZE + T10::HEAD_SIZE + T11::HEAD_SIZE + T12::HEAD_SIZE + T13::HEAD_SIZE)
+        self.15
+            .encode_to_ptr(ptr + T0::HEAD_SIZE + T1::HEAD_SIZE + T2::HEAD_SIZE + T3::HEAD_SIZE + T4::HEAD_SIZE + T5::HEAD_SIZE + T6::HEAD_SIZE + T7::HEAD_SIZE + T8::HEAD_SIZE + T9::HEAD_SIZE + T10::HEAD_SIZE + T11::HEAD_SIZE + T12::HEAD_SIZE + T13::HEAD_SIZE + T14::HEAD_SIZE)
+    }
+}
+
 impl<A: Abi, T0, T1, T2, T3, T4, T5> EventAbiEncode<A> for (T0, T1, T2, T3, T4, T5)
     where T0: Encode<A> + AbiSize,
           T1: Encode<A> + AbiSize,
@@ -4155,6 +4681,224 @@ impl<A: Abi, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> EventAbiEncode<A>
         tail = encode_event_field_at<A, T9>(v9, ptr, head_pos: head9, tail)
         tail = encode_event_field_at<A, T10>(v10, ptr, head_pos: head10, tail)
         tail = encode_event_field_at<A, T11>(v11, ptr, head_pos: head11, tail)
+    }
+}
+
+impl<A: Abi, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> EventAbiEncode<A> for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+    where T0: Encode<A> + AbiSize,
+          T1: Encode<A> + AbiSize,
+          T2: Encode<A> + AbiSize,
+          T3: Encode<A> + AbiSize,
+          T4: Encode<A> + AbiSize,
+          T5: Encode<A> + AbiSize,
+          T6: Encode<A> + AbiSize,
+          T7: Encode<A> + AbiSize,
+          T8: Encode<A> + AbiSize,
+          T9: Encode<A> + AbiSize,
+          T10: Encode<A> + AbiSize,
+          T11: Encode<A> + AbiSize,
+          T12: Encode<A> + AbiSize
+{
+    const DIRECT_EVENT_ENCODE: bool = true
+
+    #[arithmetic(unchecked)]
+    #[inline(always)]
+    fn encode_event_to_ptr(own self, _ ptr: u256) {
+        let (v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12) = self
+        let mut tail = ptr + Self::HEAD_SIZE
+        let head1 = ptr + abi_field_head_size<T0>()
+        let head2 = head1 + abi_field_head_size<T1>()
+        let head3 = head2 + abi_field_head_size<T2>()
+        let head4 = head3 + abi_field_head_size<T3>()
+        let head5 = head4 + abi_field_head_size<T4>()
+        let head6 = head5 + abi_field_head_size<T5>()
+        let head7 = head6 + abi_field_head_size<T6>()
+        let head8 = head7 + abi_field_head_size<T7>()
+        let head9 = head8 + abi_field_head_size<T8>()
+        let head10 = head9 + abi_field_head_size<T9>()
+        let head11 = head10 + abi_field_head_size<T10>()
+        let head12 = head11 + abi_field_head_size<T11>()
+        tail = encode_event_field_at<A, T0>(v0, ptr, head_pos: ptr, tail)
+        tail = encode_event_field_at<A, T1>(v1, ptr, head_pos: head1, tail)
+        tail = encode_event_field_at<A, T2>(v2, ptr, head_pos: head2, tail)
+        tail = encode_event_field_at<A, T3>(v3, ptr, head_pos: head3, tail)
+        tail = encode_event_field_at<A, T4>(v4, ptr, head_pos: head4, tail)
+        tail = encode_event_field_at<A, T5>(v5, ptr, head_pos: head5, tail)
+        tail = encode_event_field_at<A, T6>(v6, ptr, head_pos: head6, tail)
+        tail = encode_event_field_at<A, T7>(v7, ptr, head_pos: head7, tail)
+        tail = encode_event_field_at<A, T8>(v8, ptr, head_pos: head8, tail)
+        tail = encode_event_field_at<A, T9>(v9, ptr, head_pos: head9, tail)
+        tail = encode_event_field_at<A, T10>(v10, ptr, head_pos: head10, tail)
+        tail = encode_event_field_at<A, T11>(v11, ptr, head_pos: head11, tail)
+        tail = encode_event_field_at<A, T12>(v12, ptr, head_pos: head12, tail)
+    }
+}
+
+impl<A: Abi, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> EventAbiEncode<A> for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+    where T0: Encode<A> + AbiSize,
+          T1: Encode<A> + AbiSize,
+          T2: Encode<A> + AbiSize,
+          T3: Encode<A> + AbiSize,
+          T4: Encode<A> + AbiSize,
+          T5: Encode<A> + AbiSize,
+          T6: Encode<A> + AbiSize,
+          T7: Encode<A> + AbiSize,
+          T8: Encode<A> + AbiSize,
+          T9: Encode<A> + AbiSize,
+          T10: Encode<A> + AbiSize,
+          T11: Encode<A> + AbiSize,
+          T12: Encode<A> + AbiSize,
+          T13: Encode<A> + AbiSize
+{
+    const DIRECT_EVENT_ENCODE: bool = true
+
+    #[arithmetic(unchecked)]
+    #[inline(always)]
+    fn encode_event_to_ptr(own self, _ ptr: u256) {
+        let (v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13) = self
+        let mut tail = ptr + Self::HEAD_SIZE
+        let head1 = ptr + abi_field_head_size<T0>()
+        let head2 = head1 + abi_field_head_size<T1>()
+        let head3 = head2 + abi_field_head_size<T2>()
+        let head4 = head3 + abi_field_head_size<T3>()
+        let head5 = head4 + abi_field_head_size<T4>()
+        let head6 = head5 + abi_field_head_size<T5>()
+        let head7 = head6 + abi_field_head_size<T6>()
+        let head8 = head7 + abi_field_head_size<T7>()
+        let head9 = head8 + abi_field_head_size<T8>()
+        let head10 = head9 + abi_field_head_size<T9>()
+        let head11 = head10 + abi_field_head_size<T10>()
+        let head12 = head11 + abi_field_head_size<T11>()
+        let head13 = head12 + abi_field_head_size<T12>()
+        tail = encode_event_field_at<A, T0>(v0, ptr, head_pos: ptr, tail)
+        tail = encode_event_field_at<A, T1>(v1, ptr, head_pos: head1, tail)
+        tail = encode_event_field_at<A, T2>(v2, ptr, head_pos: head2, tail)
+        tail = encode_event_field_at<A, T3>(v3, ptr, head_pos: head3, tail)
+        tail = encode_event_field_at<A, T4>(v4, ptr, head_pos: head4, tail)
+        tail = encode_event_field_at<A, T5>(v5, ptr, head_pos: head5, tail)
+        tail = encode_event_field_at<A, T6>(v6, ptr, head_pos: head6, tail)
+        tail = encode_event_field_at<A, T7>(v7, ptr, head_pos: head7, tail)
+        tail = encode_event_field_at<A, T8>(v8, ptr, head_pos: head8, tail)
+        tail = encode_event_field_at<A, T9>(v9, ptr, head_pos: head9, tail)
+        tail = encode_event_field_at<A, T10>(v10, ptr, head_pos: head10, tail)
+        tail = encode_event_field_at<A, T11>(v11, ptr, head_pos: head11, tail)
+        tail = encode_event_field_at<A, T12>(v12, ptr, head_pos: head12, tail)
+        tail = encode_event_field_at<A, T13>(v13, ptr, head_pos: head13, tail)
+    }
+}
+
+impl<A: Abi, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> EventAbiEncode<A> for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+    where T0: Encode<A> + AbiSize,
+          T1: Encode<A> + AbiSize,
+          T2: Encode<A> + AbiSize,
+          T3: Encode<A> + AbiSize,
+          T4: Encode<A> + AbiSize,
+          T5: Encode<A> + AbiSize,
+          T6: Encode<A> + AbiSize,
+          T7: Encode<A> + AbiSize,
+          T8: Encode<A> + AbiSize,
+          T9: Encode<A> + AbiSize,
+          T10: Encode<A> + AbiSize,
+          T11: Encode<A> + AbiSize,
+          T12: Encode<A> + AbiSize,
+          T13: Encode<A> + AbiSize,
+          T14: Encode<A> + AbiSize
+{
+    const DIRECT_EVENT_ENCODE: bool = true
+
+    #[arithmetic(unchecked)]
+    #[inline(always)]
+    fn encode_event_to_ptr(own self, _ ptr: u256) {
+        let (v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14) = self
+        let mut tail = ptr + Self::HEAD_SIZE
+        let head1 = ptr + abi_field_head_size<T0>()
+        let head2 = head1 + abi_field_head_size<T1>()
+        let head3 = head2 + abi_field_head_size<T2>()
+        let head4 = head3 + abi_field_head_size<T3>()
+        let head5 = head4 + abi_field_head_size<T4>()
+        let head6 = head5 + abi_field_head_size<T5>()
+        let head7 = head6 + abi_field_head_size<T6>()
+        let head8 = head7 + abi_field_head_size<T7>()
+        let head9 = head8 + abi_field_head_size<T8>()
+        let head10 = head9 + abi_field_head_size<T9>()
+        let head11 = head10 + abi_field_head_size<T10>()
+        let head12 = head11 + abi_field_head_size<T11>()
+        let head13 = head12 + abi_field_head_size<T12>()
+        let head14 = head13 + abi_field_head_size<T13>()
+        tail = encode_event_field_at<A, T0>(v0, ptr, head_pos: ptr, tail)
+        tail = encode_event_field_at<A, T1>(v1, ptr, head_pos: head1, tail)
+        tail = encode_event_field_at<A, T2>(v2, ptr, head_pos: head2, tail)
+        tail = encode_event_field_at<A, T3>(v3, ptr, head_pos: head3, tail)
+        tail = encode_event_field_at<A, T4>(v4, ptr, head_pos: head4, tail)
+        tail = encode_event_field_at<A, T5>(v5, ptr, head_pos: head5, tail)
+        tail = encode_event_field_at<A, T6>(v6, ptr, head_pos: head6, tail)
+        tail = encode_event_field_at<A, T7>(v7, ptr, head_pos: head7, tail)
+        tail = encode_event_field_at<A, T8>(v8, ptr, head_pos: head8, tail)
+        tail = encode_event_field_at<A, T9>(v9, ptr, head_pos: head9, tail)
+        tail = encode_event_field_at<A, T10>(v10, ptr, head_pos: head10, tail)
+        tail = encode_event_field_at<A, T11>(v11, ptr, head_pos: head11, tail)
+        tail = encode_event_field_at<A, T12>(v12, ptr, head_pos: head12, tail)
+        tail = encode_event_field_at<A, T13>(v13, ptr, head_pos: head13, tail)
+        tail = encode_event_field_at<A, T14>(v14, ptr, head_pos: head14, tail)
+    }
+}
+
+impl<A: Abi, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> EventAbiEncode<A> for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+    where T0: Encode<A> + AbiSize,
+          T1: Encode<A> + AbiSize,
+          T2: Encode<A> + AbiSize,
+          T3: Encode<A> + AbiSize,
+          T4: Encode<A> + AbiSize,
+          T5: Encode<A> + AbiSize,
+          T6: Encode<A> + AbiSize,
+          T7: Encode<A> + AbiSize,
+          T8: Encode<A> + AbiSize,
+          T9: Encode<A> + AbiSize,
+          T10: Encode<A> + AbiSize,
+          T11: Encode<A> + AbiSize,
+          T12: Encode<A> + AbiSize,
+          T13: Encode<A> + AbiSize,
+          T14: Encode<A> + AbiSize,
+          T15: Encode<A> + AbiSize
+{
+    const DIRECT_EVENT_ENCODE: bool = true
+
+    #[arithmetic(unchecked)]
+    #[inline(always)]
+    fn encode_event_to_ptr(own self, _ ptr: u256) {
+        let (v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15) = self
+        let mut tail = ptr + Self::HEAD_SIZE
+        let head1 = ptr + abi_field_head_size<T0>()
+        let head2 = head1 + abi_field_head_size<T1>()
+        let head3 = head2 + abi_field_head_size<T2>()
+        let head4 = head3 + abi_field_head_size<T3>()
+        let head5 = head4 + abi_field_head_size<T4>()
+        let head6 = head5 + abi_field_head_size<T5>()
+        let head7 = head6 + abi_field_head_size<T6>()
+        let head8 = head7 + abi_field_head_size<T7>()
+        let head9 = head8 + abi_field_head_size<T8>()
+        let head10 = head9 + abi_field_head_size<T9>()
+        let head11 = head10 + abi_field_head_size<T10>()
+        let head12 = head11 + abi_field_head_size<T11>()
+        let head13 = head12 + abi_field_head_size<T12>()
+        let head14 = head13 + abi_field_head_size<T13>()
+        let head15 = head14 + abi_field_head_size<T14>()
+        tail = encode_event_field_at<A, T0>(v0, ptr, head_pos: ptr, tail)
+        tail = encode_event_field_at<A, T1>(v1, ptr, head_pos: head1, tail)
+        tail = encode_event_field_at<A, T2>(v2, ptr, head_pos: head2, tail)
+        tail = encode_event_field_at<A, T3>(v3, ptr, head_pos: head3, tail)
+        tail = encode_event_field_at<A, T4>(v4, ptr, head_pos: head4, tail)
+        tail = encode_event_field_at<A, T5>(v5, ptr, head_pos: head5, tail)
+        tail = encode_event_field_at<A, T6>(v6, ptr, head_pos: head6, tail)
+        tail = encode_event_field_at<A, T7>(v7, ptr, head_pos: head7, tail)
+        tail = encode_event_field_at<A, T8>(v8, ptr, head_pos: head8, tail)
+        tail = encode_event_field_at<A, T9>(v9, ptr, head_pos: head9, tail)
+        tail = encode_event_field_at<A, T10>(v10, ptr, head_pos: head10, tail)
+        tail = encode_event_field_at<A, T11>(v11, ptr, head_pos: head11, tail)
+        tail = encode_event_field_at<A, T12>(v12, ptr, head_pos: head12, tail)
+        tail = encode_event_field_at<A, T13>(v13, ptr, head_pos: head13, tail)
+        tail = encode_event_field_at<A, T14>(v14, ptr, head_pos: head14, tail)
+        tail = encode_event_field_at<A, T15>(v15, ptr, head_pos: head15, tail)
     }
 }
 


### PR DESCRIPTION
Events with 8 or more total fields crashed MIR lowering with "semantic const should reify for runtime lowering". Two bugs combined:

1. The #[event] desugar hashes the signature via core::keccak over a tuple of 2*fields+2 string fragments, but the AsBytes tuple impls stop at arity 16, so the TOPIC0 const never evaluated.

2. The missing impl should have been a type error, but the final obligation pass discharged unsatisfied goals containing string literal types as "not concrete": string literals carry a string-sorted inference variable until the String<N> fallback is applied, so the diagnostic was silently suppressed and the unevaluated const reached MIR.

Fixes:

- hir: nest the TOPIC0 keccak tuple into chunks of at most 16 elements when the signature is longer. Concatenation is associative, so the hash is byte-identical and signatures of any length compile; tuples with <= 16 elements stay flat, leaving existing events unchanged.

- core: raise the AbiSize/Encode/EventAbiEncode tuple impls from arity 12 to 16, bounding events at 16 data (non-indexed) fields. Nesting is not an option for the payload since ABI offsets are frame-relative. Exceeding the bound now reports a proper trait-bound diagnostic spanning the event definition.

- ty_check: fold obligation goals through Prober (literal fallbacks) at the final pass so unsatisfied bounds that mention string literals are reported instead of silently discharged.

- mir: the reify panic now names the const and expected type as a defensive backstop.

Tests: fe_test fixture covering 6/7/8/16 data fields (with and without an indexed field) emitted via log.emit, with every TOPIC0 asserted against externally computed keccak256 values; desugar snapshot for the nested tuple; uitests for the two new diagnostics.