### PR TITLE
Fix trait method selection cycle for projected impl bounds (#1505)

### DIFF
--- a/crates/hir/src/analysis/ty/trait_resolution/mod.rs
+++ b/crates/hir/src/analysis/ty/trait_resolution/mod.rs
@@ -244,7 +244,11 @@ pub(crate) fn normalize_trait_inst_preserving_validity<'db>(
     }
 }
 
-#[salsa::tracked(return_ref)]
+#[salsa::tracked(
+    return_ref,
+    cycle_fn=is_query_satisfiable_cycle_recover,
+    cycle_initial=is_query_satisfiable_cycle_initial
+)]
 fn is_query_satisfiable<'db>(
     db: &'db dyn HirAnalysisDb,
     origin_ingot: Ingot<'db>,
@@ -255,6 +259,28 @@ fn is_query_satisfiable<'db>(
     };
 
     ProofForest::new(db, origin_ingot, query).solve()
+}
+
+fn is_query_satisfiable_cycle_initial<'db>(
+    _db: &'db dyn HirAnalysisDb,
+    _origin_ingot: Ingot<'db>,
+    _query: Canonical<TraitSolverQuery<'db>>,
+) -> GoalSatisfiability<'db> {
+    // A cycle can arise while collecting an impl whose constraints contain an associated-type
+    // projection: resolving the projection needs the trait environment that is currently being
+    // assembled for the outer goal. Treat the incomplete pass as ambiguous so callers keep the
+    // candidate alive; the next fixpoint iteration can decide it once impl collection converges.
+    GoalSatisfiability::NeedsConfirmation(IndexSet::default())
+}
+
+fn is_query_satisfiable_cycle_recover<'db>(
+    _db: &'db dyn HirAnalysisDb,
+    _value: &GoalSatisfiability<'db>,
+    _count: u32,
+    _origin_ingot: Ingot<'db>,
+    _query: Canonical<TraitSolverQuery<'db>>,
+) -> salsa::CycleRecoveryAction<GoalSatisfiability<'db>> {
+    salsa::CycleRecoveryAction::Iterate
 }
 
 pub fn is_goal_query_satisfiable<'db>(

--- a/crates/uitest/fixtures/ty_check/impl_projection_bound_method_selection.fe
+++ b/crates/uitest/fixtures/ty_check/impl_projection_bound_method_selection.fe
@@ -1,0 +1,28 @@
+trait Tagged {}
+
+struct Holder {}
+
+impl Tagged for Holder {}
+
+trait Assoc {
+    type Out
+}
+
+impl Assoc for Holder {
+    type Out = Holder
+}
+
+trait Consume {
+    fn consume(self)
+}
+
+impl Consume for Holder
+where <Holder as Assoc>::Out: Tagged
+{
+    fn consume(self) {}
+}
+
+fn caller() {
+    let h = Holder {}
+    h.consume()
+}

--- a/crates/uitest/fixtures/ty_check/impl_projection_bound_method_selection.snap
+++ b/crates/uitest/fixtures/ty_check/impl_projection_bound_method_selection.snap
@@ -1,0 +1,5 @@
+---
+source: crates/uitest/tests/ty_check.rs
+expression: diags
+input_file: fixtures/ty_check/impl_projection_bound_method_selection.fe
+---

--- a/crates/uitest/fixtures/ty_check/impl_projection_bound_method_selection_unsatisfied.fe
+++ b/crates/uitest/fixtures/ty_check/impl_projection_bound_method_selection_unsatisfied.fe
@@ -1,0 +1,26 @@
+trait Tagged {}
+
+struct Holder {}
+
+trait Assoc {
+    type Out
+}
+
+impl Assoc for Holder {
+    type Out = Holder
+}
+
+trait Consume {
+    fn consume(self)
+}
+
+impl Consume for Holder
+where <Holder as Assoc>::Out: Tagged
+{
+    fn consume(self) {}
+}
+
+fn caller() {
+    let h = Holder {}
+    h.consume()
+}

--- a/crates/uitest/fixtures/ty_check/impl_projection_bound_method_selection_unsatisfied.snap
+++ b/crates/uitest/fixtures/ty_check/impl_projection_bound_method_selection_unsatisfied.snap
@@ -1,0 +1,13 @@
+---
+source: crates/uitest/tests/ty_check.rs
+expression: diags
+input_file: fixtures/ty_check/impl_projection_bound_method_selection_unsatisfied.fe
+---
+error[6-0003]: trait bound is not satisfied
+   ┌─ impl_projection_bound_method_selection_unsatisfied.fe:25:5
+   │
+25 │     h.consume()
+   │     ^^^^^^^^^^^
+   │     │
+   │     `Holder` doesn't implement `Consume`
+   │     trait bound `Holder::Out: Tagged` is not satisfied

--- a/newsfragments/1505.bugfix.md
+++ b/newsfragments/1505.bugfix.md
@@ -1,0 +1,1 @@
+Fixed a compiler panic when selecting a trait method from an `impl` whose `where` clause constrains an associated-type projection. Satisfied projection bounds now type-check normally, while unsatisfied bounds produce the expected trait-bound diagnostic.


### PR DESCRIPTION
Make the trait satisfiability query participate in Salsa fixpoint iteration when impl collection re-enters trait solving through an associated-type projection. Keep candidates ambiguous during the incomplete pass, then resolve them once impl collection converges.

Add positive and unsatisfied regression coverage for projection bounds on trait impls.

Fixes #1505