### PR TITLE
fix(fmt): preserve syntax across formatting round trips

### DIFF
--- a/crates/fmt/src/ast/expr.rs
+++ b/crates/fmt/src/ast/expr.rs
@@ -42,6 +42,20 @@ fn bin_op_precedence(op: &BinOp) -> u8 {
     }
 }
 
+/// Returns true for operators the parser refuses to parse as a continuation
+/// when they appear at the start of a line: `-` reads as a new expression
+/// statement starting with unary minus, and `<` / `<<` can begin a qualified
+/// type (`<T as Trait>::...`). For these the line break must be placed after
+/// the operator, never before it. Keep in sync with the line-start operator
+/// rejections in `parser/src/parser/expr.rs`.
+fn op_rejected_at_line_start(op: &BinOp) -> bool {
+    use parser::ast::{ArithBinOp, CompBinOp};
+    matches!(
+        op,
+        BinOp::Arith(ArithBinOp::Sub(_) | ArithBinOp::LShift(_)) | BinOp::Comp(CompBinOp::Lt(_))
+    )
+}
+
 /// If expression is a binary expression with the given precedence, return the BinExpr.
 fn as_bin_expr_with_precedence(expr: &ast::Expr, precedence: u8) -> Option<ast::BinExpr> {
     if let ExprKind::Bin(bin) = expr.kind()
@@ -99,15 +113,17 @@ fn format_bin_expr_inner<'a>(
 
     let precedence = bin_op_precedence(&op);
 
-    // Collect all operands and operators at this precedence level
+    // Collect all operands and operators at this precedence level.
+    // The bool records whether the parser rejects the operator at line start,
+    // in which case the break goes after the operator instead of before it.
     let mut operands: Vec<ast::Expr> = Vec::new();
-    let mut operators: Vec<String> = Vec::new();
+    let mut operators: Vec<(String, bool)> = Vec::new();
 
     fn collect<'a>(
         expr: &ast::BinExpr,
         precedence: u8,
         operands: &mut Vec<ast::Expr>,
-        operators: &mut Vec<String>,
+        operators: &mut Vec<(String, bool)>,
         ctx: &'a RewriteContext<'a>,
     ) {
         if let Some(lhs) = expr.lhs() {
@@ -119,7 +135,10 @@ fn format_bin_expr_inner<'a>(
         }
 
         if let Some(op) = expr.op() {
-            operators.push(ctx.snippet_node_or_token(&op.syntax()));
+            operators.push((
+                ctx.snippet_node_or_token(&op.syntax()),
+                op_rejected_at_line_start(&op),
+            ));
         }
 
         if let Some(rhs) = expr.rhs() {
@@ -141,7 +160,7 @@ fn format_bin_expr_inner<'a>(
     let mut result = first.to_doc(ctx);
 
     for (i, operand) in operands.iter().skip(1).enumerate() {
-        let op_str = &operators[i];
+        let (op_str, break_after_op) = &operators[i];
 
         // Check if operand is a higher-precedence binary expression
         let higher_prec_bin = if let ExprKind::Bin(inner_bin) = operand.kind() {
@@ -153,22 +172,26 @@ fn format_bin_expr_inner<'a>(
             None
         };
 
-        if let Some(inner_bin) = higher_prec_bin {
+        let operand_doc = if let Some(inner_bin) = higher_prec_bin {
             // Format inner chain without its own nesting, we control it here
-            let inner_doc = format_bin_expr_inner(&inner_bin, ctx, false);
-            result = result
-                .append(alloc.line())
-                .append(alloc.text(op_str.clone()))
-                .append(alloc.text(" "))
-                .append(inner_doc.nest(indent));
+            format_bin_expr_inner(&inner_bin, ctx, false).nest(indent)
         } else {
-            let operand_doc = operand.to_doc(ctx);
-            result = result
+            operand.to_doc(ctx)
+        };
+
+        result = if *break_after_op {
+            result
+                .append(alloc.text(" "))
+                .append(alloc.text(op_str.clone()))
+                .append(alloc.line())
+                .append(operand_doc)
+        } else {
+            result
                 .append(alloc.line())
                 .append(alloc.text(op_str.clone()))
                 .append(alloc.text(" "))
-                .append(operand_doc);
-        }
+                .append(operand_doc)
+        };
     }
 
     if apply_outer_nest {

--- a/crates/fmt/src/ast/items.rs
+++ b/crates/fmt/src/ast/items.rs
@@ -20,6 +20,19 @@ macro_rules! token_doc_item_like_if_comments {
     };
 }
 
+fn next_non_trivia_token(token: &parser::SyntaxToken) -> Option<parser::SyntaxToken> {
+    use parser::syntax_kind::SyntaxKind::*;
+
+    let mut next = token.next_token();
+    while let Some(tok) = next {
+        if !matches!(tok.kind(), WhiteSpace | Newline) {
+            return Some(tok);
+        }
+        next = tok.next_token();
+    }
+    None
+}
+
 fn token_piece_basic<'a>(
     ctx: &'a RewriteContext<'a>,
     token: parser::SyntaxToken,
@@ -30,6 +43,11 @@ fn token_piece_basic<'a>(
     let text = alloc.text(token.text().to_string());
     Some(match token.kind() {
         FnKw => TokenPiece::new(alloc.nil()),
+        // `pub` followed by `(` is a visibility restriction (`pub(ingot)`);
+        // keep the paren attached to the keyword.
+        PubKw if next_non_trivia_token(&token).is_some_and(|t| t.kind() == LParen) => {
+            TokenPiece::new(text)
+        }
         PubKw | UnsafeKw | MutKw | StructKw | ContractKw | EnumKw | TraitKw | MsgKw | ModKw
         | UseKw | ConstKw | StaticAssertKw | TypeKw | ExternKw => {
             TokenPiece::new(text).space_after()
@@ -67,6 +85,17 @@ fn token_doc_item_node_piece<'a>(
         ($($expr:expr),+ $(,)?) => {
             None$(.or_else(|| $expr))+
         };
+    }
+
+    // Visibility restriction after `pub(`: the `(` token precedes this node
+    // in the CST, so the piece renders only `ingot)` / `super)`.
+    if let Some(vis) = ast::VisRestriction::cast(node.clone()) {
+        let restriction = if vis.super_kw().is_some() {
+            "super)"
+        } else {
+            "ingot)"
+        };
+        return Some(TokenPiece::new(ctx.alloc.text(restriction)).space_after());
     }
 
     first_some!(
@@ -116,6 +145,16 @@ fn attrs_doc<'a, N: ast::AttrListOwner + AstNode>(
     }
 }
 
+/// Renders `pub `, `pub(ingot) `, or `pub(super) ` depending on the
+/// visibility restriction attached to the `pub` keyword.
+fn pub_text(vis_restriction: Option<&ast::VisRestriction>) -> &'static str {
+    match vis_restriction {
+        Some(vis) if vis.ingot_kw().is_some() => "pub(ingot) ",
+        Some(vis) if vis.super_kw().is_some() => "pub(super) ",
+        _ => "pub ",
+    }
+}
+
 /// Helper to build item modifier document (pub, unsafe).
 fn modifier_doc<'a, N: ItemModifierOwner + AstNode>(
     node: &N,
@@ -124,7 +163,7 @@ fn modifier_doc<'a, N: ItemModifierOwner + AstNode>(
     let alloc = &ctx.alloc;
     let mut doc = alloc.nil();
     if node.pub_kw().is_some() {
-        doc = doc.append(alloc.text("pub "));
+        doc = doc.append(alloc.text(pub_text(node.vis_restriction().as_ref())));
     }
     if node.unsafe_kw().is_some() {
         doc = doc.append(alloc.text("unsafe "));
@@ -168,6 +207,26 @@ fn where_doc<'a, N: ast::WhereClauseOwner + AstNode>(
     }
 }
 
+/// Counts newlines in a node's leading trivia (before its first non-trivia
+/// token or child node).
+fn node_leading_newlines(ctx: &RewriteContext, node: &parser::SyntaxNode) -> usize {
+    use parser::syntax_kind::SyntaxKind;
+    use parser::syntax_node::NodeOrToken;
+
+    let mut count = 0;
+    for child in node.children_with_tokens() {
+        match child {
+            NodeOrToken::Token(token) => match token.kind() {
+                SyntaxKind::Newline => count += newline_count(ctx.snippet(token.text_range())),
+                SyntaxKind::WhiteSpace => {}
+                _ => break,
+            },
+            NodeOrToken::Node(_) => break,
+        }
+    }
+    count
+}
+
 /// Format a block of items `{ ... }`, preserving whether there was a blank line
 /// between entries in the source (2+ newlines => one blank line; otherwise none).
 /// Takes a syntax node and a function to cast child nodes to the item type.
@@ -187,9 +246,13 @@ fn block_items_doc<'a, T: ToDoc>(
     for child in syntax.children_with_tokens() {
         let entry_doc = match child {
             NodeOrToken::Node(node) => {
-                let Some(item) = cast_fn(node) else {
+                let Some(item) = cast_fn(node.clone()) else {
                     continue;
                 };
+                // Item nodes own their leading comments and newlines, but the
+                // node's doc drops that leading trivia; count it here so blank
+                // lines between entries are preserved without doubling.
+                pending_newlines += node_leading_newlines(ctx, &node);
                 Some(item.to_doc(ctx))
             }
             NodeOrToken::Token(token) => match token.kind() {
@@ -779,7 +842,7 @@ impl ToDoc for ast::RecordFieldDef {
         let mut doc = attrs;
 
         if self.pub_kw().is_some() {
-            doc = doc.append(alloc.text("pub "));
+            doc = doc.append(alloc.text(pub_text(self.vis_restriction().as_ref())));
         }
 
         if self.mut_kw().is_some() {

--- a/crates/fmt/src/ast/types.rs
+++ b/crates/fmt/src/ast/types.rs
@@ -105,6 +105,26 @@ macro_rules! block_list_auto_impl {
 block_list_auto_impl!(block_list_auto, block_list);
 block_list_auto_impl!(block_list_spaced_auto, block_list_spaced);
 
+/// Returns true if the first non-trivia token of the node is `<` (a qualified
+/// type such as `<T as Trait>::Item`). Such a node must not be emitted
+/// directly after another `<`, or the two would lex as a single `<<` shift
+/// token on reparse; callers insert a space between them.
+pub(crate) fn starts_with_lt(syntax: &parser::SyntaxNode) -> bool {
+    syntax
+        .descendants_with_tokens()
+        .filter_map(|child| child.into_token())
+        .find(|token| {
+            !matches!(
+                token.kind(),
+                SyntaxKind::WhiteSpace
+                    | SyntaxKind::Newline
+                    | SyntaxKind::Comment
+                    | SyntaxKind::DocComment
+            )
+        })
+        .is_some_and(|token| token.kind() == SyntaxKind::Lt)
+}
+
 pub fn has_comment_tokens(syntax: &parser::SyntaxNode) -> bool {
     syntax.children_with_tokens().any(|child| {
         matches!(
@@ -197,6 +217,13 @@ impl<'a> TokenDocBuilder<'a> {
 
     fn push_piece(&mut self, piece: TokenPiece<'a>) {
         let alloc = &self.ctx.alloc;
+
+        // Leading newlines inside a node are the enclosing container's
+        // concern (it emits the separation between entries); rendering them
+        // here too would add another blank line on every format pass.
+        if self.is_start {
+            self.pending_newlines = 0;
+        }
 
         if self.pending_newlines > 0 {
             let doc = hardlines(alloc, self.pending_newlines).append(piece.doc);
@@ -980,8 +1007,16 @@ impl ToDoc for ast::QualifiedType {
                 None => return alloc.nil(),
             };
 
+            // A qualified type nested directly inside another (`< <A as B>::C
+            // as D>`) needs a space after the opening `<` so it doesn't lex
+            // as `<<`.
+            let open = if self.ty().is_some_and(|t| starts_with_lt(t.syntax())) {
+                "< "
+            } else {
+                "<"
+            };
             return alloc
-                .text("<")
+                .text(open)
                 .append(ty)
                 .append(alloc.text(" as "))
                 .append(trait_path)
@@ -1012,10 +1047,21 @@ impl ToDoc for ast::QualifiedType {
 impl ToDoc for ast::GenericArgList {
     fn to_doc<'a>(&self, ctx: &'a RewriteContext<'a>) -> Doc<'a> {
         let indent = ctx.config.indent_width as isize;
+        // A first argument that is itself a qualified type starts with `<`;
+        // keep a space after the opening `<` so it doesn't lex as `<<`.
+        let open = if self
+            .into_iter()
+            .next()
+            .is_some_and(|arg| starts_with_lt(arg.syntax()))
+        {
+            "< "
+        } else {
+            "<"
+        };
         block_list_auto(
             ctx,
             self.syntax(),
-            "<",
+            open,
             ">",
             ast::GenericArg::cast,
             indent,

--- a/crates/fmt/tests/corpus_roundtrip.rs
+++ b/crates/fmt/tests/corpus_roundtrip.rs
@@ -1,0 +1,108 @@
+//! Corpus round-trip property test.
+//!
+//! Walks every `.fe` file in the repository and asserts, for each file that
+//! parses cleanly:
+//!
+//! - `fmt(file)` succeeds,
+//! - `parse(fmt(file))` succeeds — the formatter must never emit output the
+//!   parser rejects (e.g. a line-start `-` after wrapping),
+//! - `fmt(fmt(file)) == fmt(file)` — formatting is idempotent.
+//!
+//! There is no span-erased AST-equality utility in the codebase, so semantic
+//! preservation is covered only indirectly (reparse success + idempotence).
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use fe_fmt::{Config, FormatError, format_str};
+use parser::{RecoveryMode, parse_source_file};
+
+/// Directories that contain no source corpus or deliberately broken files.
+const SKIP_DIRS: &[&str] = &["target", ".git", "node_modules"];
+
+fn collect_fe_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    for entry in fs::read_dir(dir).expect("failed to read corpus directory") {
+        let entry = entry.expect("failed to read corpus directory entry");
+        let path = entry.path();
+        if path.is_dir() {
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            if !SKIP_DIRS.contains(&name.as_ref()) && !name.starts_with('.') {
+                collect_fe_files(&path, out);
+            }
+        } else if path.extension().is_some_and(|ext| ext == "fe") {
+            out.push(path);
+        }
+    }
+}
+
+fn parses_cleanly(source: &str) -> bool {
+    let (_, errors) = parse_source_file(source, RecoveryMode::new(true));
+    errors.is_empty()
+}
+
+#[test]
+fn corpus_roundtrip() {
+    let repo_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let mut files = Vec::new();
+    collect_fe_files(&repo_root, &mut files);
+    files.sort();
+
+    // Guard against walking the wrong directory.
+    assert!(
+        files.len() > 100,
+        "expected to find a large .fe corpus, found only {} files",
+        files.len()
+    );
+
+    let config = Config::default();
+    let mut checked = 0usize;
+    let mut skipped = 0usize;
+    let mut failures = Vec::new();
+
+    for path in &files {
+        let display = path.strip_prefix(&repo_root).unwrap_or(path).display();
+        let source = fs::read_to_string(path).expect("failed to read corpus file");
+
+        let formatted = match format_str(&source, &config) {
+            Ok(formatted) => formatted,
+            // Files that do not parse (e.g. deliberately broken uitest
+            // fixtures) are outside the property; the formatter refuses them.
+            Err(FormatError::ParseErrors(_)) => {
+                skipped += 1;
+                continue;
+            }
+            Err(err) => {
+                failures.push(format!("{display}: format failed: {err:?}"));
+                continue;
+            }
+        };
+        checked += 1;
+
+        if !parses_cleanly(&formatted) {
+            failures.push(format!(
+                "{display}: formatted output no longer parses:\n{formatted}"
+            ));
+            continue;
+        }
+
+        match format_str(&formatted, &config) {
+            Ok(reformatted) => {
+                if reformatted != formatted {
+                    failures.push(format!("{display}: formatting is not idempotent"));
+                }
+            }
+            Err(err) => {
+                failures.push(format!("{display}: reformatting failed: {err:?}"));
+            }
+        }
+    }
+
+    println!("corpus round-trip: {checked} files checked, {skipped} unparsable files skipped");
+    assert!(
+        failures.is_empty(),
+        "corpus round-trip failures ({}):\n{}",
+        failures.len(),
+        failures.join("\n\n")
+    );
+}

--- a/crates/fmt/tests/fixtures/erc20.snap
+++ b/crates/fmt/tests/fixtures/erc20.snap
@@ -185,18 +185,22 @@ impl AccessControl {
     pub fn new() -> Self {
         AccessControl { roles: Map::new() }
     }
+
     pub fn has_role(self, role: u256, account: Address) -> bool {
         self.roles[(role, account)]
     }
+
     pub fn require(self, role: u256) uses (ctx: Ctx) {
         assert!(
             self.roles[(role, ctx.caller())],
             "access denied: missing role",
         )
     }
+
     pub fn grant(mut self, role: u256, to: Address) {
         self.roles[(role, to)] = true
     }
+
     pub fn revoke(mut self, role: u256, from: Address) {
         self.roles[(role, from)] = false
     }

--- a/crates/fmt/tests/fixtures/line_start_ambiguous_ops_stress.fe
+++ b/crates/fmt/tests/fixtures/line_start_ambiguous_ops_stress.fe
@@ -1,0 +1,64 @@
+// Stress cases for operators the parser rejects at line-start (`-`, `<`, `<<`)
+// mixed with higher-precedence chains and labeled call arguments at several
+// nesting depths. Every formatted output must reparse.
+
+fn sub_chain(first_operand_value: u256, second_operand_value: u256, third_operand_value: u256) -> u256 {
+    first_operand_value - second_operand_value - third_operand_value - lookup_some_stored_quantity(slot: first_operand_value) - lookup_some_stored_quantity(slot: second_operand_value)
+}
+
+fn mixed_add_sub(alpha_quantity: u256, beta_quantity: u256, gamma_quantity: u256) -> u256 {
+    alpha_quantity + compute_weighted_contribution(weight: beta_quantity, scale: gamma_quantity) - compute_weighted_contribution(weight: gamma_quantity, scale: beta_quantity) + alpha_quantity
+}
+
+fn sub_with_mul_div_rhs(total_supply_amount: u256, fee_numerator: u256, fee_denominator: u256) -> u256 {
+    total_supply_amount - compute_accumulated_fee_share(numerator: fee_numerator, denominator: fee_denominator) * total_supply_amount / 1000000000000000000
+}
+
+fn comparison_wrap(observed_balance_amount: u256, expected_balance_amount: u256) -> bool {
+    compute_normalized_balance(raw: observed_balance_amount, scale: 18) < compute_normalized_balance(raw: expected_balance_amount, scale: 18)
+}
+
+fn shift_chain_wrap(packed_word_value: u256, first_shift_amount: u256, second_shift_amount: u256) -> u256 {
+    extract_slot_payload_bits(word: packed_word_value, offset: 32) << first_shift_amount << second_shift_amount << compute_dynamic_shift(base: first_shift_amount)
+}
+
+fn nested_labeled_args(pool_balance_first: u256, pool_balance_second: u256, invariant_value: u256) {
+    store_computed_result(
+        storage_index: 0,
+        computed_value: outer_combinator(
+            first_component: pool_balance_first - compute_dynamic_fee_for_balances(xpi_value: pool_balance_first, xpj_value: pool_balance_second, base_fee: invariant_value) * invariant_value / 10000000000,
+            second_component: pool_balance_second - invariant_value,
+        ),
+    )
+}
+
+fn sub_inside_if_arm(condition_flag: bool, lookup_key_value: u256) -> u256 {
+    let computed = if condition_flag {
+        some_call_with_a_rather_long_name(first_argument: lookup_key_value, second_argument: lookup_key_value) - another_lookup_with_long_name(key: lookup_key_value) - yet_another_adjustment_term(key: lookup_key_value)
+    } else {
+        lookup_some_stored_quantity(slot: lookup_key_value) - 1
+    }
+    computed
+}
+
+fn unary_minus_operand(signed_accumulator_value: i256, signed_adjustment_value: i256) -> i256 {
+    -compute_signed_contribution(base: signed_accumulator_value, scale: signed_adjustment_value) - compute_signed_contribution(base: signed_adjustment_value, scale: signed_accumulator_value)
+}
+
+fn comparison_of_sub_chains(left_side_quantity: u256, right_side_quantity: u256, offset_quantity: u256) -> bool {
+    left_side_quantity - compute_weighted_contribution(weight: offset_quantity, scale: right_side_quantity) < right_side_quantity - compute_weighted_contribution(weight: offset_quantity, scale: left_side_quantity)
+}
+
+fn shift_of_sub_result(base_word_value: u256, subtrahend_value: u256, shift_bit_count: u256) -> u256 {
+    combine_packed_fields(high: base_word_value - subtrahend_value, low: base_word_value) << compute_dynamic_shift(base: shift_bit_count)
+}
+
+fn deeply_nested_mixed(depth_one_value: u256, depth_two_value: u256, depth_three_value: u256) -> u256 {
+    outer_combinator(
+        first_component: middle_combinator(
+            inner_component: depth_one_value - inner_lookup_with_long_name(key: depth_two_value) * depth_three_value / 10000000000 - trailing_adjustment_term(key: depth_three_value),
+            other_component: depth_two_value << compute_dynamic_shift(base: depth_one_value) << compute_dynamic_shift(base: depth_three_value),
+        ),
+        second_component: depth_one_value - depth_two_value - depth_three_value,
+    )
+}

--- a/crates/fmt/tests/fixtures/line_start_ambiguous_ops_stress.snap
+++ b/crates/fmt/tests/fixtures/line_start_ambiguous_ops_stress.snap
@@ -1,0 +1,139 @@
+---
+source: crates/fmt/tests/format_snapshots.rs
+expression: output
+input_file: tests/fixtures/line_start_ambiguous_ops_stress.fe
+---
+// Stress cases for operators the parser rejects at line-start (`-`, `<`, `<<`)
+// mixed with higher-precedence chains and labeled call arguments at several
+// nesting depths. Every formatted output must reparse.
+
+fn sub_chain(
+    first_operand_value: u256,
+    second_operand_value: u256,
+    third_operand_value: u256,
+) -> u256 {
+    first_operand_value -
+        second_operand_value -
+        third_operand_value -
+        lookup_some_stored_quantity(slot: first_operand_value) -
+        lookup_some_stored_quantity(slot: second_operand_value)
+}
+
+fn mixed_add_sub(alpha_quantity: u256, beta_quantity: u256, gamma_quantity: u256) -> u256 {
+    alpha_quantity
+        + compute_weighted_contribution(weight: beta_quantity, scale: gamma_quantity) -
+        compute_weighted_contribution(weight: gamma_quantity, scale: beta_quantity)
+        + alpha_quantity
+}
+
+fn sub_with_mul_div_rhs(
+    total_supply_amount: u256,
+    fee_numerator: u256,
+    fee_denominator: u256,
+) -> u256 {
+    total_supply_amount -
+        compute_accumulated_fee_share(numerator: fee_numerator, denominator: fee_denominator)
+            * total_supply_amount
+            / 1000000000000000000
+}
+
+fn comparison_wrap(observed_balance_amount: u256, expected_balance_amount: u256) -> bool {
+    compute_normalized_balance(raw: observed_balance_amount, scale: 18) <
+        compute_normalized_balance(raw: expected_balance_amount, scale: 18)
+}
+
+fn shift_chain_wrap(
+    packed_word_value: u256,
+    first_shift_amount: u256,
+    second_shift_amount: u256,
+) -> u256 {
+    extract_slot_payload_bits(word: packed_word_value, offset: 32) <<
+        first_shift_amount <<
+        second_shift_amount <<
+        compute_dynamic_shift(base: first_shift_amount)
+}
+
+fn nested_labeled_args(pool_balance_first: u256, pool_balance_second: u256, invariant_value: u256) {
+    store_computed_result(
+        storage_index: 0,
+        computed_value: outer_combinator(
+            first_component: pool_balance_first -
+                compute_dynamic_fee_for_balances(
+                        xpi_value: pool_balance_first,
+                        xpj_value: pool_balance_second,
+                        base_fee: invariant_value,
+                    )
+                    * invariant_value
+                    / 10000000000,
+            second_component: pool_balance_second - invariant_value,
+        ),
+    )
+}
+
+fn sub_inside_if_arm(condition_flag: bool, lookup_key_value: u256) -> u256 {
+    let computed = if condition_flag {
+        some_call_with_a_rather_long_name(
+                first_argument: lookup_key_value,
+                second_argument: lookup_key_value,
+            ) -
+            another_lookup_with_long_name(key: lookup_key_value) -
+            yet_another_adjustment_term(key: lookup_key_value)
+    } else {
+        lookup_some_stored_quantity(slot: lookup_key_value) - 1
+    }
+    computed
+}
+
+fn unary_minus_operand(signed_accumulator_value: i256, signed_adjustment_value: i256) -> i256 {
+    -compute_signed_contribution(
+            base: signed_accumulator_value,
+            scale: signed_adjustment_value,
+        ) -
+        compute_signed_contribution(
+            base: signed_adjustment_value,
+            scale: signed_accumulator_value,
+        )
+}
+
+fn comparison_of_sub_chains(
+    left_side_quantity: u256,
+    right_side_quantity: u256,
+    offset_quantity: u256,
+) -> bool {
+    left_side_quantity -
+            compute_weighted_contribution(weight: offset_quantity, scale: right_side_quantity) <
+        right_side_quantity -
+            compute_weighted_contribution(weight: offset_quantity, scale: left_side_quantity)
+}
+
+fn shift_of_sub_result(
+    base_word_value: u256,
+    subtrahend_value: u256,
+    shift_bit_count: u256,
+) -> u256 {
+    combine_packed_fields(
+            high: base_word_value - subtrahend_value,
+            low: base_word_value,
+        ) <<
+        compute_dynamic_shift(base: shift_bit_count)
+}
+
+fn deeply_nested_mixed(
+    depth_one_value: u256,
+    depth_two_value: u256,
+    depth_three_value: u256,
+) -> u256 {
+    outer_combinator(
+        first_component: middle_combinator(
+            inner_component: depth_one_value -
+                inner_lookup_with_long_name(key: depth_two_value)
+                    * depth_three_value
+                    / 10000000000 -
+                trailing_adjustment_term(key: depth_three_value),
+            other_component: depth_two_value <<
+                compute_dynamic_shift(base: depth_one_value) <<
+                compute_dynamic_shift(base: depth_three_value),
+        ),
+        second_component: depth_one_value - depth_two_value - depth_three_value,
+    )
+}

--- a/crates/fmt/tests/fixtures/line_start_minus.fe
+++ b/crates/fmt/tests/fixtures/line_start_minus.fe
@@ -1,0 +1,19 @@
+// Regression tests: the formatter must never break a line *before* an
+// operator that the parser rejects at expression-continuation position
+// (`-`, `<`, `<<`). Breaks go after the operator instead.
+
+// Repro 1: long subtraction wrapped inside an if-arm
+fn balance_of_minus_admin(flag: bool, i: u256) -> u256 {
+    let balance = if flag {
+        some_call_with_a_rather_long_name(first_argument: i, second_argument: i) - another_lookup_with_long_name(key: i)
+    } else {
+        0
+    }
+    balance
+}
+
+// Repro 2: subtraction whose right operand is a mul/div chain, as a labeled
+// call argument
+fn fee_reduction(xp_j: u256, xavg: u256, ys: u256, base: u256, dx: u256) {
+    store_value(index: 0, value: xp_j - compute_dynamic_fee_for_balances(xpi_value: xavg, xpj_value: ys, base_fee: base) * dx / 10000000000)
+}

--- a/crates/fmt/tests/fixtures/line_start_minus.snap
+++ b/crates/fmt/tests/fixtures/line_start_minus.snap
@@ -1,0 +1,31 @@
+---
+source: crates/fmt/tests/format_snapshots.rs
+expression: output
+input_file: tests/fixtures/line_start_minus.fe
+---
+// Regression tests: the formatter must never break a line *before* an
+// operator that the parser rejects at expression-continuation position
+// (`-`, `<`, `<<`). Breaks go after the operator instead.
+
+// Repro 1: long subtraction wrapped inside an if-arm
+fn balance_of_minus_admin(flag: bool, i: u256) -> u256 {
+    let balance = if flag {
+        some_call_with_a_rather_long_name(first_argument: i, second_argument: i) -
+            another_lookup_with_long_name(key: i)
+    } else {
+        0
+    }
+    balance
+}
+
+// Repro 2: subtraction whose right operand is a mul/div chain, as a labeled
+// call argument
+fn fee_reduction(xp_j: u256, xavg: u256, ys: u256, base: u256, dx: u256) {
+    store_value(
+        index: 0,
+        value: xp_j -
+            compute_dynamic_fee_for_balances(xpi_value: xavg, xpj_value: ys, base_fee: base)
+                * dx
+                / 10000000000,
+    )
+}

--- a/crates/fmt/tests/fixtures/qualified_types.snap
+++ b/crates/fmt/tests/fixtures/qualified_types.snap
@@ -11,7 +11,7 @@ fn test_basic<T>(x: T) -> <T as Iterator>::Item where T: Iterator {
 }
 
 // Nested qualified types
-fn test_nested<T>(x: T) -> <<T as IntoIterator>::IntoIter as Iterator>::Item
+fn test_nested<T>(x: T) -> < <T as IntoIterator>::IntoIter as Iterator>::Item
 where T: IntoIterator
 {
     x.into_iter().next()


### PR DESCRIPTION
Keep line breaks after parser-ambiguous operators, separate nested qualified-type angle brackets, and retain restricted visibility modifiers.

Handle item-leading trivia without accumulating blank lines, and add corpus round-trip and regression coverage for reparsing and idempotence.