### PR TITLE
Reject unsupported macro calls without panicking

### DIFF
--- a/crates/fe/tests/cli_output.rs
+++ b/crates/fe/tests/cli_output.rs
@@ -3789,3 +3789,28 @@ fn test_cli_workspace_exclude_skips_member() {
     let (output, _) = run_fe_main_in_dir(&["check"], &root);
     snap_test!(output, snapshot_path.to_str().unwrap());
 }
+
+#[test]
+fn unsupported_macro_calls_are_cli_errors() {
+    let dir = tempdir().expect("temp dir");
+    let source = dir.path().join("unsupported_macro.fe");
+    fs::write(&source, "#[test]\nfn unsupported() { funsig!(x) }\n")
+        .expect("write unsupported macro fixture");
+    let source = source.to_str().expect("source path utf8");
+
+    for command in ["check", "build", "test"] {
+        for recovery in [false, true] {
+            let mut args = vec![command, source];
+            if command != "test" {
+                args.push("--standalone");
+            }
+            if recovery {
+                args.push("--recovery-mode");
+            }
+            let (output, exit_code) = run_fe_main_in_dir(&args, dir.path());
+            assert_eq!(exit_code, 1, "fe {args:?}:\n{output}");
+            assert!(output.contains("unsupported macro call"), "{output}");
+            assert!(!output.contains("panicked at"), "{output}");
+        }
+    }
+}

--- a/crates/fe/tests/fixtures/crash_regressions/unsupported_macro_call_1132.fe
+++ b/crates/fe/tests/fixtures/crash_regressions/unsupported_macro_call_1132.fe
@@ -1,0 +1,3 @@
+fn f() {
+    funsig!(x)
+}

--- a/crates/hir/src/analysis/diagnostics.rs
+++ b/crates/hir/src/analysis/diagnostics.rs
@@ -3504,6 +3504,17 @@ impl DiagnosticVoucher for BodyDiag<'_> {
                     error_code,
                 }
             }
+            Self::UnsupportedMacroCall(primary) => CompleteDiagnostic {
+                severity: Severity::Error,
+                message: "unsupported macro call".to_string(),
+                sub_diagnostics: vec![SubDiagnostic {
+                    style: LabelStyle::Primary,
+                    message: "only `assert!(...)` is supported".to_string(),
+                    span: primary.resolve(db),
+                }],
+                notes: vec![],
+                error_code,
+            },
             Self::UnsupportedUnaryPlus(primary) => CompleteDiagnostic {
                 severity: Severity::Error,
                 message: "unary `+` is not supported".to_string(),

--- a/crates/hir/src/analysis/semantic/instance/semantic.rs
+++ b/crates/hir/src/analysis/semantic/instance/semantic.rs
@@ -290,6 +290,7 @@ fn call_like_receiver_expr<'db>(expr_data: &Expr<'db>) -> Option<ExprId> {
         | Expr::AugAssign(receiver, ..) => Some(*receiver),
         Expr::Call(..)
         | Expr::Assert(..)
+        | Expr::UnsupportedMacroCall
         | Expr::Lit(..)
         | Expr::Path(..)
         | Expr::Tuple(..)

--- a/crates/hir/src/analysis/semantic/lower/body.rs
+++ b/crates/hir/src/analysis/semantic/lower/body.rs
@@ -628,6 +628,9 @@ impl<'a, 'db> SmirLowerCtxt<'a, 'db> {
             }
             Expr::Call(_, args) => self.lower_call(expr, None, args),
             Expr::Assert(args) => self.lower_assert(expr, args),
+            Expr::UnsupportedMacroCall => {
+                unreachable!("unsupported macro calls must be rejected before semantic lowering")
+            }
             Expr::MethodCall(receiver, _, _, args) => self.lower_call(expr, Some(*receiver), args),
             Expr::Assign(dst, src) => {
                 if self.typed_body.semantic_expr_lowering(*dst).is_some() {

--- a/crates/hir/src/analysis/ty/const_check.rs
+++ b/crates/hir/src/analysis/ty/const_check.rs
@@ -187,6 +187,7 @@ impl<'db> ConstFnChecker<'db, '_> {
                 args.iter().for_each(|arg| self.check_expr(arg.expr));
                 self.check_call_target(expr);
             }
+            Expr::UnsupportedMacroCall => {}
             Expr::Assert(args) => args.iter().for_each(|arg| self.check_expr(arg.expr)),
             Expr::MethodCall(receiver, _name, _generic_args, args) => {
                 self.check_expr(*receiver);

--- a/crates/hir/src/analysis/ty/diagnostics.rs
+++ b/crates/hir/src/analysis/ty/diagnostics.rs
@@ -544,6 +544,7 @@ pub enum BodyDiag<'db> {
         trait_path: PathId<'db>,
     },
     UnsupportedUnaryPlus(DynLazySpan<'db>),
+    UnsupportedMacroCall(DynLazySpan<'db>),
     IntLiteralOutOfRange {
         primary: DynLazySpan<'db>,
         literal: String,
@@ -941,6 +942,7 @@ impl<'db> BodyDiag<'db> {
             Self::AccessedFieldNotFound { .. } => 15,
             Self::OpsTraitNotImplemented { .. } => 16,
             Self::UnsupportedUnaryPlus(..) => 52,
+            Self::UnsupportedMacroCall(..) => 89,
             Self::IntLiteralOutOfRange { .. } => 74,
             Self::BorrowFromNonPlace { .. } => 65,
             Self::CannotBorrowMut { .. } => 66,

--- a/crates/hir/src/analysis/ty/ty_check/expr.rs
+++ b/crates/hir/src/analysis/ty/ty_check/expr.rs
@@ -380,6 +380,12 @@ impl<'db> TyChecker<'db> {
             Expr::Bin(lhs, rhs, op) => self.check_binary(expr, *lhs, *rhs, *op),
             Expr::Call(..) => self.check_call(expr, expr_data),
             Expr::Assert(args) => self.check_assert(expr, args),
+            Expr::UnsupportedMacroCall => {
+                self.push_diag(BodyDiag::UnsupportedMacroCall(
+                    expr.span(self.body()).into(),
+                ));
+                ExprProp::invalid(self.db)
+            }
             Expr::MethodCall(..) => self.check_method_call(expr, expr_data),
             Expr::Path(..) => self.check_path(expr, expr_data),
             Expr::RecordInit(..) => self.check_record_init(expr, expr_data, expected),

--- a/crates/hir/src/analysis/ty/ty_check/mod.rs
+++ b/crates/hir/src/analysis/ty/ty_check/mod.rs
@@ -3201,6 +3201,7 @@ impl<'db> TypedBody<'db> {
             }
             Expr::Call(..) | Expr::MethodCall(..) => self.semantic_expr_lowering(expr).is_none(),
             Expr::Assert(_) => expr_ty.has_invalid(db),
+            Expr::UnsupportedMacroCall => true,
             Expr::RecordInit(..) => self.record_init_lowering(expr).is_none(),
             Expr::Un(inner, crate::hir_def::expr::UnOp::Mut | crate::hir_def::expr::UnOp::Ref) => {
                 expr_ty.has_invalid(db)
@@ -4336,7 +4337,7 @@ impl<'db> TypedBody<'db> {
                     seen,
                 );
             }
-            Expr::Lit(_) | Expr::Path(_) => {}
+            Expr::Lit(_) | Expr::Path(_) | Expr::UnsupportedMacroCall => {}
         }
     }
 

--- a/crates/hir/src/core/hir_def/expr.rs
+++ b/crates/hir/src/core/hir_def/expr.rs
@@ -18,6 +18,8 @@ pub enum Expr<'db> {
     Call(ExprId, Vec<CallArg<'db>>),
     /// Compiler-owned `assert!(cond[, "message"])` builtin.
     Assert(Vec<CallArg<'db>>),
+    /// A parsed macro call that is not a supported compiler builtin.
+    UnsupportedMacroCall,
     /// (receiver, method_name, generic args, call args)
     MethodCall(
         ExprId,

--- a/crates/hir/src/core/lower/expr.rs
+++ b/crates/hir/src/core/lower/expr.rs
@@ -74,6 +74,9 @@ impl<'db> Expr<'db> {
             }
 
             ast::ExprKind::MacroCall(call) => {
+                if !is_assert_macro_call(&call) {
+                    return ctxt.push_expr(Self::UnsupportedMacroCall, HirOrigin::raw(&ast));
+                }
                 let args = call
                     .args()
                     .map(|args| {
@@ -82,11 +85,7 @@ impl<'db> Expr<'db> {
                             .collect()
                     })
                     .unwrap_or_default();
-                if is_assert_macro_call(&call) {
-                    Self::Assert(args)
-                } else {
-                    return ctxt.push_invalid_expr(HirOrigin::raw(&ast));
-                }
+                Self::Assert(args)
             }
 
             ast::ExprKind::MethodCall(method_call) => {

--- a/crates/hir/src/core/print.rs
+++ b/crates/hir/src/core/print.rs
@@ -636,6 +636,7 @@ impl<'db> Expr<'db> {
                 )
             }
 
+            Expr::UnsupportedMacroCall => "<unsupported macro call>".to_string(),
             Expr::Assert(args) => {
                 let args_str = args
                     .iter()

--- a/crates/hir/src/core/visitor.rs
+++ b/crates/hir/src/core/visitor.rs
@@ -1375,6 +1375,7 @@ pub fn walk_expr<'db, V>(
             );
         }
 
+        Expr::UnsupportedMacroCall => {}
         Expr::Assert(call_args) => {
             ctxt.with_new_ctxt(
                 |span| span.into_macro_call_expr(),

--- a/crates/uitest/fixtures/ty_check/unsupported_macro_call.fe
+++ b/crates/uitest/fixtures/ty_check/unsupported_macro_call.fe
@@ -1,0 +1,25 @@
+fn statement() {
+    funsig!(x)
+}
+
+fn existing_function() {}
+
+fn function_as_macro() {
+    existing_function!()
+}
+
+fn qualified_assert() {
+    core::assert!(true)
+}
+
+fn returned() -> u256 {
+    return funsig!(x)
+}
+
+const VALUE: u256 = funsig!(x)
+
+const fn const_function() -> u256 {
+    funsig!(x)
+}
+
+const FROM_FUNCTION: u256 = const_function()

--- a/crates/uitest/fixtures/ty_check/unsupported_macro_call.snap
+++ b/crates/uitest/fixtures/ty_check/unsupported_macro_call.snap
@@ -1,0 +1,40 @@
+---
+source: crates/uitest/tests/ty_check.rs
+expression: diags
+input_file: fixtures/ty_check/unsupported_macro_call.fe
+---
+error[8-0089]: unsupported macro call
+  ┌─ unsupported_macro_call.fe:2:5
+  │
+2 │     funsig!(x)
+  │     ^^^^^^^^^^ only `assert!(...)` is supported
+
+error[8-0089]: unsupported macro call
+  ┌─ unsupported_macro_call.fe:8:5
+  │
+8 │     existing_function!()
+  │     ^^^^^^^^^^^^^^^^^^^^ only `assert!(...)` is supported
+
+error[8-0089]: unsupported macro call
+   ┌─ unsupported_macro_call.fe:12:5
+   │
+12 │     core::assert!(true)
+   │     ^^^^^^^^^^^^^^^^^^^ only `assert!(...)` is supported
+
+error[8-0089]: unsupported macro call
+   ┌─ unsupported_macro_call.fe:16:12
+   │
+16 │     return funsig!(x)
+   │            ^^^^^^^^^^ only `assert!(...)` is supported
+
+error[8-0089]: unsupported macro call
+   ┌─ unsupported_macro_call.fe:19:21
+   │
+19 │ const VALUE: u256 = funsig!(x)
+   │                     ^^^^^^^^^^ only `assert!(...)` is supported
+
+error[8-0089]: unsupported macro call
+   ┌─ unsupported_macro_call.fe:22:5
+   │
+22 │     funsig!(x)
+   │     ^^^^^^^^^^ only `assert!(...)` is supported

--- a/newsfragments/1132.bugfix.md
+++ b/newsfragments/1132.bugfix.md
@@ -1,0 +1,1 @@
+Report unsupported macro calls as compiler errors instead of panicking during semantic lowering.


### PR DESCRIPTION
Preserve unsupported macro calls in HIR and report a diagnostic before semantic lowering. Add CLI, type-checking, and crash regression coverage.

Fixes #1132