### PR TITLE
Reject associated types not declared in implemented trait

### DIFF
--- a/crates/hir/src/analysis/diagnostics.rs
+++ b/crates/hir/src/analysis/diagnostics.rs
@@ -5273,6 +5273,26 @@ impl DiagnosticVoucher for ImplDiag<'_> {
                 }
             }
 
+            Self::TypeNotDefinedInTrait {
+                primary,
+                trait_,
+                type_name,
+            } => CompleteDiagnostic {
+                severity,
+                message: "associated type not defined in trait".to_string(),
+                sub_diagnostics: vec![SubDiagnostic {
+                    style: LabelStyle::Primary,
+                    message: format!(
+                        "associated type `{}` is not defined in trait `{}`",
+                        type_name.data(db),
+                        trait_.name(db).unwrap().data(db)
+                    ),
+                    span: primary.resolve(db),
+                }],
+                notes: vec![],
+                error_code,
+            },
+
             Self::MissingAssociatedType {
                 primary,
                 type_name,

--- a/crates/hir/src/analysis/ty/diagnostics.rs
+++ b/crates/hir/src/analysis/ty/diagnostics.rs
@@ -1140,6 +1140,12 @@ pub enum ImplDiag<'db> {
         is_nominal: bool,
     },
 
+    TypeNotDefinedInTrait {
+        primary: DynLazySpan<'db>,
+        trait_: Trait<'db>,
+        type_name: IdentId<'db>,
+    },
+
     MissingAssociatedType {
         primary: DynLazySpan<'db>,
         type_name: IdentId<'db>,
@@ -1233,6 +1239,7 @@ impl ImplDiag<'_> {
             Self::InherentConstShadowsVariant { .. } => 20,
             Self::InherentConstShadowsFn { .. } => 21,
             Self::InvalidEffectHandleRaw { .. } => 22,
+            Self::TypeNotDefinedInTrait { .. } => 23,
         }
     }
 }

--- a/crates/hir/src/diagnosable.rs
+++ b/crates/hir/src/diagnosable.rs
@@ -690,11 +690,8 @@ impl<'db> ImplTrait<'db> {
         self.implementor_with_errors(db)
     }
 
-    /// Diagnostics for missing associated types (required by the trait).
-    pub fn diags_missing_assoc_types(
-        self,
-        db: &'db dyn HirAnalysisDb,
-    ) -> Vec<TyDiagCollection<'db>> {
+    /// Diagnostics for missing associated types and types not declared in the trait.
+    pub fn diags_assoc_types(self, db: &'db dyn HirAnalysisDb) -> Vec<TyDiagCollection<'db>> {
         use ty::diagnostics::ImplDiag;
         use ty::trait_lower::lower_impl_trait;
 
@@ -705,6 +702,22 @@ impl<'db> ImplTrait<'db> {
         let implementor = implementor.instantiate_identity();
         let trait_hir = implementor.trait_def(db);
         let impl_types = implementor.types(db);
+
+        for (idx, assoc) in self.types(db).iter().enumerate() {
+            let Some(name) = assoc.name.to_opt() else {
+                continue;
+            };
+            if trait_hir.assoc_ty(db, name).is_none() {
+                diags.push(
+                    ImplDiag::TypeNotDefinedInTrait {
+                        primary: self.span().associated_type(idx).name().into(),
+                        trait_: trait_hir,
+                        type_name: name,
+                    }
+                    .into(),
+                );
+            }
+        }
 
         for assoc in trait_hir.assoc_types(db) {
             let Some(name) = assoc.name(db) else { continue };
@@ -1759,7 +1772,7 @@ impl<'db> Diagnosable<'db> for ImplTrait<'db> {
         out.extend(self.diags_effect_handle_raw(db, *implementor.skip_binder()));
         out.extend(self.diags_trait_ref_and_wf(db));
         out.extend(self.diags_assoc_types_wf(db));
-        out.extend(self.diags_missing_assoc_types(db));
+        out.extend(self.diags_assoc_types(db));
         out.extend(self.diags_assoc_types_bounds(db));
         out.extend(self.diags_missing_assoc_consts(db));
         out.extend(self.diags_assoc_consts(db));

--- a/crates/uitest/fixtures/ty/def/trait_impl_trait_env_admissibility.snap
+++ b/crates/uitest/fixtures/ty/def/trait_impl_trait_env_admissibility.snap
@@ -69,6 +69,18 @@ error[6-0016]: associated const `C` has incompatible type
 114 │     const C: bool = 0
     │              ^^^^ expected `u32`, found `bool`
 
+error[6-0023]: associated type not defined in trait
+    ┌─ trait_impl_trait_env_admissibility.fe:204:10
+    │
+204 │     type Extra = bool
+    │          ^^^^^ associated type `Extra` is not defined in trait `WithDefaultItem`
+
+error[6-0023]: associated type not defined in trait
+    ┌─ trait_impl_trait_env_admissibility.fe:215:10
+    │
+215 │     type Extra = bool
+    │          ^^^^^ associated type `Extra` is not defined in trait `WithItem`
+
 error[8-0000]: type mismatch
    ┌─ trait_impl_trait_env_admissibility.fe:98:20
    │

--- a/crates/uitest/fixtures/ty_check/assoc_ty_extra.fe
+++ b/crates/uitest/fixtures/ty_check/assoc_ty_extra.fe
@@ -1,0 +1,43 @@
+trait T {
+    type X
+}
+
+struct Foo {}
+impl T for Foo {
+    type X = u32
+    type Y = u64
+}
+
+trait Empty {}
+struct Bar {}
+impl Empty for Bar {
+    type Extra = u256
+}
+
+trait WithDefault {
+    type X = u32
+}
+struct Baz {}
+impl WithDefault for Baz {
+    type Y = u64
+}
+
+struct ValidDefault {}
+impl WithDefault for ValidDefault {}
+
+struct ValidOverride {}
+impl WithDefault for ValidOverride {
+    type X = u64
+}
+
+trait Super {
+    type X
+}
+trait Sub: Super {}
+struct Child {}
+impl Super for Child {
+    type X = u32
+}
+impl Sub for Child {
+    type X = u32
+}

--- a/crates/uitest/fixtures/ty_check/assoc_ty_extra.snap
+++ b/crates/uitest/fixtures/ty_check/assoc_ty_extra.snap
@@ -1,0 +1,28 @@
+---
+source: crates/uitest/tests/ty_check.rs
+expression: diags
+input_file: fixtures/ty_check/assoc_ty_extra.fe
+---
+error[6-0023]: associated type not defined in trait
+  ┌─ assoc_ty_extra.fe:8:10
+  │
+8 │     type Y = u64
+  │          ^ associated type `Y` is not defined in trait `T`
+
+error[6-0023]: associated type not defined in trait
+   ┌─ assoc_ty_extra.fe:14:10
+   │
+14 │     type Extra = u256
+   │          ^^^^^ associated type `Extra` is not defined in trait `Empty`
+
+error[6-0023]: associated type not defined in trait
+   ┌─ assoc_ty_extra.fe:22:10
+   │
+22 │     type Y = u64
+   │          ^ associated type `Y` is not defined in trait `WithDefault`
+
+error[6-0023]: associated type not defined in trait
+   ┌─ assoc_ty_extra.fe:42:10
+   │
+42 │     type X = u32
+   │          ^ associated type `X` is not defined in trait `Sub`

--- a/newsfragments/1193.bugfix.md
+++ b/newsfragments/1193.bugfix.md
@@ -1,0 +1,1 @@
+Reject associated type definitions in trait implementations when the type is not declared in the implemented trait.


### PR DESCRIPTION
Report unexpected associated type definitions at their names. Cover extra types, defaults, and supertraits with regression tests.

Fixes #1193